### PR TITLE
GATEWAY-3383: Fixed auditing for DS and DS Deferred.

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/transform/audit/XDRTransforms.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/transform/audit/XDRTransforms.java
@@ -337,20 +337,53 @@ public class XDRTransforms {
 
     }
     
+    /**
+     * Retrieves the community id for auditing when the message being audited is a request message. For example, this
+     * method should be used when the message being audited is an ProvideAndRegister request.
+     * 
+     * @param assertion the assertion containing a homecommunity id
+     * @param target the destination of the original request message
+     * @param direction the direction of the message being auditied
+     * @param _interface the interface (nhin, entity, adapter) of the audited message
+     * @return the community id to use
+     */
     public String getMessageCommunityIdFromRequest(AssertionType assertion, NhinTargetSystemType target,
             String direction, String _interface) {
-        boolean isRequesting = NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION.equalsIgnoreCase(direction);
         
-        return getMessageCommunityId(assertion, target, _interface, isRequesting);
+        // if a request is going outbound, then the current audit is in the requesting side
+        boolean isAuditInRequestingSide = NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION.equalsIgnoreCase(direction);
+        
+        return getMessageCommunityId(assertion, target, _interface, isAuditInRequestingSide);
     }
     
+    /**
+     * Retrieves the community id for auditing when the message being audited is a response message. For example, this
+     * method should be used when the message being audited is an Acknowledgement response of a request.
+     * 
+     * @param assertion the assertion containing a homecommunity id
+     * @param target the destination of the original request message
+     * @param direction the direction of the message being auditied
+     * @param _interface the interface (nhin, entity, adapter) of the audited message
+     * @return the community id to use
+     */
     public String getMessageCommunityIdFromResponse(AssertionType assertion, NhinTargetSystemType target,
             String direction, String _interface) {
-        boolean isRequesting = NhincConstants.AUDIT_LOG_INBOUND_DIRECTION.equalsIgnoreCase(direction);
         
-        return getMessageCommunityId(assertion, target, _interface, isRequesting);
+        // if a response is going inbound, then the current audit is in the requesting side
+        boolean isAuditInRequestingSide = NhincConstants.AUDIT_LOG_INBOUND_DIRECTION.equalsIgnoreCase(direction);
+        
+        return getMessageCommunityId(assertion, target, _interface, isAuditInRequestingSide);
     }
     
