### PR TITLE
Gateway 3312 - Fixed PD fanout

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/MessageGeneratorUtils.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/MessageGeneratorUtils.java
@@ -30,11 +30,13 @@ import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.transform.marshallers.Marshaller;
+import gov.hhs.fha.nhinc.wsa.WSAHeaderHelper;
 
 import javax.xml.namespace.QName;
 
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
 
+import org.hl7.v3.PRPAIN201305UV02;
 import org.w3c.dom.Element;
 
 /**
@@ -45,11 +47,14 @@ public class MessageGeneratorUtils {
 
     private static MessageGeneratorUtils INSTANCE = new MessageGeneratorUtils();
 
-    private static String NHINC_COMMON_CONTEXT = "gov.hhs.fha.nhinc.common.nhinccommon";
-    private static String NHINC_COMMON_URN = "urn:gov:hhs:fha:nhinc:common:nhinccommon";
+    private static final String NHINC_COMMON_CONTEXT = "gov.hhs.fha.nhinc.common.nhinccommon";
+    private static final String NHINC_COMMON_URN = "urn:gov:hhs:fha:nhinc:common:nhinccommon";
 
-    private static String OASIS_QUERY_30_CONTEXT = "oasis.names.tc.ebxml_regrep.xsd.query._3";
-    private static String OASIS_QUERY_30_URN = "urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0";
+    private static final String OASIS_QUERY_30_CONTEXT = "oasis.names.tc.ebxml_regrep.xsd.query._3";
+    private static final String OASIS_QUERY_30_URN = "urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0";
+    
+    private static final String HL7_V3_CONTEXT = "org.hl7.v3";
+    private static final String HL7_V3_URN = "urn:hl7-org:v3";
 
     protected MessageGeneratorUtils() {
     }
@@ -93,6 +98,19 @@ public class MessageGeneratorUtils {
 
         return (AssertionType) marshaller.unmarshallJaxbElement(jaxbElement, NHINC_COMMON_CONTEXT);
     }
+    
+    /**
+     * Clones the assertion object but with a new message id
+     * 
+     * @param assertion
+     * @return a cloned assertion but with a new message id
+     */
+    public AssertionType cloneWithNewMsgId(AssertionType assertion) {
+        AssertionType newAssertion = clone(assertion);
+        newAssertion.setMessageId(new WSAHeaderHelper().generateMessageID());
+        
+        return newAssertion;
+    }
 
     /**
      * Clones the Adhoc Query Request.
@@ -107,6 +125,21 @@ public class MessageGeneratorUtils {
         Element jaxbElement = marshaller.marshal(adhocQueryRequest, OASIS_QUERY_30_CONTEXT, qName);
 
         return (AdhocQueryRequest) marshaller.unmarshallJaxbElement(jaxbElement, OASIS_QUERY_30_CONTEXT);
+    }
+    
+    /**
+     * Clones the PRPAIN201305UV02.
+     * 
+     * @param request
+     * @return a cloned PRPAIN201305UV02
+     */
+    public PRPAIN201305UV02 clone(PRPAIN201305UV02 request) {
+        QName qName = new QName(HL7_V3_URN, "PRPA_IN201305UV02");        
+        Marshaller marshaller = new Marshaller();
+
+        Element jaxbElement = marshaller.marshal(request, HL7_V3_CONTEXT, qName);
+        
+        return (PRPAIN201305UV02) marshaller.unmarshallJaxbElement(jaxbElement, HL7_V3_CONTEXT);
     }
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/util/MessageGeneratorUtilsTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/util/MessageGeneratorUtilsTest.java
@@ -27,6 +27,7 @@
 package gov.hhs.fha.nhinc.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
@@ -80,6 +81,16 @@ public class MessageGeneratorUtilsTest {
         assertion.setMessageId("22222");
         
         assertEquals("11111", copyAssertion.getMessageId());       
+    }
+    
+    @Test
+    public void cloneAssertionWithNewMsgId() {
+        AssertionType assertion = new AssertionType();
+        assertion.setMessageId("11111");
+        
+        AssertionType copyAssertion = msgUtils.cloneWithNewMsgId(assertion);               
+                
+        assertFalse(copyAssertion.getMessageId().equals("11111"));
     }
     
     @Test

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/util/MessageGeneratorUtilsTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/util/MessageGeneratorUtilsTest.java
@@ -34,6 +34,7 @@ import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunityType;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
 
+import org.hl7.v3.PRPAIN201305UV02;
 import org.junit.Test;
 
 /**
@@ -90,5 +91,16 @@ public class MessageGeneratorUtilsTest {
         request.setId("22222");
         
         assertEquals("11111", clonedRequest.getId());
+    }
+    
+    @Test
+    public void clonePRPAIN201305UV02() {
+        PRPAIN201305UV02 request = new PRPAIN201305UV02();
+        request.setITSVersion("11111");
+        
+        PRPAIN201305UV02 clonedRequest = msgUtils.clone(request);
+        request.setITSVersion("22222");
+        
+        assertEquals("11111", clonedRequest.getITSVersion());
     }
 }

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/AggregationService.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/AggregationService.java
@@ -238,11 +238,7 @@ public class AggregationService {
     }
     
     protected AssertionType cloneAssertionWithNewMsgId(AssertionType assertion) {
-        AssertionType newAssertion = MessageGeneratorUtils.getInstance().clone(assertion);
-        
-        newAssertion.setMessageId(new WSAHeaderHelper().generateMessageID());
-        
-        return newAssertion;
+        return MessageGeneratorUtils.getInstance().cloneWithNewMsgId(assertion);
     }
     
     protected Set<II> removeDuplicates(List<II> iiArray) {


### PR DESCRIPTION
1. Generate new message ids when fanning out requests
2. Object lock the get application context method of the ComponentObjectFactory as the cache map is static and is shared by all instances
