### PR TITLE
Gateway 2769 - switch from c3po to container managed pool

### DIFF
--- a/Product/Install/GlassFish/templates/connect/domain.selfsigned.xml.template
+++ b/Product/Install/GlassFish/templates/connect/domain.selfsigned.xml.template
@@ -302,8 +302,8 @@
         <jvm-options>-Djavax.net.ssl.keyStorePassword=changeit</jvm-options>
         <jvm-options>-Djavax.net.ssl.trustStorePassword=changeit</jvm-options>
         <jvm-options>-d64</jvm-options>
-        <jvm-options>-Xmx3000m</jvm-options>
-        <jvm-options>-Xms3000m</jvm-options>
+        <jvm-options>-Xmx5000m</jvm-options>
+        <jvm-options>-Xms5000m</jvm-options>
         <jvm-options>-XX:MaxPermSize=1024m</jvm-options>
         <jvm-options>-Dlog4j.configuration=file:${com.sun.aas.instanceRoot}/config/log4j.properties</jvm-options>
         <jvm-options>-Dwsdl.path=file:${com.sun.aas.instanceRoot}/config/nhin/wsdl/</jvm-options>

--- a/Product/Install/GlassFish/templates/connect/domain.selfsigned.xml.template
+++ b/Product/Install/GlassFish/templates/connect/domain.selfsigned.xml.template
@@ -26,8 +26,8 @@
            res-type="javax.sql.DataSource"
            wrap-jdbc-objects="false"
            name="aggregator_pool"
-           min-pool-size="3"
-           max-pool-size="100">
+           min-pool-size="1"
+           max-pool-size="10">
       <property name="URL" value="jdbc:mysql://localhost/aggregator" />
       <property name="driverClass" value="com.mysql.jdbc.Driver" />
       <property name="portNumber" value="3306" />
@@ -36,15 +36,15 @@
       <property name="Password" value="nhincpass" />
       <property name="serverName" value="localhost" />
     </jdbc-connection-pool>
-    <jdbc-resource pool-name="aggregator_pool" jndi-name="jdbc/aggregator_datasource" />
+    <jdbc-resource pool-name="aggregator_pool" jndi-name="jdbc/aggregator_datasource" enabled="true" object-type="user"/>
 
     <jdbc-connection-pool connection-validation-method="auto-commit"
            datasource-classname="com.mysql.jdbc.jdbc2.optional.MysqlDataSource"
            res-type="javax.sql.DataSource"
            wrap-jdbc-objects="false"
            name="assigningauthoritydb_pool"
-           min-pool-size="3"
-           max-pool-size="100">
+           min-pool-size="1"
+           max-pool-size="10">
       <property name="URL" value="jdbc:mysql://localhost/assigningauthoritydb" />
       <property name="driverClass" value="com.mysql.jdbc.Driver" />
       <property name="portNumber" value="3306" />
@@ -53,15 +53,15 @@
       <property name="Password" value="nhincpass" />
       <property name="serverName" value="localhost" />
     </jdbc-connection-pool>
-    <jdbc-resource pool-name="assigningauthoritydb_pool" jndi-name="jdbc/assigningauthoritydb_datasource" />
+    <jdbc-resource pool-name="assigningauthoritydb_pool" jndi-name="jdbc/assigningauthoritydb_datasource" enabled="true" object-type="user"/>
 
     <jdbc-connection-pool connection-validation-method="auto-commit"
            datasource-classname="com.mysql.jdbc.jdbc2.optional.MysqlDataSource"
            res-type="javax.sql.DataSource"
            wrap-jdbc-objects="false"
            name="asyncmsgs_pool"
-           min-pool-size="3"
-           max-pool-size="100">
+           min-pool-size="1"
+           max-pool-size="10">
       <property name="URL" value="jdbc:mysql://localhost/asyncmsgs" />
       <property name="driverClass" value="com.mysql.jdbc.Driver" />
       <property name="portNumber" value="3306" />
@@ -70,15 +70,15 @@
       <property name="Password" value="nhincpass" />
       <property name="serverName" value="localhost" />
     </jdbc-connection-pool>
-    <jdbc-resource pool-name="asyncmsgs_pool" jndi-name="jdbc/asyncmsgs_datasource" />
+    <jdbc-resource pool-name="asyncmsgs_pool" jndi-name="jdbc/asyncmsgs_datasource" enabled="true" object-type="user"/>
 
     <jdbc-connection-pool connection-validation-method="auto-commit"
            datasource-classname="com.mysql.jdbc.jdbc2.optional.MysqlDataSource"
            res-type="javax.sql.DataSource"
            wrap-jdbc-objects="false"
            name="auditrepo_pool"
-           min-pool-size="3"
-           max-pool-size="100">
+           min-pool-size="1"
+           max-pool-size="10">
       <property name="URL" value="jdbc:mysql://localhost/auditrepo" />
       <property name="driverClass" value="com.mysql.jdbc.Driver" />
       <property name="portNumber" value="3306" />
@@ -87,15 +87,15 @@
       <property name="Password" value="nhincpass" />
       <property name="serverName" value="localhost" />
     </jdbc-connection-pool>
-    <jdbc-resource pool-name="auditrepo_pool" jndi-name="jdbc/auditrepo_datasource" />
+    <jdbc-resource pool-name="auditrepo_pool" jndi-name="jdbc/auditrepo_datasource" enabled="true" object-type="user"/>
 
     <jdbc-connection-pool connection-validation-method="auto-commit"
            datasource-classname="com.mysql.jdbc.jdbc2.optional.MysqlDataSource"
            res-type="javax.sql.DataSource"
            wrap-jdbc-objects="false"
            name="patientcorrelationdb_pool"
-           min-pool-size="3"
-           max-pool-size="100">
+           min-pool-size="1"
+           max-pool-size="10">
       <property name="URL" value="jdbc:mysql://localhost/patientcorrelationdb" />
       <property name="driverClass" value="com.mysql.jdbc.Driver" />
       <property name="portNumber" value="3306" />
@@ -104,15 +104,15 @@
       <property name="Password" value="nhincpass" />
       <property name="serverName" value="localhost" />
     </jdbc-connection-pool>
