### PR TITLE
GATEWAY-3221: dependency cleanup for Websphere.

### DIFF
--- a/Product/Production/Deploy/ear/pom.xml
+++ b/Product/Production/Deploy/ear/pom.xml
@@ -216,12 +216,6 @@
             <groupId>org.connectopensource</groupId>
             <artifactId>CONNECTCommonTypesLib</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>activation</artifactId>
-                    <groupId>javax.activation</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.connectopensource</groupId>
@@ -503,6 +497,11 @@
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20090211</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
         </dependency>
     </dependencies>
     <build>

--- a/Product/Production/Deploy/websphere/pom.xml
+++ b/Product/Production/Deploy/websphere/pom.xml
@@ -11,21 +11,11 @@
     <packaging>ear</packaging>
     <name>CONNECT IBM WebSphere CE EAR</name>
     <dependencies>
-        <dependency>
-            <groupId>net.sf.kxml</groupId>
-            <artifactId>kxml2</artifactId>
-            <version>2.3.0</version>
-        </dependency>
 		<dependency>	
             <groupId>com.sun.xml.messaging.saaj</groupId> 	
             <artifactId>saaj-impl</artifactId>
             <version>1.3.18</version>	
        </dependency> 
-       <dependency>  	
-            <groupId>javax.xml.soap</groupId>
-            <artifactId>saaj-api</artifactId>
-            <version>1.3.4</version>
-       </dependency>	   
     </dependencies>
 
 

--- a/Product/pom.xml
+++ b/Product/pom.xml
@@ -237,6 +237,11 @@
                 <artifactId>bcprov-jdk16</artifactId>
                 <version>1.45</version>
             </dependency>
+            <dependency>
+                <groupId>javax.activation</groupId>
+                <artifactId>activation</artifactId>
+                <version>1.1.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <build>


### PR DESCRIPTION
Two distinct changes:
- remove incorrect kxml and saaj-api dependencies in the websphere pom
- add activation 1.1.1 to the list of managed dependencies
