### PR TITLE
GATEWAY-2947: document query.  add setArguments to builders. web wiring

### DIFF
--- a/Product/Production/Gateway/DocumentQuery_20/src/main/java/gov/hhs/fha/nhinc/docquery/_20/nhin/DocQuery.java
+++ b/Product/Production/Gateway/DocumentQuery_20/src/main/java/gov/hhs/fha/nhinc/docquery/_20/nhin/DocQuery.java
@@ -26,40 +26,45 @@
  */
 package gov.hhs.fha.nhinc.docquery._20.nhin;
 
+import gov.hhs.fha.nhinc.aspect.InboundMessageEvent;
+import gov.hhs.fha.nhinc.docquery.aspect.AdhocQueryRequestDescriptionBuilder;
 import gov.hhs.fha.nhinc.docquery.nhin.NhinDocQueryOrchImpl;
+import ihe.iti.xds_b._2007.RespondingGatewayQueryPortType;
 
 import javax.annotation.Resource;
 import javax.xml.ws.BindingType;
 import javax.xml.ws.WebServiceContext;
 import javax.xml.ws.soap.Addressing;
 
+import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
+import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryResponse;
+
 /**
- *
+ * 
  * @author Neil Webb
  */
-
 @BindingType(value = javax.xml.ws.soap.SOAPBinding.SOAP12HTTP_BINDING)
