### PR TITLE
adding the cacerts.jks to the embedded glassfish lib/classes dir, so it'll be vailaible to CXF

### DIFF
--- a/Product/SoapUI_Test/pom.xml
+++ b/Product/SoapUI_Test/pom.xml
@@ -198,6 +198,8 @@
                                 </exec>
                                 <copy file="${project.build.directory}/domain1/config/gateway.jks"
                                     todir="${project.build.directory}/domain1/lib/classes/" />
+                                <copy file="${project.build.directory}/domain1/config/cacerts.jks"
+                                    todir="${project.build.directory}/domain1/lib/classes/" />
                             </target>
                         </configuration>
                     </execution>


### PR DESCRIPTION
adding the cacerts.jks to the embedded glassfish lib/classes dir, so it'll be vailaible to CXF
