### PR TITLE
added null check before closing streams in finaly block

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/subscription/repository/manager/DataSaver.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/subscription/repository/manager/DataSaver.java
@@ -132,8 +132,12 @@ class DataSaver {
             log.error("Error accessing storage " + fileName + ": " + ex.getMessage());
         } finally {
             try {
-                xdec.close();
-                fis.close();
+            	if (xdec != null) {
+            		xdec.close();
+            	}
+            	if (fis != null) {
+            		fis.close();
+            	}
             } catch (IOException ex) {
                 log.info("Unable to close streams: " + ex.getMessage());
             }


### PR DESCRIPTION
This is a fix for GATEWAY-1767. 
To resolve the Fortify scan error:

"DataSaver null reference error in method loadList missing null check before closing streams"
