### PR TITLE
Split event processing builders

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/AdapterDelegationEvent.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/AdapterDelegationEvent.java
@@ -38,13 +38,25 @@ import java.lang.annotation.Target;
 
 /**
  * @author bhumphrey
- *
+ * 
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 @Inherited
 public @interface AdapterDelegationEvent {
     String serviceType();
+
     String version();
-    Class<? extends BaseEventDescriptionBuilder> descriptionBuilder();
+
+    /**
+     * @return builder class to instantiate for Before processing, using the arguments.
+     * @See {@link org.aspectj.lang.annotation.Before}
+     */
+    Class<? extends BaseEventDescriptionBuilder> beforeBuilder();
+
+    /**
+     * @return builder class to instantiate for AfterReturn processing, using the arguments and return value.
+     * @See {@link org.aspectj.lang.annotation.AfterReturning}
+     */
+    Class<? extends BaseEventDescriptionBuilder> afterReturningBuilder();
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/EventAspectAdvice.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/EventAspectAdvice.java
@@ -26,8 +26,6 @@
  */
 package gov.hhs.fha.nhinc.aspect;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.AfterThrowing;
@@ -41,8 +39,6 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 @Aspect
 public class EventAspectAdvice {
-
-    private static final Log log = LogFactory.getLog(EventAspectAdvice.class);
 
     private EventAdviceDelegate inboundMessageAdviceDelegate;
 
@@ -61,73 +57,73 @@ public class EventAspectAdvice {
     @Before("@annotation(annotation)")
     public void beginInboundMessageEvent(JoinPoint joinPoint, InboundMessageEvent annotation) {
         inboundMessageAdviceDelegate.begin(joinPoint.getArgs(), annotation.serviceType(), annotation.version(),
-                annotation.descriptionBuilder());
+                annotation.beforeBuilder());
     }
 
     @AfterReturning(pointcut = "@annotation(annotation)", returning = "returnValue")
     public void endInboundMessageEvent(JoinPoint joinPoint, InboundMessageEvent annotation, Object returnValue) {
         inboundMessageAdviceDelegate.end(joinPoint.getArgs(), annotation.serviceType(), annotation.version(),
-                annotation.descriptionBuilder(), returnValue);
+                annotation.afterReturningBuilder(), returnValue);
     }
 
     @Before("@annotation(annotation)")
     public void beginInboundProcessingEvent(JoinPoint joinPoint, InboundProcessingEvent annotation) {
         inboundProcessingAdviceDelegate.begin(joinPoint.getArgs(), annotation.serviceType(), annotation.version(),
-                annotation.descriptionBuilder());
+                annotation.beforeBuilder());
     }
 
     @AfterReturning(pointcut = "@annotation(annotation)", returning = "returnValue")
     public void endInboundProcessingEvent(JoinPoint joinPoint, InboundProcessingEvent annotation, Object returnValue) {
         inboundProcessingAdviceDelegate.end(joinPoint.getArgs(), annotation.serviceType(), annotation.version(),
-                annotation.descriptionBuilder(), returnValue);
+                annotation.afterReturningBuilder(), returnValue);
     }
 
     @Before("@annotation(annotation)")
     public void beginAdapterDelegationEvent(JoinPoint joinPoint, AdapterDelegationEvent annotation) {
         adapterDelegationAdviceDelegate.begin(joinPoint.getArgs(), annotation.serviceType(), annotation.version(),
-                annotation.descriptionBuilder());
+                annotation.beforeBuilder());
     }
 
     @AfterReturning(pointcut = "@annotation(annotation)", returning = "returnValue")
     public void endAdapterDelegationEvent(JoinPoint joinPoint, AdapterDelegationEvent annotation, Object returnValue) {
         adapterDelegationAdviceDelegate.end(joinPoint.getArgs(), annotation.serviceType(), annotation.version(),
-                annotation.descriptionBuilder(), returnValue);
+                annotation.afterReturningBuilder(), returnValue);
     }
 
     @Before("@annotation(annotation)")
     public void beginOutboundMessageEvent(JoinPoint joinPoint, OutboundMessageEvent annotation) {
         outboundMessageAdviceDelegate.begin(joinPoint.getArgs(), annotation.serviceType(), annotation.version(),
-                annotation.descriptionBuilder());
+                annotation.beforeBuilder());
     }
 
     @AfterReturning(pointcut = "@annotation(annotation)", returning = "returnValue")
     public void endOutboundMessageEvent(JoinPoint joinPoint, OutboundMessageEvent annotation, Object returnValue) {
         outboundMessageAdviceDelegate.end(joinPoint.getArgs(), annotation.serviceType(), annotation.version(),
-                annotation.descriptionBuilder(), returnValue);
+                annotation.afterReturningBuilder(), returnValue);
     }
 
     @Before("@annotation(annotation)")
     public void beginOutboundProcessingEvent(JoinPoint joinPoint, OutboundProcessingEvent annotation) {
         outboundProcessingAdviceDelegate.begin(joinPoint.getArgs(), annotation.serviceType(), annotation.version(),
-                annotation.descriptionBuilder());
+                annotation.beforeBuilder());
     }
 
     @AfterReturning(pointcut = "@annotation(annotation)", returning = "returnValue")
     public void endOutboundProcessingEvent(JoinPoint joinPoint, OutboundProcessingEvent annotation, Object returnValue) {
         outboundProcessingAdviceDelegate.end(joinPoint.getArgs(), annotation.serviceType(), annotation.version(),
-                annotation.descriptionBuilder(), returnValue);
+                annotation.afterReturningBuilder(), returnValue);
     }
 
     @Before("@annotation(annotation)")
     public void beginNwhinInvocationEvent(JoinPoint joinPoint, NwhinInvocationEvent annotation) {
         nwhinInvocationAdviceDelegate.begin(joinPoint.getArgs(), annotation.serviceType(), annotation.version(),
-                annotation.descriptionBuilder());
+                annotation.beforeBuilder());
     }
 
     @AfterReturning(pointcut = "@annotation(annotation)", returning = "returnValue")
     public void endNwhinInvocationEvent(JoinPoint joinPoint, NwhinInvocationEvent annotation, Object returnValue) {
         nwhinInvocationAdviceDelegate.end(joinPoint.getArgs(), annotation.serviceType(), annotation.version(),
-                annotation.descriptionBuilder(), returnValue);
+                annotation.afterReturningBuilder(), returnValue);
     }
 
     @AfterThrowing("@annotation(gov.hhs.fha.nhinc.aspect.InboundMessageEvent) &&"

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/InboundMessageEvent.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/InboundMessageEvent.java
@@ -30,17 +30,33 @@ package gov.hhs.fha.nhinc.aspect;
 
 import gov.hhs.fha.nhinc.event.BaseEventDescriptionBuilder;
 
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * @author bhumphrey
- *
+ * 
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 @Inherited
 public @interface InboundMessageEvent {
     String serviceType();
+
     String version();
-    Class<? extends BaseEventDescriptionBuilder> descriptionBuilder();
+
+    /**
+     * @return builder class to instantiate for Before processing, using the arguments.
+     * @See {@link org.aspectj.lang.annotation.Before}
+     */
+    Class<? extends BaseEventDescriptionBuilder> beforeBuilder();
+
+    /**
+     * @return builder class to instantiate for AfterReturn processing, using the arguments and return value.
+     * @See {@link org.aspectj.lang.annotation.AfterReturning}
+     */
+    Class<? extends BaseEventDescriptionBuilder> afterReturningBuilder();
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/InboundProcessingEvent.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/InboundProcessingEvent.java
@@ -30,17 +30,33 @@ package gov.hhs.fha.nhinc.aspect;
 
 import gov.hhs.fha.nhinc.event.BaseEventDescriptionBuilder;
 
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * @author bhumphrey
- *
+ * 
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 @Inherited
 public @interface InboundProcessingEvent {
     String serviceType();
+
     String version();
-    Class<? extends BaseEventDescriptionBuilder> descriptionBuilder();
+
+    /**
+     * @return builder class to instantiate for Before processing, using the arguments.
+     * @See {@link org.aspectj.lang.annotation.Before}
+     */
+    Class<? extends BaseEventDescriptionBuilder> beforeBuilder();
+
+    /**
+     * @return builder class to instantiate for AfterReturn processing, using the arguments and return value.
+     * @See {@link org.aspectj.lang.annotation.AfterReturning}
+     */
+    Class<? extends BaseEventDescriptionBuilder> afterReturningBuilder();
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/NwhinInvocationEvent.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/NwhinInvocationEvent.java
@@ -30,17 +30,33 @@ package gov.hhs.fha.nhinc.aspect;
 
 import gov.hhs.fha.nhinc.event.BaseEventDescriptionBuilder;
 
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * @author bhumphrey
- *
+ * 
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 @Inherited
 public @interface NwhinInvocationEvent {
     String serviceType();
+
     String version();
-    Class<? extends BaseEventDescriptionBuilder> descriptionBuilder();
+
+    /**
+     * @return builder class to instantiate for Before processing, using the arguments.
+     * @See {@link org.aspectj.lang.annotation.Before}
+     */
+    Class<? extends BaseEventDescriptionBuilder> beforeBuilder();
+
+    /**
+     * @return builder class to instantiate for AfterReturn processing, using the arguments and return value.
+     * @See {@link org.aspectj.lang.annotation.AfterReturning}
+     */
+    Class<? extends BaseEventDescriptionBuilder> afterReturningBuilder();
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/OutboundMessageEvent.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/OutboundMessageEvent.java
@@ -30,17 +30,33 @@ package gov.hhs.fha.nhinc.aspect;
 
 import gov.hhs.fha.nhinc.event.BaseEventDescriptionBuilder;
 
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * @author bhumphrey
- *
+ * 
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 @Inherited
 public @interface OutboundMessageEvent {
     String serviceType();
+
     String version();
-    Class<? extends BaseEventDescriptionBuilder> descriptionBuilder();
+
+    /**
+     * @return builder class to instantiate for Before processing, using the arguments.
+     * @See {@link org.aspectj.lang.annotation.Before}
+     */
+    Class<? extends BaseEventDescriptionBuilder> beforeBuilder();
+
+    /**
+     * @return builder class to instantiate for AfterReturn processing, using the arguments and return value.
+     * @See {@link org.aspectj.lang.annotation.AfterReturning}
+     */
+    Class<? extends BaseEventDescriptionBuilder> afterReturningBuilder();
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/OutboundProcessingEvent.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/OutboundProcessingEvent.java
@@ -30,18 +30,33 @@ package gov.hhs.fha.nhinc.aspect;
 
 import gov.hhs.fha.nhinc.event.BaseEventDescriptionBuilder;
 
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * @author bhumphrey
- *
+ * 
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 @Inherited
 public @interface OutboundProcessingEvent {
     String serviceType();
-    String version();
-    Class<? extends BaseEventDescriptionBuilder> descriptionBuilder();
 
+    String version();
+
+    /**
+     * @return builder class to instantiate for Before processing, using the arguments.
+     * @See {@link org.aspectj.lang.annotation.Before}
+     */
+    Class<? extends BaseEventDescriptionBuilder> beforeBuilder();
+
+    /**
+     * @return builder class to instantiate for AfterReturn processing, using the arguments and return value.
+     * @See {@link org.aspectj.lang.annotation.AfterReturning}
+     */
+    Class<? extends BaseEventDescriptionBuilder> afterReturningBuilder();
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/aspect/EventAspectAdviceSpringContextTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/aspect/EventAspectAdviceSpringContextTest.java
@@ -35,7 +35,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import gov.hhs.fha.nhinc.event.DefaultEventDescriptionBuilder;
-import gov.hhs.fha.nhinc.event.EventFactory;
 import gov.hhs.fha.nhinc.event.EventLogger;
 import gov.hhs.fha.nhinc.event.EventManager;
 import gov.hhs.fha.nhinc.event.initiator.BeginNwhinInvocationEvent;
@@ -64,30 +63,26 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author bhumphrey
- *
+ * 
  */
-
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "/CONNECT-context-test.xml", "/eventlogging.xml" })
 public class EventAspectAdviceSpringContextTest {
-    
-    @Autowired
-    private EventFactory eventFactory;
-    
+
     @Autowired
     private EventAspectAdvice eventAspectAdvice;
-    
+
     @Autowired
     private EventManager eventManager;
-    
+
     Answer<Class<DefaultEventDescriptionBuilder>> builderAnswer = new Answer<Class<DefaultEventDescriptionBuilder>>() {
         @Override
         public Class<DefaultEventDescriptionBuilder> answer(InvocationOnMock invocation) throws Throwable {
             return DefaultEventDescriptionBuilder.class;
         }
     };
-    
+
     @Before
     public void mockWebserviceConext() {
         // Mock up message context
@@ -95,133 +90,137 @@ public class EventAspectAdviceSpringContextTest {
         WrappedMessageContext msgCtx = new WrappedMessageContext(msg);
         WebServiceContextImpl.setMessageContext(msgCtx);
     }
-  
-    
+
     @Test
     public void adapterDelegationEvent() {
         assertNotNull(eventAspectAdvice);
-        
+
         EventLogger eventLogger = mock(EventLogger.class);
         eventManager.registerLogger(eventLogger);
-        
+
         JoinPoint joinPoint = mock(JoinPoint.class);
-        
-        when(joinPoint.getArgs()).thenReturn(new Object[]{});
-        
+
+        when(joinPoint.getArgs()).thenReturn(new Object[] {});
+
         AdapterDelegationEvent annotation = mock(AdapterDelegationEvent.class);
-        
+
         when(annotation.serviceType()).thenReturn("Test Type");
         when(annotation.version()).thenReturn("version");
-        when(annotation.descriptionBuilder()).then(builderAnswer);
-        
+        when(annotation.beforeBuilder()).then(builderAnswer);
+        when(annotation.afterReturningBuilder()).then(builderAnswer);
+
         eventAspectAdvice.beginAdapterDelegationEvent(joinPoint, annotation);
         verify(eventLogger).update(eq(eventManager), isA(BeginAdapterDelegationEvent.class));
-        
+
         Object returnValue = mock(Object.class);
-        
+
         eventAspectAdvice.endAdapterDelegationEvent(joinPoint, annotation, returnValue);
         verify(eventLogger).update(eq(eventManager), isA(EndAdapterDelegationEvent.class));
     }
-    
+
     @Test
     public void outboundMessageEvent() {
         assertNotNull(eventAspectAdvice);
-        
+
         EventLogger eventLogger = mock(EventLogger.class);
         eventManager.registerLogger(eventLogger);
-        
+
         JoinPoint joinPoint = mock(JoinPoint.class);
-        
-        when(joinPoint.getArgs()).thenReturn(new Object[]{});
-        
+
+        when(joinPoint.getArgs()).thenReturn(new Object[] {});
+
         OutboundMessageEvent annotation = mock(OutboundMessageEvent.class);
-        
+
         when(annotation.serviceType()).thenReturn("Test Type");
         when(annotation.version()).thenReturn("version");
-        when(annotation.descriptionBuilder()).then(builderAnswer);
-        
-        eventAspectAdvice.beginOutboundMessageEvent(joinPoint, annotation); 
+        when(annotation.beforeBuilder()).then(builderAnswer);
+        when(annotation.afterReturningBuilder()).then(builderAnswer);
+
+        eventAspectAdvice.beginOutboundMessageEvent(joinPoint, annotation);
         verify(eventLogger).update(eq(eventManager), isA(BeginOutboundMessageEvent.class));
-        
+
         Object returnValue = mock(Object.class);
-        
+
         eventAspectAdvice.endOutboundMessageEvent(joinPoint, annotation, returnValue);
         verify(eventLogger).update(eq(eventManager), isA(EndOutboundMessageEvent.class));
     }
-    
+
     @Test
     public void outboundProcessingEvent() {
         assertNotNull(eventAspectAdvice);
-        
+
         EventLogger eventLogger = mock(EventLogger.class);
         eventManager.registerLogger(eventLogger);
-        
+
         JoinPoint joinPoint = mock(JoinPoint.class);
-        when(joinPoint.getArgs()).thenReturn(new Object[]{});
-        
+        when(joinPoint.getArgs()).thenReturn(new Object[] {});
+
         OutboundProcessingEvent annotation = mock(OutboundProcessingEvent.class);
-        
+
         when(annotation.serviceType()).thenReturn("Test Type");
         when(annotation.version()).thenReturn("version");
-        when(annotation.descriptionBuilder()).then(builderAnswer);
-        
-        eventAspectAdvice.beginOutboundProcessingEvent(joinPoint, annotation); 
+        when(annotation.beforeBuilder()).then(builderAnswer);
+        when(annotation.afterReturningBuilder()).then(builderAnswer);
+
+        eventAspectAdvice.beginOutboundProcessingEvent(joinPoint, annotation);
         verify(eventLogger).update(eq(eventManager), isA(BeginOutboundProcessingEvent.class));
-        
+
         Object returnValue = mock(Object.class);
-        
+
         eventAspectAdvice.endOutboundProcessingEvent(joinPoint, annotation, returnValue);
         verify(eventLogger).update(eq(eventManager), isA(EndOutboundProcessingEvent.class));
     }
-    
+
     @Test
     public void inboundMessageEvent() {
         assertNotNull(eventAspectAdvice);
-        
+
         EventLogger eventLogger = mock(EventLogger.class);
         eventManager.registerLogger(eventLogger);
-        
+
         JoinPoint joinPoint = mock(JoinPoint.class);
-        
-        when(joinPoint.getArgs()).thenReturn(new Object[]{});
-        
+
+        when(joinPoint.getArgs()).thenReturn(new Object[] {});
+
         InboundMessageEvent annotation = mock(InboundMessageEvent.class);
-        
+
         when(annotation.serviceType()).thenReturn("Test Type");
         when(annotation.version()).thenReturn("version");
-        when(annotation.descriptionBuilder()).then(builderAnswer);
-        
-        eventAspectAdvice.beginInboundMessageEvent(joinPoint, annotation); 
+        when(annotation.beforeBuilder()).then(builderAnswer);
+        when(annotation.afterReturningBuilder()).then(builderAnswer);
+
+        eventAspectAdvice.beginInboundMessageEvent(joinPoint, annotation);
         verify(eventLogger).update(eq(eventManager), isA(BeginInboundMessageEvent.class));
-        
+
         Object returnValue = mock(Object.class);
-        
+
         eventAspectAdvice.endInboundMessageEvent(joinPoint, annotation, returnValue);
         verify(eventLogger).update(eq(eventManager), isA(EndInboundMessageEvent.class));
     }
-    
+
     @Test
     public void nwhinInvocationEvent() {
         assertNotNull(eventAspectAdvice);
-        
+
         EventLogger eventLogger = mock(EventLogger.class);
         eventManager.registerLogger(eventLogger);
-        
+
         JoinPoint joinPoint = mock(JoinPoint.class);
-        
-        when(joinPoint.getArgs()).thenReturn(new Object[]{});
-        
+
+        when(joinPoint.getArgs()).thenReturn(new Object[] {});
+
         NwhinInvocationEvent annotation = mock(NwhinInvocationEvent.class);
-        
+
         when(annotation.serviceType()).thenReturn("Test Type");
         when(annotation.version()).thenReturn("version");
-        when(annotation.descriptionBuilder()).then(builderAnswer);
-        
+        when(annotation.beforeBuilder()).then(builderAnswer);
+        when(annotation.afterReturningBuilder()).then(builderAnswer);
+
         eventAspectAdvice.beginNwhinInvocationEvent(joinPoint, annotation);
         verify(eventLogger).update(eq(eventManager), isA(BeginNwhinInvocationEvent.class));
-        
+
         Object returnValue = mock(Object.class);
-        
+
         eventAspectAdvice.endNwhinInvocationEvent(joinPoint, annotation, returnValue);
         verify(eventLogger).update(eq(eventManager), isA(EndNwhinInvocationEvent.class));
     }

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/aspect/EventAspectAdviceTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/aspect/EventAspectAdviceTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import gov.hhs.fha.nhinc.event.BaseEventDescriptionBuilder;
 import gov.hhs.fha.nhinc.event.DefaultEventDescriptionBuilder;
 
 import org.aspectj.lang.JoinPoint;
@@ -74,10 +75,17 @@ public class EventAspectAdviceTest {
         }
     };
 
-    Answer<Class<DefaultEventDescriptionBuilder>> builderAnswer = new Answer<Class<DefaultEventDescriptionBuilder>>() {
+    Answer<Class<? extends BaseEventDescriptionBuilder>> beforeBuilderAnswer = new Answer<Class<? extends BaseEventDescriptionBuilder>>() {
         @Override
-        public Class<DefaultEventDescriptionBuilder> answer(InvocationOnMock invocation) throws Throwable {
+        public Class<? extends BaseEventDescriptionBuilder> answer(InvocationOnMock invocation) throws Throwable {
             return DefaultEventDescriptionBuilder.class;
+        }
+    };
+
+    Answer<Class<? extends BaseEventDescriptionBuilder>> afterReturningBuilderAnswer = new Answer<Class<? extends BaseEventDescriptionBuilder>>() {
+        @Override
+        public Class<? extends BaseEventDescriptionBuilder> answer(InvocationOnMock invocation) throws Throwable {
+            return BaseEventDescriptionBuilder.class;
         }
     };
 
@@ -107,117 +115,123 @@ public class EventAspectAdviceTest {
     }
 
     @Test
-    public void verifyInboundMessageEvent() {
+    public void verifyInboundMessageEvent() throws Throwable {
         InboundMessageEvent mockAnnotation = mock(InboundMessageEvent.class);
 
         when(mockAnnotation.serviceType()).then(serviceTypeAnswer);
         when(mockAnnotation.version()).then(versionAnswer);
-        when(mockAnnotation.descriptionBuilder()).then(builderAnswer);
+        when(mockAnnotation.beforeBuilder()).then(beforeBuilderAnswer);
+        when(mockAnnotation.afterReturningBuilder()).then(afterReturningBuilderAnswer);
 
         advice.beginInboundMessageEvent(mockJoinPoint, mockAnnotation);
 
         verify(inboundMessageAdviceDelegate).begin(any(Object[].class), eq("test-serviceType"), eq("test-version"),
-                eq(DefaultEventDescriptionBuilder.class));
+                eq(beforeBuilderAnswer.answer(null)));
 
         advice.endInboundMessageEvent(mockJoinPoint, mockAnnotation, mockReturnValue);
 
         verify(inboundMessageAdviceDelegate).end(any(Object[].class), eq("test-serviceType"), eq("test-version"),
-                eq(DefaultEventDescriptionBuilder.class), any(Object.class));
+                eq(afterReturningBuilderAnswer.answer(null)), any(Object.class));
     }
 
     @Test
-    public void verifyOutboundMessageEvent() {
+    public void verifyOutboundMessageEvent() throws Throwable {
         OutboundMessageEvent mockAnnotation = mock(OutboundMessageEvent.class);
 
         when(mockAnnotation.serviceType()).then(serviceTypeAnswer);
         when(mockAnnotation.version()).then(versionAnswer);
-        when(mockAnnotation.descriptionBuilder()).then(builderAnswer);
+        when(mockAnnotation.beforeBuilder()).then(beforeBuilderAnswer);
+        when(mockAnnotation.afterReturningBuilder()).then(afterReturningBuilderAnswer);
 
         advice.beginOutboundMessageEvent(mockJoinPoint, mockAnnotation);
 
         verify(outboundMessageAdviceDelegate).begin(any(Object[].class), eq("test-serviceType"), eq("test-version"),
-                eq(DefaultEventDescriptionBuilder.class));
+                eq(beforeBuilderAnswer.answer(null)));
 
         advice.endOutboundMessageEvent(mockJoinPoint, mockAnnotation, mockReturnValue);
 
         verify(outboundMessageAdviceDelegate).end(any(Object[].class), eq("test-serviceType"), eq("test-version"),
-                eq(DefaultEventDescriptionBuilder.class), any(Object.class));
+                eq(afterReturningBuilderAnswer.answer(null)), any(Object.class));
     }
 
     @Test
-    public void verifyAdapterDelegationEvent() {
+    public void verifyAdapterDelegationEvent() throws Throwable {
         AdapterDelegationEvent mockAnnotation = mock(AdapterDelegationEvent.class);
 
         when(mockAnnotation.serviceType()).then(serviceTypeAnswer);
         when(mockAnnotation.version()).then(versionAnswer);
-        when(mockAnnotation.descriptionBuilder()).then(builderAnswer);
+        when(mockAnnotation.beforeBuilder()).then(beforeBuilderAnswer);
+        when(mockAnnotation.afterReturningBuilder()).then(afterReturningBuilderAnswer);
 
         advice.beginAdapterDelegationEvent(mockJoinPoint, mockAnnotation);
 
         verify(adapterDelegationAdviceDelegate).begin(any(Object[].class), eq("test-serviceType"), eq("test-version"),
-                eq(DefaultEventDescriptionBuilder.class));
+                eq(beforeBuilderAnswer.answer(null)));
 
         advice.endAdapterDelegationEvent(mockJoinPoint, mockAnnotation, mockReturnValue);
 
         verify(adapterDelegationAdviceDelegate).end(any(Object[].class), eq("test-serviceType"), eq("test-version"),
-                eq(DefaultEventDescriptionBuilder.class), any(Object.class));
+                eq(afterReturningBuilderAnswer.answer(null)), any(Object.class));
     }
 
     @Test
-    public void verifyInboundProcessingEvent() {
+    public void verifyInboundProcessingEvent() throws Throwable {
         InboundProcessingEvent mockAnnotation = mock(InboundProcessingEvent.class);
 
         when(mockAnnotation.serviceType()).then(serviceTypeAnswer);
         when(mockAnnotation.version()).then(versionAnswer);
-        when(mockAnnotation.descriptionBuilder()).then(builderAnswer);
+        when(mockAnnotation.beforeBuilder()).then(beforeBuilderAnswer);
+        when(mockAnnotation.afterReturningBuilder()).then(afterReturningBuilderAnswer);
 
         advice.beginInboundProcessingEvent(mockJoinPoint, mockAnnotation);
 
         verify(inboundProcessingAdviceDelegate).begin(any(Object[].class), eq("test-serviceType"), eq("test-version"),
-                eq(DefaultEventDescriptionBuilder.class));
+                eq(beforeBuilderAnswer.answer(null)));
 
         advice.endInboundProcessingEvent(mockJoinPoint, mockAnnotation, mockReturnValue);
 
         verify(inboundProcessingAdviceDelegate).end(any(Object[].class), eq("test-serviceType"), eq("test-version"),
-                eq(DefaultEventDescriptionBuilder.class), any(Object.class));
+                eq(afterReturningBuilderAnswer.answer(null)), any(Object.class));
     }
 
     @Test
-    public void verifyOutboundProcessingEvent() {
+    public void verifyOutboundProcessingEvent() throws Throwable {
         OutboundProcessingEvent mockAnnotation = mock(OutboundProcessingEvent.class);
 
         when(mockAnnotation.serviceType()).then(serviceTypeAnswer);
         when(mockAnnotation.version()).then(versionAnswer);
-        when(mockAnnotation.descriptionBuilder()).then(builderAnswer);
+        when(mockAnnotation.beforeBuilder()).then(beforeBuilderAnswer);
+        when(mockAnnotation.afterReturningBuilder()).then(afterReturningBuilderAnswer);
 
         advice.beginOutboundProcessingEvent(mockJoinPoint, mockAnnotation);
 
         verify(outboundProcessingAdviceDelegate).begin(any(Object[].class), eq("test-serviceType"), eq("test-version"),
-                eq(DefaultEventDescriptionBuilder.class));
+                eq(beforeBuilderAnswer.answer(null)));
 
         advice.endOutboundProcessingEvent(mockJoinPoint, mockAnnotation, mockReturnValue);
 
         verify(outboundProcessingAdviceDelegate).end(any(Object[].class), eq("test-serviceType"), eq("test-version"),
-                eq(DefaultEventDescriptionBuilder.class), any(Object.class));
+                eq(afterReturningBuilderAnswer.answer(null)), any(Object.class));
     }
 
     @Test
-    public void verifyNwhinInvocationEvent() {
+    public void verifyNwhinInvocationEvent() throws Throwable {
         NwhinInvocationEvent mockAnnotation = mock(NwhinInvocationEvent.class);
 
         when(mockAnnotation.serviceType()).then(serviceTypeAnswer);
         when(mockAnnotation.version()).then(versionAnswer);
-        when(mockAnnotation.descriptionBuilder()).then(builderAnswer);
+        when(mockAnnotation.beforeBuilder()).then(beforeBuilderAnswer);
+        when(mockAnnotation.afterReturningBuilder()).then(afterReturningBuilderAnswer);
 
         advice.beginNwhinInvocationEvent(mockJoinPoint, mockAnnotation);
 
         verify(nwhinInvocationAdviceDelegate).begin(any(Object[].class), eq("test-serviceType"), eq("test-version"),
-                eq(DefaultEventDescriptionBuilder.class));
+                eq(beforeBuilderAnswer.answer(null)));
 
         advice.endNwhinInvocationEvent(mockJoinPoint, mockAnnotation, mockReturnValue);
 
         verify(nwhinInvocationAdviceDelegate).end(any(Object[].class), eq("test-serviceType"), eq("test-version"),
-                eq(DefaultEventDescriptionBuilder.class), any(Object.class));
+                eq(afterReturningBuilderAnswer.answer(null)), any(Object.class));
     }
 
     @Test

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/aspect/EventLoggingAnnontationTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/aspect/EventLoggingAnnontationTest.java
@@ -3,7 +3,6 @@ package gov.hhs.fha.nhinc.aspect;
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-
 import gov.hhs.fha.nhinc.event.BaseEventDescriptionBuilder;
 
 import java.lang.annotation.ElementType;
@@ -33,11 +32,8 @@ public class EventLoggingAnnontationTest {
 
     @Parameters
     public static Collection<Object[]> data() {
-        Object[][] data = new Object[][] { { NwhinInvocationEvent.class }, 
-                { OutboundMessageEvent.class },
-                { OutboundProcessingEvent.class },
-                { InboundMessageEvent.class },
-                { InboundProcessingEvent.class },
+        Object[][] data = new Object[][] { { NwhinInvocationEvent.class }, { OutboundMessageEvent.class },
+                { OutboundProcessingEvent.class }, { InboundMessageEvent.class }, { InboundProcessingEvent.class },
                 { AdapterDelegationEvent.class } };
         return Arrays.asList(data);
     }
@@ -57,12 +53,22 @@ public class EventLoggingAnnontationTest {
         assertTrue(String.class.isAssignableFrom(versionMethod.getReturnType()));
 
     }
-    
+
     @Test
-    public void verifyDescriptionBuilderMethod() throws Throwable {
-        Method descriptionBuilderMethod = annotationClass.getMethod("descriptionBuilder");
-        assertNotNull(className + " has method descriptionBuilder", descriptionBuilderMethod);
-        assertTrue(BaseEventDescriptionBuilder.class.getClass().isAssignableFrom(descriptionBuilderMethod.getReturnType()));
+    public void verifyBeforeBuilderMethod() throws Throwable {
+        Method descriptionBuilderMethod = annotationClass.getMethod("beforeBuilder");
+        assertNotNull(className + " has method beforeBuilder", descriptionBuilderMethod);
+        assertTrue(BaseEventDescriptionBuilder.class.getClass().isAssignableFrom(
+                descriptionBuilderMethod.getReturnType()));
+
+    }
+
+    @Test
+    public void verifyAfterReturningBuilderMethod() throws Throwable {
+        Method descriptionBuilderMethod = annotationClass.getMethod("afterReturningBuilder");
+        assertNotNull(className + " has method afterReturningBuilder", descriptionBuilderMethod);
+        assertTrue(BaseEventDescriptionBuilder.class.getClass().isAssignableFrom(
+                descriptionBuilderMethod.getReturnType()));
 
     }
 
@@ -79,14 +85,14 @@ public class EventLoggingAnnontationTest {
     public void verifyTargetAnnotation() {
         Target t = (Target) annotationClass.getAnnotation(Target.class);
         assertNotNull(className + " has target annotation", t);
-        assertEquals( ElementType.METHOD, t.value()[0]);
+        assertEquals(ElementType.METHOD, t.value()[0]);
     }
-    
+
     @Test
     public void verifyInhertitedAnnotation() {
         Inherited i = (Inherited) annotationClass.getAnnotation(Inherited.class);
         assertNotNull(className + " has inhertied annotation", i);
-        
+
     }
 
 }

--- a/Product/Production/Gateway/DocumentQuery_20/src/main/java/gov/hhs/fha/nhinc/docquery/_20/nhin/DocQuery.java
+++ b/Product/Production/Gateway/DocumentQuery_20/src/main/java/gov/hhs/fha/nhinc/docquery/_20/nhin/DocQuery.java
@@ -28,6 +28,7 @@ package gov.hhs.fha.nhinc.docquery._20.nhin;
 
 import gov.hhs.fha.nhinc.aspect.InboundMessageEvent;
 import gov.hhs.fha.nhinc.docquery.aspect.AdhocQueryRequestDescriptionBuilder;
+import gov.hhs.fha.nhinc.docquery.aspect.AdhocQueryResponseDescriptionBuilder;
 import gov.hhs.fha.nhinc.docquery.nhin.NhinDocQueryOrchImpl;
 import ihe.iti.xds_b._2007.RespondingGatewayQueryPortType;
 
@@ -58,8 +59,9 @@ public class DocQuery implements RespondingGatewayQueryPortType {
      *            the body of the request
      * @return the query response for the document query
      */
-    @InboundMessageEvent(descriptionBuilder = AdhocQueryRequestDescriptionBuilder.class,
-            serviceType = "Document Query", version = "2.0")
+    @InboundMessageEvent(beforeBuilder = AdhocQueryRequestDescriptionBuilder.class,
+            afterReturningBuilder = AdhocQueryResponseDescriptionBuilder.class, serviceType = "Document Query",
+            version = "2.0")
     public AdhocQueryResponse respondingGatewayCrossGatewayQuery(AdhocQueryRequest body) {
         return new DocQueryImpl(orchImpl).respondingGatewayCrossGatewayQuery(body, context);
     }

--- a/Product/Production/Gateway/DocumentSubmission_11/src/main/java/gov/hhs/fha/nhinc/docsubmission/_11/nhin/NhinXDR.java
+++ b/Product/Production/Gateway/DocumentSubmission_11/src/main/java/gov/hhs/fha/nhinc/docsubmission/_11/nhin/NhinXDR.java
@@ -26,17 +26,17 @@
  */
 package gov.hhs.fha.nhinc.docsubmission._11.nhin;
 
+import gov.hhs.fha.nhinc.aspect.InboundMessageEvent;
+import gov.hhs.fha.nhinc.docsubmission.nhin.NhinDocSubmissionOrchImpl;
+import gov.hhs.fha.nhinc.event.DefaultEventDescriptionBuilder;
+
 import javax.annotation.Resource;
 import javax.xml.ws.BindingType;
 import javax.xml.ws.WebServiceContext;
 import javax.xml.ws.soap.Addressing;
 
-import gov.hhs.fha.nhinc.aspect.InboundMessageEvent;
-import gov.hhs.fha.nhinc.docsubmission.nhin.NhinDocSubmissionOrchImpl;
-import gov.hhs.fha.nhinc.event.DefaultEventDescriptionBuilder;
-
 /**
- *
+ * 
  * @author dunnek
  */
 @BindingType(value = javax.xml.ws.soap.SOAPBinding.SOAP12HTTP_BINDING)
@@ -47,11 +47,15 @@ public class NhinXDR implements ihe.iti.xdr._2007.DocumentRepositoryXDRPortType 
 
     /**
      * The web service implementation for Document Submission.
-     * @param body The message of the request
+     * 
+     * @param body
+     *            The message of the request
      * @return a registry response
      */
     @Override
-    @InboundMessageEvent(serviceType="Document Submission", version="1.1", descriptionBuilder=DefaultEventDescriptionBuilder.class)
+    @InboundMessageEvent(serviceType = "Document Submission", version = "1.1",
+            beforeBuilder = DefaultEventDescriptionBuilder.class,
+            afterReturningBuilder = DefaultEventDescriptionBuilder.class)
     public oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType documentRepositoryProvideAndRegisterDocumentSetB(
             ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType body) {
         return new NhinDocSubmissionImpl(orchImpl).documentRepositoryProvideAndRegisterDocumentSetB(body, context);
@@ -59,7 +63,9 @@ public class NhinXDR implements ihe.iti.xdr._2007.DocumentRepositoryXDRPortType 
 
     /**
      * The web service implementation for Document Submission.
-     * @param body the message of the request
+     * 
+     * @param body
+     *            the message of the request
      * @return a retrieved document
      */
     @Override
@@ -77,6 +83,4 @@ public class NhinXDR implements ihe.iti.xdr._2007.DocumentRepositoryXDRPortType 
         this.context = context;
     }
 
-    
-    
 }

--- a/Product/Production/Gateway/DocumentSubmission_11/src/main/java/gov/hhs/fha/nhinc/docsubmission/_11/nhin/deferred/request/NhinXDRRequest.java
+++ b/Product/Production/Gateway/DocumentSubmission_11/src/main/java/gov/hhs/fha/nhinc/docsubmission/_11/nhin/deferred/request/NhinXDRRequest.java
@@ -26,17 +26,17 @@
  */
 package gov.hhs.fha.nhinc.docsubmission._11.nhin.deferred.request;
 
+import gov.hhs.fha.nhinc.aspect.InboundMessageEvent;
+import gov.hhs.fha.nhinc.docsubmission.nhin.deferred.request.NhinDocSubmissionDeferredRequestOrchImpl;
+import gov.hhs.fha.nhinc.event.DefaultEventDescriptionBuilder;
+
 import javax.annotation.Resource;
 import javax.xml.ws.BindingType;
 import javax.xml.ws.WebServiceContext;
 import javax.xml.ws.soap.Addressing;
 
-import gov.hhs.fha.nhinc.aspect.InboundMessageEvent;
-import gov.hhs.fha.nhinc.docsubmission.nhin.deferred.request.NhinDocSubmissionDeferredRequestOrchImpl;
-import gov.hhs.fha.nhinc.event.DefaultEventDescriptionBuilder;
-
 /**
- *
+ * 
  * @author JHOPPESC
  */
 @BindingType(value = javax.xml.ws.soap.SOAPBinding.SOAP12HTTP_BINDING)
@@ -47,11 +47,15 @@ public class NhinXDRRequest implements ihe.iti.xdr._2007.XDRDeferredRequestPortT
 
     /**
      * The web service implemenation for Document Submission request.
-     * @param body The message of the request
+     * 
+     * @param body
+     *            The message of the request
      * @return an acknowledgement
      */
     @Override
-    @InboundMessageEvent(serviceType="Document Submission Deferred Request", version="1.1", descriptionBuilder=DefaultEventDescriptionBuilder.class)
+    @InboundMessageEvent(serviceType = "Document Submission Deferred Request", version = "1.1",
+            beforeBuilder = DefaultEventDescriptionBuilder.class,
+            afterReturningBuilder = DefaultEventDescriptionBuilder.class)
     public gov.hhs.healthit.nhin.XDRAcknowledgementType provideAndRegisterDocumentSetBDeferredRequest(
             ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType body) {
         return new NhinDocSubmissionDeferredRequestImpl(orchImpl).provideAndRegisterDocumentSetBRequest(body, context);
@@ -65,7 +69,5 @@ public class NhinXDRRequest implements ihe.iti.xdr._2007.XDRDeferredRequestPortT
     public void setContext(WebServiceContext context) {
         this.context = context;
     }
-
-    
 
 }

--- a/Product/Production/Gateway/DocumentSubmission_11/src/main/java/gov/hhs/fha/nhinc/docsubmission/_11/nhin/deferred/response/NhinXDRResponse.java
+++ b/Product/Production/Gateway/DocumentSubmission_11/src/main/java/gov/hhs/fha/nhinc/docsubmission/_11/nhin/deferred/response/NhinXDRResponse.java
@@ -26,17 +26,17 @@
  */
 package gov.hhs.fha.nhinc.docsubmission._11.nhin.deferred.response;
 
+import gov.hhs.fha.nhinc.aspect.InboundMessageEvent;
+import gov.hhs.fha.nhinc.docsubmission.nhin.deferred.response.NhinDocSubmissionDeferredResponseOrchImpl;
+import gov.hhs.fha.nhinc.event.DefaultEventDescriptionBuilder;
+
 import javax.annotation.Resource;
 import javax.xml.ws.BindingType;
 import javax.xml.ws.WebServiceContext;
 import javax.xml.ws.soap.Addressing;
 
-import gov.hhs.fha.nhinc.aspect.InboundMessageEvent;
-import gov.hhs.fha.nhinc.docsubmission.nhin.deferred.response.NhinDocSubmissionDeferredResponseOrchImpl;
-import gov.hhs.fha.nhinc.event.DefaultEventDescriptionBuilder;
-
 /**
- *
+ * 
  * @author JHOPPESC
  */
 @BindingType(value = javax.xml.ws.soap.SOAPBinding.SOAP12HTTP_BINDING)
@@ -47,14 +47,19 @@ public class NhinXDRResponse implements ihe.iti.xdr._2007.XDRDeferredResponsePor
 
     /**
      * The web service implementation for Document Submission response.
-     * @param body the message body
+     * 
+     * @param body
+     *            the message body
      * @return an acknowledgement
      */
     @Override
-    @InboundMessageEvent(serviceType="Document Submission Deferred Response", version="1.1", descriptionBuilder=DefaultEventDescriptionBuilder.class)
+    @InboundMessageEvent(serviceType = "Document Submission Deferred Response", version = "1.1",
+            beforeBuilder = DefaultEventDescriptionBuilder.class,
+            afterReturningBuilder = DefaultEventDescriptionBuilder.class)
     public gov.hhs.healthit.nhin.XDRAcknowledgementType provideAndRegisterDocumentSetBDeferredResponse(
             oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType body) {
-        return new NhinDocSubmissionDeferredResponseImpl(orchImpl).provideAndRegisterDocumentSetBResponse(body, context);
+        return new NhinDocSubmissionDeferredResponseImpl(orchImpl)
+                .provideAndRegisterDocumentSetBResponse(body, context);
     }
 
     public void setOrchestratorImpl(NhinDocSubmissionDeferredResponseOrchImpl orchImpl) {
@@ -65,6 +70,5 @@ public class NhinXDRResponse implements ihe.iti.xdr._2007.XDRDeferredResponsePor
     public void setContext(WebServiceContext context) {
         this.context = context;
     }
-    
-    
+
 }

--- a/Product/Production/Gateway/DocumentSubmission_20/src/main/java/gov/hhs/fha/nhinc/docsubmission/_20/entity/EntityDocSubmissionSecured_g1.java
+++ b/Product/Production/Gateway/DocumentSubmission_20/src/main/java/gov/hhs/fha/nhinc/docsubmission/_20/entity/EntityDocSubmissionSecured_g1.java
@@ -26,17 +26,17 @@
  */
 package gov.hhs.fha.nhinc.docsubmission._20.entity;
 
+import gov.hhs.fha.nhinc.aspect.InboundMessageEvent;
+import gov.hhs.fha.nhinc.common.nhinccommonentity.RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType;
+import gov.hhs.fha.nhinc.docsubmission.entity.EntityDocSubmissionOrchImpl;
+import gov.hhs.fha.nhinc.event.DefaultEventDescriptionBuilder;
+
 import javax.annotation.Resource;
 import javax.xml.ws.BindingType;
 import javax.xml.ws.WebServiceContext;
 import javax.xml.ws.soap.Addressing;
 
 import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
-
-import gov.hhs.fha.nhinc.aspect.InboundMessageEvent;
-import gov.hhs.fha.nhinc.common.nhinccommonentity.RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType;
-import gov.hhs.fha.nhinc.docsubmission.entity.EntityDocSubmissionOrchImpl;
-import gov.hhs.fha.nhinc.event.DefaultEventDescriptionBuilder;
 
 @BindingType(value = javax.xml.ws.soap.SOAPBinding.SOAP12HTTP_BINDING)
 @Addressing(enabled = true)
@@ -47,7 +47,9 @@ public class EntityDocSubmissionSecured_g1 implements gov.hhs.fha.nhinc.nhincent
     private EntityDocSubmissionOrchImpl orchImpl;
 
     @Override
-    @InboundMessageEvent(serviceType="Document Submission", version="2.0", descriptionBuilder=DefaultEventDescriptionBuilder.class)
+    @InboundMessageEvent(serviceType = "Document Submission", version = "2.0",
+            beforeBuilder = DefaultEventDescriptionBuilder.class,
+            afterReturningBuilder = DefaultEventDescriptionBuilder.class)
     public RegistryResponseType provideAndRegisterDocumentSetB(
             RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType body) {
 
@@ -57,7 +59,6 @@ public class EntityDocSubmissionSecured_g1 implements gov.hhs.fha.nhinc.nhincent
         return response;
     }
 
-    
     @Resource
     public void setContext(WebServiceContext context) {
         this.context = context;

--- a/Product/Production/Gateway/DocumentSubmission_20/src/main/java/gov/hhs/fha/nhinc/docsubmission/_20/nhin/NhinXDR_g1.java
+++ b/Product/Production/Gateway/DocumentSubmission_20/src/main/java/gov/hhs/fha/nhinc/docsubmission/_20/nhin/NhinXDR_g1.java
@@ -30,8 +30,8 @@ import gov.hhs.fha.nhinc.aspect.InboundMessageEvent;
 import gov.hhs.fha.nhinc.docsubmission.nhin.NhinDocSubmissionOrchImpl;
 import gov.hhs.fha.nhinc.event.DefaultEventDescriptionBuilder;
 
-import javax.xml.ws.BindingType;
 import javax.annotation.Resource;
+import javax.xml.ws.BindingType;
 import javax.xml.ws.WebServiceContext;
 import javax.xml.ws.soap.Addressing;
 
@@ -43,10 +43,12 @@ import javax.xml.ws.soap.Addressing;
 @Addressing(enabled = true)
 public class NhinXDR_g1 implements ihe.iti.xdr._2007.DocumentRepositoryXDRPortType {
     private WebServiceContext context;
-    
+
     private NhinDocSubmissionOrchImpl orchImpl;
 
-    @InboundMessageEvent(serviceType="Document Submission", version="2.0", descriptionBuilder=DefaultEventDescriptionBuilder.class)
+    @InboundMessageEvent(serviceType = "Document Submission", version = "2.0",
+            beforeBuilder = DefaultEventDescriptionBuilder.class,
+            afterReturningBuilder = DefaultEventDescriptionBuilder.class)
     public oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType documentRepositoryProvideAndRegisterDocumentSetB(
             ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType body) {
         return new NhinDocSubmissionImpl_g1(orchImpl).documentRepositoryProvideAndRegisterDocumentSetB(body, context);
@@ -56,7 +58,7 @@ public class NhinXDR_g1 implements ihe.iti.xdr._2007.DocumentRepositoryXDRPortTy
             ihe.iti.xds_b._2007.RetrieveDocumentSetRequestType body) {
         throw new UnsupportedOperationException("Not implemented yet.");
     }
-    
+
     public void setOrchestratorImpl(NhinDocSubmissionOrchImpl orchImpl) {
         this.orchImpl = orchImpl;
     }
@@ -65,9 +67,5 @@ public class NhinXDR_g1 implements ihe.iti.xdr._2007.DocumentRepositoryXDRPortTy
     public void setContext(WebServiceContext context) {
         this.context = context;
     }
-
-   
-    
-    
 
 }

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyJavaImpl.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyJavaImpl.java
@@ -26,10 +26,14 @@
  */
 package gov.hhs.fha.nhinc.docquery.adapter.proxy;
 
+import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docquery.adapter.AdapterDocQueryOrchImpl;
+import gov.hhs.fha.nhinc.docquery.aspect.AdhocQueryRequestDescriptionBuilder;
+import gov.hhs.fha.nhinc.docquery.aspect.AdhocQueryResponseDescriptionBuilder;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryResponse;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -40,6 +44,9 @@ import org.apache.commons.logging.LogFactory;
 public class AdapterDocQueryProxyJavaImpl implements AdapterDocQueryProxy {
     private static Log log = LogFactory.getLog(AdapterDocQueryProxyJavaImpl.class);
 
+    @AdapterDelegationEvent(beforeBuilder = AdhocQueryRequestDescriptionBuilder.class,
+            afterReturningBuilder = AdhocQueryResponseDescriptionBuilder.class, serviceType = "Document Query",
+            version = "")
     public AdhocQueryResponse respondingGatewayCrossGatewayQuery(AdhocQueryRequest msg, AssertionType assertion) {
         log.debug("Using Java Implementation for Adapter Doc Query Service");
         return new AdapterDocQueryOrchImpl().respondingGatewayCrossGatewayQuery(msg, assertion);

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyNoOpImpl.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyNoOpImpl.java
@@ -26,15 +26,22 @@
  */
 package gov.hhs.fha.nhinc.docquery.adapter.proxy;
 
+import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.docquery.aspect.AdhocQueryRequestDescriptionBuilder;
+import gov.hhs.fha.nhinc.docquery.aspect.AdhocQueryResponseDescriptionBuilder;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryResponse;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 public class AdapterDocQueryProxyNoOpImpl implements AdapterDocQueryProxy {
     private static Log log = LogFactory.getLog(AdapterDocQueryProxyNoOpImpl.class);
 
+    @AdapterDelegationEvent(beforeBuilder = AdhocQueryRequestDescriptionBuilder.class,
+            afterReturningBuilder = AdhocQueryResponseDescriptionBuilder.class, serviceType = "Document Query",
+            version = "")
     public AdhocQueryResponse respondingGatewayCrossGatewayQuery(AdhocQueryRequest msg, AssertionType assertion) {
         log.debug("Using NoOp Implementation for Adapter Doc Query Service");
         return new AdhocQueryResponse();

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyWebServiceSecuredImpl.java
@@ -27,8 +27,11 @@
 package gov.hhs.fha.nhinc.docquery.adapter.proxy;
 
 import gov.hhs.fha.nhinc.adapterdocquerysecured.AdapterDocQuerySecuredPortType;
+import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docquery.adapter.proxy.description.AdapterDocQuerySecuredServicePortDescriptor;
+import gov.hhs.fha.nhinc.docquery.aspect.AdhocQueryRequestDescriptionBuilder;
+import gov.hhs.fha.nhinc.docquery.aspect.AdhocQueryResponseDescriptionBuilder;
 import gov.hhs.fha.nhinc.gateway.aggregator.document.DocumentConstants;
 import gov.hhs.fha.nhinc.messaging.client.CONNECTClient;
 import gov.hhs.fha.nhinc.messaging.client.CONNECTClientFactory;
@@ -76,6 +79,9 @@ public class AdapterDocQueryProxyWebServiceSecuredImpl implements AdapterDocQuer
         }
     }
 
+    @AdapterDelegationEvent(beforeBuilder = AdhocQueryRequestDescriptionBuilder.class,
+            afterReturningBuilder = AdhocQueryResponseDescriptionBuilder.class, serviceType = "Document Query",
+            version = "")
     public AdhocQueryResponse respondingGatewayCrossGatewayQuery(AdhocQueryRequest msg, AssertionType assertion) {
         AdhocQueryResponse response = null;
 

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyWebServiceUnsecuredImpl.java
@@ -27,9 +27,12 @@
 package gov.hhs.fha.nhinc.docquery.adapter.proxy;
 
 import gov.hhs.fha.nhinc.adapterdocquery.AdapterDocQueryPortType;
+import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommonadapter.RespondingGatewayCrossGatewayQueryRequestType;
 import gov.hhs.fha.nhinc.docquery.adapter.proxy.description.AdapterDocQueryServicePortDescriptor;
+import gov.hhs.fha.nhinc.docquery.aspect.AdhocQueryRequestDescriptionBuilder;
+import gov.hhs.fha.nhinc.docquery.aspect.AdhocQueryResponseDescriptionBuilder;
 import gov.hhs.fha.nhinc.gateway.aggregator.document.DocumentConstants;
 import gov.hhs.fha.nhinc.messaging.client.CONNECTClient;
 import gov.hhs.fha.nhinc.messaging.client.CONNECTClientFactory;
@@ -76,6 +79,9 @@ public class AdapterDocQueryProxyWebServiceUnsecuredImpl implements AdapterDocQu
         }
     }
 
+    @AdapterDelegationEvent(beforeBuilder = AdhocQueryRequestDescriptionBuilder.class,
+            afterReturningBuilder = AdhocQueryResponseDescriptionBuilder.class, serviceType = "Document Query",
+            version = "")
     public AdhocQueryResponse respondingGatewayCrossGatewayQuery(AdhocQueryRequest msg, AssertionType assertion) {
         log.debug("Begin respondingGatewayCrossGatewayQuery");
         AdhocQueryResponse response = null;

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryRequestDescriptionBuilder.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryRequestDescriptionBuilder.java
@@ -45,9 +45,9 @@ import com.google.common.collect.ImmutableList;
 public class AdhocQueryRequestDescriptionBuilder extends BaseEventDescriptionBuilder {
 
     private static final Log LOG = LogFactory.getLog(AdhocQueryRequestDescriptionBuilder.class);
+    private AssertionDescriptionExtractor assertionExtractor = new AssertionDescriptionExtractor();
     private Optional<AdhocQueryRequest> request;
     private Optional<AssertionType> assertion;
-    private AssertionDescriptionExtractor assertionExtractor;
 
     public AdhocQueryRequestDescriptionBuilder() {
         request = Optional.absent();
@@ -122,6 +122,10 @@ public class AdhocQueryRequestDescriptionBuilder extends BaseEventDescriptionBui
 
     public void setAssertionExtractor(AssertionDescriptionExtractor assertionExtractor) {
         this.assertionExtractor = assertionExtractor;
+    }
+
+    protected AssertionDescriptionExtractor getAssertionExtractor() {
+        return assertionExtractor;
     }
 
     private Optional<AdhocQueryRequest> extractRequest(Object[] arguments) {

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryRequestDescriptionBuilder.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryRequestDescriptionBuilder.java
@@ -28,7 +28,9 @@
  */
 package gov.hhs.fha.nhinc.docquery.aspect;
 
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.event.BaseEventDescriptionBuilder;
+import gov.hhs.fha.nhinc.event.builder.AssertionDescriptionExtractor;
 
 import java.util.Arrays;
 
@@ -37,23 +39,19 @@ import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 
 public class AdhocQueryRequestDescriptionBuilder extends BaseEventDescriptionBuilder {
 
     private static final Log LOG = LogFactory.getLog(AdhocQueryRequestDescriptionBuilder.class);
-    private AdhocQueryRequest request;
+    private Optional<AdhocQueryRequest> request;
+    private Optional<AssertionType> assertion;
+    private AssertionDescriptionExtractor assertionExtractor;
 
-    public AdhocQueryRequestDescriptionBuilder(AdhocQueryRequest request) {
-        this.request = request;
-    }
-
-    /**
-     * Constructor for aspects. Response should be set via <code>setArguments</code>.
-     * 
-     * @see #setArguments(Object...)
-     */
     public AdhocQueryRequestDescriptionBuilder() {
+        request = Optional.absent();
+        assertion = Optional.absent();
     }
 
     @Override
@@ -74,8 +72,8 @@ public class AdhocQueryRequestDescriptionBuilder extends BaseEventDescriptionBui
 
     @Override
     public void buildPayloadTypes() {
-        if (request != null) {
-            setPayLoadTypes(ImmutableList.of(request.getClass().getSimpleName()));
+        if (request.isPresent()) {
+            setPayLoadTypes(ImmutableList.of(request.get().getClass().getSimpleName()));
         }
     }
 
@@ -87,14 +85,16 @@ public class AdhocQueryRequestDescriptionBuilder extends BaseEventDescriptionBui
 
     @Override
     public void buildNPI() {
-        // NPI not available in request
-
+        if (assertion.isPresent()) {
+            setNpi(assertionExtractor.getNPI(assertion.get()));
+        }
     }
 
     @Override
     public void buildInitiatingHCID() {
-        // initiating HCID not available in request
-
+        if (assertion.isPresent()) {
+            setInitiatingHCID(assertionExtractor.getInitiatingHCID(assertion.get()));
+        }
     }
 
     @Override
@@ -104,19 +104,37 @@ public class AdhocQueryRequestDescriptionBuilder extends BaseEventDescriptionBui
 
     @Override
     public void setArguments(Object... arguments) {
-        if (arguments.length != 1 || !(arguments[0] instanceof AdhocQueryRequest)) {
+        Optional<AdhocQueryRequest> request = extractRequest(arguments);
+        Optional<AssertionType> assertion = extractAssertion(arguments);
+        if (!request.isPresent()) {
             LOG.warn("Unexpected argument list: " + Arrays.toString(arguments));
         } else {
-            request = (AdhocQueryRequest) arguments[0];
+            this.request = request;
+            this.assertion = assertion;
+
         }
     }
 
-    /* (non-Javadoc)
-     * @see gov.hhs.fha.nhinc.event.BaseEventDescriptionBuilder#setReturnValue(java.lang.Object)
-     */
     @Override
     public void setReturnValue(Object returnValue) {
-        // TODO Auto-generated method stub
-        
+        // return value not dealt with by request builder
+    }
+
+    public void setAssertionExtractor(AssertionDescriptionExtractor assertionExtractor) {
+        this.assertionExtractor = assertionExtractor;
+    }
+
+    private Optional<AdhocQueryRequest> extractRequest(Object[] arguments) {
+        if (arguments != null && arguments.length > 0 && arguments[0] instanceof AdhocQueryRequest) {
+            return Optional.of((AdhocQueryRequest) arguments[0]);
+        }
+        return Optional.absent();
+    }
+
+    private Optional<AssertionType> extractAssertion(Object[] arguments) {
+        if (arguments != null && arguments.length > 1 && arguments[1] instanceof AssertionType) {
+            return Optional.of((AssertionType) arguments[1]);
+        }
+        return Optional.absent();
     }
 }

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryResponseDescriptionBuilder.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryResponseDescriptionBuilder.java
@@ -33,7 +33,6 @@ import gov.hhs.fha.nhinc.gateway.aggregator.document.DocumentConstants;
 import gov.hhs.fha.nhinc.util.JaxbDocumentUtils;
 import gov.hhs.fha.nhinc.util.NhincCollections;
 
-import java.util.Arrays;
 import java.util.List;
 
 import javax.xml.bind.JAXBElement;
@@ -136,6 +135,20 @@ public class AdhocQueryResponseDescriptionBuilder extends BaseEventDescriptionBu
         }
     }
 
+    @Override
+    public void setArguments(Object... arguments) {
+        // response builder ignores input arguments
+    }
+
+    @Override
+    public void setReturnValue(Object returnValue) {
+        if (returnValue == null || !(returnValue instanceof AdhocQueryResponse)) {
+            LOG.warn("Unexpected argument list: " + returnValue);
+        } else {
+            response = (AdhocQueryResponse) returnValue;
+        }
+    }
+
     private boolean hasStatus() {
         return response != null && response.getStatus() != null;
     }
@@ -222,25 +235,5 @@ public class AdhocQueryResponseDescriptionBuilder extends BaseEventDescriptionBu
             return JaxbDocumentUtils.findSlotType(extrinsicObjectType.getSlot(),
                     DocumentConstants.EBXML_RESPONSE_SIZE_SLOTNAME);
         }
-    }
-
-    @Override
-    public void setArguments(Object... arguments) {
-        if (arguments == null || arguments.length != 1 || !(arguments[0] instanceof AdhocQueryResponse)) {
-            LOG.warn("Unexpected argument list: " + Arrays.toString(arguments));
-        } else {
-            response = (AdhocQueryResponse) arguments[0];
-        }
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see gov.hhs.fha.nhinc.event.BaseEventDescriptionBuilder#setReturnValue(java.lang.Object)
-     */
-    @Override
-    public void setReturnValue(Object returnValue) {
-        // TODO Auto-generated method stub
-
     }
 }

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryResponseDescriptionBuilder.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryResponseDescriptionBuilder.java
@@ -143,7 +143,7 @@ public class AdhocQueryResponseDescriptionBuilder extends BaseEventDescriptionBu
     @Override
     public void setReturnValue(Object returnValue) {
         if (returnValue == null || !(returnValue instanceof AdhocQueryResponse)) {
-            LOG.warn("Unexpected argument list: " + returnValue);
+            LOG.warn("Unexpected return value: " + returnValue);
         } else {
             response = (AdhocQueryResponse) returnValue;
         }

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryResponseDescriptionBuilder.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryResponseDescriptionBuilder.java
@@ -226,19 +226,21 @@ public class AdhocQueryResponseDescriptionBuilder extends BaseEventDescriptionBu
 
     @Override
     public void setArguments(Object... arguments) {
-        if (arguments.length != 1 || !(arguments[0] instanceof AdhocQueryResponse)) {
+        if (arguments == null || arguments.length != 1 || !(arguments[0] instanceof AdhocQueryResponse)) {
             LOG.warn("Unexpected argument list: " + Arrays.toString(arguments));
         } else {
             response = (AdhocQueryResponse) arguments[0];
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see gov.hhs.fha.nhinc.event.BaseEventDescriptionBuilder#setReturnValue(java.lang.Object)
      */
     @Override
     public void setReturnValue(Object returnValue) {
         // TODO Auto-generated method stub
-        
+
     }
 }

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/nhin/NhinDocQueryOrchImpl.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/nhin/NhinDocQueryOrchImpl.java
@@ -26,12 +26,7 @@
  */
 package gov.hhs.fha.nhinc.docquery.nhin;
 
-import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
-import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryResponse;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
+import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AcknowledgementType;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommonadapter.RespondingGatewayCrossGatewayQueryRequestType;
@@ -39,13 +34,20 @@ import gov.hhs.fha.nhinc.docquery.DocQueryAuditLog;
 import gov.hhs.fha.nhinc.docquery.DocQueryPolicyChecker;
 import gov.hhs.fha.nhinc.docquery.adapter.proxy.AdapterDocQueryProxy;
 import gov.hhs.fha.nhinc.docquery.adapter.proxy.AdapterDocQueryProxyObjectFactory;
+import gov.hhs.fha.nhinc.docquery.aspect.AdhocQueryRequestDescriptionBuilder;
+import gov.hhs.fha.nhinc.docquery.aspect.AdhocQueryResponseDescriptionBuilder;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.properties.PropertyAccessException;
 import gov.hhs.fha.nhinc.properties.PropertyAccessor;
 import gov.hhs.fha.nhinc.util.HomeCommunityMap;
+import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
+import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryResponse;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
- *
+ * 
  * @author jhoppesc
  */
 public class NhinDocQueryOrchImpl {
@@ -61,11 +63,14 @@ public class NhinDocQueryOrchImpl {
     }
 
     /**
-     *
+     * 
      * @param body
      * @param assertion
      * @return <code>AdhocQueryResponse</code>
      */
+    @InboundProcessingEvent(beforeBuilder = AdhocQueryRequestDescriptionBuilder.class,
+            afterReturningBuilder = AdhocQueryResponseDescriptionBuilder.class, serviceType = "Document Query",
+            version = "")
     public AdhocQueryResponse respondingGatewayCrossGatewayQuery(AdhocQueryRequest msg, AssertionType assertion) {
         log.info("Begin - NhinDocQueryOrchImpl.respondingGatewayCrossGatewayQuery()");
 
@@ -107,10 +112,13 @@ public class NhinDocQueryOrchImpl {
 
     /**
      * Creates an audit log for an AdhocQueryRequest.
-     *
-     * @param crossGatewayDocQueryRequest AdhocQueryRequest message to log
-     * @param direction Indicates whether the message is going out or comming in
-     * @param _interface Indicates which interface component is being logged??
+     * 
+     * @param crossGatewayDocQueryRequest
+     *            AdhocQueryRequest message to log
+     * @param direction
+     *            Indicates whether the message is going out or comming in
+     * @param _interface
+     *            Indicates which interface component is being logged??
      * @return Returns an acknowledgement object indicating whether the audit was successfully completed.
      */
     private AcknowledgementType auditAdhocQueryRequest(RespondingGatewayCrossGatewayQueryRequestType msg,
@@ -124,10 +132,13 @@ public class NhinDocQueryOrchImpl {
 
     /**
      * Creates an audit log for an AdhocQueryResponse.
-     *
-     * @param crossGatewayDocQueryResponse AdhocQueryResponse message to log
-     * @param direction Indicates whether the message is going out or comming in
-     * @param _interface Indicates which interface component is being logged??
+     * 
+     * @param crossGatewayDocQueryResponse
+     *            AdhocQueryResponse message to log
+     * @param direction
+     *            Indicates whether the message is going out or comming in
+     * @param _interface
+     *            Indicates which interface component is being logged??
      * @param requestCommunityID
      * @return Returns an acknowledgement object indicating whether the audit was successfully completed.
      */
@@ -142,8 +153,9 @@ public class NhinDocQueryOrchImpl {
 
     /**
      * Checks to see if the security policy will permit the query to be executed.
-     *
-     * @param message The AdhocQuery request message.
+     * 
+     * @param message
+     *            The AdhocQuery request message.
      * @return Returns true if the security policy permits the query; false if denied.
      */
     private boolean checkPolicy(RespondingGatewayCrossGatewayQueryRequestType message) {
@@ -155,7 +167,7 @@ public class NhinDocQueryOrchImpl {
 
     /**
      * Checks to see if the query should be handled internally or passed through to an adapter.
-     *
+     * 
      * @return Returns true if the documentQueryPassthrough property of the gateway.properties file is true.
      */
     private boolean isInPassThroughMode() {
@@ -174,7 +186,7 @@ public class NhinDocQueryOrchImpl {
 
     /**
      * Forwards the AdhocQueryRequest to an agency's adapter doc query service
-     *
+     * 
      * @param adhocQueryRequestMsg
      * @param communityID
      * @return
@@ -205,7 +217,7 @@ public class NhinDocQueryOrchImpl {
 
     /**
      * Forwards the AdhocQueryRequest to this agency's adapter doc query service
-     *
+     * 
      * @param adhocQueryRequestMsg
      * @param requestCommunityID
      * @return

--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryRequestDescriptionBuilderTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryRequestDescriptionBuilderTest.java
@@ -29,6 +29,7 @@
 package gov.hhs.fha.nhinc.docquery.aspect;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -58,7 +59,6 @@ public class AdhocQueryRequestDescriptionBuilderTest extends BaseDescriptionBuil
         assertionExtractor = mock(AssertionDescriptionExtractor.class);
         when(assertionExtractor.getInitiatingHCID(assertion)).thenReturn("hcid");
         when(assertionExtractor.getNPI(assertion)).thenReturn("npi");
-        builder.setAssertionExtractor(assertionExtractor);
     }
 
     @Test
@@ -72,11 +72,18 @@ public class AdhocQueryRequestDescriptionBuilderTest extends BaseDescriptionBuil
 
     @Test
     public void withAssertion() {
+        builder.setAssertionExtractor(assertionExtractor);
         Object[] arguments = { request, assertion };
         builder.setArguments(arguments);
         EventDescription eventDescription = assertBasicBuild(builder);
         assertEquals("hcid", eventDescription.getInitiatingHCID());
         assertEquals("npi", eventDescription.getNPI());
+    }
+
+    @Test
+    public void defaultAssertionExtractorUponConstruction() {
+        AssertionDescriptionExtractor defaultExtractor = builder.getAssertionExtractor();
+        assertNotNull(defaultExtractor);
     }
 
     private EventDescription assertBasicBuild(AdhocQueryRequestDescriptionBuilder builder) {

--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryResponseDescriptionBuilderTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryResponseDescriptionBuilderTest.java
@@ -73,11 +73,10 @@ public class AdhocQueryResponseDescriptionBuilderTest extends BaseDescriptionBui
     }
 
     @Test
-    public void validArgumentTypes() {
+    public void validRespnoseTypes() {
         AdhocQueryResponseDescriptionBuilder builder = new AdhocQueryResponseDescriptionBuilder();
         AdhocQueryResponse response = getBasicResponse();
-        Object[] arguments = { response };
-        builder.setArguments(arguments);
+        builder.setReturnValue(response);
         assertBasicResponseBuilt(builder);
     }
 
@@ -85,7 +84,7 @@ public class AdhocQueryResponseDescriptionBuilderTest extends BaseDescriptionBui
     public void nullArguments() {
         AdhocQueryResponseDescriptionBuilder builder = new AdhocQueryResponseDescriptionBuilder();
         try {
-            builder.setArguments((Object[]) null);
+            builder.setReturnValue(null);
         } catch (NullPointerException npe) {
             fail("Should accept null gracefully");
         }

--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryResponseDescriptionBuilderTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/aspect/AdhocQueryResponseDescriptionBuilderTest.java
@@ -31,6 +31,7 @@ package gov.hhs.fha.nhinc.docquery.aspect;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import gov.hhs.fha.nhinc.event.BaseDescriptionBuilderTest;
 import gov.hhs.fha.nhinc.event.EventDescription;
@@ -78,6 +79,16 @@ public class AdhocQueryResponseDescriptionBuilderTest extends BaseDescriptionBui
         Object[] arguments = { response };
         builder.setArguments(arguments);
         assertBasicResponseBuilt(builder);
+    }
+
+    @Test
+    public void nullArguments() {
+        AdhocQueryResponseDescriptionBuilder builder = new AdhocQueryResponseDescriptionBuilder();
+        try {
+            builder.setArguments((Object[]) null);
+        } catch (NullPointerException npe) {
+            fail("Should accept null gracefully");
+        }
     }
 
     @Test

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxy.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxy.java
@@ -33,8 +33,10 @@ import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
 
 public interface AdapterDocSubmissionProxy {
-    
-    @AdapterDelegationEvent(serviceType="Document Submission", version="", descriptionBuilder=DefaultEventDescriptionBuilder.class)
+
+    @AdapterDelegationEvent(serviceType = "Document Submission", version = "",
+            beforeBuilder = DefaultEventDescriptionBuilder.class,
+            afterReturningBuilder = DefaultEventDescriptionBuilder.class)
     public RegistryResponseType provideAndRegisterDocumentSetB(ProvideAndRegisterDocumentSetRequestType msg,
             AssertionType assertion);
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/aspect/InboundProcessingEventDescriptionBuilder.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/aspect/InboundProcessingEventDescriptionBuilder.java
@@ -26,11 +26,11 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.aspect;
 
-import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
-import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.event.BaseEventDescriptionBuilder;
 import gov.hhs.fha.nhinc.event.builder.AssertionDescriptionExtractor;
+import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
+import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
 
 /**
  * @author akong

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/nhin/NhinDocSubmissionOrchImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/nhin/NhinDocSubmissionOrchImpl.java
@@ -64,7 +64,9 @@ public class NhinDocSubmissionOrchImpl {
         auditLogger = getXDRAuditLogger();
     }
 
-    @InboundProcessingEvent(serviceType = "Document Submission", version = "", descriptionBuilder = InboundProcessingEventDescriptionBuilder.class)
+    @InboundProcessingEvent(serviceType = "Document Submission", version = "",
+            beforeBuilder = InboundProcessingEventDescriptionBuilder.class,
+            afterReturningBuilder = InboundProcessingEventDescriptionBuilder.class)
     public RegistryResponseType documentRepositoryProvideAndRegisterDocumentSetB(
             ProvideAndRegisterDocumentSetRequestType body, AssertionType assertion) {
         RegistryResponseType response = null;


### PR DESCRIPTION
The @Before and @AfterFinishing invocations may require completely different builders.  Mine do for DQ, for instance.  This adds a new field to the annotation to allow that separation.
