### PR TITLE
Gateway 3050 ii

### DIFF
--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectClient.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectClient.java
@@ -32,6 +32,7 @@ import javax.mail.Address;
 import javax.mail.internet.MimeMessage;
 
 import org.nhindirect.gateway.smtp.MessageProcessResult;
+import org.nhindirect.gateway.smtp.SmtpAgent;
 
 /**
  * Interface defining a Mail Client.
@@ -72,5 +73,11 @@ public interface DirectClient {
      * @return number of messages handled.
      */
     int handleMessages(MessageHandler handler);
+    
+    /**
+     * Make the smtp agent on this direct cliet available to the caller.
+     * @return SmtpAgent property of this client.
+     */
+    SmtpAgent getSmtpAgent();
 
 }

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectClientUtils.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectClientUtils.java
@@ -54,6 +54,10 @@ public class DirectClientUtils {
         addRecipients(recipients, message, RecipientType.CC, AddressSource.CC);
         addRecipients(recipients, message, RecipientType.BCC, AddressSource.BCC);
         
+        if (recipients.isEmpty()) {
+            throw new DirectException("No recipients found in message.");
+        }
+        
         return recipients;
     }
 
@@ -87,7 +91,12 @@ public class DirectClientUtils {
     private static void addRecipients(NHINDAddressCollection recipients, MimeMessage message, RecipientType type,
             AddressSource source) throws MessagingException {
 
-        for (Address address : message.getRecipients(type)) {
+        Address[] addresses = message.getRecipients(type);
+        if (addresses == null) {
+            return;
+        }
+        
+        for (Address address : addresses) {
             recipients.add(new NHINDAddress(address.toString(), source));
         }
     }

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectClientUtils.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectClientUtils.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2012, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.direct;
+
+import javax.mail.Address;
+import javax.mail.MessagingException;
+import javax.mail.Message.RecipientType;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+import org.nhindirect.stagent.AddressSource;
+import org.nhindirect.stagent.NHINDAddress;
+import org.nhindirect.stagent.NHINDAddressCollection;
+
+/**
+ * Helper class to provide shared utility methods for interacting with the direct code.
+ */
+public class DirectClientUtils {
+
+    /**
+     * Extract the NHINDAddressCollection from the mime headers of the message.
+     * @param message mime message
+     * @return NHINDAddressCollection - collection of NHIND Addresses
+     * @throws MessagingException if there was an exception
+     */
+    protected static NHINDAddressCollection getNhindRecipients(MimeMessage message) throws MessagingException {
+
+        NHINDAddressCollection recipients = new NHINDAddressCollection();
+        addRecipients(recipients, message, RecipientType.TO, AddressSource.To);
+        addRecipients(recipients, message, RecipientType.CC, AddressSource.CC);
+        addRecipients(recipients, message, RecipientType.BCC, AddressSource.BCC);
+        
+        return recipients;
+    }
+
+    /**
+     * Extract the NHINDAddress sender from the mime headers of the message.
+     * @param message mime message
+     * @return NHINDAddress for the sender
+     * @throws MessagingException if there was an error
+     */
+    protected static NHINDAddress getNhindSender(MimeMessage message) throws MessagingException {
+        return new NHINDAddress(new InternetAddress(getSender(message).toString()), AddressSource.From);
+    }
+    
+    /**
+     * Extract the Address for the sender from the mime headers of the message. Ensures that one and only one Sender
+     * is extracted.
+     * @param message mime message
+     * @return Address for the sender
+     * @throws MessagingException if there was an error
+     */
+    protected static Address getSender(MimeMessage message) throws MessagingException {
+        Address[] fromAddresses = message.getFrom();
+        if (fromAddresses.length != 1) {
+            throw new DirectException("Expected one from address, but encountered: " + fromAddresses.length);
+        }
+        
+        return fromAddresses[0];
+    }
+    
+    
+    private static void addRecipients(NHINDAddressCollection recipients, MimeMessage message, RecipientType type,
+            AddressSource source) throws MessagingException {
+
+        for (Address address : message.getRecipients(type)) {
+            recipients.add(new NHINDAddress(address.toString(), source));
+        }
+    }
+}

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectMailClient.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectMailClient.java
@@ -46,9 +46,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.nhindirect.gateway.smtp.MessageProcessResult;
 import org.nhindirect.gateway.smtp.SmtpAgent;
-import org.nhindirect.stagent.AddressSource;
-import org.nhindirect.stagent.NHINDAddress;
-import org.nhindirect.stagent.NHINDAddressCollection;
 import org.nhindirect.stagent.mail.notifications.NotificationMessage;
 
 /**
@@ -89,15 +86,15 @@ public class DirectMailClient implements DirectClient {
         MimeMessage mimeMessage = new MimeMessageBuilder(session, sender, recipients).subject(MSG_SUBJECT)
                 .text(MSG_TEXT).attachment(attachment).attachmentName(attachmentName).build();
 
-        send(sender, recipients, mimeMessage, session);
+        send(mimeMessage, session);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public void send(Address sender, Address[] recipients, MimeMessage message) {
-        send(sender, recipients, message, getMailSession());
+    public void send(MimeMessage message) {
+        send(message, getMailSession());
     }
 
     /**
@@ -193,19 +190,27 @@ public class DirectMailClient implements DirectClient {
         MailUtils.closeQuietly(store, inbox, MailUtils.FOLDER_EXPUNGE_INBOX_TRUE);
         return numberOfHandledMsgs;
     }
+    
+    /**
+     * @return the smtpAgent direct smtp agent.
+     */
+    public SmtpAgent getSmtpAgent() {
+        return smtpAgent;
+    }
+
 
     private Session getMailSession() {
         return MailUtils.getMailSession(mailServerProps, mailServerProps.getProperty("direct.mail.user"),
                 mailServerProps.getProperty("direct.mail.pass"));
     }
 
-    private void send(Address sender, Address[] recipients, MimeMessage mimeMessage, Session session) {
-        MessageProcessResult result = processAsDirectMessage(sender, recipients, mimeMessage);
+    private void send(MimeMessage mimeMessage, Session session) {
+        MessageProcessResult result = processAsDirectMessage(mimeMessage);
         if (null == result || null == result.getProcessedMessage()) {
             throw new DirectException("Message processed by Direct is null.");
         }
         try {
-            sendDirectProcessedMessage(recipients, session, result);
+            sendDirectProcessedMessage(mimeMessage.getAllRecipients(), session, result);
         } catch (MessagingException e) {
             throw new DirectException("Could not send message.", e);
         }
@@ -224,15 +229,13 @@ public class DirectMailClient implements DirectClient {
         }
     }
 
-    private MessageProcessResult processAsDirectMessage(Address sender, Address[] recipients, MimeMessage mimeMessage) {
-
-        NHINDAddressCollection recipientsCollection = new NHINDAddressCollection();
-        for (Address recipient : recipients) {
-            recipientsCollection.add(new NHINDAddress(recipient.toString(), (AddressSource) null));
+    private MessageProcessResult processAsDirectMessage(MimeMessage mimeMessage) {
+        try {
+            return smtpAgent.processMessage(mimeMessage, DirectClientUtils.getNhindRecipients(mimeMessage),
+                    DirectClientUtils.getNhindSender(mimeMessage));
+        } catch (MessagingException e) {
+            throw new DirectException("Error occurred while extracting addresses.", e);
         }
-
-        NHINDAddress senderNhindAddress = new NHINDAddress(sender.toString(), AddressSource.From);
-        return smtpAgent.processMessage(mimeMessage, recipientsCollection, senderNhindAddress);
     }
 
     /**
@@ -249,10 +252,4 @@ public class DirectMailClient implements DirectClient {
         return numberOfMsgsInFolder < maxNumberOfMsgsToHandle ? numberOfMsgsInFolder : maxNumberOfMsgsToHandle;
     }
 
-    /**
-     * @return the smtpAgent direct smtp agent.
-     */
-    public SmtpAgent getSmtpAgent() {
-        return smtpAgent;
-    }
 }

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectMailClient.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectMailClient.java
@@ -179,7 +179,7 @@ public class DirectMailClient implements DirectClient {
         for (Message message : messages) {
             try {
                 if ((message instanceof MimeMessage)) {
-                    handler.handleMessage((MimeMessage) message);
+                    handler.handleMessage((MimeMessage) message, this);
                     numberOfHandledMsgs++;
                 }
                 message.setFlag(Flags.Flag.DELETED, true);
@@ -249,4 +249,10 @@ public class DirectMailClient implements DirectClient {
         return numberOfMsgsInFolder < maxNumberOfMsgsToHandle ? numberOfMsgsInFolder : maxNumberOfMsgsToHandle;
     }
 
+    /**
+     * @return the smtpAgent direct smtp agent.
+     */
+    public SmtpAgent getSmtpAgent() {
+        return smtpAgent;
+    }
 }

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/InboundMessageHandler.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/InboundMessageHandler.java
@@ -84,11 +84,11 @@ public class InboundMessageHandler implements MessageHandler {
         if (processedMessage == null) {
             logNotfications(result);
             return;
+        } else {
+            // use the internal direct client to resend the derypted message.
+            // TODO - this needs to be a decision point - how do we handle the DIRECT message once it's been decrypted?
+            internalDirectClient.send(message);
         }
-        
-        // use the internal direct client to resend the derypted message.
-        // TODO - this needs to be a decision point - how do we handle the DIRECT message once it's been decrypted?
-        internalDirectClient.send(origSender, (NHINDAddress[]) origRecipients.toArray(), message);        
     }
     
     
@@ -100,6 +100,7 @@ public class InboundMessageHandler implements MessageHandler {
             } catch (Exception e) {
                 LOG.warn("Exception while logging notification messages.", e);
             }
-        }        
+        }
+        LOG.warn(builder.toString());
     }
 }

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/InboundMessageHandler.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/InboundMessageHandler.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2012, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.direct;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.nhindirect.gateway.smtp.MessageProcessResult;
+import org.nhindirect.stagent.MessageEnvelope;
+import org.nhindirect.stagent.NHINDAddress;
+import org.nhindirect.stagent.NHINDAddressCollection;
+import org.nhindirect.stagent.mail.notifications.NotificationMessage;
+
+/**
+ * Handles inbound messages from an external mail client. Inbound messages are un-directified and either
+ * - sent to a recipient on an internal mail client
+ *      - SMTP+Mime
+ *      - SMTP+XDM
+ * - process XDM as XDR
+ * - SOAP+XDR       
+ */
+public class InboundMessageHandler implements MessageHandler {
+
+    private static final Log LOG = LogFactory.getLog(InboundMessageHandler.class);
+    
+    private final DirectClient internalDirectClient;
+    
+    /**
+     * Constructor.
+     * @param intDirectMailClient internal direct mail client for sending messages after they have been decyrypted.
+     */
+    public InboundMessageHandler(DirectClient internalDirectClient) {
+        super();
+        this.internalDirectClient = internalDirectClient;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void handleMessage(MimeMessage message, DirectClient externalDirectClient) {
+
+        MessageProcessResult result = null;
+        NHINDAddress origSender = null;
+        NHINDAddressCollection origRecipients = null;
+        
+        try {
+            origSender = DirectClientUtils.getNhindSender(message);
+            origRecipients = DirectClientUtils.getNhindRecipients(message);
+            result = externalDirectClient.getSmtpAgent().processMessage(message, origRecipients, origSender);
+        } catch (MessagingException e) {
+            throw new DirectException("Error processing message.", e);
+        }
+        
+        externalDirectClient.sendMdn(origSender, result);
+        
+        MessageEnvelope processedMessage = result.getProcessedMessage();
+        if (processedMessage == null) {
+            logNotfications(result);
+            return;
+        }
+        
+        // use the internal direct client to resend the derypted message.
+        // TODO - this needs to be a decision point - how do we handle the DIRECT message once it's been decrypted?
+        internalDirectClient.send(origSender, (NHINDAddress[]) origRecipients.toArray(), message);        
+    }
+    
+    
+    private void logNotfications(MessageProcessResult result) {
+        StringBuilder builder = new StringBuilder("Inbound Mime Message could not be processed by DIRECT.");
+        for (NotificationMessage notif : result.getNotificationMessages()) {
+            try {
+                builder.append(" " + notif.getContent());
+            } catch (Exception e) {
+                LOG.warn("Exception while logging notification messages.", e);
+            }
+        }        
+    }
+}

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/MailUtils.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/MailUtils.java
@@ -42,7 +42,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class MailUtils {
 
-    private static final Log log = LogFactory.getLog(MailUtils.class);
+    private static final Log LOG = LogFactory.getLog(MailUtils.class);
 
     /**
      * Folder Name for "Inbox".
@@ -69,7 +69,7 @@ public class MailUtils {
             try {
                 folder.close(expunge);
             } catch (Exception e) {
-                log.warn("Exception while closing java mail folder, expunge = " + expunge + ".", e);
+                LOG.warn("Exception while closing java mail folder, expunge = " + expunge + ".", e);
             }
         }
         closeQuietly(store);
@@ -85,7 +85,7 @@ public class MailUtils {
             try {
                 store.close();
             } catch (Exception e) {
-                log.warn("Exception while closing java mail store.", e);
+                LOG.warn("Exception while closing java mail store.", e);
             }
         }
     }

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/MessageHandler.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/MessageHandler.java
@@ -36,7 +36,8 @@ public interface MessageHandler {
     /**
      * Handle a message retrieved from the mail server.
      * @param message to be handled.
+     * @param directClient CONNECT-DIRECT client used to send and receive messages.
      */
-    void handleMessage(MimeMessage message);
+    void handleMessage(MimeMessage message, DirectClient directClient);
     
 }

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/OutboundMessageHandler.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/OutboundMessageHandler.java
@@ -26,7 +26,6 @@
  */
 package gov.hhs.fha.nhinc.direct;
 
-import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
 /**
@@ -50,11 +49,7 @@ public class OutboundMessageHandler implements MessageHandler {
      */
     @Override
     public void handleMessage(MimeMessage message, DirectClient directClient) {
-        try {
-            externalDirectClient.send(DirectClientUtils.getSender(message), message.getAllRecipients(), message);
-        } catch (MessagingException e) {
-            throw new DirectException("Could not convert and send RFC5322 MIME message as DIRECT message.", e);
-        }
+        externalDirectClient.send(message);
     }
     
 }

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/OutboundMessageHandler.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/OutboundMessageHandler.java
@@ -35,26 +35,26 @@ import javax.mail.internet.MimeMessage;
  */
 public class OutboundMessageHandler implements MessageHandler {
 
-    private final DirectMailClient extDirectMailClient;
+    private final DirectClient externalDirectClient;
     
     /**
      * Constructor.
      * @param extDirectMailClient external direct mail client for sending messages after they have been "directified".
      */
-    public OutboundMessageHandler(DirectMailClient extDirectMailClient) {
-        this.extDirectMailClient = extDirectMailClient;
+    public OutboundMessageHandler(DirectClient externalDirectClient) {
+        this.externalDirectClient = externalDirectClient;
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public void handleMessage(MimeMessage message) {
+    public void handleMessage(MimeMessage message, DirectClient directClient) {
         try {
-            extDirectMailClient.send(message.getFrom()[0], message.getAllRecipients(), message);
+            externalDirectClient.send(DirectClientUtils.getSender(message), message.getAllRecipients(), message);
         } catch (MessagingException e) {
             throw new DirectException("Could not convert and send RFC5322 MIME message as DIRECT message.", e);
         }
     }
-
+    
 }

--- a/Product/Production/Services/DirectCore/src/test/java/gov/hhs/fha/nhinc/direct/DirectClientUtilsTest.java
+++ b/Product/Production/Services/DirectCore/src/test/java/gov/hhs/fha/nhinc/direct/DirectClientUtilsTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2012, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.direct;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.mail.Address;
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMessage.RecipientType;
+
+import org.junit.Test;
+
+/**
+ * Test {@link DirectClientUtils}.
+ */
+public class DirectClientUtilsTest {
+
+    private static final Address[] EMPTY_ADDRESS_ARRAY = new Address[] {};
+    private final MimeMessage mockMessage = mock(MimeMessage.class);
+    
+    
+    /**
+     * Test {@link DirectClientUtils#getSender(MimeMessage)} 
+     * Method should throw DirectException if multiple senders are present.
+     * @throws MessagingException
+     */
+    @Test(expected = DirectException.class)
+    public void willThrowDirectExceptionWhenMultipleFromsPresent() throws MessagingException {
+        when(mockMessage.getFrom()).thenReturn(new Address[] {
+                new InternetAddress("test@test1.com"), new InternetAddress("test@test2.com")});        
+        DirectClientUtils.getSender(mockMessage);
+    }
+
+    /**
+     * Test {@link DirectClientUtils#getSender(MimeMessage)} 
+     * Method should throw DirectException if zero senders are present.
+     * @throws MessagingException
+     */
+    @Test(expected = DirectException.class)
+    public void willThrowDirectExceptionWhenNoFromsPresent() throws MessagingException {
+        when(mockMessage.getFrom()).thenReturn(EMPTY_ADDRESS_ARRAY);        
+        DirectClientUtils.getSender(mockMessage);
+    }
+
+    /**
+     * Test {@link DirectClientUtils#getNhindRecipients(MimeMessage)}
+     * @throws MessagingException
+     */
+    @Test
+    public void canGetNhindRecipients() throws MessagingException {
+
+        when(mockMessage.getRecipients(RecipientType.TO)).thenReturn(
+                new Address[] { new InternetAddress("test@test1.com") });
+        when(mockMessage.getRecipients(RecipientType.CC)).thenReturn(EMPTY_ADDRESS_ARRAY);
+        when(mockMessage.getRecipients(RecipientType.BCC)).thenReturn(EMPTY_ADDRESS_ARRAY);
+
+        assertNotNull(DirectClientUtils.getNhindRecipients(mockMessage));
+    }
+    
+    /**
+     * Test {@link DirectClientUtils#getNhindRecipients(MimeMessage)}
+     * @throws MessagingException
+     */
+    @Test(expected = DirectException.class)
+    public void willThrowDirectExceptionWhenNoRecipientsPresent() throws MessagingException {
+
+        when(mockMessage.getRecipients(RecipientType.TO)).thenReturn(EMPTY_ADDRESS_ARRAY);
+        when(mockMessage.getRecipients(RecipientType.CC)).thenReturn(EMPTY_ADDRESS_ARRAY);
+        when(mockMessage.getRecipients(RecipientType.BCC)).thenReturn(EMPTY_ADDRESS_ARRAY);
+
+        assertNotNull(DirectClientUtils.getNhindRecipients(mockMessage));
+    }
+
+}

--- a/Product/Production/Services/DirectCore/src/test/java/gov/hhs/fha/nhinc/direct/DirectMailClientTest.java
+++ b/Product/Production/Services/DirectCore/src/test/java/gov/hhs/fha/nhinc/direct/DirectMailClientTest.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -149,7 +150,8 @@ public class DirectMailClientTest {
         MessageHandler mockMessageHandler = mock(MessageHandler.class);
         assertEquals(NUM_MSGS_ONE_BATCH, testDirectMailClient.handleMessages(mockMessageHandler));
 
-        verify(mockMessageHandler, times(NUM_MSGS_ONE_BATCH)).handleMessage(any(Message.class));
+        verify(mockMessageHandler, times(NUM_MSGS_ONE_BATCH)).handleMessage(any(Message.class), 
+                eq(testDirectMailClient));
     }
 
     /**
@@ -188,7 +190,8 @@ public class DirectMailClientTest {
             int numberOfMsgsHandledInBatch = testDirectMailClient.handleMessages(mockMessageHandler);
             numberOfMsgsHandled += numberOfMsgsHandledInBatch;
             assertTrue(numberOfMsgsHandledInBatch <= DirectUnitTestUtil.MAX_NUM_MSGS_IN_BATCH);
-            verify(mockMessageHandler, times(numberOfMsgsHandled)).handleMessage(any(Message.class));
+            verify(mockMessageHandler, times(numberOfMsgsHandled)).handleMessage(any(Message.class), 
+                    eq(testDirectMailClient));
 
             // there is a greenmail bug that only expunges every other message... delete read messages
             DirectUnitTestUtil.expungeMissedMessages(greenMail, user);
@@ -208,7 +211,7 @@ public class DirectMailClientTest {
         MessageHandler testOutBoundMessageHandler = new OutboundMessageHandler(mockExternalDirectMailClient);
 
         MimeMessage mimeMessage = getSampleMimeMessage();
-        testOutBoundMessageHandler.handleMessage(mimeMessage);
+        testOutBoundMessageHandler.handleMessage(mimeMessage, testDirectMailClient);
 
         verify(mockExternalDirectMailClient).send(getSender(), getRecipients(), mimeMessage);
     }

--- a/Product/Production/Services/DirectCore/src/test/java/gov/hhs/fha/nhinc/direct/DirectMailClientTest.java
+++ b/Product/Production/Services/DirectCore/src/test/java/gov/hhs/fha/nhinc/direct/DirectMailClientTest.java
@@ -26,8 +26,6 @@
  */
 package gov.hhs.fha.nhinc.direct;
 
-import static gov.hhs.fha.nhinc.direct.DirectUnitTestUtil.PASS;
-import static gov.hhs.fha.nhinc.direct.DirectUnitTestUtil.USER;
 import static gov.hhs.fha.nhinc.direct.DirectUnitTestUtil.getMailServerProps;
 import static gov.hhs.fha.nhinc.direct.DirectUnitTestUtil.getMockDocument;
 import static gov.hhs.fha.nhinc.direct.DirectUnitTestUtil.getRecipients;
@@ -35,7 +33,6 @@ import static gov.hhs.fha.nhinc.direct.DirectUnitTestUtil.getSender;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -49,7 +46,6 @@ import java.util.Collection;
 import java.util.Properties;
 
 import javax.mail.MessagingException;
-import javax.mail.Session;
 import javax.mail.internet.MimeMessage;
 
 import org.junit.After;
@@ -78,7 +74,7 @@ public class DirectMailClientTest {
 
     private static final String ATTACHMENT_NAME = "mymockattachment";
 
-    private Properties mailServerProps;
+    protected Properties mailServerProps;
     private SmtpAgent mockSmtpAgent;
     private DirectMailClient testDirectMailClient;
 
@@ -136,8 +132,7 @@ public class DirectMailClientTest {
     @Test
     public void canSendAndReceiveInOneBatch() throws IOException {
         MessageProcessResult mockMessageProcessResult = getMockMessageProcessResult();
-        when(
-                mockSmtpAgent.processMessage(any(MimeMessage.class), any(NHINDAddressCollection.class),
+        when(mockSmtpAgent.processMessage(any(MimeMessage.class), any(NHINDAddressCollection.class),
                         any(NHINDAddress.class))).thenReturn(mockMessageProcessResult);
 
         for (int i = 0; i < NUM_MSGS_ONE_BATCH; i++) {
@@ -163,8 +158,7 @@ public class DirectMailClientTest {
     @Test
     public void canSendAndReceiveMultipleMsgsInBatches() throws IOException {
         MessageProcessResult mockMessageProcessResult = getMockMessageProcessResult();
-        when(
-                mockSmtpAgent.processMessage(any(MimeMessage.class), any(NHINDAddressCollection.class),
+        when(mockSmtpAgent.processMessage(any(MimeMessage.class), any(NHINDAddressCollection.class),
                         any(NHINDAddress.class))).thenReturn(mockMessageProcessResult);
 
         // blast out all of the messages at once...
@@ -202,20 +196,6 @@ public class DirectMailClientTest {
         assertEquals("No messages should be left on the server", 0, greenMail.getReceivedMessages().length);
     }
 
-    /**
-     * Verify that the Outbound Message Handler will use the external direct mail client to directify the message.
-     */
-    @Test
-    public void canHandleOutboundMsg() {
-        DirectMailClient mockExternalDirectMailClient = mock(DirectMailClient.class);
-        MessageHandler testOutBoundMessageHandler = new OutboundMessageHandler(mockExternalDirectMailClient);
-
-        MimeMessage mimeMessage = getSampleMimeMessage();
-        testOutBoundMessageHandler.handleMessage(mimeMessage, testDirectMailClient);
-
-        verify(mockExternalDirectMailClient).send(getSender(), getRecipients(), mimeMessage);
-    }
-
     @Test
     public void canSendSingleMDNMessage() throws MessagingException {
         MessageProcessResult mockMessageProcessResult = getMockMessageProcessResult();
@@ -229,20 +209,6 @@ public class DirectMailClientTest {
         MessageProcessResult mockMessageProcessResult = getMockMessageProcessResult(numMdnMessages);
         testDirectMailClient.sendMdn(getSender(), mockMessageProcessResult);
         assertEquals(numMdnMessages, greenMail.getReceivedMessages().length);
-    }
-
-    /**
-     * @return mime message with sample generic content.
-     */
-    private MimeMessage getSampleMimeMessage() {
-        MimeMessage mimeMessage = null;
-        try {
-            Session session = MailUtils.getMailSession(mailServerProps, USER, PASS);
-            mimeMessage = DirectUnitTestUtil.getMimeMessageBuilder(session).build();
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-        return mimeMessage;
     }
 
     private MessageProcessResult getMockMessageProcessResult() {

--- a/Product/Production/Services/DirectCore/src/test/java/gov/hhs/fha/nhinc/direct/DirectUnitTestUtil.java
+++ b/Product/Production/Services/DirectCore/src/test/java/gov/hhs/fha/nhinc/direct/DirectUnitTestUtil.java
@@ -16,6 +16,7 @@ import javax.mail.MessagingException;
 import javax.mail.Session;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
 
 import org.apache.commons.io.IOUtils;
 
@@ -75,6 +76,8 @@ public class DirectUnitTestUtil {
      * Max number of messages to process at once, allows us to throttle and distribute load.
      */
     protected static final int MAX_NUM_MSGS_IN_BATCH = 5;
+
+    private static final int DUMMY_PORT = 998;
 
     /**
      * Sets up the properties in order to connect to the green mail test server.
@@ -170,6 +173,21 @@ public class DirectUnitTestUtil {
         return new InternetAddress[] {toInternetAddress(RECIPIENT)};
     }
     
+    /**
+     * @return mime message with sample generic content.
+     */
+    public static MimeMessage getSampleMimeMessage() {
+        MimeMessage mimeMessage = null;
+        try {
+            Session session = MailUtils.getMailSession(getMailServerProps(DUMMY_PORT, DUMMY_PORT), USER, PASS);
+            mimeMessage = getMimeMessageBuilder(session).build();
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+        return mimeMessage;
+    }
+
+
     /**
      * Return a stubbed out mime message builder.
      * @param session mail session

--- a/Product/Production/Services/DirectCore/src/test/java/gov/hhs/fha/nhinc/direct/InboundMessageHandlerTest.java
+++ b/Product/Production/Services/DirectCore/src/test/java/gov/hhs/fha/nhinc/direct/InboundMessageHandlerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2012, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.direct;
+
+import static gov.hhs.fha.nhinc.direct.DirectUnitTestUtil.getSampleMimeMessage;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.mail.Address;
+import javax.mail.internet.MimeMessage;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.nhindirect.gateway.smtp.MessageProcessResult;
+import org.nhindirect.gateway.smtp.SmtpAgent;
+import org.nhindirect.stagent.MessageEnvelope;
+import org.nhindirect.stagent.NHINDAddress;
+import org.nhindirect.stagent.NHINDAddressCollection;
+
+/**
+ * Test {@link InboundMessageHandler}.
+ */
+public class InboundMessageHandlerTest {
+
+    private final SmtpAgent mockSmtpAgent = mock(SmtpAgent.class);
+    private final DirectMailClient mockExternalDirectMailClient = mock(DirectMailClient.class);
+    private final DirectMailClient mockInternalDirectMailClient = mock(DirectMailClient.class);
+    private final MessageProcessResult mockResult = mock(MessageProcessResult.class);
+    private final MessageEnvelope mockProcessedMessage = mock(MessageEnvelope.class);
+
+    private final MessageHandler testInBoundMessageHandler = new InboundMessageHandler(mockInternalDirectMailClient);
+
+    /**
+     * Set up before each test.
+     */
+    @Before
+    public void setUp() {
+        when(mockSmtpAgent.processMessage(any(MimeMessage.class), any(NHINDAddressCollection.class),
+                any(NHINDAddress.class))).thenReturn(mockResult);
+        when(mockResult.getProcessedMessage()).thenReturn(mockProcessedMessage);
+        when(mockExternalDirectMailClient.getSmtpAgent()).thenReturn(mockSmtpAgent);
+    }
+    
+    /**
+     * Test {@link InboundMessageHandler#handleMessage(MimeMessage, DirectClient)}
+     * Verify that an inbound message is handled and passed to the internal smtp mail server.
+     */
+    @Test
+    public void canHandleInboundMessage() {
+                
+        testInBoundMessageHandler.handleMessage(getSampleMimeMessage(), mockExternalDirectMailClient);
+
+        // verify the smtp agent is used to process the message.
+        verify(mockSmtpAgent).processMessage(any(MimeMessage.class), any(NHINDAddressCollection.class),
+                any(NHINDAddress.class));
+
+        // verify that the external direct mail client is used to send the MDN notification emails.
+        verify(mockExternalDirectMailClient).sendMdn(any(Address.class), eq(mockResult));
+        
+        // verify that the internal direct mail client is used to resend the message
+        verify(mockInternalDirectMailClient).send(any(MimeMessage.class));
+    }
+    
+    /**
+     * Test {@link InboundMessageHandler#handleMessage(MimeMessage, DirectClient)}
+     * Verify that the notification messages are logged if the processed message is null. 
+     */
+    @Test
+    public void willLogNotificationsWhenProcessedMessageIsNull() {
+
+        when(mockResult.getProcessedMessage()).thenReturn(null);
+
+        testInBoundMessageHandler.handleMessage(getSampleMimeMessage(), mockExternalDirectMailClient);
+
+        // verify the smtp agent is used to process the message.
+        verify(mockSmtpAgent).processMessage(any(MimeMessage.class), any(NHINDAddressCollection.class),
+                any(NHINDAddress.class));
+
+        // verify that the external direct mail client is used to send the MDN notification emails.
+        verify(mockExternalDirectMailClient).sendMdn(any(Address.class), eq(mockResult));
+
+        // verify that the internal direct mail client is not used to resend the message
+        verify(mockInternalDirectMailClient, times(0)).send(any(MimeMessage.class));
+
+    }
+    
+}

--- a/Product/Production/Services/DirectCore/src/test/java/gov/hhs/fha/nhinc/direct/OutboundMessageHandlerTest.java
+++ b/Product/Production/Services/DirectCore/src/test/java/gov/hhs/fha/nhinc/direct/OutboundMessageHandlerTest.java
@@ -26,55 +26,32 @@
  */
 package gov.hhs.fha.nhinc.direct;
 
-import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType.Document;
+import static gov.hhs.fha.nhinc.direct.DirectUnitTestUtil.getSampleMimeMessage;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-import javax.mail.Address;
 import javax.mail.internet.MimeMessage;
 
-import org.nhindirect.gateway.smtp.MessageProcessResult;
-import org.nhindirect.gateway.smtp.SmtpAgent;
+import org.junit.Test;
 
 /**
- * Interface defining a Mail Client.
+ * Test {@link OutboundMessageHandler}.
  */
-public interface DirectClient {
-
-    /**
-     * Use the mail server to send a DIRECT message.
-     *
-     * @param sender of the message
-     * @param recipients of the message
-     * @param attachment for the message
-     * @param attachmentName for the attachment
-     */
-    void send(Address sender, Address[] recipients, Document attachment, String attachmentName);
-
-    /**
-     * Use the mail server to send a DIRECT message. When you already have a mail message and you want to send it
-     * as a DIRECT message. Sender and recipients are extracted from the mime message.
-     *
-     * @param message (mime) to be sent using the direct
-     */
-    void send(MimeMessage message);
-
-    /**
-     * Use the mail server to send MDN messages if result contains notification messages.
-     *
-     * @param recipient of the message (should match the sender of the message which was processed)
-     * @param result to be processed for MDN Messages.
-     */
-    void sendMdn(Address recipient, MessageProcessResult result);
-
-    /**
-     * @param handler used to handle messages pulled from the mail server.
-     * @return number of messages handled.
-     */
-    int handleMessages(MessageHandler handler);
+public class OutboundMessageHandlerTest {
     
     /**
-     * Make the smtp agent on this direct cliet available to the caller.
-     * @return SmtpAgent property of this client.
+     * Verify that the Outbound Message Handler will use the external direct mail client to directify the message.
+     * The internal direct mail client passed in will be ignored.
      */
-    SmtpAgent getSmtpAgent();
+    @Test
+    public void canHandleOutboundMsg() {
+        DirectMailClient mockExternalDirectMailClient = mock(DirectMailClient.class);
+        MessageHandler testOutBoundMessageHandler = new OutboundMessageHandler(mockExternalDirectMailClient);
 
+        MimeMessage mimeMessage = getSampleMimeMessage();
+        testOutBoundMessageHandler.handleMessage(mimeMessage, mock(DirectMailClient.class));
+
+        verify(mockExternalDirectMailClient).send(mimeMessage);
+    }
+    
 }


### PR DESCRIPTION
Adds code for inbound message handling - decrypting the message, sending an MDN and then doing something with the decrypted message.  Currently the code uses the internal direct mail client to pass the message to the internal mail server to it's target recipient.  The following other use cases still need to be implemented based on configuration + logic:
- process XDM as XDR
- SOAP+XDR  
