### PR TITLE
Remove HandlerChain from docRetrieve GATEWAY-2644

### DIFF
--- a/Product/Production/Gateway/CONNECTNhinServicesWeb/src/main/java/gov/hhs/fha/nhinc/docretrieve/nhin/DocRetrieve.java
+++ b/Product/Production/Gateway/CONNECTNhinServicesWeb/src/main/java/gov/hhs/fha/nhinc/docretrieve/nhin/DocRetrieve.java
@@ -1,8 +1,8 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- *  
+ *
  * Copyright 2010(Year date of delivery) United States Government, as represented by the Secretary of Health and Human Services.  All rights reserved.
- *  
+ *
  */
 package gov.hhs.fha.nhinc.docretrieve.nhin;
 
@@ -20,7 +20,7 @@ import javax.xml.ws.soap.Addressing;
 @WebService(serviceName = "RespondingGateway_Retrieve_Service", portName = "RespondingGateway_Retrieve_Port_Soap", endpointInterface = "ihe.iti.xds_b._2007.RespondingGatewayRetrievePortType", targetNamespace = "urn:ihe:iti:xds-b:2007", wsdlLocation = "WEB-INF/wsdl/DocRetrieve/NhinDocRetrieve.wsdl")
 @BindingType(value = "http://www.w3.org/2003/05/soap/bindings/HTTP/")
 @Addressing(enabled=true)
-@HandlerChain(file="../../../../../../handler-chain.xml")
+/* @HandlerChain(file="../../../../../../handler-chain.xml") */
 public class DocRetrieve
 {
     @Resource


### PR DESCRIPTION
I would like to contribute the required change to remove the HandlerChain from Document retrieve interface
