### PR TITLE
GATEWAY-410: remove links to NSFW web site in ivy.xml files

### DIFF
--- a/Product/IntegrationTest/JunitIntegrationTests/Adapters/Framework/AdapterFrameworkIntTest/ivy.xml
+++ b/Product/IntegrationTest/JunitIntegrationTests/Adapters/Framework/AdapterFrameworkIntTest/ivy.xml
@@ -31,9 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-         then org=groupId, name=artifactId, rev=version
--->
 	<dependency name="AdapterDocumentRepository" rev="latest.integration">
 		<exclude module="AdapterDocumentRepository"/>
 	</dependency>

--- a/Product/IntegrationTest/JunitIntegrationTests/Adapters/General/AdapterGeneralIntTest/ivy.xml
+++ b/Product/IntegrationTest/JunitIntegrationTests/Adapters/General/AdapterGeneralIntTest/ivy.xml
@@ -31,8 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-         then org=groupId, name=artifactId, rev=version -->
     <dependency name="CONNECTCoreLib" rev="latest.integration">
             <exclude module="CONNECTCoreLib"/>
      </dependency>

--- a/Product/IntegrationTest/JunitIntegrationTests/Common/CommonIntTest/ivy.xml
+++ b/Product/IntegrationTest/JunitIntegrationTests/Common/CommonIntTest/ivy.xml
@@ -31,8 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-         then org=groupId, name=artifactId, rev=version -->
 
     <!-- Project dependencies -->
     <dependency name="CONNECTCoreLib" rev="latest.integration">

--- a/Product/IntegrationTest/JunitIntegrationTests/Gateway/GatewayIntTest/ivy.xml
+++ b/Product/IntegrationTest/JunitIntegrationTests/Gateway/GatewayIntTest/ivy.xml
@@ -31,10 +31,6 @@
     </configurations>
 
     <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
     <dependency name="CONNECTCoreLib" rev="latest.integration">
             <exclude module="CONNECTCoreLib"/>

--- a/Product/IntegrationTest/JunitIntegrationTests/Gateway/HiemSubscriptionRepositoryIntegrationTest/ivy.xml
+++ b/Product/IntegrationTest/JunitIntegrationTests/Gateway/HiemSubscriptionRepositoryIntegrationTest/ivy.xml
@@ -31,8 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-         then org=groupId, name=artifactId, rev=version -->
 
     <!-- compile time jars -->
     <dependency org="javax.ejb"                 name="ejb-api"                  rev="3.0"           conf="compile->default" />

--- a/Product/IntegrationTest/JunitIntegrationTests/Gateway/LoadTest/ivy.xml
+++ b/Product/IntegrationTest/JunitIntegrationTests/Gateway/LoadTest/ivy.xml
@@ -31,9 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-         then org=groupId, name=artifactId, rev=version -->
-
     <!-- compile time jars -->
     <dependency org="javax.ejb"                 name="ejb-api"                  rev="3.0"           conf="compile->default" />
 

--- a/Product/Production/Adapters/AdminDistribution_a0/ivy.xml
+++ b/Product/Production/Adapters/AdminDistribution_a0/ivy.xml
@@ -31,9 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
 
     <!-- Project dependencies -->
     

--- a/Product/Production/Adapters/DocumentQuery_a0/ivy.xml
+++ b/Product/Production/Adapters/DocumentQuery_a0/ivy.xml
@@ -22,9 +22,6 @@
 	</configurations>
 
 	<dependencies>
-		<!-- To find dependency params use http://www.mavensearch.net/ to find 
-			the XML descriptor. then org=groupId, name=artifactId, rev=version -->
-
 		<!-- Project dependencies -->
 
 		<!-- runtime jars -->

--- a/Product/Production/Adapters/DocumentRetrieve_a0/ivy.xml
+++ b/Product/Production/Adapters/DocumentRetrieve_a0/ivy.xml
@@ -31,9 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
 
     <!-- Project dependencies -->
     

--- a/Product/Production/Adapters/DocumentSubmission_a0/ivy.xml
+++ b/Product/Production/Adapters/DocumentSubmission_a0/ivy.xml
@@ -31,9 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
 
     <!-- Project dependencies -->
     

--- a/Product/Production/Adapters/Framework/AdapterCommonDataLayerEJB/ivy.xml
+++ b/Product/Production/Adapters/Framework/AdapterCommonDataLayerEJB/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
     <dependency name="CONNECTCoreLib" rev="latest.integration">
             <exclude module="CONNECTCoreLib"/>

--- a/Product/Production/Adapters/Framework/AdapterDocumentAssemblyProxyEJB/ivy.xml
+++ b/Product/Production/Adapters/Framework/AdapterDocumentAssemblyProxyEJB/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
 
     <!-- compile time jars -->

--- a/Product/Production/Adapters/Framework/AdapterDocumentRepository/ivy.xml
+++ b/Product/Production/Adapters/Framework/AdapterDocumentRepository/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
 
     <!-- compile time jars -->

--- a/Product/Production/Adapters/Framework/AdapterDocumentRepositoryEJB/ivy.xml
+++ b/Product/Production/Adapters/Framework/AdapterDocumentRepositoryEJB/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
 
     <!-- compile time jars -->