-    <jdbc-resource pool-name="patientcorrelationdb_pool" jndi-name="jdbc/patientcorrelationdb_datasource" />
+    <jdbc-resource pool-name="patientcorrelationdb_pool" jndi-name="jdbc/patientcorrelationdb_datasource" enabled="true" object-type="user"/>
 
     <jdbc-connection-pool connection-validation-method="auto-commit"
            datasource-classname="com.mysql.jdbc.jdbc2.optional.MysqlDataSource"
            res-type="javax.sql.DataSource"
            wrap-jdbc-objects="false"
            name="docrepository_pool"
-           min-pool-size="3"
-           max-pool-size="100">
+           min-pool-size="1"
+           max-pool-size="10">
       <property name="URL" value="jdbc:mysql://localhost/docrepository" />
       <property name="driverClass" value="com.mysql.jdbc.Driver" />
       <property name="portNumber" value="3306" />
@@ -121,15 +121,15 @@
       <property name="Password" value="nhincpass" />
       <property name="serverName" value="localhost" />
     </jdbc-connection-pool>
-    <jdbc-resource pool-name="docrepository_pool" jndi-name="jdbc/docrepository_datasource" />
+    <jdbc-resource pool-name="docrepository_pool" jndi-name="jdbc/docrepository_datasource" enabled="true" object-type="user"/>
 
     <jdbc-connection-pool connection-validation-method="auto-commit"
            datasource-classname="com.mysql.jdbc.jdbc2.optional.MysqlDataSource"
            res-type="javax.sql.DataSource"
            wrap-jdbc-objects="false"
            name="subscriptionrepository_pool"
-           min-pool-size="3"
-           max-pool-size="100">
+           min-pool-size="1"
+           max-pool-size="10">
       <property name="URL" value="jdbc:mysql://localhost/subscriptionrepository" />
       <property name="driverClass" value="com.mysql.jdbc.Driver" />
       <property name="portNumber" value="3306" />
@@ -138,15 +138,15 @@
       <property name="Password" value="nhincpass" />
       <property name="serverName" value="localhost" />
     </jdbc-connection-pool>
-    <jdbc-resource pool-name="subscriptionrepository_pool" jndi-name="jdbc/subscriptionrepository_datasource" />
+    <jdbc-resource pool-name="subscriptionrepository_pool" jndi-name="jdbc/subscriptionrepository_datasource" enabled="true" object-type="user"/>
 
     <jdbc-connection-pool connection-validation-method="auto-commit"
            datasource-classname="com.mysql.jdbc.jdbc2.optional.MysqlDataSource"
            res-type="javax.sql.DataSource"
            wrap-jdbc-objects="false"
            name="patientdb_pool"
-           min-pool-size="3"
-           max-pool-size="100">
+           min-pool-size="1"
+           max-pool-size="10">
       <property name="URL" value="jdbc:mysql://localhost/patientdb" />
       <property name="driverClass" value="com.mysql.jdbc.Driver" />
       <property name="portNumber" value="3306" />
@@ -155,15 +155,15 @@
       <property name="Password" value="nhincpass" />
       <property name="serverName" value="localhost" />
     </jdbc-connection-pool>
-    <jdbc-resource pool-name="patientdb_pool" jndi-name="jdbc/patientdb_datasource" />
+    <jdbc-resource pool-name="patientdb_pool" jndi-name="jdbc/patientdb_datasource" enabled="true" object-type="user"/>
 
     <jdbc-connection-pool connection-validation-method="auto-commit"
            datasource-classname="com.mysql.jdbc.jdbc2.optional.MysqlDataSource"
            res-type="javax.sql.DataSource"
            wrap-jdbc-objects="false"
            name="perfrepo_pool"
-           min-pool-size="3"
-           max-pool-size="100">
+           min-pool-size="1"
+           max-pool-size="10">
       <property name="URL" value="jdbc:mysql://localhost/perfrepo" />
       <property name="driverClass" value="com.mysql.jdbc.Driver" />
       <property name="portNumber" value="3306" />
@@ -172,7 +172,25 @@
       <property name="Password" value="nhincpass" />
       <property name="serverName" value="localhost" />
     </jdbc-connection-pool>
-    <jdbc-resource pool-name="perfrepo_pool" jndi-name="jdbc/perfrepo_datasource" />
+    <jdbc-resource pool-name="perfrepo_pool" jndi-name="jdbc/perfrepo_datasource" enabled="true" object-type="user"/>
+
+    <jdbc-connection-pool connection-validation-method="auto-commit"
+           datasource-classname="com.mysql.jdbc.jdbc2.optional.MysqlDataSource"
+           res-type="javax.sql.DataSource"
+           wrap-jdbc-objects="false"
+           name="transrepo_pool"
+           min-pool-size="1"
+           max-pool-size="10">
+      <property name="URL" value="jdbc:mysql://localhost/transrepo" />
+      <property name="driverClass" value="com.mysql.jdbc.Driver" />
+      <property name="portNumber" value="3306" />
+      <property name="databaseName" value="transrepo" />
+      <property name="User" value="nhincuser" />
+      <property name="Password" value="nhincpass" />
+      <property name="serverName" value="localhost" />
+    </jdbc-connection-pool>
+    <jdbc-resource pool-name="transrepo_pool" jndi-name="jdbc/transrepo_datasource" enabled="true" object-type="user"/>
+
   </resources>
   <configs>
     <config name="server-config">
@@ -284,8 +302,8 @@
         <jvm-options>-Djavax.net.ssl.keyStorePassword=changeit</jvm-options>
         <jvm-options>-Djavax.net.ssl.trustStorePassword=changeit</jvm-options>
         <jvm-options>-d64</jvm-options>
-        <jvm-options>-Xmx5000m</jvm-options>
-        <jvm-options>-Xms5000m</jvm-options>
+        <jvm-options>-Xmx3000m</jvm-options>
+        <jvm-options>-Xms3000m</jvm-options>
         <jvm-options>-XX:MaxPermSize=1024m</jvm-options>
         <jvm-options>-Dlog4j.configuration=file:${com.sun.aas.instanceRoot}/config/log4j.properties</jvm-options>
         <jvm-options>-Dwsdl.path=file:${com.sun.aas.instanceRoot}/config/nhin/wsdl/</jvm-options>
