### PR TITLE
ignoring snapshots from forgerock

### DIFF
--- a/Product/pom.xml
+++ b/Product/pom.xml
@@ -370,6 +370,9 @@
             <id>forgerock</id>
             <url>http://repo.forgerock.org</url>
         </repository>
+        <snapshots>
+            <enabled>false</enabled>
+        </snapshots>
     </repositories>
     <profiles>
         <profile>


### PR DESCRIPTION
this should prevent errors like 

```
Caused by: org.apache.maven.artifact.resolver.ArtifactNotFoundException: Failure to find org.connectopensource:DBScripts:jar:
4.0.0-SNAPSHOT in http://repo.forgerock.org was cached in the local repository, resolution will not be reattempted until the
update interval of forgerock has elapsed or updates are forced
```
