### PR TITLE
Gateway-3353:Fix Universal Client error by adding Properties.jar inside ...

### DIFF
--- a/Product/Production/Adapters/General/CONNECTUniversalClientGUI/pom.xml
+++ b/Product/Production/Adapters/General/CONNECTUniversalClientGUI/pom.xml
@@ -58,6 +58,11 @@
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
+	        <groupId>org.connectopensource</groupId>
+	        <artifactId>Properties</artifactId>
+	        <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
             <groupId>javax</groupId>
             <artifactId>javaee-api</artifactId>
             <version>6.0</version>

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/mpi/adapter/component/proxy/AdapterComponentMpiProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/mpi/adapter/component/proxy/AdapterComponentMpiProxyWebServiceSecuredImpl.java
@@ -63,12 +63,7 @@ public class AdapterComponentMpiProxyWebServiceSecuredImpl implements AdapterCom
             ServicePortDescriptor<AdapterComponentMpiSecuredPortType> portDescriptor, String url,
             AssertionType assertion) throws PropertyAccessException {
 
-        String targetHomeCommunityId = null;
-        targetHomeCommunityId = PropertyAccessor.getInstance().getProperty(
-                NhincConstants.GATEWAY_PROPERTY_FILE, NhincConstants.HOME_COMMUNITY_ID_PROPERTY);
-
-        return CONNECTCXFClientFactory.getInstance().getCONNECTClientSecured(portDescriptor, assertion, url,
-                targetHomeCommunityId, NhincConstants.ADAPTER_COMPONENT_MPI_SECURED_SERVICE_NAME );
+        return CONNECTCXFClientFactory.getInstance().getCONNECTClientSecured(portDescriptor, url, assertion);
     }
 
     /**


### PR DESCRIPTION
The Universal Client requires Properties.jar to be included to invoke Secured Services without security exceptions.

The AdapterComponentMpiProxyWebServiceSecuredImpl also changed to the same way as other adapter services to get CXF client as an improvement.