@@ -513,6 +531,16 @@
       <resource-ref ref="jdbc/__TimerPool"></resource-ref>
       <resource-ref ref="jdbc/__CallFlowPool"></resource-ref>
       <resource-ref ref="jdbc/__default"></resource-ref>
+      <resource-ref ref="jdbc/aggregator_datasource"></resource-ref>
+      <resource-ref ref="jdbc/assigningauthoritydb_datasource"></resource-ref>
+      <resource-ref ref="jdbc/asyncmsgs_datasource"></resource-ref>
+      <resource-ref ref="jdbc/auditrepo_datasource"></resource-ref>
+      <resource-ref ref="jdbc/patientcorrelationdb_datasource"></resource-ref>
+      <resource-ref ref="jdbc/docrepository_datasource"></resource-ref>
+      <resource-ref ref="jdbc/subscriptionrepository_datasource"></resource-ref>
+      <resource-ref ref="jdbc/patientdb_datasource"></resource-ref>
+      <resource-ref ref="jdbc/perfrepo_datasource"></resource-ref>
+      <resource-ref ref="jdbc/transrepo_datasource"></resource-ref>
     </server>
   </servers>
   <property name="administrative.domain.name" value="domain1"></property>

--- a/Product/Install/deploy.xml
+++ b/Product/Install/deploy.xml
@@ -622,15 +622,6 @@
         </else>
     </if>
     <if>
-        <available file="${glassfish.home}/domains/domain1/lib/c3p0-0.9.1.2.jar"
-                type="file" />
-        <then />
-        <else>
-            <fail
-                    message="C3PO Jar file are missing. Please copy $NHINC_THIRDPARTY_DIR\C3PO\*.jar to AS_HOME\lib\." />
-        </else>
-    </if>
-    <if>
         <available file="${glassfish.home}/domains/domain1/lib/log4j-1.2.15.jar"
                 type="file" />
         <then />

--- a/Product/IntegrationTest/JunitIntegrationTests/Common/CommonIntTest/ivy.xml
+++ b/Product/IntegrationTest/JunitIntegrationTests/Common/CommonIntTest/ivy.xml
@@ -47,7 +47,6 @@
 
     <!-- runtime jars -->
         <dependency org="org.hibernate"       		name="hibernate"                rev="3.2.5.ga"		conf="runtime->default"		transitive="false" />
-        <dependency org="c3p0"                		name="c3p0"                     rev="0.9.1.2"		conf="runtime->default"		transitive="false" />
         <dependency org="commons-collections" 		name="commons-collections"      rev="2.1.1"			conf="runtime->default"		transitive="false" />
         <dependency org="commons-logging"     		name="commons-logging"          rev="1.1.1"			conf="compile->default"		transitive="false" />
         <dependency org="log4j"               		name="log4j"                    rev="1.2.15"		conf="compile->default"		transitive="false" />

--- a/Product/IntegrationTest/JunitIntegrationTests/Gateway/GatewayIntTest/ivy.xml
+++ b/Product/IntegrationTest/JunitIntegrationTests/Gateway/GatewayIntTest/ivy.xml
@@ -40,7 +40,6 @@
 
     <!-- runtime jars -->
         <dependency org="org.hibernate"       name="hibernate"                      rev="3.2.5.ga"            conf="runtime->default" transitive="false" />
-        <dependency org="c3p0"                name="c3p0"                           rev="0.9.1.2"             conf="runtime->default" transitive="false" />
         <dependency org="commons-collections" name="commons-collections"            rev="2.1.1"               conf="runtime->default" transitive="false" />
         <dependency org="commons-logging"     name="commons-logging"                rev="1.1.1"               conf="compile->default" transitive="false" />
         <dependency org="log4j"               name="log4j"                          rev="1.2.15"              conf="compile->default" transitive="false" />

--- a/Product/Production/Adapters/General/CONNECTAdapterPDPOpenSSO/pom.xml
+++ b/Product/Production/Adapters/General/CONNECTAdapterPDPOpenSSO/pom.xml
@@ -23,10 +23,6 @@
                     <artifactId>hibernate</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>c3p0</groupId>
-                    <artifactId>c3p0</artifactId>
-                </exclusion>
-                <exclusion>
                     <artifactId>activation</artifactId>
                     <groupId>javax.activation</groupId>
                 </exclusion>

--- a/Product/Production/Adapters/General/CONNECTConsumerPreferencesProfileGUI/pom.xml
+++ b/Product/Production/Adapters/General/CONNECTConsumerPreferencesProfileGUI/pom.xml
@@ -32,10 +32,6 @@
                     <artifactId>hibernate</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>c3p0</groupId>
-                    <artifactId>c3p0</artifactId>
-                </exclusion>
-                <exclusion>
                     <artifactId>activation</artifactId>
                     <groupId>javax.activation</groupId>
                 </exclusion>
@@ -133,12 +129,6 @@
                     <artifactId>cglib</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>c3p0</groupId>
-            <artifactId>c3p0</artifactId>
-            <version>0.9.1.2</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>

--- a/Product/Production/Adapters/General/CONNECTDeferredQueueManagerGUI/pom.xml
+++ b/Product/Production/Adapters/General/CONNECTDeferredQueueManagerGUI/pom.xml
@@ -32,10 +32,6 @@
                     <artifactId>hibernate</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>c3p0</groupId>
-                    <artifactId>c3p0</artifactId>
-                </exclusion>
-                <exclusion>
                     <artifactId>activation</artifactId>
                     <groupId>javax.activation</groupId>
                 </exclusion>
@@ -133,12 +129,6 @@
                     <artifactId>cglib</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>c3p0</groupId>
-            <artifactId>c3p0</artifactId>
-            <version>0.9.1.2</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>

--- a/Product/Production/Adapters/General/CONNECTUniversalClientGUI/pom.xml
+++ b/Product/Production/Adapters/General/CONNECTUniversalClientGUI/pom.xml
@@ -32,10 +32,6 @@
                     <artifactId>hibernate</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>c3p0</groupId>
-                    <artifactId>c3p0</artifactId>
-                </exclusion>
-                <exclusion>
                     <artifactId>activation</artifactId>
                     <groupId>javax.activation</groupId>
                 </exclusion>