+    /**
+     * Retrieves the community id for auditing.
+     * 
+     * @param assertion the assertion containing a homecommunity id
+     * @param target the destination of the original request message
+     * @param _interface the interface (nhin, entity, adapter) of the audited message
+     * @param isRequesting true if the message being audited is in the requesting side
+     * @return the community id to use
+     */
     public String getMessageCommunityId(AssertionType assertion, NhinTargetSystemType target,
             String _interface, boolean isRequesting) {
         String communityId = null;

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/transform/audit/XDRTransforms.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/transform/audit/XDRTransforms.java
@@ -26,27 +26,34 @@
  */
 package gov.hhs.fha.nhinc.transform.audit;
 
-import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
-import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
-import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
-import org.apache.log4j.Logger;
 import gov.hhs.fha.nhinc.common.auditlog.LogEventRequestType;
-import com.services.nhinc.schema.auditmessage.AuditMessageType.ActiveParticipant;
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.common.nhinccommon.UserType;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.transform.marshallers.JAXBContextHandler;
+import gov.hhs.fha.nhinc.util.HomeCommunityMap;
+import gov.hhs.healthit.nhin.XDRAcknowledgementType;
+import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
+
+import java.io.ByteArrayOutputStream;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.Marshaller;
+
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryObjectListType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryPackageType;
+import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
+
+import org.apache.log4j.Logger;
+
 import com.services.nhinc.schema.auditmessage.AuditMessageType;
+import com.services.nhinc.schema.auditmessage.AuditMessageType.ActiveParticipant;
 import com.services.nhinc.schema.auditmessage.AuditSourceIdentificationType;
 import com.services.nhinc.schema.auditmessage.CodedValueType;
 import com.services.nhinc.schema.auditmessage.EventIdentificationType;
 import com.services.nhinc.schema.auditmessage.ParticipantObjectIdentificationType;
-import gov.hhs.fha.nhinc.common.nhinccommon.UserType;
-import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
-import gov.hhs.fha.nhinc.transform.marshallers.JAXBContextHandler;
-import gov.hhs.healthit.nhin.XDRAcknowledgementType;
-import javax.xml.bind.JAXBElement;
-import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryObjectListType;
-import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryPackageType;
-import java.io.ByteArrayOutputStream;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
 
 /**
  * 
@@ -56,7 +63,7 @@ public class XDRTransforms {
     private static final Logger LOG = Logger.getLogger(XDRTransforms.class);
 
     public LogEventRequestType transformRequestToAuditMsg(ProvideAndRegisterDocumentSetRequestType request,
-            AssertionType assertion, String direction, String _interface) {
+            AssertionType assertion, NhinTargetSystemType target, String direction, String _interface) {
         LogEventRequestType result = null;
         AuditMessageType auditMsg = null;
 
@@ -98,7 +105,8 @@ public class XDRTransforms {
         auditMsg.getParticipantObjectIdentification().add(participantObject);
 
         /* Create the AuditSourceIdentifierType object */
-        AuditSourceIdentificationType auditSource = getAuditSourceIdentificationType(assertion.getUserInfo());
+        String communityId = getMessageCommunityIdFromRequest(assertion, target, direction, _interface);
+        AuditSourceIdentificationType auditSource = getAuditSourceIdentificationType(communityId);
         auditMsg.getAuditSourceIdentification().add(auditSource);
 
         result.setAuditMessage(auditMsg);
@@ -111,7 +119,7 @@ public class XDRTransforms {
 
     public LogEventRequestType transformRequestToAuditMsg(
             gov.hhs.fha.nhinc.common.nhinccommonproxy.RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request,
-            AssertionType assertion, String direction, String _interface) {
+            AssertionType assertion, NhinTargetSystemType target, String direction, String _interface) {
         LogEventRequestType result = null;
         AuditMessageType auditMsg = null;
 
@@ -156,7 +164,8 @@ public class XDRTransforms {
         auditMsg.getParticipantObjectIdentification().add(participantObject);
 
         /* Create the AuditSourceIdentifierType object */
-        AuditSourceIdentificationType auditSource = getAuditSourceIdentificationType(assertion.getUserInfo());
+        String communityId = getMessageCommunityIdFromRequest(assertion, target, direction, _interface);
+        AuditSourceIdentificationType auditSource = getAuditSourceIdentificationType(communityId);
         auditMsg.getAuditSourceIdentification().add(auditSource);
 
         result.setAuditMessage(auditMsg);
@@ -168,7 +177,7 @@ public class XDRTransforms {
 
     public LogEventRequestType transformRequestToAuditMsg(
             gov.hhs.fha.nhinc.common.nhinccommonentity.RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request,
-            AssertionType assertion, String direction, String _interface) {
+            AssertionType assertion, NhinTargetSystemType target, String direction, String _interface) {
         LogEventRequestType result = null;
         AuditMessageType auditMsg = null;
 
@@ -215,7 +224,8 @@ public class XDRTransforms {
         auditMsg.getParticipantObjectIdentification().add(participantObject);
 
         /* Create the AuditSourceIdentifierType object */
-        AuditSourceIdentificationType auditSource = getAuditSourceIdentificationType(assertion.getUserInfo());
+        String communityId = getMessageCommunityIdFromRequest(assertion, target, direction, _interface);
+        AuditSourceIdentificationType auditSource = getAuditSourceIdentificationType(communityId);
         auditMsg.getAuditSourceIdentification().add(auditSource);
 
         result.setAuditMessage(auditMsg);
@@ -227,7 +237,7 @@ public class XDRTransforms {
 
     public LogEventRequestType transformRequestToAuditMsg(
             gov.hhs.fha.nhinc.common.nhinccommonentity.RespondingGatewayProvideAndRegisterDocumentSetSecuredResponseRequestType request,
-            AssertionType assertion, String direction, String _interface) {
+            AssertionType assertion, NhinTargetSystemType target, String direction, String _interface) {
         LogEventRequestType result = null;
         AuditMessageType auditMsg = null;
 
@@ -265,57 +275,8 @@ public class XDRTransforms {
         auditMsg.getParticipantObjectIdentification().add(participantObject);
         
         /* Create the AuditSourceIdentifierType object */
-        AuditSourceIdentificationType auditSource = getAuditSourceIdentificationType(assertion.getUserInfo());
-        auditMsg.getAuditSourceIdentification().add(auditSource);
-
-        result.setAuditMessage(auditMsg);
-        result.setDirection(direction);
-        result.setInterface(_interface);
-
-        return result;
-    }
-
-    public LogEventRequestType transformRequestToAuditMsg(
-            gov.hhs.fha.nhinc.common.nhinccommonproxy.RespondingGatewayProvideAndRegisterDocumentSetSecuredResponseRequestType request,
-            AssertionType assertion, String direction, String _interface) {
-        LogEventRequestType result = null;
-        AuditMessageType auditMsg = null;
-
-        if (request == null) {
-            LOG.error("Requst Object was null");
-            return null;
-        }
-        if (assertion == null) {
-            LOG.error("Assertion was null");
-            return null;
-        }
-
-        // check to see that the required fields are not null
-        boolean missingReqFields = areRequiredResponseFieldsNull(request.getRegistryResponse(), assertion);
-
-        if (missingReqFields) {
-            LOG.error("One or more required fields was missing");
-            return null;
-        }
-
-        result = new LogEventRequestType();
-
-        auditMsg = new AuditMessageType();
-        // Create EventIdentification
-        CodedValueType eventID = getCodedValueTypeForXDRResponse();
-
-        EventIdentificationType oEventIdentificationType = getEventIdentificationType(eventID);
-        auditMsg.setEventIdentification(oEventIdentificationType);
-
-        ActiveParticipant participant = getActiveParticipant(assertion.getUserInfo());
-        auditMsg.getActiveParticipant().add(participant);
-        
-        /* Assign ParticipationObjectIdentification */
-        ParticipantObjectIdentificationType participantObject = getParticipantObjectIdentificationType("");
-        auditMsg.getParticipantObjectIdentification().add(participantObject);
-
-        /* Create the AuditSourceIdentifierType object */
-        AuditSourceIdentificationType auditSource = getAuditSourceIdentificationType(assertion.getUserInfo());
+        String communityId = getMessageCommunityIdFromRequest(assertion, target, direction, _interface);
+        AuditSourceIdentificationType auditSource = getAuditSourceIdentificationType(communityId);
         auditMsg.getAuditSourceIdentification().add(auditSource);
 
         result.setAuditMessage(auditMsg);
@@ -326,7 +287,7 @@ public class XDRTransforms {
     }
 
     public LogEventRequestType transformResponseToAuditMsg(RegistryResponseType response, AssertionType assertion,
-            String direction, String _interface) {
+            NhinTargetSystemType target, String direction, String _interface, boolean isRequesting) {
         LogEventRequestType result = null;
         AuditMessageType auditMsg = null;
 
@@ -364,7 +325,8 @@ public class XDRTransforms {
         auditMsg.getParticipantObjectIdentification().add(participantObject);
 
         /* Create the AuditSourceIdentifierType object */
-        AuditSourceIdentificationType auditSource = getAuditSourceIdentificationType(assertion.getUserInfo());
+        String communityId = getMessageCommunityId(assertion, target, _interface, isRequesting);
+        AuditSourceIdentificationType auditSource = getAuditSourceIdentificationType(communityId);
         auditMsg.getAuditSourceIdentification().add(auditSource);
 
         result.setAuditMessage(auditMsg);
@@ -374,7 +336,43 @@ public class XDRTransforms {
         return result;
 
     }
+    
+    public String getMessageCommunityIdFromRequest(AssertionType assertion, NhinTargetSystemType target,
+            String direction, String _interface) {
+        boolean isRequesting = NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION.equalsIgnoreCase(direction);
+        
+        return getMessageCommunityId(assertion, target, _interface, isRequesting);
+    }
+    
+    public String getMessageCommunityIdFromResponse(AssertionType assertion, NhinTargetSystemType target,
+            String direction, String _interface) {
+        boolean isRequesting = NhincConstants.AUDIT_LOG_INBOUND_DIRECTION.equalsIgnoreCase(direction);
+        
+        return getMessageCommunityId(assertion, target, _interface, isRequesting);
+    }
+    
+    public String getMessageCommunityId(AssertionType assertion, NhinTargetSystemType target,
+            String _interface, boolean isRequesting) {
+        String communityId = null;
 
+        if (NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE.equalsIgnoreCase(_interface)
+                || NhincConstants.AUDIT_LOG_ENTITY_INTERFACE.equalsIgnoreCase(_interface)) {
+            communityId = getLocalHomeCommunityId();
+        } else if (NhincConstants.AUDIT_LOG_NHIN_INTERFACE.equalsIgnoreCase(_interface)) {
+            if (isRequesting) {
+                communityId = HomeCommunityMap.getCommunityIdFromTargetSystem(target);
+            } else {
+                communityId = HomeCommunityMap.getHomeCommunityIdFromAssertion(assertion);
+            }
+        }
+
+        return communityId;
+    }
+    
+    protected String getLocalHomeCommunityId() {
+        return HomeCommunityMap.getLocalHomeCommunityId();
+    }
+    
     protected boolean areRequiredXDSfieldsNull(ProvideAndRegisterDocumentSetRequestType body, AssertionType assertion) {
         try {
 
@@ -727,21 +725,8 @@ public class XDRTransforms {
         }
     }
 
-    private AuditSourceIdentificationType getAuditSourceIdentificationType(UserType userInfo) {
-        AuditSourceIdentificationType result;
-
-        String communityId = "";
-        String communityName = "";
-        if (userInfo != null && userInfo.getOrg() != null) {
-            if (userInfo.getOrg().getHomeCommunityId() != null) {
-                communityId = userInfo.getOrg().getHomeCommunityId();
-            }
-            if (userInfo.getOrg().getName() != null) {
-                communityName = userInfo.getOrg().getName();
-            }
-        }
-        result = AuditDataTransformHelper.createAuditSourceIdentification(communityId, communityName);
-        return result;
+    private AuditSourceIdentificationType getAuditSourceIdentificationType(String communityId) {     
+        return AuditDataTransformHelper.createAuditSourceIdentification(communityId, communityId);
     }
 
     private CodedValueType getCodedValueTypeForXDR() {
@@ -815,7 +800,7 @@ public class XDRTransforms {
      * 
      */
     public LogEventRequestType transformAcknowledgementToAuditMsg(XDRAcknowledgementType acknowledgement,
-            AssertionType assertion, String direction, String _interface, String action) {
+            AssertionType assertion, NhinTargetSystemType target, String direction, String _interface, String action) {
         LogEventRequestType result = null;
         AuditMessageType auditMsg = null;
 
@@ -860,7 +845,8 @@ public class XDRTransforms {
         auditMsg.getParticipantObjectIdentification().add(participantObject);
 
         /* Create the AuditSourceIdentifierType object */
-        AuditSourceIdentificationType auditSource = getAuditSourceIdentificationType(assertion.getUserInfo());
+        String communityId = getMessageCommunityIdFromResponse(assertion, target, direction, _interface);
+        AuditSourceIdentificationType auditSource = getAuditSourceIdentificationType(communityId);
         auditMsg.getAuditSourceIdentification().add(auditSource);
 
         result.setAuditMessage(auditMsg);

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/transform/audit/XDRAcknowledgementTransformsHCIDTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/transform/audit/XDRAcknowledgementTransformsHCIDTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2009-13, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.transform.audit;
+
+import static org.junit.Assert.assertEquals;
+import gov.hhs.fha.nhinc.common.auditlog.LogEventRequestType;
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.healthit.nhin.XDRAcknowledgementType;
+import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
+
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class XDRAcknowledgementTransformsHCIDTest {
+
+    private static final String LOCAL_HCID = "localHCID";
+    private static final String ASSERTION_HCID = "assertionHCID";
+    private static final String TARGET_HCID = "targetHCID";
+
+    private XDRMessageHelper messageHelper = new XDRMessageHelper();
+
+    private XDRTransforms xdrTransform;
+    private AssertionType assertion;
+    private XDRAcknowledgementType acknowledgement;
+    private NhinTargetSystemType target;
+
+    @Before
+    public void setup() {
+        xdrTransform = createXDRTransforms();
+        assertion = messageHelper.createAssertion(ASSERTION_HCID);
+        target = messageHelper.createNhinTargetSystem(TARGET_HCID);
+        acknowledgement = new XDRAcknowledgementType();
+        acknowledgement.setMessage(new RegistryResponseType());
+    }
+
+    @Test
+    public void getHcidNhinOutbound() {
+        String direction = NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_NHIN_INTERFACE;
+
+        LogEventRequestType result = xdrTransform.transformAcknowledgementToAuditMsg(acknowledgement, assertion,
+                target, direction, _interface, null);
+
+        assertEquals(ASSERTION_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+
+    @Test
+    public void getHcidNhinInbound() {
+        String direction = NhincConstants.AUDIT_LOG_INBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_NHIN_INTERFACE;
+
+        LogEventRequestType result = xdrTransform.transformAcknowledgementToAuditMsg(acknowledgement, assertion,
+                target, direction, _interface, null);
+
+        assertEquals(TARGET_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+
+    @Test
+    public void getHcidEntityInbound() {
+        String direction = NhincConstants.AUDIT_LOG_INBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_ENTITY_INTERFACE;
+
+        LogEventRequestType result = xdrTransform.transformAcknowledgementToAuditMsg(acknowledgement, assertion,
+                target, direction, _interface, null);
+
+        assertEquals(LOCAL_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+
+    @Test
+    public void getHcidEntityOutbound() {
+        String direction = NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_ENTITY_INTERFACE;
+
+        LogEventRequestType result = xdrTransform.transformAcknowledgementToAuditMsg(acknowledgement, assertion,
+                target, direction, _interface, null);
+
+        assertEquals(LOCAL_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+
+    @Test
+    public void getHcidAdapterInbound() {
+        String direction = NhincConstants.AUDIT_LOG_INBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE;
+
+        LogEventRequestType result = xdrTransform.transformAcknowledgementToAuditMsg(acknowledgement, assertion,
+                target, direction, _interface, null);
+
+        assertEquals(LOCAL_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+
+    @Test
+    public void getHcidAdapterOutbound() {
+        String direction = NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE;
+
+        LogEventRequestType result = xdrTransform.transformAcknowledgementToAuditMsg(acknowledgement, assertion,
+                target, direction, _interface, null);
+
+        assertEquals(LOCAL_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+
+    private XDRTransforms createXDRTransforms() {
+        
+        return new XDRTransforms() {
+            @Override
+            protected String getLocalHomeCommunityId() {
+                return LOCAL_HCID;
+            }
+        };
+    }
+}

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/transform/audit/XDRMessageHelper.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/transform/audit/XDRMessageHelper.java
@@ -26,14 +26,18 @@
  */
 package gov.hhs.fha.nhinc.transform.audit;
 
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.common.nhinccommon.UserType;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
-import java.io.File;
+
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.transform.stream.StreamSource;
-import oasis.names.tc.ebxml_regrep.xsd.lcm._3.SubmitObjectsRequest;
+
+import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
 
 /**
  * 
@@ -41,6 +45,10 @@ import oasis.names.tc.ebxml_regrep.xsd.lcm._3.SubmitObjectsRequest;
  */
 public class XDRMessageHelper {
     private static final String XML_FILENAME = "ProvideAndRegisterDocumentSet-bRequest.xml";
+    
+    public static final String CONST_USER_NAME = "userName";
+    public static final String CONST_HC_NAME = "Home Community";
+    public static final String CONST_HC_DESC = "HC Description";
 
     public ProvideAndRegisterDocumentSetRequestType getSampleMessage() {
         ProvideAndRegisterDocumentSetRequestType result = null;
@@ -65,5 +73,39 @@ public class XDRMessageHelper {
         return result;
 
     }
+    
+    public RegistryResponseType createRegistryResponseType() {
+        RegistryResponseType response = new RegistryResponseType();
+        response.setStatus("Success");
+        
+        return response;
+    }
+    
+    public HomeCommunityType createHomeCommunity(String hcid) {
+        HomeCommunityType hc = new HomeCommunityType();
+        hc.setDescription(CONST_HC_DESC);
+        hc.setHomeCommunityId(hcid);
+        hc.setName(CONST_HC_NAME);
+
+        return hc;
+    }
+
+    public AssertionType createAssertion(String hcid) {
+        AssertionType assertion = new AssertionType();
+        assertion.setUserInfo(new UserType());
+        assertion.getUserInfo().setUserName(CONST_USER_NAME);
+        assertion.getUserInfo().setOrg(createHomeCommunity(hcid));
+        assertion.setHomeCommunity(createHomeCommunity(hcid));
+
+        return assertion;
+    }
+    
+    public NhinTargetSystemType createNhinTargetSystem(String hcid) {
+        NhinTargetSystemType nhinTarget = new NhinTargetSystemType(); 
+        nhinTarget.setHomeCommunity(createHomeCommunity(hcid));
+        
+        return nhinTarget;
+    }
+
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/transform/audit/XDRProvideAndRegisterTransformsHCIDTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/transform/audit/XDRProvideAndRegisterTransformsHCIDTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2009-13, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.transform.audit;
+
+import static org.junit.Assert.assertEquals;
+import gov.hhs.fha.nhinc.common.auditlog.LogEventRequestType;
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
+
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class XDRProvideAndRegisterTransformsHCIDTest {
+
+    private static final String LOCAL_HCID = "localHCID";
+    private static final String ASSERTION_HCID = "assertionHCID";
+    private static final String TARGET_HCID = "targetHCID";
+
+    private XDRMessageHelper messageHelper = new XDRMessageHelper();
+
+    private XDRTransforms xdrTransform;
+    private AssertionType assertion;
+    private ProvideAndRegisterDocumentSetRequestType request;
+    private NhinTargetSystemType target;
+
+    @Before
+    public void setup() {
+        xdrTransform = createXDRTransforms();
+        assertion = messageHelper.createAssertion(ASSERTION_HCID);
+        target = messageHelper.createNhinTargetSystem(TARGET_HCID);
+        request = new ProvideAndRegisterDocumentSetRequestType();
+    }
+
+    @Test
+    public void getHcidNhinOutbound() {
+        String direction = NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_NHIN_INTERFACE;
+
+        LogEventRequestType result = xdrTransform.transformRequestToAuditMsg(request, assertion, target, direction,
+                _interface);
+        
+        assertEquals(TARGET_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+
+    @Test
+    public void getHcidNhinInbound() {
+        String direction = NhincConstants.AUDIT_LOG_INBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_NHIN_INTERFACE;
+
+        LogEventRequestType result = xdrTransform.transformRequestToAuditMsg(request, assertion, target, direction,
+                _interface);
+
+        assertEquals(ASSERTION_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+
+    @Test
+    public void getHcidEntityInbound() {
+        String direction = NhincConstants.AUDIT_LOG_INBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_ENTITY_INTERFACE;
+
+        LogEventRequestType result = xdrTransform.transformRequestToAuditMsg(request, assertion, target, direction,
+                _interface);
+        
+        assertEquals(LOCAL_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+
+    @Test
+    public void getHcidEntityOutbound() {
+        String direction = NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_ENTITY_INTERFACE;
+
+        LogEventRequestType result = xdrTransform.transformRequestToAuditMsg(request, assertion, target, direction,
+                _interface);
+        
+        assertEquals(LOCAL_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+
+    @Test
+    public void getHcidAdapterInbound() {
+        String direction = NhincConstants.AUDIT_LOG_INBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE;
+
+        LogEventRequestType result = xdrTransform.transformRequestToAuditMsg(request, assertion, target, direction,
+                _interface);
+        
+        assertEquals(LOCAL_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+
+    @Test
+    public void getHcidAdapterOutbound() {
+        String direction = NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE;
+
+        LogEventRequestType result = xdrTransform.transformRequestToAuditMsg(request, assertion, target, direction,
+                _interface);
+        
+        assertEquals(LOCAL_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+
+    private XDRTransforms createXDRTransforms() {
+
+        return new XDRTransforms() {
+            @Override
+            protected String getLocalHomeCommunityId() {
+                return LOCAL_HCID;
+            }
+
+            @Override
+            protected boolean areRequiredXDSfieldsNull(ProvideAndRegisterDocumentSetRequestType body,
+                    AssertionType assertion) {
+                return false;
+            }
+        };
+    }
+}

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/transform/audit/XDRRegistryResponseTransformsHCIDTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/transform/audit/XDRRegistryResponseTransformsHCIDTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2009-13, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.transform.audit;
+
+import static org.junit.Assert.assertEquals;
+import gov.hhs.fha.nhinc.common.auditlog.LogEventRequestType;
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
+
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class XDRRegistryResponseTransformsHCIDTest {
+
+    private static final String LOCAL_HCID = "localHCID";
+    private static final String ASSERTION_HCID = "assertionHCID";
+    private static final String TARGET_HCID = "targetHCID";
+    
+    private XDRMessageHelper messageHelper = new XDRMessageHelper();
+
+    private XDRTransforms xdrTransform;
+    private AssertionType assertion;
+    private RegistryResponseType registryResponse;
+    private NhinTargetSystemType target;
+
+    @Before
+    public void setup() {
+        xdrTransform = createXDRTransforms();
+        assertion = messageHelper.createAssertion(ASSERTION_HCID);
+        target = messageHelper.createNhinTargetSystem(TARGET_HCID);
+        registryResponse = messageHelper.createRegistryResponseType();
+    }
+
+    @Test
+    public void getHcidNhinOutboundInRequestingSide() {
+        String direction = NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_NHIN_INTERFACE;
+        
+        LogEventRequestType result = xdrTransform.transformResponseToAuditMsg(registryResponse, assertion, target,
+                direction, _interface, true);
+        
+        assertEquals(TARGET_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+    
+    @Test
+    public void getHcidNhinInboundInRequestingSide() { 
+        String direction = NhincConstants.AUDIT_LOG_INBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_NHIN_INTERFACE;
+        
+        LogEventRequestType result = xdrTransform.transformResponseToAuditMsg(registryResponse, assertion, target,
+                direction, _interface, true);
+        
+        assertEquals(TARGET_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+    
+    @Test
+    public void getHcidNhinOutboundInRespondingSide() {
+        String direction = NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_NHIN_INTERFACE;
+        
+        LogEventRequestType result = xdrTransform.transformResponseToAuditMsg(registryResponse, assertion, target,
+                direction, _interface, false);
+        
+        assertEquals(ASSERTION_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+    
+    @Test
+    public void getHcidNhinInboundInRespondingSide() { 
+        String direction = NhincConstants.AUDIT_LOG_INBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_NHIN_INTERFACE;
+        
+        LogEventRequestType result = xdrTransform.transformResponseToAuditMsg(registryResponse, assertion, target,
+                direction, _interface, false);
+        
+        assertEquals(ASSERTION_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+    
+    @Test
+    public void getHcidEntityInboundInRequestingSide() { 
+        String direction = NhincConstants.AUDIT_LOG_INBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_ENTITY_INTERFACE;
+        
+        LogEventRequestType result = xdrTransform.transformResponseToAuditMsg(registryResponse, assertion, target,
+                direction, _interface, true);        
+        assertEquals(LOCAL_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+    
+    @Test
+    public void getHcidEntityInboundInRespondingSide() { 
+        String direction = NhincConstants.AUDIT_LOG_INBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_ENTITY_INTERFACE;
+        
+        LogEventRequestType result = xdrTransform.transformResponseToAuditMsg(registryResponse, assertion, target,
+                direction, _interface, false);        
+        assertEquals(LOCAL_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+    
+    @Test
+    public void getHcidEntityOutboundInRequestingSide() { 
+        String direction = NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_ENTITY_INTERFACE;
+        
+        LogEventRequestType result = xdrTransform.transformResponseToAuditMsg(registryResponse, assertion, target,
+                direction, _interface, true);        
+        assertEquals(LOCAL_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+    
+    @Test
+    public void getHcidEntityOutboundInRespondingSide() { 
+        String direction = NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_ENTITY_INTERFACE;
+        
+        LogEventRequestType result = xdrTransform.transformResponseToAuditMsg(registryResponse, assertion, target,
+                direction, _interface, false);        
+        assertEquals(LOCAL_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+    
+    @Test
+    public void getHcidAdapterInboundInRequestingSide() { 
+        String direction = NhincConstants.AUDIT_LOG_INBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE;
+        
+        LogEventRequestType result = xdrTransform.transformResponseToAuditMsg(registryResponse, assertion, target,
+                direction, _interface, true);       
+        assertEquals(LOCAL_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+    
+    @Test
+    public void getHcidAdapterInboundInRespondingSide() { 
+        String direction = NhincConstants.AUDIT_LOG_INBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE;
+        
+        LogEventRequestType result = xdrTransform.transformResponseToAuditMsg(registryResponse, assertion, target,
+                direction, _interface, false);       
+        assertEquals(LOCAL_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+    
+    @Test
+    public void getHcidAdapterOutboundInRequestingSide() { 
+        String direction = NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE;
+        
+        LogEventRequestType result = xdrTransform.transformResponseToAuditMsg(registryResponse, assertion, target,
+                direction, _interface, true);       
+        assertEquals(LOCAL_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+    
+    @Test
+    public void getHcidAdapterOutboundInRespondingSide() { 
+        String direction = NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE;
+        
+        LogEventRequestType result = xdrTransform.transformResponseToAuditMsg(registryResponse, assertion, target,
+                direction, _interface, false);       
+        assertEquals(LOCAL_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
+    }
+
+    private XDRTransforms createXDRTransforms() {
+
+        return new XDRTransforms() {
+            @Override
+            protected String getLocalHomeCommunityId() {
+                return LOCAL_HCID;
+            }
+        };
+    }
+}

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/transform/audit/XDRTransformsTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/transform/audit/XDRTransformsTest.java
@@ -31,8 +31,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import gov.hhs.fha.nhinc.common.auditlog.LogEventRequestType;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
-import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
-import gov.hhs.fha.nhinc.common.nhinccommon.UserType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
@@ -48,10 +47,8 @@ import org.junit.Test;
  * @author dunnek
  */
 public class XDRTransformsTest {
-    private static final String CONST_USER_NAME = "userName";
+    private static final String CONST_USER_NAME = XDRMessageHelper.CONST_USER_NAME;
     private static final String CONST_HCID = "1.1";
-    private static final String CONST_HC_NAME = "Home COmmunity";
-    private static final String CONST_HC_DESC = "HC Description";
 
     public XDRTransformsTest() {
     }
@@ -79,7 +76,7 @@ public class XDRTransformsTest {
         String direction = NhincConstants.AUDIT_LOG_INBOUND_DIRECTION;
         String _interface = "interface";
         XDRTransforms instance = createTransformsClass_OverrideRequiredFields();
-        LogEventRequestType result = instance.transformResponseToAuditMsg(null, assertion, direction, _interface);
+        LogEventRequestType result = instance.transformResponseToAuditMsg(null, assertion, null, direction, _interface, false);
         assertNull(result);
 
     }
@@ -91,8 +88,9 @@ public class XDRTransformsTest {
         String direction = NhincConstants.AUDIT_LOG_INBOUND_DIRECTION;
         String _interface = "interface";
         XDRTransforms instance = createTransformsClass_OverrideRequiredFields();
+        NhinTargetSystemType target = new NhinTargetSystemType();
         LogEventRequestType result = instance.transformResponseToAuditMsg(new RegistryResponseType(), assertion,
-                direction, _interface);
+                target, direction, _interface, false);
         assertNotNull(result);
 
     }
@@ -105,8 +103,10 @@ public class XDRTransformsTest {
         String _interface = "interface";
         XDRTransforms instance = createTransformsClass_OverrideRequiredFields();
         RegistryResponseType response = new RegistryResponseType();
+        NhinTargetSystemType target = new NhinTargetSystemType();
 
-        LogEventRequestType result = instance.transformResponseToAuditMsg(response, assertion, direction, _interface);
+        LogEventRequestType result = instance.transformResponseToAuditMsg(response, assertion, target, direction,
+                _interface, false);
         assertNotNull(result);
         assertEquals(_interface, result.getInterface());
         assertEquals(direction, result.getDirection());
@@ -122,7 +122,8 @@ public class XDRTransformsTest {
         XDRTransforms instance = createTransformsClass_OverrideRequiredFields();
         RegistryResponseType response = new RegistryResponseType();
         response.setStatus("Success");
-        LogEventRequestType result = instance.transformResponseToAuditMsg(response, assertion, direction, _interface);
+        NhinTargetSystemType target = new NhinTargetSystemType();
+        LogEventRequestType result = instance.transformResponseToAuditMsg(response, assertion, target, direction, _interface, false);
         assertNotNull(result);
         assertEquals(_interface, result.getInterface());
         assertEquals(direction, result.getDirection());
@@ -142,7 +143,7 @@ public class XDRTransformsTest {
         String _interface = "";
         XDRTransforms instance = createTransformsClass_OverrideRequiredFields();
         LogEventRequestType expResult = null;
-        LogEventRequestType result = instance.transformRequestToAuditMsg(request, assertion, direction, _interface);
+        LogEventRequestType result = instance.transformRequestToAuditMsg(request, assertion, null, direction, _interface);
         assertNull(result);
         assertEquals(expResult, result);
 
@@ -159,7 +160,8 @@ public class XDRTransformsTest {
         String direction = "";
         String _interface = "";
         XDRTransforms instance = createTransformsClass_OverrideRequiredFields();
-        LogEventRequestType result = instance.transformRequestToAuditMsg(request, assertion, direction, _interface);
+        NhinTargetSystemType target = new NhinTargetSystemType();
+        LogEventRequestType result = instance.transformRequestToAuditMsg(request, assertion, target, direction, _interface);
 
         assertNotNull(result);
         // TODO review the generated test code and remove the default call to fail.
@@ -172,10 +174,11 @@ public class XDRTransformsTest {
         System.out.println("transformRequestToAuditMsg");
         ProvideAndRegisterDocumentSetRequestType request = new XDRMessageHelper().getSampleMessage();
         AssertionType assertion = createAssertion();
-        String direction = NhincConstants.AUDIT_LOG_INBOUND_DIRECTION;
-        String _interface = "interface";
+        String direction = NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION;     
+        String _interface = NhincConstants.AUDIT_LOG_NHIN_INTERFACE;
         XDRTransforms instance = createTransformsClass_OverrideRequiredFields();
-        LogEventRequestType result = instance.transformRequestToAuditMsg(request, assertion, direction, _interface);
+        NhinTargetSystemType target = createNhinTargetSystem(CONST_HCID);
+        LogEventRequestType result = instance.transformRequestToAuditMsg(request, assertion, target, direction, _interface);
 
         assertNotNull(result);
         assertNotNull(result.getAuditMessage());
@@ -188,7 +191,7 @@ public class XDRTransformsTest {
         assertEquals(1, result.getAuditMessage().getActiveParticipant().size());
         assertEquals(1, result.getAuditMessage().getAuditSourceIdentification().size());
 
-        assertEquals(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, result.getDirection());
+        assertEquals(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, result.getDirection());
         assertEquals(_interface, result.getInterface());
 
         assertEquals(CONST_USER_NAME, result.getAuditMessage().getActiveParticipant().get(0).getUserID());
@@ -197,7 +200,7 @@ public class XDRTransformsTest {
         assertNotNull(result.getAuditMessage().getAuditSourceIdentification());
 
         assertEquals(CONST_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
-        assertEquals(CONST_HC_NAME, result.getAuditMessage().getAuditSourceIdentification().get(0)
+        assertEquals(CONST_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0)
                 .getAuditEnterpriseSiteID());
         // TODO review the generated test code and remove the default call to fail.
 
@@ -212,8 +215,9 @@ public class XDRTransformsTest {
         String direction = "";
         String _interface = "";
         XDRTransforms instance = createTransformsClass_OverrideRequiredFields();
+        NhinTargetSystemType target = new NhinTargetSystemType();
         LogEventRequestType expResult = null;
-        LogEventRequestType result = instance.transformRequestToAuditMsg(request, assertion, direction, _interface);
+        LogEventRequestType result = instance.transformRequestToAuditMsg(request, assertion, target, direction, _interface);
         assertNull(result);
         assertEquals(expResult, result);
 
@@ -232,9 +236,10 @@ public class XDRTransformsTest {
         AssertionType assertion = createAssertion();
         String direction = "";
         String _interface = "";
+        NhinTargetSystemType target = new NhinTargetSystemType();
         XDRTransforms instance = createTransformsClass_OverrideRequiredFields();
         LogEventRequestType result = instance
-                .transformRequestToAuditMsg(proxyRequest, assertion, direction, _interface);
+                .transformRequestToAuditMsg(proxyRequest, assertion, target, direction, _interface);
 
         assertNotNull(result);
         // TODO review the generated test code and remove the default call to fail.
@@ -250,11 +255,12 @@ public class XDRTransformsTest {
         proxyRequest.setProvideAndRegisterDocumentSetRequest(request);
 
         AssertionType assertion = createAssertion();
-        String direction = NhincConstants.AUDIT_LOG_INBOUND_DIRECTION;
-        String _interface = "interface";
+        String direction = NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION;
+        String _interface = NhincConstants.AUDIT_LOG_NHIN_INTERFACE;
+        NhinTargetSystemType target = createNhinTargetSystem(CONST_HCID);
         XDRTransforms instance = createTransformsClass_OverrideRequiredFields();
         LogEventRequestType result = instance
-                .transformRequestToAuditMsg(proxyRequest, assertion, direction, _interface);
+                .transformRequestToAuditMsg(proxyRequest, assertion, target, direction, _interface);
 
         assertNotNull(result);
         assertNotNull(result.getAuditMessage());
@@ -267,7 +273,7 @@ public class XDRTransformsTest {
         assertEquals(1, result.getAuditMessage().getActiveParticipant().size());
         assertEquals(1, result.getAuditMessage().getAuditSourceIdentification().size());
 
-        assertEquals(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, result.getDirection());
+        assertEquals(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, result.getDirection());
         assertEquals(_interface, result.getInterface());
 
         assertEquals(CONST_USER_NAME, result.getAuditMessage().getActiveParticipant().get(0).getUserID());
@@ -276,7 +282,7 @@ public class XDRTransformsTest {
         assertNotNull(result.getAuditMessage().getAuditSourceIdentification());
 
         assertEquals(CONST_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0).getAuditSourceID());
-        assertEquals(CONST_HC_NAME, result.getAuditMessage().getAuditSourceIdentification().get(0)
+        assertEquals(CONST_HCID, result.getAuditMessage().getAuditSourceIdentification().get(0)
                 .getAuditEnterpriseSiteID());
         // TODO review the generated test code and remove the default call to fail.
 
@@ -290,9 +296,10 @@ public class XDRTransformsTest {
         AssertionType assertion = null;
         String direction = "";
         String _interface = "";
+        NhinTargetSystemType target = new NhinTargetSystemType();
         XDRTransforms instance = createTransformsClass_OverrideRequiredFields();
         LogEventRequestType expResult = null;
-        LogEventRequestType result = instance.transformRequestToAuditMsg(request, assertion, direction, _interface);
+        LogEventRequestType result = instance.transformRequestToAuditMsg(request, assertion, target, direction, _interface);
         assertNull(result);
         assertEquals(expResult, result);
 
@@ -516,24 +523,12 @@ public class XDRTransformsTest {
         return result;
     }
 
-    private HomeCommunityType createHomeCommunity() {
-        HomeCommunityType hc = new HomeCommunityType();
-        hc.setDescription(CONST_HC_DESC);
-        hc.setHomeCommunityId(CONST_HCID);
-        hc.setName(CONST_HC_NAME);
-
-        return hc;
-    }
-
     private AssertionType createAssertion() {
-        AssertionType assertion = new AssertionType();
-        assertion.setUserInfo(new UserType());
-
-        assertion.getUserInfo().setUserName(CONST_USER_NAME);
-
-        assertion.getUserInfo().setOrg(createHomeCommunity());
-
-        return assertion;
+        return new XDRMessageHelper().createAssertion(CONST_HCID);
+    }
+    
+    private NhinTargetSystemType createNhinTargetSystem(String hcid) {
+        return new XDRMessageHelper().createNhinTargetSystem(hcid);
     }
 
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/AuditRepositoryLogger.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/AuditRepositoryLogger.java
@@ -269,9 +269,8 @@ public class AuditRepositoryLogger implements AuditRepositoryDocumentRetrieveLog
             RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType message, AssertionType assertion,
             String direction) {
         LOG.debug("Entering AuditRepositoryLogger.logEntityXDRReq(...)");
-        LogEventRequestType auditMsg = null;
-        auditMsg = xdrAuditTransformer.transformRequestToAuditMsg(message.getProvideAndRegisterDocumentSetRequest(),
-                assertion, direction, NhincConstants.AUDIT_LOG_ENTITY_INTERFACE);
+        LogEventRequestType auditMsg = xdrAuditTransformer.transformRequestToAuditMsg(message.getProvideAndRegisterDocumentSetRequest(),
+                assertion, null, direction, NhincConstants.AUDIT_LOG_ENTITY_INTERFACE);
         LOG.debug("Exiting AuditRepositoryLogger.logEntityXDRReq(...)");
         return auditMsg;
     }
@@ -287,7 +286,8 @@ public class AuditRepositoryLogger implements AuditRepositoryDocumentRetrieveLog
     public LogEventRequestType logAdapterXDRResponse(RegistryResponseType response, AssertionType assertion,
             String direction) {
         LOG.debug("Entering AuditRepositoryLogger.logAdapterXDRResponse(...)");
-        LogEventRequestType auditMsg = null;
+        LogEventRequestType auditMsg = xdrAuditTransformer.transformResponseToAuditMsg(response, assertion, null,
+                direction, NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE, true);
         LOG.debug("Exiting AuditRepositoryLogger.logAdapterXDRResponse(...)");
         return auditMsg;
     }
@@ -303,9 +303,8 @@ public class AuditRepositoryLogger implements AuditRepositoryDocumentRetrieveLog
     public LogEventRequestType logEntityXDRResponse(RegistryResponseType response, AssertionType assertion,
             String direction) {
         LOG.debug("Entering AuditRepositoryLogger.logEntityXDRResponse(...)");
-        LogEventRequestType auditMsg = null;
-            auditMsg = xdrAuditTransformer.transformResponseToAuditMsg(response, assertion, direction,
-                    NhincConstants.AUDIT_LOG_ENTITY_INTERFACE);
+        LogEventRequestType auditMsg = xdrAuditTransformer.transformResponseToAuditMsg(response, assertion, null,
+                direction, NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, true);
         LOG.debug("Exiting AuditRepositoryLogger.logEntityXDRResponse(...)");
         return auditMsg;
     }
@@ -322,9 +321,8 @@ public class AuditRepositoryLogger implements AuditRepositoryDocumentRetrieveLog
             gov.hhs.fha.nhinc.common.nhinccommonentity.RespondingGatewayProvideAndRegisterDocumentSetSecuredResponseRequestType response,
             AssertionType assertion, String direction) {
         LOG.debug("Entering AuditRepositoryLogger.logEntityXDRResponse(...)");
-        LogEventRequestType auditMsg = null;
-            auditMsg = xdrAuditTransformer.transformRequestToAuditMsg(response, assertion, direction,
-                    NhincConstants.AUDIT_LOG_ENTITY_INTERFACE);
+        LogEventRequestType auditMsg = xdrAuditTransformer.transformRequestToAuditMsg(response, assertion, null,
+                direction, NhincConstants.AUDIT_LOG_ENTITY_INTERFACE);
         LOG.debug("Exiting AuditRepositoryLogger.logEntityXDRResponse(...)");
         return auditMsg;
     }
@@ -750,17 +748,15 @@ public class AuditRepositoryLogger implements AuditRepositoryDocumentRetrieveLog
      * @return
      */
     public LogEventRequestType logXDRReq(ProvideAndRegisterDocumentSetRequestType message, AssertionType assertion,
-            String direction) {
+            NhinTargetSystemType target, String direction) {
         LOG.debug("Entering AuditRepositoryLogger.logNhinXDRReq(...)");
-        LogEventRequestType auditMsg = null;
-
         if (message == null) {
             LOG.error("Message is null");
             return null;
         }
-            XDRTransforms auditTransformer = new XDRTransforms();
-            auditMsg = auditTransformer.transformRequestToAuditMsg(message, assertion, direction,
-                    NhincConstants.AUDIT_LOG_NHIN_INTERFACE);
+        XDRTransforms auditTransformer = new XDRTransforms();
+        LogEventRequestType auditMsg = auditTransformer.transformRequestToAuditMsg(message, assertion, target, direction,
+                NhincConstants.AUDIT_LOG_NHIN_INTERFACE);
         LOG.debug("Exiting AuditRepositoryLogger.logNhinXDRReq(...)");
         return auditMsg;
     }
@@ -782,6 +778,10 @@ public class AuditRepositoryLogger implements AuditRepositoryDocumentRetrieveLog
             LOG.error("Message is null");
             return null;
         }
+        
+        XDRTransforms auditTransformer = new XDRTransforms();
+        auditMsg = auditTransformer.transformRequestToAuditMsg(message, assertion, null, direction,
+                NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE);
 
         LOG.debug("Exiting AuditRepositoryLogger.logAdapterXDRReq(...)");
         return auditMsg;
@@ -797,12 +797,11 @@ public class AuditRepositoryLogger implements AuditRepositoryDocumentRetrieveLog
      */
     public LogEventRequestType logXDRReq(
             gov.hhs.fha.nhinc.common.nhinccommonproxy.RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType message,
-            AssertionType assertion, String direction) {
+            AssertionType assertion, NhinTargetSystemType target, String direction) {
         LOG.debug("Entering AuditRepositoryLogger.logXDRReq(...)");
-        LogEventRequestType auditMsg = null;
-            XDRTransforms auditTransformer = new XDRTransforms();
-            auditMsg = auditTransformer.transformRequestToAuditMsg(message, assertion, direction,
-                    NhincConstants.AUDIT_LOG_NHIN_INTERFACE);
+        XDRTransforms auditTransformer = new XDRTransforms();
+        LogEventRequestType auditMsg = auditTransformer.transformRequestToAuditMsg(message, assertion, target,
+                direction, NhincConstants.AUDIT_LOG_NHIN_INTERFACE);
         LOG.debug("Exiting AuditRepositoryLogger.logNhinXDRReq(...)");
         return auditMsg;
     }
@@ -816,33 +815,13 @@ public class AuditRepositoryLogger implements AuditRepositoryDocumentRetrieveLog
      * @return
      */
     public LogEventRequestType logNhinXDRResponse(RegistryResponseType message, AssertionType assertion,
-            String direction) {
-        LOG.debug("Entering AuditRepositoryLogger.logNhinXDRReq(...)");
+            NhinTargetSystemType target, String direction, boolean isRequesting) {
+        LOG.debug("Entering AuditRepositoryLogger.logNhinXDRResponse(...)");
         LogEventRequestType auditMsg = null;
             XDRTransforms auditTransformer = new XDRTransforms();
-            auditMsg = auditTransformer.transformResponseToAuditMsg(message, assertion, direction,
-                    NhincConstants.AUDIT_LOG_NHIN_INTERFACE);
-        LOG.debug("Exiting AuditRepositoryLogger.logNhinXDRReq(...)");
-        return auditMsg;
-    }
-
-    /**
-     * Create an audit log for an XDR Response Request at the NHIN interface.
-     * 
-     * @param message The Nhin XDR Response
-     * @param assertion The assertion to be audited
-     * @param direction The direction this message is going (Inbound or Outbound)
-     * @return
-     */
-    public LogEventRequestType logNhinXDRResponseRequest(
-            gov.hhs.fha.nhinc.common.nhinccommonproxy.RespondingGatewayProvideAndRegisterDocumentSetSecuredResponseRequestType message,
-            AssertionType assertion, String direction) {
-        LOG.debug("Entering AuditRepositoryLogger.logNhinXDRReq(...)");
-        LogEventRequestType auditMsg = null;
-            XDRTransforms auditTransformer = new XDRTransforms();
-            auditMsg = auditTransformer.transformRequestToAuditMsg(message, assertion, direction,
-                    NhincConstants.AUDIT_LOG_NHIN_INTERFACE);
-        LOG.debug("Exiting AuditRepositoryLogger.logNhinXDRReq(...)");
+            auditMsg = auditTransformer.transformResponseToAuditMsg(message, assertion, target, direction,
+                    NhincConstants.AUDIT_LOG_NHIN_INTERFACE, isRequesting);
+        LOG.debug("Exiting AuditRepositoryLogger.logNhinXDRResponse(...)");
         return auditMsg;
     }
 
@@ -877,13 +856,10 @@ public class AuditRepositoryLogger implements AuditRepositoryDocumentRetrieveLog
      * @return
      */
     public LogEventRequestType logAcknowledgement(XDRAcknowledgementType acknowledgement, AssertionType assertion,
-            String direction, String action) {
+            NhinTargetSystemType target, String direction, String action) {
         LOG.debug("Entering AuditRepositoryLogger.logAcknowledgement(...)");
-
-        LogEventRequestType auditMsg = null;
-
-            auditMsg = xdrAuditTransformer.transformAcknowledgementToAuditMsg(acknowledgement, assertion, direction,
-                    NhincConstants.AUDIT_LOG_NHIN_INTERFACE, action);
+        LogEventRequestType auditMsg = xdrAuditTransformer.transformAcknowledgementToAuditMsg(acknowledgement,
+                assertion, target, direction, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, action);
 
         LOG.debug("Exiting AuditRepositoryLogger.logAcknowledgement(...)");
         return auditMsg;
@@ -899,10 +875,10 @@ public class AuditRepositoryLogger implements AuditRepositoryDocumentRetrieveLog
      */
     public LogEventRequestType logAdapterAcknowledgement(XDRAcknowledgementType acknowledgement, AssertionType assertion,
             String direction, String action) {
-        LOG.debug("Entering AuditRepositoryLogger.logAcknowledgement(...)");
-
-        LogEventRequestType auditMsg = null;
-        LOG.debug("Exiting AuditRepositoryLogger.logAcknowledgement(...)");
+        LOG.debug("Entering AuditRepositoryLogger.logAdapterAcknowledgement(...)");        
+        LogEventRequestType auditMsg = xdrAuditTransformer.transformAcknowledgementToAuditMsg(acknowledgement,
+                assertion, null, direction, NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE, action);
+        LOG.debug("Exiting AuditRepositoryLogger.logAdapterAcknowledgement(...)");
         return auditMsg;
     }
 
@@ -917,9 +893,8 @@ public class AuditRepositoryLogger implements AuditRepositoryDocumentRetrieveLog
     public LogEventRequestType logEntityAcknowledgement(XDRAcknowledgementType acknowledgement,
             AssertionType assertion, String direction, String action) {
         LOG.debug("Entering AuditRepositoryLogger.logAcknowledgement(...)");
-        LogEventRequestType auditMsg = null;
-            auditMsg = xdrAuditTransformer.transformAcknowledgementToAuditMsg(acknowledgement, assertion, direction,
-                    NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, action);
+        LogEventRequestType auditMsg = xdrAuditTransformer.transformAcknowledgementToAuditMsg(acknowledgement,
+                assertion, null, direction, NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, action);
         LOG.debug("Exiting AuditRepositoryLogger.logAcknowledgement(...)");
         return auditMsg;
     }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/XDRAuditLogger.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/XDRAuditLogger.java
@@ -37,6 +37,7 @@ import gov.hhs.fha.nhinc.auditrepository.nhinc.proxy.AuditRepositoryProxyObjectF
 import gov.hhs.fha.nhinc.common.auditlog.LogEventRequestType;
 import gov.hhs.fha.nhinc.common.nhinccommon.AcknowledgementType;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.common.nhinccommonentity.RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType;
 import gov.hhs.healthit.nhin.XDRAcknowledgementType;
 
@@ -56,13 +57,13 @@ public class XDRAuditLogger {
      * @return acknowledgment type.
      */
     public AcknowledgementType auditNhinXDR(ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion,
-            String direction) {
+            NhinTargetSystemType target, String direction) {
         AcknowledgementType ack = new AcknowledgementType();
 
         LOG.debug("begin auditNhinXDR()");
         // Set up the audit logging request message
         AuditRepositoryLogger auditLogger = new AuditRepositoryLogger();
-        LogEventRequestType auditLogMsg = auditLogger.logXDRReq(request, assertion, direction);
+        LogEventRequestType auditLogMsg = auditLogger.logXDRReq(request, assertion, target, direction);
 
         if (auditLogMsg != null) {
             if (auditLogMsg.getAuditMessage() != null) {
@@ -121,12 +122,12 @@ public class XDRAuditLogger {
      */
     public AcknowledgementType auditXDR(
             gov.hhs.fha.nhinc.common.nhinccommonproxy.RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request,
-            AssertionType assertion, String direction) {
+            AssertionType assertion, NhinTargetSystemType target, String direction) {
         AcknowledgementType ack = new AcknowledgementType();
 
         // Set up the audit logging request message
         AuditRepositoryLogger auditLogger = new AuditRepositoryLogger();
-        LogEventRequestType auditLogMsg = auditLogger.logXDRReq(request, assertion, direction);
+        LogEventRequestType auditLogMsg = auditLogger.logXDRReq(request, assertion, target, direction);
 
         if (auditLogMsg != null &&
             auditLogMsg.getAuditMessage() != null) {
@@ -230,34 +231,13 @@ public class XDRAuditLogger {
      * @return
      */
     public AcknowledgementType auditNhinXDRResponse(RegistryResponseType response, AssertionType assertion,
-            String direction) {        
+            NhinTargetSystemType target, String direction, boolean isRequesting) {        
         AcknowledgementType ack = new AcknowledgementType();
 
         // Set up the audit logging request message
         AuditRepositoryLogger auditLogger = new AuditRepositoryLogger();
-        LogEventRequestType auditLogMsg = auditLogger.logNhinXDRResponse(response, assertion, direction);
-
-        if (auditLogMsg != null && auditLogMsg.getAuditMessage() != null) {
-            audit(auditLogMsg, assertion);
-        }
-        return ack;
-    }
-
-    /**
-     * Creates a generic Audit Log message for an Nhin XDR Response Request.
-     * @param request The XDR Response Request to be audited
-     * @param assertion The assertion to be audited
-     * @param direction The direction this message is going (Inbound or Outbound)
-     * @return
-     */
-    public AcknowledgementType auditNhinXDRResponseRequest(
-            gov.hhs.fha.nhinc.common.nhinccommonproxy.RespondingGatewayProvideAndRegisterDocumentSetSecuredResponseRequestType request,
-            AssertionType assertion, String direction) {
-        AcknowledgementType ack = new AcknowledgementType();
-
-        // Set up the audit logging request message
-        AuditRepositoryLogger auditLogger = new AuditRepositoryLogger();
-        LogEventRequestType auditLogMsg = auditLogger.logNhinXDRResponseRequest(request, assertion, direction);
+        LogEventRequestType auditLogMsg = auditLogger.logNhinXDRResponse(response, assertion, target, direction,
+                isRequesting);
 
         if (auditLogMsg != null && auditLogMsg.getAuditMessage() != null) {
             audit(auditLogMsg, assertion);
@@ -288,14 +268,15 @@ public class XDRAuditLogger {
      * @return
      */
     public AcknowledgementType auditAcknowledgement(XDRAcknowledgementType acknowledgement, AssertionType assertion,
-            String direction, String action) {
+            NhinTargetSystemType target, String direction, String action) {
 
         LOG.debug("Start auditAcknowledgement for " + action);
         AcknowledgementType ack = new AcknowledgementType();
 
         // Set up the audit logging request message
         AuditRepositoryLogger auditLogger = new AuditRepositoryLogger();
-        LogEventRequestType auditLogMsg = auditLogger.logAcknowledgement(acknowledgement, assertion, direction, action);
+        LogEventRequestType auditLogMsg = auditLogger.logAcknowledgement(acknowledgement, assertion, target, direction,
+                action);
 
         if (auditLogMsg != null && auditLogMsg.getAuditMessage() != null) {
             audit(auditLogMsg, assertion);

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/entity/deferred/request/OutboundDocSubmissionDeferredRequestStrategyImpl_g0.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/entity/deferred/request/OutboundDocSubmissionDeferredRequestStrategyImpl_g0.java
@@ -35,6 +35,7 @@ import gov.hhs.fha.nhinc.orchestration.Orchestratable;
 import gov.hhs.fha.nhinc.orchestration.OrchestrationStrategy;
 import gov.hhs.healthit.nhin.XDRAcknowledgementType;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 
 import org.apache.log4j.Logger;
 
@@ -76,14 +77,14 @@ public class OutboundDocSubmissionDeferredRequestStrategyImpl_g0 implements Orch
     public void execute(OutboundDocSubmissionDeferredRequestOrchestratable message) {
         LOG.debug("Begin OutboundDocSubmissionOrchestratableImpl_g0.process");
 
-        auditRequestToNhin(message.getRequest(), message.getAssertion());
+        auditRequestToNhin(message.getRequest(), message.getAssertion(), message.getTarget());
         
         NhinDocSubmissionDeferredRequestProxy nhincDocSubmission = getNhinDocSubmissionDeferredRequestProxy();
         XDRAcknowledgementType response = nhincDocSubmission.provideAndRegisterDocumentSetBRequest11(
                 message.getRequest(), message.getAssertion(), message.getTarget());
         message.setResponse(response);
 
-        auditResponseFromNhin(response, message.getAssertion());
+        auditResponseFromNhin(response, message.getAssertion(), message.getTarget());
         LOG.debug("End OutboundDocSubmissionDeferredRequestStrategyImpl_g0.process");
     }
 
@@ -100,8 +101,9 @@ public class OutboundDocSubmissionDeferredRequestStrategyImpl_g0 implements Orch
      * @param request
      * @param assertion
      */
-    private void auditRequestToNhin(ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion) {
-        getXDRAuditLogger().auditNhinXDR(request, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
+    private void auditRequestToNhin(ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion,
+            NhinTargetSystemType target) {
+        getXDRAuditLogger().auditNhinXDR(request, assertion, target, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
     }
 
     /**
@@ -109,9 +111,10 @@ public class OutboundDocSubmissionDeferredRequestStrategyImpl_g0 implements Orch
      * @param response
      * @param assertion
      */
-    private void auditResponseFromNhin(XDRAcknowledgementType response,  AssertionType assertion) {
-        getXDRAuditLogger().auditAcknowledgement(response, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
-                NhincConstants.XDR_REQUEST_ACTION);
+    private void auditResponseFromNhin(XDRAcknowledgementType response, AssertionType assertion,
+            NhinTargetSystemType target) {
+        getXDRAuditLogger().auditAcknowledgement(response, assertion, target,
+                NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.XDR_REQUEST_ACTION);
     }
 
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/entity/deferred/request/OutboundDocSubmissionDeferredRequestStrategyImpl_g1.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/entity/deferred/request/OutboundDocSubmissionDeferredRequestStrategyImpl_g1.java
@@ -35,6 +35,7 @@ import gov.hhs.fha.nhinc.orchestration.Orchestratable;
 import gov.hhs.fha.nhinc.orchestration.OrchestrationStrategy;
 import gov.hhs.healthit.nhin.XDRAcknowledgementType;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 
 import org.apache.log4j.Logger;
 
@@ -77,7 +78,7 @@ public class OutboundDocSubmissionDeferredRequestStrategyImpl_g1 implements Orch
     public void execute(OutboundDocSubmissionDeferredRequestOrchestratable message) {
         LOG.debug("Begin OutboundDocSubmissionOrchestratableImpl_g1.process");
 
-        auditRequestToNhin(message.getRequest(), message.getAssertion());
+        auditRequestToNhin(message.getRequest(), message.getAssertion(), message.getTarget());
        
         NhinDocSubmissionDeferredRequestProxy nhincDocSubmission = getNhinDocSubmissionDeferredRequestProxy();
         XDRAcknowledgementType response = new XDRAcknowledgementType();
@@ -85,7 +86,7 @@ public class OutboundDocSubmissionDeferredRequestStrategyImpl_g1 implements Orch
                 message.getAssertion(), message.getTarget()));
         message.setResponse(response);
 
-        auditResponseFromNhin(response, message.getAssertion());
+        auditResponseFromNhin(response, message.getAssertion(), message.getTarget());
         LOG.debug("End OutboundDocSubmissionDeferredRequestStrategyImpl_g1.process");
     }
 
@@ -99,21 +100,25 @@ public class OutboundDocSubmissionDeferredRequestStrategyImpl_g1 implements Orch
 
     /**
      * Creates a generic Audit Log message for a Doc Submission method to the NHIN.
+     * 
      * @param request
      * @param assertion
      */
-    private void auditRequestToNhin(ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion) {
-        getXDRAuditLogger().auditNhinXDR(request, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
+    private void auditRequestToNhin(ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion,
+            NhinTargetSystemType target) {
+        getXDRAuditLogger().auditNhinXDR(request, assertion, target, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
     }
 
     /**
      * Creates a generic Audit Log message for a Doc Submission method from the NHIN.
+     * 
      * @param response
      * @param assertion
      */
-    private void auditResponseFromNhin(XDRAcknowledgementType response,  AssertionType assertion) {
-        getXDRAuditLogger().auditAcknowledgement(response, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
-                NhincConstants.XDR_REQUEST_ACTION);
+    private void auditResponseFromNhin(XDRAcknowledgementType response, AssertionType assertion,
+            NhinTargetSystemType target) {
+        getXDRAuditLogger().auditAcknowledgement(response, assertion, target,
+                NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.XDR_REQUEST_ACTION);
     }
 
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/entity/deferred/response/OutboundDocSubmissionDeferredResponseStrategyImpl_g1.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/entity/deferred/response/OutboundDocSubmissionDeferredResponseStrategyImpl_g1.java
@@ -27,8 +27,12 @@
 
 package gov.hhs.fha.nhinc.docsubmission.entity.deferred.response;
 
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
 import gov.hhs.fha.nhinc.docsubmission.nhin.deferred.response.proxy20.NhinDocSubmissionDeferredResponseProxy;
 import gov.hhs.fha.nhinc.docsubmission.nhin.deferred.response.proxy20.NhinDocSubmissionDeferredResponseProxyObjectFactory;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.orchestration.Orchestratable;
 import gov.hhs.fha.nhinc.orchestration.OrchestrationStrategy;
 import gov.hhs.healthit.nhin.XDRAcknowledgementType;
@@ -47,6 +51,14 @@ public class OutboundDocSubmissionDeferredResponseStrategyImpl_g1 implements Orc
     protected NhinDocSubmissionDeferredResponseProxy getNhinDocSubmissionDeferredResponseProxy() {
         return new NhinDocSubmissionDeferredResponseProxyObjectFactory().getNhinDocSubmissionDeferredResponseProxy();
     }
+    
+    /**
+     * Gets an instance of the XDRAuditLogger
+     * @return
+     */
+    protected XDRAuditLogger getXDRAuditLogger() {
+        return new XDRAuditLogger();
+    }
 
     @Override
     public void execute(Orchestratable message) {
@@ -60,6 +72,8 @@ public class OutboundDocSubmissionDeferredResponseStrategyImpl_g1 implements Orc
     public void execute(OutboundDocSubmissionDeferredResponseOrchestratable message) {
         LOG.trace("Begin OutboundDocSubmissionOrchestratableImpl_g1.process");
 
+        auditRequestToNhin(message.getRequest(), message.getAssertion(), message.getTarget());
+        
         XDRAcknowledgementType ack = new XDRAcknowledgementType();
         NhinDocSubmissionDeferredResponseProxy nhincDocSubmission = getNhinDocSubmissionDeferredResponseProxy();
         RegistryResponseType response = nhincDocSubmission.provideAndRegisterDocumentSetBDeferredResponse20(
@@ -67,8 +81,21 @@ public class OutboundDocSubmissionDeferredResponseStrategyImpl_g1 implements Orc
 
         ack.setMessage(response);
         message.setResponse(ack);
+        
+        auditResponseFromNhin(ack, message.getAssertion(), message.getTarget());
 
         LOG.trace("End OutboundDocSubmissionDeferredResponseStrategyImpl_g1.process");
+    }
+    
+    private void auditRequestToNhin(RegistryResponseType request, AssertionType assertion, NhinTargetSystemType target) {
+        getXDRAuditLogger().auditNhinXDRResponse(request, assertion, target,
+                NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, true);
+    }
+
+    private void auditResponseFromNhin(XDRAcknowledgementType response, AssertionType assertion,
+            NhinTargetSystemType target) {
+        getXDRAuditLogger().auditAcknowledgement(response, assertion, target,
+                NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.XDR_RESPONSE_ACTION);
     }
 
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/AbstractInboundDocSubmission.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/AbstractInboundDocSubmission.java
@@ -57,10 +57,10 @@ public abstract class AbstractInboundDocSubmission implements InboundDocSubmissi
     }
 
     private void auditRequestFromNhin(ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion) {
-        auditLogger.auditNhinXDR(request, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
+        auditLogger.auditNhinXDR(request, assertion, null, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
     }
 
     private void auditResponseToNhin(RegistryResponseType response, AssertionType assertion) {
-        auditLogger.auditNhinXDRResponse(response, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
+        auditLogger.auditNhinXDRResponse(response, assertion, null, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, false);
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/AbstractInboundDocSubmissionDeferredRequest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/AbstractInboundDocSubmissionDeferredRequest.java
@@ -59,11 +59,11 @@ public abstract class AbstractInboundDocSubmissionDeferredRequest implements Inb
     }
 
     private void auditRequestFromNhin(ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion) {
-        auditLogger.auditNhinXDR(request, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
+        auditLogger.auditNhinXDR(request, assertion, null, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
     }
 
     private void auditResponseToNhin(XDRAcknowledgementType response, AssertionType assertion) {
-        auditLogger.auditAcknowledgement(response, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
+        auditLogger.auditAcknowledgement(response, assertion, null, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
                 NhincConstants.XDR_REQUEST_ACTION);
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/AbstractInboundDocSubmissionDeferredResponse.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/AbstractInboundDocSubmissionDeferredResponse.java
@@ -56,11 +56,11 @@ public abstract class AbstractInboundDocSubmissionDeferredResponse implements In
     }
 
     private void auditRequestFromNhin(RegistryResponseType body, AssertionType assertion) {
-        auditLogger.auditNhinXDRResponse(body, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
+        auditLogger.auditNhinXDRResponse(body, assertion, null, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, false);
     }
 
     private void auditResponseToNhin(XDRAcknowledgementType response, AssertionType assertion) {
-        auditLogger.auditAcknowledgement(response, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
+        auditLogger.auditAcknowledgement(response, assertion, null, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
                 NhincConstants.XDR_RESPONSE_ACTION);
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/PassthroughOutboundDocSubmission.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/PassthroughOutboundDocSubmission.java
@@ -68,24 +68,25 @@ public class PassthroughOutboundDocSubmission implements OutboundDocSubmission {
         RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request = createAuditRequest(body, assertion,
                 targetSystem);
 
-        auditRequestToNhin(request, assertion);
+        auditRequestToNhin(request, assertion, request.getNhinTargetSystem());
 
         OutboundDocSubmissionOrchestratable dsOrchestratable = createOrchestratable(dsDelegate, body, targetSystem, assertion);
         RegistryResponseType response = ((OutboundDocSubmissionOrchestratable) dsDelegate.process(dsOrchestratable))
                 .getResponse();
 
-        auditResponseFromNhin(response, assertion);
+        auditResponseFromNhin(response, assertion, request.getNhinTargetSystem());
 
         return response;
     }
 
     private void auditRequestToNhin(RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request,
-            AssertionType assertion) {
-        auditLogger.auditXDR(request, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
+            AssertionType assertion, NhinTargetSystemType target) {
+        auditLogger.auditXDR(request, assertion, target, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
     }
 
-    private void auditResponseFromNhin(RegistryResponseType response, AssertionType assertion) {
-        auditLogger.auditNhinXDRResponse(response, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
+    private void auditResponseFromNhin(RegistryResponseType response, AssertionType assertion,
+            NhinTargetSystemType target) {
+        auditLogger.auditNhinXDRResponse(response, assertion, target, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, true);
     }
 
     private OutboundDocSubmissionOrchestratable createOrchestratable(OutboundDocSubmissionDelegate delegate,

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/StandardOutboundDocSubmission.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/StandardOutboundDocSubmission.java
@@ -183,13 +183,13 @@ public class StandardOutboundDocSubmission implements OutboundDocSubmission {
             gov.hhs.fha.nhinc.common.nhinccommonproxy.RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request,
             AssertionType assertion) {
 
-        auditRequestToNhin(request, assertion);
+        auditRequestToNhin(request, assertion, request.getNhinTargetSystem());
 
         OutboundDocSubmissionDelegate dsDelegate = getOutboundDocSubmissionDelegate();
         OutboundDocSubmissionOrchestratable dsOrchestratable = createOrchestratable(dsDelegate, request, assertion);
         RegistryResponseType response = ((OutboundDocSubmissionOrchestratable) dsDelegate.process(dsOrchestratable)).getResponse();
 
-        auditResponseFromNhin(response, assertion);
+        auditResponseFromNhin(response, assertion, request.getNhinTargetSystem());
 
         return response;
     }
@@ -218,12 +218,13 @@ public class StandardOutboundDocSubmission implements OutboundDocSubmission {
 
     private void auditRequestToNhin(
             gov.hhs.fha.nhinc.common.nhinccommonproxy.RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request,
-            AssertionType assertion) {
-        auditLogger.auditXDR(request, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
+            AssertionType assertion, NhinTargetSystemType target) {
+        auditLogger.auditXDR(request, assertion, target, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
     }
 
-    private void auditResponseFromNhin(RegistryResponseType response, AssertionType assertion) {
-        auditLogger.auditNhinXDRResponse(response, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
+    private void auditResponseFromNhin(RegistryResponseType response, AssertionType assertion,
+            NhinTargetSystemType target) {
+        auditLogger.auditNhinXDRResponse(response, assertion, target, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, true);
     }
 
     private HomeCommunityType getNhinTargetHomeCommunity(

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/request/PassthroughOutboundDocSubmissionDeferredRequest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/request/PassthroughOutboundDocSubmissionDeferredRequest.java
@@ -62,7 +62,7 @@ public class PassthroughOutboundDocSubmissionDeferredRequest implements Outbound
         RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request = createRequestForInternalProcessing(
                 body, targetSystem);
 
-        auditRequestToNhin(request, assertion);
+        auditRequestToNhin(request, assertion, request.getNhinTargetSystem());
 
         OutboundDocSubmissionDeferredRequestDelegate delegate = getOutboundDocSubmissionDeferredRequestDelegate();
         OutboundDocSubmissionDeferredRequestOrchestratable dsOrchestratable = createOrchestratable(delegate, request,
@@ -70,7 +70,7 @@ public class PassthroughOutboundDocSubmissionDeferredRequest implements Outbound
         XDRAcknowledgementType response = ((OutboundDocSubmissionDeferredRequestOrchestratable) delegate
                 .process(dsOrchestratable)).getResponse();
 
-        auditResponseFromNhin(response, assertion);
+        auditResponseFromNhin(response, assertion, request.getNhinTargetSystem());
 
         return response;
     }
@@ -97,12 +97,13 @@ public class PassthroughOutboundDocSubmissionDeferredRequest implements Outbound
     }
 
     private void auditRequestToNhin(RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request,
-            AssertionType assertion) {
-        auditLogger.auditXDR(request, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
+            AssertionType assertion, NhinTargetSystemType target) {
+        auditLogger.auditXDR(request, assertion, target, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
     }
 
-    private void auditResponseFromNhin(XDRAcknowledgementType response, AssertionType assertion) {
-        auditLogger.auditAcknowledgement(response, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
+    private void auditResponseFromNhin(XDRAcknowledgementType response, AssertionType assertion,
+            NhinTargetSystemType target) {
+        auditLogger.auditAcknowledgement(response, assertion, target, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
                 NhincConstants.XDR_REQUEST_ACTION);
     }
 

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/PassthroughInboundDocSubmissionTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/PassthroughInboundDocSubmissionTest.java
@@ -31,6 +31,7 @@ import java.lang.reflect.Method;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.docsubmission.DocSubmissionUtils;
 import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
 import gov.hhs.fha.nhinc.docsubmission.adapter.proxy.AdapterDocSubmissionProxy;
@@ -46,11 +47,13 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 
 /**
  * @author akong
@@ -87,10 +90,11 @@ public class PassthroughInboundDocSubmissionTest {
         verify(auditLogger).auditAdapterXDRResponse(eq(actualResponse), eq(assertion),
                 eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
 
-        verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
+        verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), isNull(NhinTargetSystemType.class),
+                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
 
-        verify(auditLogger).auditNhinXDRResponse(eq(actualResponse), eq(assertion),
-                eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION));
+        verify(auditLogger).auditNhinXDRResponse(eq(actualResponse), eq(assertion), isNull(NhinTargetSystemType.class),
+                eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(false));
     }
 
     @Test
@@ -115,10 +119,11 @@ public class PassthroughInboundDocSubmissionTest {
         assertEquals("urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error", actualResponse.getRegistryErrorList()
                 .getRegistryError().get(0).getSeverity());
 
-        verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
+        verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), isNull(NhinTargetSystemType.class),
+                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
 
-        verify(auditLogger).auditNhinXDRResponse(eq(actualResponse), eq(assertion),
-                eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION));
+        verify(auditLogger).auditNhinXDRResponse(eq(actualResponse), eq(assertion), isNull(NhinTargetSystemType.class),
+                eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(false));
     }
     
     @Test

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/StandardInboundDocSubmissionTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/StandardInboundDocSubmissionTest.java
@@ -29,6 +29,7 @@ package gov.hhs.fha.nhinc.docsubmission.inbound;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -39,6 +40,7 @@ import java.lang.reflect.Method;
 import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.docsubmission.DocSubmissionUtils;
 import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
 import gov.hhs.fha.nhinc.docsubmission.XDRPolicyChecker;
@@ -104,10 +106,11 @@ public class StandardInboundDocSubmissionTest {
         verify(auditLogger).auditAdapterXDRResponse(eq(actualResponse), eq(assertion),
                 eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
 
-        verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
+        verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), isNull(NhinTargetSystemType.class),
+                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
 
-        verify(auditLogger).auditNhinXDRResponse(eq(actualResponse), eq(assertion),
-                eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION));
+        verify(auditLogger).auditNhinXDRResponse(eq(actualResponse), eq(assertion), isNull(NhinTargetSystemType.class),
+                eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(false));
     }
 
     @Test
@@ -141,10 +144,11 @@ public class StandardInboundDocSubmissionTest {
         assertEquals("urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error", actualResponse.getRegistryErrorList()
                 .getRegistryError().get(0).getSeverity());
 
-        verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
+        verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), isNull(NhinTargetSystemType.class),
+                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
 
-        verify(auditLogger).auditNhinXDRResponse(eq(actualResponse), eq(assertion),
-                eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION));
+        verify(auditLogger).auditNhinXDRResponse(eq(actualResponse), eq(assertion), isNull(NhinTargetSystemType.class),
+                eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(false));
     }
     
     @Test
@@ -169,10 +173,11 @@ public class StandardInboundDocSubmissionTest {
         assertEquals("urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error", actualResponse.getRegistryErrorList()
                 .getRegistryError().get(0).getSeverity());
 
-        verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
+        verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), isNull(NhinTargetSystemType.class),
+                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
 
-        verify(auditLogger).auditNhinXDRResponse(eq(actualResponse), eq(assertion),
-                eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION));
+        verify(auditLogger).auditNhinXDRResponse(eq(actualResponse), eq(assertion), isNull(NhinTargetSystemType.class),
+                eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(false));
     }
     
     @Test

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/PassthroughInboundDocSubmissionDeferredRequestTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/PassthroughInboundDocSubmissionDeferredRequestTest.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -39,6 +40,7 @@ import java.lang.reflect.Method;
 
 import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.docsubmission.DocSubmissionUtils;
 import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
 import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.request.proxy.AdapterDocSubmissionDeferredRequestProxy;
@@ -87,9 +89,10 @@ public class PassthroughInboundDocSubmissionDeferredRequestTest {
         verify(auditLogger).auditAdapterAcknowledgement(eq(actualResponse), eq(assertion),
                 eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.XDR_REQUEST_ACTION));
 
-        verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
+        verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), isNull(NhinTargetSystemType.class),
+                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
 
-        verify(auditLogger).auditAcknowledgement(eq(actualResponse), eq(assertion),
+        verify(auditLogger).auditAcknowledgement(eq(actualResponse), eq(assertion), isNull(NhinTargetSystemType.class),
                 eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.XDR_REQUEST_ACTION));
     }
     
@@ -115,9 +118,10 @@ public class PassthroughInboundDocSubmissionDeferredRequestTest {
         assertEquals("urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error", actualResponse.getMessage().getRegistryErrorList()
                 .getRegistryError().get(0).getSeverity());
 
-        verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
+        verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), isNull(NhinTargetSystemType.class),
+                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
 
-        verify(auditLogger).auditAcknowledgement(eq(actualResponse), eq(assertion),
+        verify(auditLogger).auditAcknowledgement(eq(actualResponse), eq(assertion), isNull(NhinTargetSystemType.class),
                 eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.XDR_REQUEST_ACTION));
     }
     

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/StandardInboundDocSubmissionDeferredRequestTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/StandardInboundDocSubmissionDeferredRequestTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -40,6 +41,7 @@ import java.lang.reflect.Method;
 import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.docsubmission.DocSubmissionUtils;
 import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
 import gov.hhs.fha.nhinc.docsubmission.XDRPolicyChecker;
@@ -109,9 +111,10 @@ public class StandardInboundDocSubmissionDeferredRequestTest {
         verify(auditLogger).auditAdapterAcknowledgement(eq(actualResponse), eq(assertion),
                 eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.XDR_REQUEST_ACTION));
 
-        verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
+        verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), isNull(NhinTargetSystemType.class),
+                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
 
-        verify(auditLogger).auditAcknowledgement(eq(actualResponse), eq(assertion),
+        verify(auditLogger).auditAcknowledgement(eq(actualResponse), eq(assertion), isNull(NhinTargetSystemType.class),
                 eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.XDR_REQUEST_ACTION));
     }
 
@@ -151,9 +154,10 @@ public class StandardInboundDocSubmissionDeferredRequestTest {
 
         assertSame(expectedResponse, actualResponse);
 
-        verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
+        verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), isNull(NhinTargetSystemType.class),
+                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
 
-        verify(auditLogger).auditAcknowledgement(eq(actualResponse), eq(assertion),
+        verify(auditLogger).auditAcknowledgement(eq(actualResponse), eq(assertion), isNull(NhinTargetSystemType.class),
                 eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.XDR_REQUEST_ACTION));
     }
     
@@ -184,9 +188,10 @@ public class StandardInboundDocSubmissionDeferredRequestTest {
 
         assertSame(expectedResponse, actualResponse);
 
-        verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
+        verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), isNull(NhinTargetSystemType.class),
+                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
 
-        verify(auditLogger).auditAcknowledgement(eq(actualResponse), eq(assertion),
+        verify(auditLogger).auditAcknowledgement(eq(actualResponse), eq(assertion), isNull(NhinTargetSystemType.class),
                 eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.XDR_REQUEST_ACTION));
     }
     

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/PassthroughInboundDocSubmissionDeferredResponseTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/PassthroughInboundDocSubmissionDeferredResponseTest.java
@@ -30,11 +30,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
 import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.response.proxy.AdapterDocSubmissionDeferredResponseProxy;
 import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.response.proxy.AdapterDocSubmissionDeferredResponseProxyObjectFactory;
@@ -83,10 +85,10 @@ public class PassthroughInboundDocSubmissionDeferredResponseTest {
         verify(auditLogger).auditAdapterAcknowledgement(eq(actualResponse), eq(assertion),
                 eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.XDR_RESPONSE_ACTION));
 
-        verify(auditLogger).auditNhinXDRResponse(eq(regResponse), eq(assertion),
-                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
+        verify(auditLogger).auditNhinXDRResponse(eq(regResponse), eq(assertion), isNull(NhinTargetSystemType.class),
+                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(false));
 
-        verify(auditLogger).auditAcknowledgement(eq(actualResponse), eq(assertion),
+        verify(auditLogger).auditAcknowledgement(eq(actualResponse), eq(assertion), isNull(NhinTargetSystemType.class),
                 eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.XDR_RESPONSE_ACTION));
     }
 

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/StandardInboundDocSubmissionDeferredResponseTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/StandardInboundDocSubmissionDeferredResponseTest.java
@@ -30,12 +30,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
 import gov.hhs.fha.nhinc.docsubmission.XDRPolicyChecker;
 import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.response.proxy.AdapterDocSubmissionDeferredResponseProxy;
@@ -105,10 +107,10 @@ public class StandardInboundDocSubmissionDeferredResponseTest {
         verify(auditLogger).auditAdapterAcknowledgement(eq(actualResponse), eq(assertion),
                 eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.XDR_RESPONSE_ACTION));
 
-        verify(auditLogger).auditNhinXDRResponse(eq(regResponse), eq(assertion),
-                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
+        verify(auditLogger).auditNhinXDRResponse(eq(regResponse), eq(assertion), isNull(NhinTargetSystemType.class),
+                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(false));
 
-        verify(auditLogger).auditAcknowledgement(eq(actualResponse), eq(assertion),
+        verify(auditLogger).auditAcknowledgement(eq(actualResponse), eq(assertion), isNull(NhinTargetSystemType.class),
                 eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.XDR_RESPONSE_ACTION));
     }
 
@@ -147,10 +149,10 @@ public class StandardInboundDocSubmissionDeferredResponseTest {
         assertEquals("urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error", actualResponse.getMessage()
                 .getRegistryErrorList().getRegistryError().get(0).getSeverity());
 
-        verify(auditLogger).auditNhinXDRResponse(eq(regResponse), eq(assertion),
-                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
+        verify(auditLogger).auditNhinXDRResponse(eq(regResponse), eq(assertion), isNull(NhinTargetSystemType.class),
+                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(false));
 
-        verify(auditLogger).auditAcknowledgement(eq(actualResponse), eq(assertion),
+        verify(auditLogger).auditAcknowledgement(eq(actualResponse), eq(assertion), isNull(NhinTargetSystemType.class),
                 eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.XDR_RESPONSE_ACTION));
     }
 
@@ -177,10 +179,10 @@ public class StandardInboundDocSubmissionDeferredResponseTest {
         assertEquals("urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error", actualResponse.getMessage()
                 .getRegistryErrorList().getRegistryError().get(0).getSeverity());
 
-        verify(auditLogger).auditNhinXDRResponse(eq(regResponse), eq(assertion),
-                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
+        verify(auditLogger).auditNhinXDRResponse(eq(regResponse), eq(assertion), isNull(NhinTargetSystemType.class),
+                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(false));
 
-        verify(auditLogger).auditAcknowledgement(eq(actualResponse), eq(assertion),
+        verify(auditLogger).auditAcknowledgement(eq(actualResponse), eq(assertion), isNull(NhinTargetSystemType.class),
                 eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.XDR_RESPONSE_ACTION));
     }
 

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/PassthroughOutboundDocSubmissionTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/PassthroughOutboundDocSubmissionTest.java
@@ -35,6 +35,7 @@ import java.lang.reflect.Method;
 import gov.hhs.fha.nhinc.aspect.OutboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.common.nhinccommon.UrlInfoType;
 import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionBaseEventDescriptionBuilder;
@@ -91,10 +92,12 @@ public class PassthroughOutboundDocSubmissionTest {
                 oneOf(mockXDRLog)
                         .auditXDR(
                                 with(any(gov.hhs.fha.nhinc.common.nhinccommonproxy.RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType.class)),
-                                with(any(AssertionType.class)), with(any(String.class)));
+                                with(any(AssertionType.class)), with(any(NhinTargetSystemType.class)),
+                                with(any(String.class)));
 
                 oneOf(mockXDRLog).auditNhinXDRResponse(with(any(RegistryResponseType.class)),
-                        with(any(AssertionType.class)), with(any(String.class)));
+                        with(any(AssertionType.class)), with(any(NhinTargetSystemType.class)), with(any(String.class)),
+                        with(equal(true)));
             }
         });
     }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/StandardOutboundDocSubmissionTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/StandardOutboundDocSubmissionTest.java
@@ -36,6 +36,7 @@ import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunityType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.common.nhinccommon.UrlInfoType;
 import gov.hhs.fha.nhinc.common.nhinccommonentity.RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType;
 import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
@@ -222,10 +223,12 @@ public class StandardOutboundDocSubmissionTest {
                 oneOf(mockXDRLog)
                         .auditXDR(
                                 with(any(gov.hhs.fha.nhinc.common.nhinccommonproxy.RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType.class)),
-                                with(any(AssertionType.class)), with(any(String.class)));
+                                with(any(AssertionType.class)), with(any(NhinTargetSystemType.class)),
+                                with(any(String.class)));
 
                 oneOf(mockXDRLog).auditNhinXDRResponse(with(any(RegistryResponseType.class)),
-                        with(any(AssertionType.class)), with(any(String.class)));
+                        with(any(AssertionType.class)), with(any(NhinTargetSystemType.class)), with(any(String.class)),
+                        with(equal(true)));
             }
         });
     }
@@ -243,7 +246,8 @@ public class StandardOutboundDocSubmissionTest {
                 oneOf(mockXDRLog)
                         .auditXDR(
                                 with(any(gov.hhs.fha.nhinc.common.nhinccommonproxy.RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType.class)),
-                                with(any(AssertionType.class)), with(any(String.class)));
+                                with(any(AssertionType.class)), with(any(NhinTargetSystemType.class)),
+                                with(any(String.class)));
             }
         });
     }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/request/PassthroughOutboundDocSubmissionDeferredRequestTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/request/PassthroughOutboundDocSubmissionDeferredRequestTest.java
@@ -35,6 +35,7 @@ import java.lang.reflect.Method;
 import gov.hhs.fha.nhinc.aspect.OutboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.common.nhinccommon.UrlInfoType;
 import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionArgTransformerBuilder;
@@ -99,10 +100,10 @@ public class PassthroughOutboundDocSubmissionDeferredRequestTest {
                 oneOf(mockXDRLog)
                         .auditXDR(
                                 with(any(gov.hhs.fha.nhinc.common.nhinccommonproxy.RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType.class)),
-                                with(any(AssertionType.class)), with(any(String.class)));
+                                with(any(AssertionType.class)), with(any(NhinTargetSystemType.class)), with(any(String.class)));
 
                 oneOf(mockXDRLog).auditAcknowledgement(with(any(XDRAcknowledgementType.class)),
-                        with(any(AssertionType.class)), with(any(String.class)), with(any(String.class)));
+                        with(any(AssertionType.class)), with(any(NhinTargetSystemType.class)), with(any(String.class)), with(any(String.class)));
             }
         });
     }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/response/PassthroughOutboundDocSubmissionDeferredResponseTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/response/PassthroughOutboundDocSubmissionDeferredResponseTest.java
@@ -32,8 +32,6 @@ import static org.junit.Assert.assertNotNull;
 import gov.hhs.fha.nhinc.aspect.OutboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
-import gov.hhs.fha.nhinc.common.nhinccommonproxy.RespondingGatewayProvideAndRegisterDocumentSetSecuredResponseRequestType;
-import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DeferredResponseDescriptionBuilder;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionArgTransformerBuilder;
 import gov.hhs.fha.nhinc.docsubmission.entity.deferred.response.OutboundDocSubmissionDeferredResponseDelegate;
@@ -61,13 +59,11 @@ public class PassthroughOutboundDocSubmissionDeferredResponseTest {
             setImposteriser(ClassImposteriser.INSTANCE);
         }
     };
-    final XDRAuditLogger mockXDRLog = context.mock(XDRAuditLogger.class);
     final OutboundDocSubmissionDeferredResponseDelegate mockDelegate = context
             .mock(OutboundDocSubmissionDeferredResponseDelegate.class);
 
     @Test
     public void testProvideAndRegisterDocumentSetB() {
-        expect2MockAudits();
         expectMockDelegateProcessAndReturnValidResponse();
 
         XDRAcknowledgementType response = runProvideAndRegisterDocumentSetBResponse();
@@ -81,8 +77,7 @@ public class PassthroughOutboundDocSubmissionDeferredResponseTest {
     public void testGetters() {
         PassthroughOutboundDocSubmissionDeferredResponse passthruOrch = new PassthroughOutboundDocSubmissionDeferredResponse();
 
-        assertNotNull(passthruOrch.getOutboundDocSubmissionDeferredResponseDelegate());
-        assertNotNull(passthruOrch.getXDRAuditLogger());
+        assertNotNull(passthruOrch.getOutboundDocSubmissionDeferredResponseDelegate());        
     }
 
     private XDRAcknowledgementType runProvideAndRegisterDocumentSetBResponse() {
@@ -92,19 +87,6 @@ public class PassthroughOutboundDocSubmissionDeferredResponseTest {
 
         PassthroughOutboundDocSubmissionDeferredResponse passthruOrch = createPassthruDocSubmissionDeferredResponseOrchImpl();
         return passthruOrch.provideAndRegisterDocumentSetBAsyncResponse(request, assertion, targetCommunities);
-    }
-
-    private void expect2MockAudits() {
-        context.checking(new Expectations() {
-            {
-                oneOf(mockXDRLog).auditNhinXDRResponseRequest(
-                        with(any(RespondingGatewayProvideAndRegisterDocumentSetSecuredResponseRequestType.class)),
-                        with(any(AssertionType.class)), with(any(String.class)));
-
-                oneOf(mockXDRLog).auditAcknowledgement(with(any(XDRAcknowledgementType.class)),
-                        with(any(AssertionType.class)), with(any(String.class)), with(any(String.class)));
-            }
-        });
     }
 
     private void expectMockDelegateProcessAndReturnValidResponse() {
@@ -132,10 +114,6 @@ public class PassthroughOutboundDocSubmissionDeferredResponseTest {
 
     private PassthroughOutboundDocSubmissionDeferredResponse createPassthruDocSubmissionDeferredResponseOrchImpl() {
         return new PassthroughOutboundDocSubmissionDeferredResponse() {
-        	protected XDRAuditLogger getXDRAuditLogger() {
-                return mockXDRLog;
-            }
-
             protected OutboundDocSubmissionDeferredResponseDelegate getOutboundDocSubmissionDeferredResponseDelegate() {
                 return mockDelegate;
             }


### PR DESCRIPTION
1. Added nhin target to audit
2. Due to the fact that DS and DS Deferred Request and Responses re-uses the same messages but will have different audit entries (ex. RegistryResponse is a response for DS sync but a request for DS Deferred Response), a flag was added to determine whether the message is being processed in the requesting gateway or responding.
3. Fixed missing audits.
