### PR TITLE
Gateway-3389 Fix for AD passthrough auditing

### DIFF
--- a/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/inbound/PassthroughInboundAdminDistribution.java
+++ b/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/inbound/PassthroughInboundAdminDistribution.java
@@ -46,7 +46,8 @@ public class PassthroughInboundAdminDistribution extends AbstractInboundAdminDis
     private static final Logger LOG = Logger.getLogger(PassthroughInboundAdminDistribution.class);
     private AdminDistributionUtils adminUtils = AdminDistributionUtils.getInstance();
     private AdapterAdminDistributionProxyObjectFactory adapterFactory = new AdapterAdminDistributionProxyObjectFactory();
-
+    private Boolean inPassthrough = true;
+    
     /**
      * Constructor.
      */
@@ -67,11 +68,15 @@ public class PassthroughInboundAdminDistribution extends AbstractInboundAdminDis
         this.adminUtils = adminUtils;
         this.adapterFactory = adapterFactory;
     }
+    
+    public void setPassthrough(Boolean passthrough){
+    	this.inPassthrough = passthrough;
+    }
 
     @Override
     void processAdminDistribution(EDXLDistribution body, AssertionType assertion) {
         try {
-            adminUtils.convertDataToFileLocationIfEnabled(body);
+        	adminUtils.convertDataToFileLocationIfEnabled(body);
             sendToAdapter(body, assertion);
         } catch (LargePayloadException lpe) {
             LOG.error("Failed to retrieve payload document.", lpe);
@@ -79,8 +84,9 @@ public class PassthroughInboundAdminDistribution extends AbstractInboundAdminDis
     }
 
     private void sendToAdapter(EDXLDistribution body, AssertionType assertion) {
-        auditRequestToAdapter(body, assertion);
-
+        if(!inPassthrough){	
+        	auditRequestToAdapter(body, assertion);
+        }
         AdapterAdminDistributionProxy adapterProxy = adapterFactory.getAdapterAdminDistProxy();
         adapterProxy.sendAlertMessage(body, assertion);
     }

--- a/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/inbound/StandardInboundAdminDistribution.java
+++ b/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/inbound/StandardInboundAdminDistribution.java
@@ -67,6 +67,7 @@ public class StandardInboundAdminDistribution extends AbstractInboundAdminDistri
     @Override
     void processAdminDistribution(EDXLDistribution body, AssertionType assertion) {
         if (isPolicyValid(body, assertion)) {
+        	passthroughAdminDist.setPassthrough(false);
             passthroughAdminDist.processAdminDistribution(body, assertion);
         } else {
             LOG.warn("Invalid policy.  Will not send message to adapter.");

--- a/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/outbound/PassthroughOutboundAdminDistribution.java
+++ b/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/outbound/PassthroughOutboundAdminDistribution.java
@@ -26,7 +26,6 @@
  */
 package gov.hhs.fha.nhinc.admindistribution.outbound;
 
-import gov.hhs.fha.nhinc.admindistribution.AdminDistributionAuditLogger;
 import gov.hhs.fha.nhinc.admindistribution.MessageGeneratorUtils;
 import gov.hhs.fha.nhinc.admindistribution.aspect.ADRequestTransformingBuilder;
 import gov.hhs.fha.nhinc.admindistribution.entity.OutboundAdminDistributionDelegate;
@@ -38,11 +37,9 @@ import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.common.nhinccommonentity.RespondingGatewaySendAlertMessageSecuredType;
 import gov.hhs.fha.nhinc.common.nhinccommonentity.RespondingGatewaySendAlertMessageType;
 import gov.hhs.fha.nhinc.event.DefaultEventDescriptionBuilder;
-import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 
 public class PassthroughOutboundAdminDistribution implements OutboundAdminDistribution {
 
-    private AdminDistributionAuditLogger auditLogger = new AdminDistributionAuditLogger();
     private MessageGeneratorUtils msgUtils = MessageGeneratorUtils.getInstance();
     private OutboundAdminDistributionDelegate adDelegate = new OutboundAdminDistributionDelegate();
 
@@ -56,10 +53,8 @@ public class PassthroughOutboundAdminDistribution implements OutboundAdminDistri
     /**
      * Constructor.
      */
-    public PassthroughOutboundAdminDistribution(OutboundAdminDistributionDelegate adDelegate,
-            AdminDistributionAuditLogger auditLogger) {
+    public PassthroughOutboundAdminDistribution(OutboundAdminDistributionDelegate adDelegate) {
         this.adDelegate = adDelegate;
-        this.auditLogger = auditLogger;
     }
 
     /**
@@ -93,17 +88,13 @@ public class PassthroughOutboundAdminDistribution implements OutboundAdminDistri
             version = "")
     public void sendAlertMessage(RespondingGatewaySendAlertMessageType request, AssertionType assertion,
             NhinTargetCommunitiesType targetCommunities) {
-        NhinTargetSystemType target = msgUtils.convertFirstToNhinTargetSystemType(targetCommunities);
-
-        auditRequestFromAdapter(request, assertion, target);
-
+        
+    	NhinTargetSystemType target = msgUtils.convertFirstToNhinTargetSystemType(targetCommunities);
         sendToNhin(request, assertion, target);
     }
 
     private void sendToNhin(RespondingGatewaySendAlertMessageType request, AssertionType assertion,
             NhinTargetSystemType target) {
-
-        auditRequestToNhin(request, assertion, target);
 
         OutboundAdminDistributionOrchestratable orchestratable = new OutboundAdminDistributionOrchestratable(adDelegate);
         orchestratable.setRequest(request);
@@ -112,17 +103,5 @@ public class PassthroughOutboundAdminDistribution implements OutboundAdminDistri
         orchestratable.setPassthru(true);
 
         adDelegate.process(orchestratable);
-    }
-
-    private void auditRequestFromAdapter(RespondingGatewaySendAlertMessageType request, AssertionType assertion,
-            NhinTargetSystemType target) {
-        auditLogger.auditNhincAdminDist(request.getEDXLDistribution(), assertion, target,
-                NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
-    }
-
-    private void auditRequestToNhin(RespondingGatewaySendAlertMessageType request, AssertionType assertion,
-            NhinTargetSystemType target) {
-        auditLogger.auditNhincAdminDist(request.getEDXLDistribution(), assertion, target,
-                NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
     }
 }

--- a/Product/Production/Services/AdminDistributionCore/src/test/java/gov/hhs/fha/nhinc/admindistribution/inbound/PassthroughInboundAdminDistributionTest.java
+++ b/Product/Production/Services/AdminDistributionCore/src/test/java/gov/hhs/fha/nhinc/admindistribution/inbound/PassthroughInboundAdminDistributionTest.java
@@ -26,25 +26,20 @@
  */
 package gov.hhs.fha.nhinc.admindistribution.inbound;
 
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import gov.hhs.fha.nhinc.admindistribution.AdminDistributionAuditLogger;
 import gov.hhs.fha.nhinc.admindistribution.AdminDistributionUtils;
 import gov.hhs.fha.nhinc.admindistribution.adapter.proxy.AdapterAdminDistributionProxy;
 import gov.hhs.fha.nhinc.admindistribution.adapter.proxy.AdapterAdminDistributionProxyObjectFactory;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
-import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.largefile.LargePayloadException;
-import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
-
 import oasis.names.tc.emergency.edxl.de._1.EDXLDistribution;
 
 import org.junit.Test;
-
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * @author akong
@@ -56,27 +51,21 @@ public class PassthroughInboundAdminDistributionTest {
     public void passthroughAdminDistribution() {
         EDXLDistribution request = new EDXLDistribution();
         AssertionType assertion = new AssertionType();
-        NhinTargetSystemType target = null;
-
-        AdminDistributionAuditLogger auditLogger = mock(AdminDistributionAuditLogger.class);
+        
         AdminDistributionUtils adminUtils = mock(AdminDistributionUtils.class);
         AdapterAdminDistributionProxyObjectFactory adapterFactory = mock(AdapterAdminDistributionProxyObjectFactory.class);
         AdapterAdminDistributionProxy adapterProxy = mock(AdapterAdminDistributionProxy.class);
+        AdminDistributionAuditLogger auditLogger = new AdminDistributionAuditLogger();
         
         when(adapterFactory.getAdapterAdminDistProxy()).thenReturn(adapterProxy);
 
-        PassthroughInboundAdminDistribution passthroughAdminDist = new PassthroughInboundAdminDistribution(auditLogger,
-                adminUtils, adapterFactory);
+        PassthroughInboundAdminDistribution passthroughAdminDist = new PassthroughInboundAdminDistribution(auditLogger, 
+        		adminUtils, adapterFactory);
 
         passthroughAdminDist.sendAlertMessage(request, assertion);
 
         verify(adapterProxy).sendAlertMessage(eq(request), eq(assertion));
-
-        verify(auditLogger).auditNhinAdminDist(eq(request), eq(assertion),
-                eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(target), eq(NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE));
-
-        verify(auditLogger).auditNhinAdminDist(eq(request), eq(assertion),
-                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(target), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE));
+        
     }
     
     @Test
@@ -85,14 +74,14 @@ public class PassthroughInboundAdminDistributionTest {
         AssertionType assertion = new AssertionType();
         LargePayloadException exception = new LargePayloadException();
 
-        AdminDistributionAuditLogger auditLogger = mock(AdminDistributionAuditLogger.class);
         AdminDistributionUtils adminUtils = mock(AdminDistributionUtils.class);
         AdapterAdminDistributionProxyObjectFactory adapterFactory = mock(AdapterAdminDistributionProxyObjectFactory.class);
+        AdminDistributionAuditLogger auditLogger = new AdminDistributionAuditLogger();
         
         doThrow(exception).when(adminUtils).convertDataToFileLocationIfEnabled(request);
         
         PassthroughInboundAdminDistribution passthroughAdminDist = new PassthroughInboundAdminDistribution(auditLogger,
-                adminUtils, adapterFactory);
+        		adminUtils, adapterFactory);
 
         passthroughAdminDist.sendAlertMessage(request, assertion);
         

--- a/Product/Production/Services/AdminDistributionCore/src/test/java/gov/hhs/fha/nhinc/admindistribution/outbound/PassthroughOutboundAdminDistributionTest.java
+++ b/Product/Production/Services/AdminDistributionCore/src/test/java/gov/hhs/fha/nhinc/admindistribution/outbound/PassthroughOutboundAdminDistributionTest.java
@@ -27,18 +27,14 @@
 package gov.hhs.fha.nhinc.admindistribution.outbound;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import gov.hhs.fha.nhinc.admindistribution.AdminDistributionAuditLogger;
 import gov.hhs.fha.nhinc.admindistribution.entity.OutboundAdminDistributionDelegate;
 import gov.hhs.fha.nhinc.admindistribution.entity.OutboundAdminDistributionOrchestratable;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
-import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.common.nhinccommonentity.RespondingGatewaySendAlertMessageSecuredType;
 import gov.hhs.fha.nhinc.common.nhinccommonentity.RespondingGatewaySendAlertMessageType;
-import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 
 import org.junit.Test;
 
@@ -52,20 +48,13 @@ public class PassthroughOutboundAdminDistributionTest {
         NhinTargetCommunitiesType targetCommunities = new NhinTargetCommunitiesType();
 
         OutboundAdminDistributionDelegate adDelegate = mock(OutboundAdminDistributionDelegate.class);
-        AdminDistributionAuditLogger auditLogger = mock(AdminDistributionAuditLogger.class);
-
-        PassthroughOutboundAdminDistribution passthroughAdmin = new PassthroughOutboundAdminDistribution(adDelegate,
-                auditLogger);
+        
+        PassthroughOutboundAdminDistribution passthroughAdmin = new PassthroughOutboundAdminDistribution(adDelegate);
 
         passthroughAdmin.sendAlertMessage(request, assertion, targetCommunities);
 
         verify(adDelegate).process(any(OutboundAdminDistributionOrchestratable.class));
 
-        verify(auditLogger).auditNhincAdminDist(eq(request.getEDXLDistribution()), eq(assertion),
-                any(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
-        
-        verify(auditLogger).auditNhincAdminDist(eq(request.getEDXLDistribution()), eq(assertion),
-                any(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION));
     }
     
     @Test
@@ -76,20 +65,13 @@ public class PassthroughOutboundAdminDistributionTest {
         NhinTargetCommunitiesType targetCommunities = new NhinTargetCommunitiesType();
 
         OutboundAdminDistributionDelegate adDelegate = mock(OutboundAdminDistributionDelegate.class);
-        AdminDistributionAuditLogger auditLogger = mock(AdminDistributionAuditLogger.class);
-
-        PassthroughOutboundAdminDistribution passthroughAdmin = new PassthroughOutboundAdminDistribution(adDelegate,
-                auditLogger);
+        
+        PassthroughOutboundAdminDistribution passthroughAdmin = new PassthroughOutboundAdminDistribution(adDelegate);
 
         passthroughAdmin.sendAlertMessage(request, assertion, targetCommunities);
 
         verify(adDelegate).process(any(OutboundAdminDistributionOrchestratable.class));
-
-        verify(auditLogger).auditNhincAdminDist(eq(request.getEDXLDistribution()), eq(assertion),
-                any(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
         
-        verify(auditLogger).auditNhincAdminDist(eq(request.getEDXLDistribution()), eq(assertion),
-                any(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION));
     }
 
 }


### PR DESCRIPTION
- Removed adapter, proxy, and entity calls for passthrough AD auditing.
- Updated unit tests.
