### PR TITLE
Gateway-3357:Change Request sent to PD,DQ,DR Services in UC

### DIFF
--- a/Product/Production/Adapters/General/CONNECTUniversalClientGUI/src/main/java/universalclientgui/DocumentQueryClient.java
+++ b/Product/Production/Adapters/General/CONNECTUniversalClientGUI/src/main/java/universalclientgui/DocumentQueryClient.java
@@ -95,7 +95,8 @@ public class DocumentQueryClient {
 
                 RespondingGatewayCrossGatewayQueryRequestType request = createAdhocQueryRequest(patientSearchData,
                         creationFromDate, creationToDate);
-
+                NhinTargetCommunitiesType target = new NhinTargetCommunitiesType();
+                request.setNhinTargetCommunities(target);
                 EntityDocQueryProxyWebServiceUnsecuredImpl instance = new EntityDocQueryProxyWebServiceUnsecuredImpl();
                 AdhocQueryResponse response = instance.respondingGatewayCrossGatewayQuery(
                         request.getAdhocQueryRequest(), request.getAssertion(), request.getNhinTargetCommunities());

--- a/Product/Production/Adapters/General/CONNECTUniversalClientGUI/src/main/java/universalclientgui/DocumentRetrieveClient.java
+++ b/Product/Production/Adapters/General/CONNECTUniversalClientGUI/src/main/java/universalclientgui/DocumentRetrieveClient.java
@@ -56,10 +56,12 @@ public class DocumentRetrieveClient {
 
     public String retriveDocument(DocumentInformation documentInformation) {
         try {
+            NhinTargetCommunitiesType target = new NhinTargetCommunitiesType();
             String url = getUrl();
             if (NullChecker.isNotNullish(url)) {
                 RespondingGatewayCrossGatewayRetrieveRequestType request = createCrossGatewayRetrieveRequest(documentInformation);
 
+                request.setNhinTargetCommunities(target);
                 EntityDocRetrieveProxyWebServiceUnsecuredImpl instance = new EntityDocRetrieveProxyWebServiceUnsecuredImpl();
                 RetrieveDocumentSetResponseType response = instance.respondingGatewayCrossGatewayRetrieve(
                         request.getRetrieveDocumentSetRequest(), request.getAssertion(),

--- a/Product/Production/Adapters/General/CONNECTUniversalClientGUI/src/main/java/universalclientgui/PatientDiscoveryClient.java
+++ b/Product/Production/Adapters/General/CONNECTUniversalClientGUI/src/main/java/universalclientgui/PatientDiscoveryClient.java
@@ -28,6 +28,7 @@
 package universalclientgui;
 
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
 import gov.hhs.fha.nhinc.connectmgr.ConnectionManagerCache;
 import gov.hhs.fha.nhinc.connectmgr.ConnectionManagerException;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
@@ -90,7 +91,9 @@ public class PatientDiscoveryClient {
         try {
 
             RespondingGatewayPRPAIN201305UV02RequestType request = new RespondingGatewayPRPAIN201305UV02RequestType();
+            NhinTargetCommunitiesType target = new NhinTargetCommunitiesType();
             request.setAssertion(assertion);
+            request.setNhinTargetCommunities(target);
 
             String orgId = getHomeCommunityId();
 


### PR DESCRIPTION
CONNECT 4.0 requires empty NhinTargetCommunities for all Services. Hence PD, DQ, DR request has been changed to accomodate this in UC.
