### PR TITLE
GW-3264 Fixed Event Logging on AdminDist for Empty Content Object

### DIFF
--- a/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/aspect/EDXLDistributionPayloadSizeExtractor.java
+++ b/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/aspect/EDXLDistributionPayloadSizeExtractor.java
@@ -31,6 +31,8 @@ import java.util.List;
 
 import oasis.names.tc.emergency.edxl.de._1.ContentObjectType;
 import oasis.names.tc.emergency.edxl.de._1.EDXLDistribution;
+import oasis.names.tc.emergency.edxl.de._1.NonXMLContentType;
+import oasis.names.tc.emergency.edxl.de._1.XmlContentType;
 
 /**
  * @author zmelnick
@@ -49,8 +51,10 @@ public class EDXLDistributionPayloadSizeExtractor {
         List<String> payloadSize = new ArrayList<String>();
         if (alertMessage != null) {
             List<ContentObjectType> contents = alertMessage.getContentObject();
-            for (ContentObjectType message : contents) {
-                payloadSize.add(getPayloadSize(message));
+            if(!contents.isEmpty()){
+            	for (ContentObjectType message : contents) {
+            		payloadSize.add(getPayloadSize(message));
+            	}
             }
         }
         return payloadSize;
@@ -65,8 +69,24 @@ public class EDXLDistributionPayloadSizeExtractor {
     }
 
     private boolean isPayloadSizeEmpty(ContentObjectType message) {
-        return message.getXmlContent() != null
-                || (message.getNonXMLContent() != null && message.getNonXMLContent().getSize() == null);
+    	return isNonContentXMLEmpty(message.getNonXMLContent()) ||
+    			isContentXMLEmpty(message.getXmlContent());
+    }
+    
+    private boolean isContentXMLEmpty(XmlContentType contentXML){
+    	if(contentXML != null){
+    		int embeddedXMLSize = contentXML.getEmbeddedXMLContent().size();
+    		int keyXMLSize = contentXML.getKeyXMLContent().size();
+    		return embeddedXMLSize == 0 && keyXMLSize == 0;
+    	}
+    	return contentXML != null;
+    }
+    
+    private boolean isNonContentXMLEmpty(NonXMLContentType nonContentXML){
+    	if(nonContentXML != null){
+    		return nonContentXML.getSize() == null;
+    	}
+    	return nonContentXML == null;
     }
 
 }

--- a/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/aspect/EDXLDistributionPayloadSizeExtractor.java
+++ b/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/aspect/EDXLDistributionPayloadSizeExtractor.java
@@ -26,6 +26,7 @@
  */
 package gov.hhs.fha.nhinc.admindistribution.aspect;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -51,42 +52,42 @@ public class EDXLDistributionPayloadSizeExtractor {
         List<String> payloadSize = new ArrayList<String>();
         if (alertMessage != null) {
             List<ContentObjectType> contents = alertMessage.getContentObject();
-            if(!contents.isEmpty()){
-            	for (ContentObjectType message : contents) {
+            for (ContentObjectType message : contents) {
             		payloadSize.add(getPayloadSize(message));
-            	}
             }
         }
         return payloadSize;
     }
 
     private String getPayloadSize(ContentObjectType message) {
-        if (isPayloadSizeEmpty(message)) {
-            return "";
-        } else {
-            return message.getNonXMLContent().getSize().toString();
-        }
-    }
-
-    private boolean isPayloadSizeEmpty(ContentObjectType message) {
-    	return isNonContentXMLEmpty(message.getNonXMLContent()) ||
-    			isContentXMLEmpty(message.getXmlContent());
+        int result = 0;
+        result += getContentXMLSize(message.getXmlContent());
+    	result += getNonContentXMLSize(message.getNonXMLContent());
+    	return "" + result;
     }
     
-    private boolean isContentXMLEmpty(XmlContentType contentXML){
-    	if(contentXML != null){
+    private int getContentXMLSize(XmlContentType contentXML){
+    	if(contentXML == null){
+    		return 0;
+    	}else {
     		int embeddedXMLSize = contentXML.getEmbeddedXMLContent().size();
     		int keyXMLSize = contentXML.getKeyXMLContent().size();
-    		return embeddedXMLSize == 0 && keyXMLSize == 0;
+    		return embeddedXMLSize + keyXMLSize;
     	}
-    	return contentXML != null;
     }
     
-    private boolean isNonContentXMLEmpty(NonXMLContentType nonContentXML){
-    	if(nonContentXML != null){
-    		return nonContentXML.getSize() == null;
+    private int getNonContentXMLSize(NonXMLContentType nonContentXML){
+    	if(nonContentXML == null){
+    		return 0;
+    	}else{
+    		BigInteger size = nonContentXML.getSize();
+    		if(size != null) {
+    			return size.intValue();
+    		}
+    		else {
+    			return 0;
+    		}
     	}
-    	return nonContentXML == null;
     }
 
 }

--- a/Product/Production/Services/AdminDistributionCore/src/test/java/gov/hhs/fha/nhinc/admindistribution/aspect/EDXLDistributionPayloadSizeExtractorTest.java
+++ b/Product/Production/Services/AdminDistributionCore/src/test/java/gov/hhs/fha/nhinc/admindistribution/aspect/EDXLDistributionPayloadSizeExtractorTest.java
@@ -63,6 +63,19 @@ public class EDXLDistributionPayloadSizeExtractorTest {
 
         assertEquals(BigInteger.TEN.toString(), extractor.getPayloadSizes(alert).get(0));
     }
+    
+    @Test
+    public void testPayloadSizeOnSingleNonXMLEmptyPayload() {
+    	EDXLDistribution alert = new EDXLDistribution();
+    	ContentObjectType payload = new ContentObjectType();
+    	NonXMLContentType payloadContent = createMockNonXmlPayload();
+    	payload.setNonXMLContent(payloadContent);
+    	alert.getContentObject().add(payload);
+    	EDXLDistributionPayloadSizeExtractor extractor = new EDXLDistributionPayloadSizeExtractor();
+
+    	assertTrue(extractor.getPayloadSizes(alert).size() == 1);
+    	assertEquals("", extractor.getPayloadSizes(alert).get(0));
+    }
 
     @Test
     public void testPayloadSizeMultipleNonXMLPayload() {

--- a/Product/Production/Services/AdminDistributionCore/src/test/java/gov/hhs/fha/nhinc/admindistribution/aspect/EDXLDistributionPayloadSizeExtractorTest.java
+++ b/Product/Production/Services/AdminDistributionCore/src/test/java/gov/hhs/fha/nhinc/admindistribution/aspect/EDXLDistributionPayloadSizeExtractorTest.java
@@ -36,11 +36,14 @@ import java.util.List;
 
 import javax.activation.DataHandler;
 
+import oasis.names.tc.emergency.edxl.de._1.AnyXMLType;
 import oasis.names.tc.emergency.edxl.de._1.ContentObjectType;
 import oasis.names.tc.emergency.edxl.de._1.EDXLDistribution;
 import oasis.names.tc.emergency.edxl.de._1.NonXMLContentType;
 import oasis.names.tc.emergency.edxl.de._1.XmlContentType;
 
+import org.jmock.Expectations;
+import org.jmock.Mockery;
 import org.junit.Test;
 
 /**
@@ -49,6 +52,8 @@ import org.junit.Test;
  */
 public class EDXLDistributionPayloadSizeExtractorTest {
 
+	private Mockery context = new Mockery();
+	
     @Test
     public void emptyBuild() {
         EDXLDistributionPayloadSizeExtractor extractor = new EDXLDistributionPayloadSizeExtractor();
@@ -74,7 +79,7 @@ public class EDXLDistributionPayloadSizeExtractorTest {
     	EDXLDistributionPayloadSizeExtractor extractor = new EDXLDistributionPayloadSizeExtractor();
 
     	assertTrue(extractor.getPayloadSizes(alert).size() == 1);
-    	assertEquals("", extractor.getPayloadSizes(alert).get(0));
+    	assertEquals("0", extractor.getPayloadSizes(alert).get(0));
     }
 
     @Test
@@ -101,7 +106,7 @@ public class EDXLDistributionPayloadSizeExtractorTest {
         setXmlPayload(alert);
         List<String> payloadSizes = extractor.getPayloadSizes(alert);
         assertEquals(1, payloadSizes.size());
-        assertEquals("", payloadSizes.get(0));
+        assertEquals("0", payloadSizes.get(0));
     }
 
     @Test
@@ -114,10 +119,83 @@ public class EDXLDistributionPayloadSizeExtractorTest {
 
         List<String> payloadSizes = extractor.getPayloadSizes(alert);
         assertEquals(2, payloadSizes.size());
-        assertEquals("", payloadSizes.get(0));
+        assertEquals("0", payloadSizes.get(0));
         assertEquals("10", payloadSizes.get(1));
     }
+    
+    @Test
+    public void testPayloadSizeContentXMLbothXMLContentTypesEmpty() {
+    	EDXLDistributionPayloadSizeExtractor extractor = new EDXLDistributionPayloadSizeExtractor();
+        EDXLDistribution alert = new EDXLDistribution();
+        
+        final List<AnyXMLType> emptyList = context.mock(List.class);
+        XmlContentType contentType = new XmlContentType(){
+        	@Override
+        	public List<AnyXMLType> getKeyXMLContent(){
+        		return emptyList;
+        	}
+        	@Override
+        	public List<AnyXMLType> getEmbeddedXMLContent(){
+        		return emptyList;
+        	}
+        };
+        
+        context.checking(new Expectations(){
+        	{
+        		oneOf(emptyList).size();
+        		will(returnValue(0));
+        		oneOf(emptyList).size();
+        		will(returnValue(0));
+        	}
+        });
+       
+        ContentObjectType payload = new ContentObjectType();
+        payload.setXmlContent(contentType);
+        alert.getContentObject().add(payload);
+        
+        List<String> payloadSizes = extractor.getPayloadSizes(alert);
+        context.assertIsSatisfied();
+        assertEquals(1, payloadSizes.size());
+        assertEquals("0", payloadSizes.get(0));
+    }
 
+    @Test
+    public void testPayloadSizeContentXMLMixedXMLContentTypeSizes() {
+    	EDXLDistributionPayloadSizeExtractor extractor = new EDXLDistributionPayloadSizeExtractor();
+        EDXLDistribution alert = new EDXLDistribution();
+        
+        final List<AnyXMLType> keyList = context.mock(List.class, "keyList");
+        final List<AnyXMLType> embeddedList = context.mock(List.class, "embeddedList");
+        
+        XmlContentType contentType = new XmlContentType(){
+        	@Override
+        	public List<AnyXMLType> getKeyXMLContent(){
+        		return keyList;
+        	}
+        	@Override
+        	public List<AnyXMLType> getEmbeddedXMLContent(){
+        		return embeddedList;
+        	}
+        };
+        
+        context.checking(new Expectations(){
+        	{
+        		oneOf(keyList).size();
+        		will(returnValue(4));
+        		oneOf(embeddedList).size();
+        		will(returnValue(5));
+        	}
+        });
+       
+        ContentObjectType payload = new ContentObjectType();
+        payload.setXmlContent(contentType);
+        alert.getContentObject().add(payload);
+        
+        List<String> payloadSizes = extractor.getPayloadSizes(alert);
+        context.assertIsSatisfied();
+        assertEquals(1, payloadSizes.size());
+        assertEquals("9", payloadSizes.get(0));
+    }
     /**
      * @param alert
      */


### PR DESCRIPTION
- Fixed payload size extractor for event logging in ADCore to not throw NPE when ContentObject is empty.
- Added a junit test for empty nonXML ContentObjectType for the payload extractor.