-@Addressing(enabled=true)
-public class DocQuery implements ihe.iti.xds_b._2007.RespondingGatewayQueryPortType
-{
+@Addressing(enabled = true)
+public class DocQuery implements RespondingGatewayQueryPortType {
     private NhinDocQueryOrchImpl orchImpl;
-    
+
     @Resource
     private WebServiceContext context;
 
     /**
      * The web service implementation for Document Query.
-     * @param body the body of the request
+     * 
+     * @param body
+     *            the body of the request
      * @return the query response for the document query
      */
-    public oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryResponse respondingGatewayCrossGatewayQuery(
-    		oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest body)
-    {
+    @InboundMessageEvent(descriptionBuilder = AdhocQueryRequestDescriptionBuilder.class,
+            serviceType = "Document Query", version = "2.0")
+    public AdhocQueryResponse respondingGatewayCrossGatewayQuery(AdhocQueryRequest body) {
         return new DocQueryImpl(orchImpl).respondingGatewayCrossGatewayQuery(body, context);
     }
-    
+
     public void setOrchestratorImpl(NhinDocQueryOrchImpl orchImpl) {
         this.orchImpl = orchImpl;
     }
-
 }

--- a/Product/Production/Gateway/DocumentQuery_20/src/main/resources/applicationContext.xml
+++ b/Product/Production/Gateway/DocumentQuery_20/src/main/resources/applicationContext.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:aop="http://www.springframework.org/schema/aop" xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="
+http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
+http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+">
+
+    <aop:aspectj-autoproxy proxy-target-class="true" />
+    <context:annotation-config />
+
+    <bean id="nhinDocQueryOrchImpl" class="gov.hhs.fha.nhinc.docquery.nhin.NhinDocQueryOrchImpl" />
+
+    <bean id="nhinDQ" class="gov.hhs.fha.nhinc.docquery._20.nhin.DocQuery">
+        <property name="orchestratorImpl">
+            <ref bean="nhinDocQueryOrchImpl" />
+        </property>
+    </bean>
+
+    <bean id="entityDocQueryOrchImpl" class="gov.hhs.fha.nhinc.docquery.entity.EntityDocQueryOrchImpl" />
+
+    <bean id="entityDQUnsecured" class="gov.hhs.fha.nhinc.docquery._20.entity.EntityDocQueryUnsecured">
+        <property name="orchestratorImpl">
+            <ref bean="entityDocQueryOrchImpl" />
+        </property>
+    </bean>
+
+    <bean id="entityDQSecured" class="gov.hhs.fha.nhinc.docquery._20.entity.EntityDocQuerySecured">
+        <property name="orchestratorImpl">
+            <ref bean="entityDocQueryOrchImpl" />
+        </property>
+    </bean>
+
+    <bean id="passthruDocQueryOrchImpl" class="gov.hhs.fha.nhinc.docquery.passthru.PassthruDocQueryOrchImpl" />
+
+    <bean id="passthruDQUnsecured" class="gov.hhs.fha.nhinc.docquery._20.passthru.NhincProxyDocQueryUnsecured">
+        <property name="orchestratorImpl">
+            <ref bean="passthruDocQueryOrchImpl" />
+        </property>
+    </bean>
+
+    <bean id="passthruDQSecured" class="gov.hhs.fha.nhinc.docquery._20.passthru.NhincProxyDocQuerySecured">
+        <property name="orchestratorImpl">
+            <ref bean="passthruDocQueryOrchImpl" />
+        </property>
+    </bean>
+
+    <bean id="SOAPHeaderHandler" class="gov.hhs.fha.nhinc.callback.SOAPHeaderHandler" />
+    <bean id="TransactionHandler" class="gov.hhs.fha.nhinc.logging.transaction.TransactionHandler" />
+</beans>

--- a/Product/Production/Gateway/DocumentQuery_20/src/main/resources/webservices.xml
+++ b/Product/Production/Gateway/DocumentQuery_20/src/main/resources/webservices.xml
@@ -13,22 +13,9 @@ http://www.springframework.org/schema/beans http://www.springframework.org/schem
 http://cxf.apache.org/bindings/soap http://cxf.apache.org/schemas/configuration/soap.xsd
 http://cxf.apache.org/jaxws http://cxf.apache.org/schemas/jaxws.xsd http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd">
 
-    <import resource="classpath:META-INF/cxf/cxf.xml" />
-    <import resource="classpath:META-INF/cxf/cxf-extension-soap.xml" />
-    <import resource="classpath:META-INF/cxf/cxf-servlet.xml" />
-    <import resource="classpath:CONNECT-interceptor-beans.xml" />
-
     <!-- Document Query -->
 
     <!-- Nhin services -->
-
-    <bean id="nhinDocQueryOrchImpl" class="gov.hhs.fha.nhinc.docquery.nhin.NhinDocQueryOrchImpl" />
-
-    <bean id="nhinDQ" class="gov.hhs.fha.nhinc.docquery._20.nhin.DocQuery">
-        <property name="orchestratorImpl">
-            <ref bean="nhinDocQueryOrchImpl" />
-        </property>
-    </bean>
 
     <jaxws:endpoint xmlns:ndq="urn:ihe:iti:xds-b:2007" id="NhinDocumentQuery"
         address="/NhinService/RespondingGateway_Query_Service/DocQuery" serviceName="ndq:RespondingGateway_Query_Service"
@@ -53,14 +40,6 @@ http://cxf.apache.org/jaxws http://cxf.apache.org/schemas/jaxws.xsd http://www.s
 
     <!-- Entity services -->
 
-    <bean id="entityDocQueryOrchImpl" class="gov.hhs.fha.nhinc.docquery.entity.EntityDocQueryOrchImpl" />
-
-    <bean id="entityDQUnsecured" class="gov.hhs.fha.nhinc.docquery._20.entity.EntityDocQueryUnsecured">
-        <property name="orchestratorImpl">
-            <ref bean="entityDocQueryOrchImpl" />
-        </property>
-    </bean>
-
     <jaxws:endpoint xmlns:edq="urn:gov:hhs:fha:nhinc:entitydocquery" id="EntityDocumentQuery"
         address="/EntityService/EntityDocQueryUnsecured" serviceName="edq:EntityDocQuery" endpointName="edq:EntityDocQueryPortSoap"
         implementorClass="gov.hhs.fha.nhinc.docquery._20.entity.EntityDocQueryUnsecured" implementor="#entityDQUnsecured"
@@ -69,12 +48,6 @@ http://cxf.apache.org/jaxws http://cxf.apache.org/schemas/jaxws.xsd http://www.s
             <ref bean="TransactionHandler" />
         </jaxws:handlers>
     </jaxws:endpoint>
-
-    <bean id="entityDQSecured" class="gov.hhs.fha.nhinc.docquery._20.entity.EntityDocQuerySecured">
-        <property name="orchestratorImpl">
-            <ref bean="entityDocQueryOrchImpl" />
-        </property>
-    </bean>
 
     <jaxws:endpoint xmlns:edqs="urn:gov:hhs:fha:nhinc:entitydocquery" id="EntityDocumentQuerySecured"
         address="/EntityService/EntityDocQuerySecured" serviceName="edqs:EntityDocQuerySecured" endpointName="edqs:EntityDocQuerySecuredPortSoap"
@@ -94,20 +67,6 @@ http://cxf.apache.org/jaxws http://cxf.apache.org/schemas/jaxws.xsd http://www.s
     </jaxws:endpoint>
 
     <!-- MsgProxy/NhincProxy/Passthru services -->
-
-    <bean id="passthruDocQueryOrchImpl" class="gov.hhs.fha.nhinc.docquery.passthru.PassthruDocQueryOrchImpl" />
-
-    <bean id="passthruDQUnsecured" class="gov.hhs.fha.nhinc.docquery._20.passthru.NhincProxyDocQueryUnsecured">
-        <property name="orchestratorImpl">
-            <ref bean="passthruDocQueryOrchImpl" />
-        </property>
-    </bean>
-
-    <bean id="passthruDQSecured" class="gov.hhs.fha.nhinc.docquery._20.passthru.NhincProxyDocQuerySecured">
-        <property name="orchestratorImpl">
-            <ref bean="passthruDocQueryOrchImpl" />
-        </property>
-    </bean>
 
     <jaxws:endpoint xmlns:mpdq="urn:gov:hhs:fha:nhinc:nhincproxydocquery" id="NhincProxyDocumentQuery"
         address="/EntityService/NhincProxyDocQueryUnsecured" serviceName="mpdq:NhincProxyDocQuery"
@@ -136,11 +95,4 @@ http://cxf.apache.org/jaxws http://cxf.apache.org/schemas/jaxws.xsd http://www.s
             <ref bean="TransactionHandler" />
         </jaxws:handlers>
     </jaxws:endpoint>
-
-    <bean id="SOAPHeaderHandler" class="gov.hhs.fha.nhinc.callback.SOAPHeaderHandler" />
-    <bean id="TransactionHandler" class="gov.hhs.fha.nhinc.logging.transaction.TransactionHandler" />
-
-    <!-- Aspect Service -->
-    <aop:aspectj-autoproxy />
-   
 </beans>

--- a/Product/Production/Gateway/DocumentQuery_20/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/DocumentQuery_20/src/main/webapp/WEB-INF/web.xml
@@ -12,6 +12,21 @@
         <load-on-startup>1</load-on-startup>
     </servlet>
 
+    <context-param>
+        <param-name>contextConfigLocation</param-name>
+        <param-value>
+            classpath:CONNECT-interceptor-beans.xml
+            classpath:CONNECT-context.xml
+            classpath:eventlogging.xml
+            classpath:applicationContext.xml
+            classpath:webservices.xml
+        </param-value>
+    </context-param>
+
+    <listener>
+        <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
+    </listener>
+
     <servlet-mapping>
         <servlet-name>cxf</servlet-name>
         <url-pattern>/*</url-pattern>
@@ -81,5 +96,10 @@
         <res-auth>Container</res-auth>
         <res-sharing-scope>Shareable</res-sharing-scope>
     </resource-ref>
-    
+    <resource-ref>
+        <res-ref-name>jdbc/eventdb_datasource</res-ref-name>
+        <res-type>javax.sql.DataSource</res-type>
+        <res-auth>Container</res-auth>
+        <res-sharing-scope>Shareable</res-sharing-scope>
+    </resource-ref>
 </web-app>

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryRequestDescriptionBuilder.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryRequestDescriptionBuilder.java
@@ -29,16 +29,31 @@
 package gov.hhs.fha.nhinc.docquery.aspect;
 
 import gov.hhs.fha.nhinc.event.BaseEventDescriptionBuilder;
+
+import java.util.Arrays;
+
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import com.google.common.collect.ImmutableList;
 
 public class AdhocQueryRequestDescriptionBuilder extends BaseEventDescriptionBuilder {
 
-    private final AdhocQueryRequest request;
+    private static final Log LOG = LogFactory.getLog(AdhocQueryRequestDescriptionBuilder.class);
+    private AdhocQueryRequest request;
 
     public AdhocQueryRequestDescriptionBuilder(AdhocQueryRequest request) {
         this.request = request;
+    }
+
+    /**
+     * Constructor for aspects. Response should be set via <code>setArguments</code>.
+     * 
+     * @see #setArguments(Object...)
+     */
+    public AdhocQueryRequestDescriptionBuilder() {
     }
 
     @Override
@@ -89,7 +104,10 @@ public class AdhocQueryRequestDescriptionBuilder extends BaseEventDescriptionBui
 
     @Override
     public void setArguments(Object... arguments) {
-        // TODO Auto-generated method stub
-        
+        if (arguments.length != 1 || !(arguments[0] instanceof AdhocQueryRequest)) {
+            LOG.warn("Unexpected argument list: " + Arrays.toString(arguments));
+        } else {
+            request = (AdhocQueryRequest) arguments[0];
+        }
     }
 }

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryResponseDescriptionBuilder.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryResponseDescriptionBuilder.java
@@ -33,6 +33,7 @@ import gov.hhs.fha.nhinc.gateway.aggregator.document.DocumentConstants;
 import gov.hhs.fha.nhinc.util.JaxbDocumentUtils;
 import gov.hhs.fha.nhinc.util.NhincCollections;
 
+import java.util.Arrays;
 import java.util.List;
 
 import javax.xml.bind.JAXBElement;
@@ -43,6 +44,9 @@ import oasis.names.tc.ebxml_regrep.xsd.rim._3.ExtrinsicObjectType;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.IdentifiableType;
 import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryError;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
@@ -52,12 +56,21 @@ import com.google.common.collect.Lists;
 
 public class AdhocQueryResponseDescriptionBuilder extends BaseEventDescriptionBuilder {
 
+    private static final Log LOG = LogFactory.getLog(AdhocQueryResponseDescriptionBuilder.class);
     private static final HCIDExtractor HCID_EXTRACTOR = new HCIDExtractor();
     private static final ErrorExtractor ERROR_EXTRACTOR = new ErrorExtractor();
     private static final PayloadTypeExtractor PAYLOAD_TYPE_EXTRACTOR = new PayloadTypeExtractor();
     private static final PayloadSizeExtractor PAYLOAD_SIZE_EXTRACTOR = new PayloadSizeExtractor();
 
-    private final AdhocQueryResponse response;
+    private AdhocQueryResponse response;
+
+    /**
+     * Constructor for aspects. Response should be set via <code>setArguments</code>.
+     * 
+     * @see #setArguments(Object...)
+     */
+    public AdhocQueryResponseDescriptionBuilder() {
+    }
 
     public AdhocQueryResponseDescriptionBuilder(AdhocQueryResponse response) {
         this.response = response;
@@ -213,7 +226,10 @@ public class AdhocQueryResponseDescriptionBuilder extends BaseEventDescriptionBu
 
     @Override
     public void setArguments(Object... arguments) {
-        // TODO Auto-generated method stub
-
+        if (arguments.length != 1 || !(arguments[0] instanceof AdhocQueryResponse)) {
+            LOG.warn("Unexpected argument list: " + Arrays.toString(arguments));
+        } else {
+            response = (AdhocQueryResponse) arguments[0];
+        }
     }
 }

--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryRequestDescriptionBuilderTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryRequestDescriptionBuilderTest.java
@@ -51,8 +51,20 @@ public class AdhocQueryRequestDescriptionBuilderTest extends BaseDescriptionBuil
     @Test
     public void basicBuild() {
         AdhocQueryRequest request = new AdhocQueryRequest();
-
         AdhocQueryRequestDescriptionBuilder builder = new AdhocQueryRequestDescriptionBuilder(request);
+        assertBasicBuild(builder);
+    }
+
+    @Test
+    public void validArgumentTypes() {
+        AdhocQueryRequestDescriptionBuilder builder = new AdhocQueryRequestDescriptionBuilder();
+        AdhocQueryRequest request = new AdhocQueryRequest();
+        Object[] arguments = { request };
+        builder.setArguments(arguments);
+        assertBasicBuild(builder);
+    }
+
+    private void assertBasicBuild(AdhocQueryRequestDescriptionBuilder builder) {
         EventDescription eventDescription = getEventDescription(builder);
 
         assertEquals(1, eventDescription.getPayloadTypes().size());

--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryResponseDescriptionBuilderTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryResponseDescriptionBuilderTest.java
@@ -66,25 +66,18 @@ public class AdhocQueryResponseDescriptionBuilderTest extends BaseDescriptionBui
 
     @Test
     public void basicBuild() {
-        AdhocQueryResponse response = new AdhocQueryResponse();
-        response.setStatus(DocumentConstants.XDS_QUERY_RESPONSE_STATUS_PARTIAL_SUCCESS);
-        addQueryResult(response, Optional.of("payloadType"), Optional.of(12345));
-
+        AdhocQueryResponse response = getBasicResponse();
         AdhocQueryResponseDescriptionBuilder builder = new AdhocQueryResponseDescriptionBuilder(response);
-        EventDescription eventDescription = getEventDescription(builder);
+        assertBasicResponseBuilt(builder);
+    }
 
-        assertEquals(1, eventDescription.getStatuses().size());
-        assertEquals(DocumentConstants.XDS_QUERY_RESPONSE_STATUS_PARTIAL_SUCCESS, eventDescription.getStatuses().get(0));
-        assertEquals(1, eventDescription.getRespondingHCIDs().size());
-        assertEquals("home", eventDescription.getRespondingHCIDs().get(0));
-        assertEquals(1, eventDescription.getPayloadTypes().size());
-        assertEquals("payloadType", eventDescription.getPayloadTypes().get(0));
-        assertEquals(1, eventDescription.getPayloadSizes().size());
-        assertEquals("" + 12345, eventDescription.getPayloadSizes().get(0));
-
-        assertNull(eventDescription.getTimeStamp());
-        assertNull(eventDescription.getNPI()); // TODO: check with BH - is that correct
-        assertNull(eventDescription.getInitiatingHCID());
+    @Test
+    public void validArgumentTypes() {
+        AdhocQueryResponseDescriptionBuilder builder = new AdhocQueryResponseDescriptionBuilder();
+        AdhocQueryResponse response = getBasicResponse();
+        Object[] arguments = { response };
+        builder.setArguments(arguments);
+        assertBasicResponseBuilt(builder);
     }
 
     @Test
@@ -164,6 +157,30 @@ public class AdhocQueryResponseDescriptionBuilderTest extends BaseDescriptionBui
         assertEquals("", eventDescription.getPayloadTypes().get(0));
         assertEquals(1, eventDescription.getPayloadSizes().size());
         assertEquals("", eventDescription.getPayloadSizes().get(0));
+    }
+
+    private AdhocQueryResponse getBasicResponse() {
+        AdhocQueryResponse response = new AdhocQueryResponse();
+        response.setStatus(DocumentConstants.XDS_QUERY_RESPONSE_STATUS_PARTIAL_SUCCESS);
+        addQueryResult(response, Optional.of("payloadType"), Optional.of(12345));
+        return response;
+    }
+
+    private void assertBasicResponseBuilt(AdhocQueryResponseDescriptionBuilder builder) {
+        EventDescription eventDescription = getEventDescription(builder);
+
+        assertEquals(1, eventDescription.getStatuses().size());
+        assertEquals(DocumentConstants.XDS_QUERY_RESPONSE_STATUS_PARTIAL_SUCCESS, eventDescription.getStatuses().get(0));
+        assertEquals(1, eventDescription.getRespondingHCIDs().size());
+        assertEquals("home", eventDescription.getRespondingHCIDs().get(0));
+        assertEquals(1, eventDescription.getPayloadTypes().size());
+        assertEquals("payloadType", eventDescription.getPayloadTypes().get(0));
+        assertEquals(1, eventDescription.getPayloadSizes().size());
+        assertEquals("" + 12345, eventDescription.getPayloadSizes().get(0));
+
+        assertNull(eventDescription.getTimeStamp());
+        assertNull(eventDescription.getNPI()); // TODO: check with BH - is that correct
+        assertNull(eventDescription.getInitiatingHCID());
     }
 
     private void addError(AdhocQueryResponse response, RegistryError error) {


### PR DESCRIPTION
The integration tests now create BEGIN_INBOUND_MESSAGE events for AdhocQueryRequest.  Next steps are:
- add annotations to all of the methods in the call stack
- modify the description builders to accept all the added params as the stack gets deeper