--- a/Product/Production/Adapters/Framework/AdapterMpiEJB/ivy.xml
+++ b/Product/Production/Adapters/Framework/AdapterMpiEJB/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
 
     <!-- compile time jars -->

--- a/Product/Production/Adapters/Framework/DocumentAssemblyManagerEJB/ivy.xml
+++ b/Product/Production/Adapters/Framework/DocumentAssemblyManagerEJB/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
   
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
 
     <!-- compile time jars -->

--- a/Product/Production/Adapters/Framework/DocumentManagerEJB/ivy.xml
+++ b/Product/Production/Adapters/Framework/DocumentManagerEJB/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
 
     <!-- compile time jars -->

--- a/Product/Production/Adapters/Framework/NHINAdapterServiceEJB/ivy.xml
+++ b/Product/Production/Adapters/Framework/NHINAdapterServiceEJB/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
 
     <!-- compile time jars -->

--- a/Product/Production/Adapters/Framework/TemplateManager/ivy.xml
+++ b/Product/Production/Adapters/Framework/TemplateManager/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
 
     <!-- compile time jars -->

--- a/Product/Production/Adapters/General/AdapterDocRegistry2Soap12Web/ivy.xml
+++ b/Product/Production/Adapters/General/AdapterDocRegistry2Soap12Web/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
 
     <!-- compile time jars -->

--- a/Product/Production/Adapters/General/AdapterDocRepository2Soap12Web/ivy.xml
+++ b/Product/Production/Adapters/General/AdapterDocRepository2Soap12Web/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
 
     <!-- compile time jars -->

--- a/Product/Production/Adapters/General/CONNECTAdapterPDPOpenSSO/ivy.xml
+++ b/Product/Production/Adapters/General/CONNECTAdapterPDPOpenSSO/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
 
     <!-- compile time jars -->

--- a/Product/Production/Adapters/General/CONNECTAdapterWeb/ivy.xml
+++ b/Product/Production/Adapters/General/CONNECTAdapterWeb/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
     
     <!-- runtime jars -->

--- a/Product/Production/Adapters/General/CONNECTConsumerPreferencesProfileGUI/ivy.xml
+++ b/Product/Production/Adapters/General/CONNECTConsumerPreferencesProfileGUI/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
 
     <!-- compile time jars -->

--- a/Product/Production/Adapters/General/CONNECTDeferredQueueManagerGUI/ivy.xml
+++ b/Product/Production/Adapters/General/CONNECTDeferredQueueManagerGUI/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
 
     <!-- compile time jars -->

--- a/Product/Production/Adapters/General/CONNECTUniversalClientGUI/ivy.xml
+++ b/Product/Production/Adapters/General/CONNECTUniversalClientGUI/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
 
     <!-- compile time jars -->

--- a/Product/Production/Adapters/GenericFileTransfer/FTAConfigManager/ivy.xml
+++ b/Product/Production/Adapters/GenericFileTransfer/FTAConfigManager/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
 
     <!-- compile time jars -->

--- a/Product/Production/Adapters/GenericFileTransfer/FTATransferAdapterEJB/ivy.xml
+++ b/Product/Production/Adapters/GenericFileTransfer/FTATransferAdapterEJB/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
 
     <!-- compile time jars -->

--- a/Product/Production/Adapters/GenericFileTransfer/FileTransferAdapterEJB/ivy.xml
+++ b/Product/Production/Adapters/GenericFileTransfer/FileTransferAdapterEJB/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
 
     <!-- compile time jars -->

--- a/Product/Production/Adapters/GenericFileTransfer/FileTransferAdapterGUI/ivy.xml
+++ b/Product/Production/Adapters/GenericFileTransfer/FileTransferAdapterGUI/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
 
     <!-- compile time jars -->

--- a/Product/Production/Adapters/GenericFileTransfer/FileTrasnferTimer/ivy.xml
+++ b/Product/Production/Adapters/GenericFileTransfer/FileTrasnferTimer/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
 
     <!-- compile time jars -->

--- a/Product/Production/Adapters/PatientDiscovery_a0/ivy.xml
+++ b/Product/Production/Adapters/PatientDiscovery_a0/ivy.xml
@@ -31,9 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
 
     <!-- Project dependencies -->
     

--- a/Product/Production/Common/CONNECTCommonTypesLib/ivy.xml
+++ b/Product/Production/Common/CONNECTCommonTypesLib/ivy.xml
@@ -13,10 +13,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
 
     <!-- compile time jars -->

--- a/Product/Production/Common/CONNECTCommonWeb/ivy.xml
+++ b/Product/Production/Common/CONNECTCommonWeb/ivy.xml
@@ -31,10 +31,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
  <!-- Project dependencies -->
   <dependency name="CONNECTCommonTypesLib" rev="latest.integration">
     <exclude module="CONNECTCommonTypesLib"/>

--- a/Product/Production/Common/CONNECTCoreLib/ivy.xml
+++ b/Product/Production/Common/CONNECTCoreLib/ivy.xml
@@ -9,10 +9,6 @@
   </configurations>
 
   <dependencies>