@@ -138,12 +134,6 @@
                     <artifactId>cglib</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>c3p0</groupId>
-            <artifactId>c3p0</artifactId>
-            <version>0.9.1.2</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>

--- a/Product/Production/Common/CONNECTCommonWeb/ivy.xml
+++ b/Product/Production/Common/CONNECTCommonWeb/ivy.xml
@@ -43,9 +43,8 @@
 
     <!-- runtime jars -->
     <dependency org="org.hibernate"       name="hibernate"                      rev="3.2.5.ga"            conf="runtime->default" transitive="false" />
-    <dependency org="c3p0"                name="c3p0"                           rev="0.9.1.2"             conf="runtime->default" transitive="false" />
     <dependency org="commons-collections" name="commons-collections"            rev="2.1.1"               conf="runtime->default" transitive="false" />
-	<dependency org="commons-logging"     name="commons-logging"                rev="1.1.1"               conf="compile->default" transitive="false" />
+	  <dependency org="commons-logging"     name="commons-logging"                rev="1.1.1"               conf="compile->default" transitive="false" />
     <dependency org="log4j"               name="log4j"                          rev="1.2.15"              conf="compile->default" transitive="false" />	
     <dependency org="com.thoughtworks.xstream" name="xstream-distribution" rev="1.3.1"/>
     <dependency org="javax"                 name="javaee-api"           rev="6.0"                   conf="runtime->default" transitive="false" />

--- a/Product/Production/Common/CONNECTCommonWeb/pom.xml
+++ b/Product/Production/Common/CONNECTCommonWeb/pom.xml
@@ -35,10 +35,6 @@
                     <artifactId>hibernate</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>c3p0</groupId>
-                    <artifactId>c3p0</artifactId>
-                </exclusion>
-                <exclusion>
                     <artifactId>activation</artifactId>
                     <groupId>javax.activation</groupId>
                 </exclusion>

--- a/Product/Production/Common/CONNECTCoreLib/ivy.xml
+++ b/Product/Production/Common/CONNECTCoreLib/ivy.xml
@@ -23,7 +23,6 @@
     <dependency org="org.springframework" name="spring" rev="2.5.6" conf="compile->default" transitive="false" />
     <dependency org="log4j" name="log4j" rev="1.2.15" conf="compile->default" transitive="false" />
     <dependency org="org.hibernate" name="hibernate" rev="3.2.5.ga" conf="compile->default" transitive="false" />
-    <dependency org="c3p0" name="c3p0" rev="0.9.1.2" conf="compile->default" transitive="false" />
     <dependency org="commons-logging" name="commons-logging" rev="1.1.1" conf="compile->default" transitive="false" />
     <dependency org="mysql" name="mysql-connector-java" rev="5.1.10" conf="compile->default" transitive="false" />
     <dependency org="OpenSSO" name="openssoclientsdk" rev="1.0" conf="compile->default" transitive="false" />

--- a/Product/Production/Common/Properties/Dev/hibernate/AsyncMsgs.hibernate.cfg.xml
+++ b/Product/Production/Common/Properties/Dev/hibernate/AsyncMsgs.hibernate.cfg.xml
@@ -7,12 +7,6 @@
 
     <session-factory>
 
-        <!-- Database connection settings -->
-        <property name="connection.driver_class">com.mysql.jdbc.Driver</property>
-        <property name="connection.url">jdbc:mysql://localhost/asyncmsgs</property>
-        <property name="connection.username">nhincuser</property>
-        <property name="connection.password">nhincpass</property>
-
         <!-- SQL dialect -->
         <property name="dialect">org.hibernate.dialect.MySQLDialect</property>
 
@@ -24,18 +18,8 @@
 
         <!-- Echo all executed SQL to stdout -->
         <property name="show_sql">true</property>
-        <!-- configuration pool via c3p0-->
-		<property name="c3p0.acquireRetryAttempts">4</property>
-      <property name="c3p0.acquire_increment">1</property>
-      <property name="c3p0.idle_test_period">100</property> <!-- seconds --> 
-      <property name="c3p0.max_size">100</property>
-      <property name="c3p0.max_statements">0</property>
-      <property name="c3p0.min_size">3</property>
-      <property name="c3p0.timeout">100</property> <!-- seconds -->
-      
-       <!-- DEPRECATED very expensive property name="c3p0.validate>-->
-        <!-- Drop and re-create the database schema on startup -->
-        <!-- <property name="hbm2ddl.auto">create</property> -->
+
+        <property name="connection.datasource">jdbc/asyncmsgs_datasource</property>
 
         <mapping resource="AsyncMsgs.hbm.xml"/>
 

--- a/Product/Production/Common/Properties/Dev/hibernate/CorrelatedIdentifers.hibernate.cfg.xml
+++ b/Product/Production/Common/Properties/Dev/hibernate/CorrelatedIdentifers.hibernate.cfg.xml
@@ -7,35 +7,16 @@
 
     <session-factory>
 
-        <!-- Database connection settings -->
-        <property name="connection.driver_class">com.mysql.jdbc.Driver</property>
-        <property name="connection.url">jdbc:mysql://localhost/patientcorrelationdb</property>
-        <property name="connection.username">nhincuser</property>
-        <property name="connection.password">nhincpass</property>
-
         <!-- SQL dialect -->
         <property name="dialect">org.hibernate.dialect.MySQLDialect</property>
-
-        <!-- Enable Hibernate's automatic session context management -->
-        <!-- <property name="current_session_context_class">thread</property> -->
 
         <!-- Disable the second-level cache  -->
         <property name="cache.provider_class">org.hibernate.cache.NoCacheProvider</property>
 
         <!-- Echo all executed SQL to stdout -->
         <property name="show_sql">true</property>
