### PR TITLE
GATEWAY-2873: Fix for windows getResource path issue

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/openSAML/extraction/OpenSAMLAssertionExtractorImplTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/openSAML/extraction/OpenSAMLAssertionExtractorImplTest.java
@@ -84,6 +84,8 @@ public class OpenSAMLAssertionExtractorImplTest {
     @Test
     public void testCompleteSamlAssertion() throws Exception {
         
+    	// the first "/" is intentionally not using File.separator due to differences in how windows and unix based
+    	// operating systems handle the class.getResource method. Please see GATEWAY-2873 for more details.
         AssertionType assertionType = openSAMLAssertionExtractorImpl.extractSAMLAssertion(getElementForSamlFile(
                 "/" + "testing_saml" + File.separator + "complete_saml.xml"));
         assertNotNull(assertionType);

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/openSAML/extraction/OpenSAMLAssertionExtractorImplTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/openSAML/extraction/OpenSAMLAssertionExtractorImplTest.java
@@ -85,7 +85,7 @@ public class OpenSAMLAssertionExtractorImplTest {
     public void testCompleteSamlAssertion() throws Exception {
         
         AssertionType assertionType = openSAMLAssertionExtractorImpl.extractSAMLAssertion(getElementForSamlFile(
-                File.separator + "testing_saml" + File.separator + "complete_saml.xml"));
+                "/" + "testing_saml" + File.separator + "complete_saml.xml"));
         assertNotNull(assertionType);
 
         verifyHomeCommunity(assertionType.getHomeCommunity(), "2.16.840.1.113883.3.424", null);


### PR DESCRIPTION
File.Separator resolves to "/" for linux/unix but I believe "\" in windows. the class.getResource() method is expecting a file path starting with "/", so that character has been hard coded.