- <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-       then org=groupId, name=artifactId, rev=version
- -->
-
  <!-- Project dependencies -->
   <dependency name="CONNECTCommonTypesLib" rev="latest.integration">
     <exclude module="CONNECTCommonTypesLib"/>

--- a/Product/Production/Gateway/AdminDistribution_10/ivy.xml
+++ b/Product/Production/Gateway/AdminDistribution_10/ivy.xml
@@ -9,9 +9,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
 
     <!-- Project dependencies -->
     <dependency name="CONNECTCoreLib" rev="latest.integration">

--- a/Product/Production/Gateway/AdminDistribution_20/ivy.xml
+++ b/Product/Production/Gateway/AdminDistribution_20/ivy.xml
@@ -9,9 +9,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
 
     <!-- Project dependencies -->
     <dependency name="CONNECTCoreLib" rev="latest.integration">

--- a/Product/Production/Gateway/CONNECTGatewayWeb/ivy.xml
+++ b/Product/Production/Gateway/CONNECTGatewayWeb/ivy.xml
@@ -9,10 +9,6 @@
   </configurations>
 
   <dependencies>
- <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
- then org=groupId, name=artifactId, rev=version
- -->
-
     <!-- Project dependencies -->
     <dependency name="CONNECTCoreLib" rev="latest.integration">
       <exclude module="CONNECTCoreLib"/>

--- a/Product/Production/Gateway/DocumentQuery_20/ivy.xml
+++ b/Product/Production/Gateway/DocumentQuery_20/ivy.xml
@@ -9,9 +9,6 @@
   </configurations>
 
   <dependencies>
- <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
- then org=groupId, name=artifactId, rev=version
- -->
 
     <!-- Project dependencies -->
     <dependency name="CONNECTCoreLib" rev="latest.integration">

--- a/Product/Production/Gateway/DocumentRetrieve_20/ivy.xml
+++ b/Product/Production/Gateway/DocumentRetrieve_20/ivy.xml
@@ -9,9 +9,6 @@
   </configurations>
 
   <dependencies>
- <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
- then org=groupId, name=artifactId, rev=version
- -->
 
     <!-- Project dependencies -->
     <dependency name="CONNECTCoreLib" rev="latest.integration">

--- a/Product/Production/Gateway/DocumentRetrieve_30/ivy.xml
+++ b/Product/Production/Gateway/DocumentRetrieve_30/ivy.xml
@@ -9,9 +9,6 @@
   </configurations>
 
   <dependencies>
- <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
- then org=groupId, name=artifactId, rev=version
- -->
 
     <!-- Project dependencies -->
     <dependency name="CONNECTCoreLib" rev="latest.integration">

--- a/Product/Production/Gateway/DocumentSubmission_11/ivy.xml
+++ b/Product/Production/Gateway/DocumentSubmission_11/ivy.xml
@@ -9,9 +9,6 @@
   </configurations>
 
   <dependencies>
- <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
- then org=groupId, name=artifactId, rev=version
- -->
 
     <!-- Project dependencies -->
     <dependency name="CONNECTCoreLib" rev="latest.integration">

--- a/Product/Production/Gateway/DocumentSubmission_20/ivy.xml
+++ b/Product/Production/Gateway/DocumentSubmission_20/ivy.xml
@@ -9,9 +9,6 @@
   </configurations>
 
   <dependencies>
- <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
- then org=groupId, name=artifactId, rev=version
- -->
 
     <!-- Project dependencies -->
     <dependency name="CONNECTCoreLib" rev="latest.integration">

--- a/Product/Production/Gateway/HIEM_20/ivy.xml
+++ b/Product/Production/Gateway/HIEM_20/ivy.xml
@@ -9,9 +9,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
 
     <!-- Project dependencies -->
     <dependency name="CONNECTCoreLib" rev="latest.integration">

--- a/Product/Production/Gateway/PatientDiscovery_10/ivy.xml
+++ b/Product/Production/Gateway/PatientDiscovery_10/ivy.xml
@@ -9,9 +9,6 @@
   </configurations>
 
   <dependencies>
- <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
- then org=groupId, name=artifactId, rev=version
- -->
 
     <!-- Project dependencies -->
     <dependency name="CONNECTCoreLib" rev="latest.integration">

--- a/Product/Production/Utilities/ConfigurationUtility/ivy.xml
+++ b/Product/Production/Utilities/ConfigurationUtility/ivy.xml
@@ -12,10 +12,6 @@
   </configurations>
 
   <dependencies>
-    <!-- To find dependency params use http://www.mavensearch.net/ to find the XML descriptor.
-                 then org=groupId, name=artifactId, rev=version
-    -->
-
     <!-- Project dependencies -->
     <dependency name="CONNECTCoreLib" rev="latest.integration">
       <exclude module="CONNECTCoreLib"/>


### PR DESCRIPTION
At some point, the maven search site indicated in the ivy.xml files
changed to no longer be a search engine for Maven artifacts.  It's now
NSFW.  This patch removes the comments that link to it.