-        <!-- configuration pool via c3p0-->
-		<property name="c3p0.acquireRetryAttempts">4</property>
-      <property name="c3p0.acquire_increment">1</property>
-      <property name="c3p0.idle_test_period">100</property> <!-- seconds --> 
-      <property name="c3p0.max_size">100</property>
-      <property name="c3p0.max_statements">0</property>
-      <property name="c3p0.min_size">3</property>
-      <property name="c3p0.timeout">100</property> <!-- seconds -->
-      
-       <!-- DEPRECATED very expensive property name="c3p0.validate>-->
-        <!-- Drop and re-create the database schema on startup -->
-        <!-- <property name="hbm2ddl.auto">create</property> -->
+
+        <property name="connection.datasource">jdbc/patientcorrelationdb_datasource</property>
 
         <mapping resource="CorrelatedIdentifers.hbm.xml"/>
         <mapping resource="PDDeferredCorrelation.hbm.xml"/>

--- a/Product/Production/Common/Properties/Dev/hibernate/HiemSubRepHibernate.cfg.xml
+++ b/Product/Production/Common/Properties/Dev/hibernate/HiemSubRepHibernate.cfg.xml
@@ -7,35 +7,16 @@
 
     <session-factory>
 
-        <!-- Database connection settings -->
-        <property name="connection.driver_class">com.mysql.jdbc.Driver</property>
-        <property name="connection.url">jdbc:mysql://localhost/subscriptionrepository</property>
-        <property name="connection.username">nhincuser</property>
-        <property name="connection.password">nhincpass</property>
-
         <!-- SQL dialect -->
         <property name="dialect">org.hibernate.dialect.MySQLDialect</property>
-
-        <!-- Enable Hibernate's automatic session context management -->
-        <!-- <property name="current_session_context_class">thread</property> -->
 
         <!-- Disable the second-level cache  -->
         <property name="cache.provider_class">org.hibernate.cache.NoCacheProvider</property>
 
         <!-- Echo all executed SQL to stdout -->
         <property name="show_sql">true</property>
-        <!-- configuration pool via c3p0-->
-        <property name="c3p0.acquireRetryAttempts">4</property>
-        <property name="c3p0.acquire_increment">1</property>
-        <property name="c3p0.idle_test_period">100</property> <!-- seconds --> 
-        <property name="c3p0.max_size">100</property>
-        <property name="c3p0.max_statements">0</property>
-        <property name="c3p0.min_size">3</property>
-        <property name="c3p0.timeout">100</property> <!-- seconds -->
-      
-        <!-- DEPRECATED very expensive property name="c3p0.validate>-->
-        <!-- Drop and re-create the database schema on startup -->
-        <!-- <property name="hbm2ddl.auto">create</property> -->
+
+        <property name="connection.datasource">jdbc/subscriptionrepository_datasource</property>
 
         <mapping resource="SubscriptionStorageItem.hbm.xml"/>
 

--- a/Product/Production/Common/Properties/Dev/hibernate/aggregator.cfg.xml
+++ b/Product/Production/Common/Properties/Dev/hibernate/aggregator.cfg.xml
@@ -7,12 +7,6 @@
 
     <session-factory>
 
-        <!-- Database connection settings -->
-        <property name="connection.driver_class">com.mysql.jdbc.Driver</property>
-        <property name="connection.url">jdbc:mysql://localhost/aggregator</property>
-        <property name="connection.username">nhincuser</property>
-        <property name="connection.password">nhincpass</property>  
-
         <!-- SQL dialect -->
         <property name="dialect">org.hibernate.dialect.MySQLDialect</property>
 
@@ -24,18 +18,8 @@
 
         <!-- Echo all executed SQL to stdout -->
         <property name="show_sql">true</property>
-        <!-- configuration pool via c3p0-->
-		<property name="c3p0.acquireRetryAttempts">4</property>
-        <property name="c3p0.acquire_increment">1</property>
-        <property name="c3p0.idle_test_period">100</property> <!-- seconds --> 
-        <property name="c3p0.max_size">100</property>
-        <property name="c3p0.max_statements">0</property>
-        <property name="c3p0.min_size">3</property>
-        <property name="c3p0.timeout">100</property> <!-- seconds -->
-      
-        <!-- DEPRECATED very expensive property name="c3p0.validate>-->
-        <!-- Drop and re-create the database schema on startup -->
-        <!-- <property name="hbm2ddl.auto">create</property> -->
+
+        <property name="connection.datasource">jdbc/aggregator_datasource</property>
 
         <mapping resource="AggTransaction.hbm.xml"/>
         <mapping resource="AggMessageResult.hbm.xml"/>

--- a/Product/Production/Common/Properties/Dev/hibernate/assignauthority.hibernate.cfg.xml
+++ b/Product/Production/Common/Properties/Dev/hibernate/assignauthority.hibernate.cfg.xml
@@ -7,12 +7,6 @@
 
     <session-factory>
 
-        <!-- Database connection settings -->
-        <property name="connection.driver_class">com.mysql.jdbc.Driver</property>
-        <property name="connection.url">jdbc:mysql://localhost/assigningauthoritydb</property>
-        <property name="connection.username">nhincuser</property>
-        <property name="connection.password">nhincpass</property>
-
         <!-- SQL dialect -->
         <property name="dialect">org.hibernate.dialect.MySQLDialect</property>
 
@@ -24,18 +18,8 @@
 
         <!-- Echo all executed SQL to stdout -->
         <property name="show_sql">true</property>
-        <!-- configuration pool via c3p0-->
-        <property name="c3p0.acquireRetryAttempts">4</property>
-      <property name="c3p0.acquire_increment">1</property>
-      <property name="c3p0.idle_test_period">100</property> <!-- seconds --> 
-      <property name="c3p0.max_size">100</property>
-      <property name="c3p0.max_statements">0</property>
-      <property name="c3p0.min_size">3</property>
-      <property name="c3p0.timeout">100</property> <!-- seconds -->
-      
-       <!-- DEPRECATED very expensive property name="c3p0.validate>-->
-        <!-- Drop and re-create the database schema on startup -->
-        <!-- <property name="hbm2ddl.auto">create</property> -->
+
+        <property name="connection.datasource">jdbc/assigningauthoritydb_datasource</property>
 
         <mapping resource="assignauthoritytohomecommunitymapping.hbm.xml"/>
 

--- a/Product/Production/Common/Properties/Dev/hibernate/auditrepo.hibernate.cfg.xml
+++ b/Product/Production/Common/Properties/Dev/hibernate/auditrepo.hibernate.cfg.xml
@@ -13,32 +13,22 @@
 
 <hibernate-configuration>
 <session-factory>
-      <property name="hibernate.connection.driver_class">
 
-com.mysql.jdbc.Driver</property>
-      <property name="hibernate.connection.url">
-
-jdbc:mysql:///auditrepo</property>
-      <property name="hibernate.connection.username">nhincuser</property>
-      <property name="hibernate.connection.password">nhincpass</property>
       <property name="show_sql">true</property>
+
       <property name="dialect">org.hibernate.dialect.MySQLDialect</property>
+
       <property name="hibernate.hbm2ddl.auto">update</property>
+
       <property name="transaction.factory_class">org.hibernate.transaction.JDBCTransactionFactory</property>
-      <!--  thread is the short name for      org.hibernate.context.ThreadLocalSessionContext 
-      and let Hibernate bind the session automatically to the thread    -->    
-      <property name="current_session_context_class">thread</property>    
-      <!-- this will show us all sql statements -->    
+
+      <!--  thread is the short name for      org.hibernate.context.ThreadLocalSessionContext
+      and let Hibernate bind the session automatically to the thread    -->
+      <property name="current_session_context_class">thread</property>
+
       <property name="hibernate.show_sql">true</property>
-      <!-- configuration pool via c3p0-->
-	  <property name="c3p0.acquireRetryAttempts">4</property>
-      <property name="c3p0.acquire_increment">1</property>
-      <property name="c3p0.idle_test_period">100</property> <!-- seconds --> 
-      <property name="c3p0.max_size">100</property>
-      <property name="c3p0.max_statements">0</property>
-      <property name="c3p0.min_size">3</property>
-      <property name="c3p0.timeout">100</property> <!-- seconds -->
-       <!-- DEPRECATED very expensive property name="c3p0.validate>-->
+
+      <property name="connection.datasource">jdbc/auditrepo_datasource</property>
 
       <!-- Mapping files -->
       <mapping resource="auditrepo.hbm.xml"/>

--- a/Product/Production/Common/Properties/Dev/hibernate/docrepo.hibernate.cfg.xml
+++ b/Product/Production/Common/Properties/Dev/hibernate/docrepo.hibernate.cfg.xml
@@ -7,35 +7,16 @@
 
     <session-factory>
 
-        <!-- Database connection settings -->
-        <property name="connection.driver_class">com.mysql.jdbc.Driver</property>
-        <property name="connection.url">jdbc:mysql://localhost/docrepository</property>
-        <property name="connection.username">nhincuser</property>
-        <property name="connection.password">nhincpass</property>
-
         <!-- SQL dialect -->
         <property name="dialect">org.hibernate.dialect.MySQLDialect</property>
-
-        <!-- Enable Hibernate's automatic session context management -->
-        <!-- <property name="current_session_context_class">thread</property> -->
 
         <!-- Disable the second-level cache  -->
         <property name="cache.provider_class">org.hibernate.cache.NoCacheProvider</property>
 
         <!-- Echo all executed SQL to stdout -->
         <property name="show_sql">true</property>
-        <!-- configuration pool via c3p0-->
-		<property name="c3p0.acquireRetryAttempts">4</property>
-      <property name="c3p0.acquire_increment">1</property>
-      <property name="c3p0.idle_test_period">100</property> <!-- seconds --> 
-      <property name="c3p0.max_size">100</property>
-      <property name="c3p0.max_statements">0</property>
-      <property name="c3p0.min_size">3</property>
-      <property name="c3p0.timeout">100</property> <!-- seconds -->
-      
-       <!-- DEPRECATED very expensive property name="c3p0.validate>-->
-        <!-- Drop and re-create the database schema on startup -->
-        <!-- <property name="hbm2ddl.auto">create</property> -->
+
+        <property name="connection.datasource">jdbc/docrepository_datasource</property>
 
         <mapping resource="Document.hbm.xml"/>
         <mapping resource="EventCode.hbm.xml"/>

--- a/Product/Production/Common/Properties/Dev/hibernate/dyndocrepo.hibernate.cfg.xml
+++ b/Product/Production/Common/Properties/Dev/hibernate/dyndocrepo.hibernate.cfg.xml
@@ -7,35 +7,18 @@
 
     <session-factory>
 
-        <!-- Database connection settings -->
-        <property name="connection.driver_class">com.mysql.jdbc.Driver</property>
-        <property name="connection.url">jdbc:mysql://localhost/docrepository</property>
-        <property name="connection.username">nhincuser</property>
-        <property name="connection.password">nhincpass</property>
-
         <!-- SQL dialect -->
         <property name="dialect">org.hibernate.dialect.MySQLDialect</property>
-
-        <!-- Enable Hibernate's automatic session context management -->
-        <!-- <property name="current_session_context_class">thread</property> -->
 
         <!-- Disable the second-level cache  -->
         <property name="cache.provider_class">org.hibernate.cache.NoCacheProvider</property>
 
         <!-- Echo all executed SQL to stdout -->
         <property name="show_sql">true</property>
-        <!-- configuration pool via c3p0-->
-		<property name="c3p0.acquireRetryAttempts">4</property>
-      <property name="c3p0.acquire_increment">1</property>
-      <property name="c3p0.idle_test_period">100</property> <!-- seconds --> 
-      <property name="c3p0.max_size">100</property>
-      <property name="c3p0.max_statements">0</property>
-      <property name="c3p0.min_size">3</property>
-      <property name="c3p0.timeout">100</property> <!-- seconds -->
-      
-       <!-- DEPRECATED very expensive property name="c3p0.validate>-->
-        <!-- Drop and re-create the database schema on startup -->
+
         <property name="hibernate.hbm2ddl.auto">update</property>
+
+        <property name="connection.datasource">jdbc/docrepository_datasource</property>
 
         <mapping resource="Document.hbm.xml"/>
         <mapping resource="EventCode.hbm.xml"/>

--- a/Product/Production/Common/Properties/Dev/hibernate/patientdb.hibernate.cfg.xml
+++ b/Product/Production/Common/Properties/Dev/hibernate/patientdb.hibernate.cfg.xml
@@ -13,28 +13,23 @@
 
 <hibernate-configuration>
 <session-factory>
-      <property name="hibernate.connection.driver_class">com.mysql.jdbc.Driver</property>
-      <property name="hibernate.connection.url">jdbc:mysql:///patientdb</property>
-      <property name="hibernate.connection.username">nhincuser</property>
-      <property name="hibernate.connection.password">nhincpass</property>
+
       <property name="show_sql">true</property>
+
       <property name="dialect">org.hibernate.dialect.MySQLDialect</property>
+
       <property name="hibernate.hbm2ddl.auto">update</property>
+
       <property name="transaction.factory_class">org.hibernate.transaction.JDBCTransactionFactory</property>
-      <!--  thread is the short name for      org.hibernate.context.ThreadLocalSessionContext 
-      and let Hibernate bind the session automatically to the thread    -->    
-      <property name="current_session_context_class">thread</property>    
-      <!-- this will show us all sql statements -->    
+
+      <!--  thread is the short name for      org.hibernate.context.ThreadLocalSessionContext
+      and let Hibernate bind the session automatically to the thread    -->
+      <property name="current_session_context_class">thread</property>
+
+      <!-- this will show us all sql statements -->
       <property name="hibernate.show_sql">true</property>
-      <!-- configuration pool via c3p0-->
-      <property name="c3p0.acquireRetryAttempts">4</property>
-      <property name="c3p0.acquire_increment">1</property>
-      <property name="c3p0.idle_test_period">100</property> <!-- seconds --> 
-      <property name="c3p0.max_size">100</property>
-      <property name="c3p0.max_statements">0</property>
-      <property name="c3p0.min_size">3</property>
-      <property name="c3p0.timeout">100</property> <!-- seconds -->
-       <!-- DEPRECATED very expensive property name="c3p0.validate>-->
+
+      <property name="connection.datasource">jdbc/patientdb_datasource</property>
 
       <!-- Mapping files -->
       <mapping resource="Patient.hbm.xml"/>

--- a/Product/Production/Common/Properties/Dev/hibernate/perfrepo.hibernate.cfg.xml
+++ b/Product/Production/Common/Properties/Dev/hibernate/perfrepo.hibernate.cfg.xml
@@ -7,35 +7,16 @@
 
     <session-factory>
 
-        <!-- Database connection settings -->
-        <property name="connection.driver_class">com.mysql.jdbc.Driver</property>
-        <property name="connection.url">jdbc:mysql://localhost/perfrepo</property>
-        <property name="connection.username">nhincuser</property>
-        <property name="connection.password">nhincpass</property>  
-
         <!-- SQL dialect -->
         <property name="dialect">org.hibernate.dialect.MySQLDialect</property>
-
-        <!-- Enable Hibernate's automatic session context management -->
-        <!-- <property name="current_session_context_class">thread</property> -->
 
         <!-- Disable the second-level cache  -->
         <property name="cache.provider_class">org.hibernate.cache.NoCacheProvider</property>
 
         <!-- Echo all executed SQL to stdout -->
         <property name="show_sql">true</property>
-        <!-- configuration pool via c3p0-->
-        <property name="c3p0.acquireRetryAttempts">4</property>
-        <property name="c3p0.acquire_increment">1</property>
-        <property name="c3p0.idle_test_period">100</property> <!-- seconds --> 
-        <property name="c3p0.max_size">100</property>
-        <property name="c3p0.max_statements">0</property>
-        <property name="c3p0.min_size">3</property>
-        <property name="c3p0.timeout">100</property> <!-- seconds -->
-      
-        <!-- DEPRECATED very expensive property name="c3p0.validate>-->
-        <!-- Drop and re-create the database schema on startup -->
-        <!-- <property name="hbm2ddl.auto">create</property> -->
+
+        <property name="connection.datasource">jdbc/perfrepo_datasource</property>
 
         <!-- Mapping files -->
         <mapping resource="perfrepository.hbm.xml"/>

--- a/Product/Production/Common/Properties/Dev/hibernate/transrepo.hibernate.cfg.xml
+++ b/Product/Production/Common/Properties/Dev/hibernate/transrepo.hibernate.cfg.xml
@@ -21,7 +21,6 @@
 
         <property name="connection.datasource">jdbc/transrepo_datasource</property>
       
-       <!-- DEPRECATED very expensive property name="c3p0.validate>-->
         <!-- Drop and re-create the database schema on startup -->
         <!-- <property name="hbm2ddl.auto">create</property> -->
 

--- a/Product/Production/Common/Properties/Dev/hibernate/transrepo.hibernate.cfg.xml
+++ b/Product/Production/Common/Properties/Dev/hibernate/transrepo.hibernate.cfg.xml
@@ -7,12 +7,6 @@
 
     <session-factory>
 
-        <!-- Database connection settings -->
-        <property name="connection.driver_class">com.mysql.jdbc.Driver</property>
-        <property name="connection.url">jdbc:mysql://localhost/transrepo</property>
-        <property name="connection.username">nhincuser</property>
-        <property name="connection.password">nhincpass</property>
-
         <!-- SQL dialect -->
         <property name="dialect">org.hibernate.dialect.MySQLDialect</property>
 
@@ -24,14 +18,8 @@
 
         <!-- Echo all executed SQL to stdout -->
         <property name="show_sql">true</property>
-        <!-- configuration pool via c3p0-->
-		<property name="c3p0.acquireRetryAttempts">4</property>
-      <property name="c3p0.acquire_increment">1</property>
-      <property name="c3p0.idle_test_period">100</property> <!-- seconds --> 
-      <property name="c3p0.max_size">100</property>
-      <property name="c3p0.max_statements">0</property>
-      <property name="c3p0.min_size">3</property>
-      <property name="c3p0.timeout">100</property> <!-- seconds -->
+
+        <property name="connection.datasource">jdbc/transrepo_datasource</property>
       
        <!-- DEPRECATED very expensive property name="c3p0.validate>-->
         <!-- Drop and re-create the database schema on startup -->

--- a/Product/Production/Deploy/ear/pom.xml
+++ b/Product/Production/Deploy/ear/pom.xml
@@ -218,10 +218,6 @@
                     <groupId>org.hibernate</groupId>
                     <artifactId>hibernate</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>c3p0</groupId>
-                    <artifactId>c3p0</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -341,11 +337,6 @@
             <!-- Used to include the asm it needs in a private package space. -->
             <groupId>cglib</groupId>
             <artifactId>cglib-nodep</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>c3p0</groupId>
-            <artifactId>c3p0</artifactId>
-            <version>0.9.1.2</version>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>

--- a/Product/Production/Gateway/AdminDistribution_10/pom.xml
+++ b/Product/Production/Gateway/AdminDistribution_10/pom.xml
@@ -31,10 +31,6 @@
                     <artifactId>hibernate</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>c3p0</groupId>
-                    <artifactId>c3p0</artifactId>
-                </exclusion>
-                <exclusion>
                     <artifactId>activation</artifactId>
                     <groupId>javax.activation</groupId>
                 </exclusion>

--- a/Product/Production/Gateway/AdminDistribution_20/pom.xml
+++ b/Product/Production/Gateway/AdminDistribution_20/pom.xml
@@ -32,10 +32,6 @@
                     <artifactId>hibernate</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>c3p0</groupId>
-                    <artifactId>c3p0</artifactId>
-                </exclusion>
-                <exclusion>
                     <artifactId>activation</artifactId>
                     <groupId>javax.activation</groupId>
                 </exclusion>

--- a/Product/Production/Gateway/DocumentQuery_20/pom.xml
+++ b/Product/Production/Gateway/DocumentQuery_20/pom.xml
@@ -32,10 +32,6 @@
                     <artifactId>hibernate</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>c3p0</groupId>
-                    <artifactId>c3p0</artifactId>
-                </exclusion>
-                <exclusion>
                     <artifactId>activation</artifactId>
                     <groupId>javax.activation</groupId>
                 </exclusion>

--- a/Product/Production/Gateway/DocumentRetrieve_20/pom.xml
+++ b/Product/Production/Gateway/DocumentRetrieve_20/pom.xml
@@ -32,10 +32,6 @@
                     <artifactId>hibernate</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>c3p0</groupId>
-                    <artifactId>c3p0</artifactId>
-                </exclusion>
-                <exclusion>
                     <artifactId>activation</artifactId>
                     <groupId>javax.activation</groupId>
                 </exclusion>

--- a/Product/Production/Gateway/DocumentRetrieve_30/pom.xml
+++ b/Product/Production/Gateway/DocumentRetrieve_30/pom.xml
@@ -32,10 +32,6 @@
                     <artifactId>hibernate</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>c3p0</groupId>
-                    <artifactId>c3p0</artifactId>
-                </exclusion>
-                <exclusion>
                     <artifactId>activation</artifactId>
                     <groupId>javax.activation</groupId>
                 </exclusion>

--- a/Product/Production/Gateway/DocumentSubmission_11/pom.xml
+++ b/Product/Production/Gateway/DocumentSubmission_11/pom.xml
@@ -32,10 +32,6 @@
                     <artifactId>hibernate</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>c3p0</groupId>
-                    <artifactId>c3p0</artifactId>
-                </exclusion>
-                <exclusion>
                     <artifactId>activation</artifactId>
                     <groupId>javax.activation</groupId>
                 </exclusion>

--- a/Product/Production/Gateway/DocumentSubmission_20/pom.xml
+++ b/Product/Production/Gateway/DocumentSubmission_20/pom.xml
@@ -32,10 +32,6 @@
                     <artifactId>hibernate</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>c3p0</groupId>
-                    <artifactId>c3p0</artifactId>
-                </exclusion>
-                <exclusion>
                     <artifactId>activation</artifactId>
                     <groupId>javax.activation</groupId>
                 </exclusion>

--- a/Product/Production/Gateway/PatientDiscovery_10/pom.xml
+++ b/Product/Production/Gateway/PatientDiscovery_10/pom.xml
@@ -32,10 +32,6 @@
                     <artifactId>hibernate</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>c3p0</groupId>
-                    <artifactId>c3p0</artifactId>
-                </exclusion>
-                <exclusion>
                     <artifactId>activation</artifactId>
                     <groupId>javax.activation</groupId>
                 </exclusion>

--- a/Product/Production/Gateway/pom.xml
+++ b/Product/Production/Gateway/pom.xml
@@ -52,10 +52,6 @@
                     <artifactId>hibernate</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>c3p0</groupId>
-                    <artifactId>c3p0</artifactId>
-                </exclusion>
-                <exclusion>
                     <artifactId>activation</artifactId>
                     <groupId>javax.activation</groupId>
                 </exclusion>

--- a/Product/build.xml
+++ b/Product/build.xml
@@ -387,7 +387,6 @@
         <property name="common.lib" location="${common.home}/CONNECTCommonTypesLib/dist/debug" />
         <property name="opensaml.home" location="${thirdparty.home}/openSAML" />
         <property name="hibernate.home" location="${thirdparty.home}/HibernateLibraries" />
-        <property name="c3po.home" location="${thirdparty.home}/C3PO" />
         <property name="mysql.home" location="${thirdparty.home}/MySQLDB" />
         <property name="xstream.home" location="${thirdparty.home}/XStream" />
 
@@ -436,9 +435,6 @@
                 <include name="jta.jar" />
                 <include name="cglib-2.1.3.jar" />
                 <include name="hibernate3.jar" />
-            </fileset>
-            <fileset dir="${c3po.home}">
-                <include name="c3p0-0.9.1.2.jar" />
             </fileset>
 
             <fileset dir="${mysql.home}">

--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ Lastly, we're going to install the Glassfish Application Server
 
         $ ant install
 
+The "mysql-connector-java-5.1.10.jar" must be copied into the following folder, for container managed database resources
+
+        <GLASSFISH_HOME>/domains/domain1/lib/ext
 
 ####Setup GlassFish
 These steps will install and configure a Glassfish Application Server to deploy and use CONNECT. Lets get started.


### PR DESCRIPTION
Notes:
- "mysql-connector-java-5.1.10.jar" must be copied into the following folder:
  
  ```
  ${GLASSFISH_HOME}/domains/domain1/lib/ext
  ```
- we'll need to drop that jar in place for other containers when they are added, like websphere.
- connection pool sizes would likely need to be tweaked based on a particular deployment.
