### PR TITLE
GATEWAY-3388: Fixed DS passthru audit.

### DIFF
--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/PassthroughInboundDocSubmission.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/PassthroughInboundDocSubmission.java
@@ -44,14 +44,14 @@ import org.apache.log4j.Logger;
 public class PassthroughInboundDocSubmission extends AbstractInboundDocSubmission {
 
     private static final Logger LOG = Logger.getLogger(PassthroughInboundDocSubmission.class);
-    private DocSubmissionUtils dsUtils = DocSubmissionUtils.getInstance();
     private MessageGeneratorUtils msgUtils = MessageGeneratorUtils.getInstance();
+    private DocSubmissionUtils dsUtils;
     
     /**
      * Constructor.
      */
     public PassthroughInboundDocSubmission() {
-        super(new AdapterDocSubmissionProxyObjectFactory(), new XDRAuditLogger());
+        this(new AdapterDocSubmissionProxyObjectFactory(), new XDRAuditLogger(), DocSubmissionUtils.getInstance());
     }
 
     /**

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/PassthroughInboundDocSubmission.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/PassthroughInboundDocSubmission.java
@@ -26,18 +26,16 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.inbound;
 
-import org.apache.log4j.Logger;
-
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docsubmission.DocSubmissionUtils;
 import gov.hhs.fha.nhinc.docsubmission.MessageGeneratorUtils;
 import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
-import gov.hhs.fha.nhinc.docsubmission.adapter.proxy.AdapterDocSubmissionProxy;
 import gov.hhs.fha.nhinc.docsubmission.adapter.proxy.AdapterDocSubmissionProxyObjectFactory;
 import gov.hhs.fha.nhinc.largefile.LargePayloadException;
-import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
+
+import org.apache.log4j.Logger;
 
 /**
  * @author akong
@@ -46,18 +44,26 @@ import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
 public class PassthroughInboundDocSubmission extends AbstractInboundDocSubmission {
 
     private static final Logger LOG = Logger.getLogger(PassthroughInboundDocSubmission.class);
-    private AdapterDocSubmissionProxyObjectFactory adapterFactory = new AdapterDocSubmissionProxyObjectFactory();
     private DocSubmissionUtils dsUtils = DocSubmissionUtils.getInstance();
     private MessageGeneratorUtils msgUtils = MessageGeneratorUtils.getInstance();
     
+    /**
+     * Constructor.
+     */
     public PassthroughInboundDocSubmission() {
-        super();
+        super(new AdapterDocSubmissionProxyObjectFactory(), new XDRAuditLogger());
     }
 
-    public PassthroughInboundDocSubmission(AdapterDocSubmissionProxyObjectFactory adapterFactory, XDRAuditLogger auditLogger,
-            DocSubmissionUtils dsUtils) {
-        this.adapterFactory = adapterFactory;
-        this.auditLogger = auditLogger;
+    /**
+     * Constructor with dependency injection of strategy components.
+     * 
+     * @param adapterFactory
+     * @param auditLogger
+     * @param dsUtils
+     */
+    public PassthroughInboundDocSubmission(AdapterDocSubmissionProxyObjectFactory adapterFactory,
+            XDRAuditLogger auditLogger, DocSubmissionUtils dsUtils) {
+        super(adapterFactory, auditLogger);
         this.dsUtils = dsUtils;
     }
 
@@ -74,26 +80,6 @@ public class PassthroughInboundDocSubmission extends AbstractInboundDocSubmissio
         }
 
         return response;
-    }
-
-    private RegistryResponseType sendToAdapter(ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion) {
-
-        auditRequestToAdapter(request, assertion);
-
-        AdapterDocSubmissionProxy proxy = adapterFactory.getAdapterDocSubmissionProxy();
-        RegistryResponseType response = proxy.provideAndRegisterDocumentSetB(request, assertion);
-
-        auditResponseFromAdapter(response, assertion);
-
-        return response;
-    }
-
-    private void auditRequestToAdapter(ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion) {
-        auditLogger.auditAdapterXDR(request, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
-    }
-
-    private void auditResponseFromAdapter(RegistryResponseType response, AssertionType assertion) {
-        auditLogger.auditAdapterXDRResponse(response, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
     }
 
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/StandardInboundDocSubmission.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/StandardInboundDocSubmission.java
@@ -48,14 +48,15 @@ public class StandardInboundDocSubmission extends AbstractInboundDocSubmission {
 
     private static final Logger LOG = Logger.getLogger(StandardInboundDocSubmission.class);
     private MessageGeneratorUtils msgUtils = MessageGeneratorUtils.getInstance();
-    private PropertyAccessor propertyAccessor = PropertyAccessor.getInstance();
-    private XDRPolicyChecker policyChecker = new XDRPolicyChecker();
+    private PropertyAccessor propertyAccessor;
+    private XDRPolicyChecker policyChecker;
 
     /**
      * Constructor.
      */
     public StandardInboundDocSubmission() {
-        super(new AdapterDocSubmissionProxyObjectFactory(), new XDRAuditLogger());
+        this(new AdapterDocSubmissionProxyObjectFactory(), new XDRPolicyChecker(), PropertyAccessor.getInstance(),
+                new XDRAuditLogger());
     }
 
     /**

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/AbstractInboundDocSubmissionDeferredRequest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/AbstractInboundDocSubmissionDeferredRequest.java
@@ -29,6 +29,8 @@ package gov.hhs.fha.nhinc.docsubmission.inbound.deferred.request;
 import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
+import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.request.proxy.AdapterDocSubmissionDeferredRequestProxy;
+import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.request.proxy.AdapterDocSubmissionDeferredRequestProxyObjectFactory;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionBaseEventDescriptionBuilder;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionArgTransformerBuilder;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
@@ -40,7 +42,14 @@ public abstract class AbstractInboundDocSubmissionDeferredRequest implements Inb
     abstract XDRAcknowledgementType processDocSubmissionRequest(ProvideAndRegisterDocumentSetRequestType body,
             AssertionType assertion);
     
-    protected XDRAuditLogger auditLogger = new XDRAuditLogger();
+    private XDRAuditLogger auditLogger;
+    private AdapterDocSubmissionDeferredRequestProxyObjectFactory adapterFactory;
+    
+    public AbstractInboundDocSubmissionDeferredRequest(
+            AdapterDocSubmissionDeferredRequestProxyObjectFactory adapterFactory, XDRAuditLogger auditLogger) {
+        this.adapterFactory = adapterFactory;
+        this.auditLogger = auditLogger;
+    }
     
     @InboundProcessingEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionArgTransformerBuilder.class, 
@@ -57,12 +66,26 @@ public abstract class AbstractInboundDocSubmissionDeferredRequest implements Inb
 
         return response;
     }
+    
+    protected XDRAcknowledgementType sendToAdapter(ProvideAndRegisterDocumentSetRequestType body, AssertionType assertion) {
+        AdapterDocSubmissionDeferredRequestProxy proxy = adapterFactory.getAdapterDocSubmissionDeferredRequestProxy();
+        return proxy.provideAndRegisterDocumentSetBRequest(body, assertion);
+    }
+    
+    protected void auditRequestToAdapter(ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion) {
+        auditLogger.auditAdapterXDR(request, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
+    }
 
-    private void auditRequestFromNhin(ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion) {
+    protected void auditResponseFromAdapter(XDRAcknowledgementType response, AssertionType assertion) {
+        auditLogger.auditAdapterAcknowledgement(response, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
+                NhincConstants.XDR_REQUEST_ACTION);
+    }
+
+    protected void auditRequestFromNhin(ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion) {
         auditLogger.auditNhinXDR(request, assertion, null, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
     }
 
-    private void auditResponseToNhin(XDRAcknowledgementType response, AssertionType assertion) {
+    protected void auditResponseToNhin(XDRAcknowledgementType response, AssertionType assertion) {
         auditLogger.auditAcknowledgement(response, assertion, null, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
                 NhincConstants.XDR_REQUEST_ACTION);
     }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/PassthroughInboundDocSubmissionDeferredRequest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/PassthroughInboundDocSubmissionDeferredRequest.java
@@ -45,14 +45,15 @@ public class PassthroughInboundDocSubmissionDeferredRequest extends AbstractInbo
 
     private static final Logger LOG = Logger.getLogger(PassthroughInboundDocSubmissionDeferredRequest.class);
 
-    private DocSubmissionUtils dsUtils = DocSubmissionUtils.getInstance();
     private MessageGeneratorUtils msgUtils = MessageGeneratorUtils.getInstance();
+    private DocSubmissionUtils dsUtils;
 
     /**
      * Constructor.
      */
     public PassthroughInboundDocSubmissionDeferredRequest() {
-        super(new AdapterDocSubmissionDeferredRequestProxyObjectFactory(), new XDRAuditLogger());
+        this(new AdapterDocSubmissionDeferredRequestProxyObjectFactory(), new XDRAuditLogger(), DocSubmissionUtils
+                .getInstance());
     }
 
     /**

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/PassthroughInboundDocSubmissionDeferredRequest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/PassthroughInboundDocSubmissionDeferredRequest.java
@@ -26,18 +26,16 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.inbound.deferred.request;
 
-import org.apache.log4j.Logger;
-
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docsubmission.DocSubmissionUtils;
 import gov.hhs.fha.nhinc.docsubmission.MessageGeneratorUtils;
 import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
-import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.request.proxy.AdapterDocSubmissionDeferredRequestProxy;
 import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.request.proxy.AdapterDocSubmissionDeferredRequestProxyObjectFactory;
 import gov.hhs.fha.nhinc.largefile.LargePayloadException;
-import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.healthit.nhin.XDRAcknowledgementType;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
+
+import org.apache.log4j.Logger;
 
 /**
  * @author akong
@@ -46,22 +44,32 @@ import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 public class PassthroughInboundDocSubmissionDeferredRequest extends AbstractInboundDocSubmissionDeferredRequest {
 
     private static final Logger LOG = Logger.getLogger(PassthroughInboundDocSubmissionDeferredRequest.class);
-    private AdapterDocSubmissionDeferredRequestProxyObjectFactory adapterFactory = new AdapterDocSubmissionDeferredRequestProxyObjectFactory();
+
     private DocSubmissionUtils dsUtils = DocSubmissionUtils.getInstance();
     private MessageGeneratorUtils msgUtils = MessageGeneratorUtils.getInstance();
 
+    /**
+     * Constructor.
+     */
     public PassthroughInboundDocSubmissionDeferredRequest() {
-        super();
+        super(new AdapterDocSubmissionDeferredRequestProxyObjectFactory(), new XDRAuditLogger());
     }
 
+    /**
+     * Constructor with dependency injection of strategy components.
+     * 
+     * @param adapterFactory
+     * @param auditLogger
+     * @param dsUtils
+     */
     public PassthroughInboundDocSubmissionDeferredRequest(
             AdapterDocSubmissionDeferredRequestProxyObjectFactory adapterFactory, XDRAuditLogger auditLogger,
             DocSubmissionUtils dsUtils) {
-        this.adapterFactory = adapterFactory;
-        this.auditLogger = auditLogger;
+        super(adapterFactory, auditLogger);
         this.dsUtils = dsUtils;
     }
 
+    @Override
     XDRAcknowledgementType processDocSubmissionRequest(ProvideAndRegisterDocumentSetRequestType body,
             AssertionType assertion) {
 
@@ -77,25 +85,4 @@ public class PassthroughInboundDocSubmissionDeferredRequest extends AbstractInbo
 
         return response;
     }
-
-    private XDRAcknowledgementType sendToAdapter(ProvideAndRegisterDocumentSetRequestType body, AssertionType assertion) {
-        auditRequestToAdapter(body, assertion);
-
-        AdapterDocSubmissionDeferredRequestProxy proxy = adapterFactory.getAdapterDocSubmissionDeferredRequestProxy();
-        XDRAcknowledgementType response = proxy.provideAndRegisterDocumentSetBRequest(body, assertion);
-
-        auditResponseFromAdapter(response, assertion);
-
-        return response;
-    }
-    
-    private void auditRequestToAdapter(ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion) {
-        auditLogger.auditAdapterXDR(request, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
-    }
-
-    private void auditResponseFromAdapter(XDRAcknowledgementType response, AssertionType assertion) {
-        auditLogger.auditAdapterAcknowledgement(response, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
-                NhincConstants.XDR_REQUEST_ACTION);
-    }
-
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/StandardInboundDocSubmissionDeferredRequest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/StandardInboundDocSubmissionDeferredRequest.java
@@ -31,6 +31,7 @@ import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
 import gov.hhs.fha.nhinc.docsubmission.XDRPolicyChecker;
 import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.request.error.proxy.AdapterDocSubmissionDeferredRequestErrorProxy;
 import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.request.error.proxy.AdapterDocSubmissionDeferredRequestErrorProxyObjectFactory;
+import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.request.proxy.AdapterDocSubmissionDeferredRequestProxyObjectFactory;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import gov.hhs.fha.nhinc.properties.PropertyAccessException;
@@ -49,37 +50,52 @@ public class StandardInboundDocSubmissionDeferredRequest extends AbstractInbound
     private static final Logger LOG = Logger.getLogger(StandardInboundDocSubmissionDeferredRequest.class);
 
     private XDRPolicyChecker policyChecker = new XDRPolicyChecker();
-    private PassthroughInboundDocSubmissionDeferredRequest passthroughDSRequest = new PassthroughInboundDocSubmissionDeferredRequest();
     private PropertyAccessor propertyAccessor = PropertyAccessor.getInstance();
     private AdapterDocSubmissionDeferredRequestErrorProxyObjectFactory errorAdapterFactory = new AdapterDocSubmissionDeferredRequestErrorProxyObjectFactory();
 
+    /**
+     * Constructor.
+     */
     public StandardInboundDocSubmissionDeferredRequest() {
-        super();
+        super(new AdapterDocSubmissionDeferredRequestProxyObjectFactory(), new XDRAuditLogger());
     }
 
+    /**
+     * Constructor with dependency injection of strategy components.
+     * 
+     * @param adapterFactory
+     * @param policyChecker
+     * @param propertyAccessor
+     * @param auditLogger
+     * @param errorAdapterFactory
+     */
     public StandardInboundDocSubmissionDeferredRequest(
-            PassthroughInboundDocSubmissionDeferredRequest passthroughDSRequest, XDRPolicyChecker policyChecker,
+            AdapterDocSubmissionDeferredRequestProxyObjectFactory adapterFactory, XDRPolicyChecker policyChecker,
             PropertyAccessor propertyAccessor, XDRAuditLogger auditLogger,
             AdapterDocSubmissionDeferredRequestErrorProxyObjectFactory errorAdapterFactory) {
+        super(adapterFactory, auditLogger);
         this.policyChecker = policyChecker;
-        this.passthroughDSRequest = passthroughDSRequest;
         this.propertyAccessor = propertyAccessor;
-        this.auditLogger = auditLogger;
         this.errorAdapterFactory = errorAdapterFactory;
     }
 
+    @Override
     XDRAcknowledgementType processDocSubmissionRequest(ProvideAndRegisterDocumentSetRequestType body,
             AssertionType assertion) {
         XDRAcknowledgementType response = null;
 
+        auditRequestToAdapter(body, assertion);
+        
         String localHCID = getLocalHCID();
         if (isPolicyValid(body, assertion, localHCID)) {
             LOG.debug("Policy Check Succeeded");
-            response = passthroughDSRequest.processDocSubmissionRequest(body, assertion);
+            response = sendToAdapter(body, assertion);
         } else {
             LOG.error("Policy Check Failed");
             response = sendErrorToAdapter(body, assertion, "Policy Check Failed");
         }
+        
+        auditResponseFromAdapter(response, assertion);
 
         return response;
     }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/StandardInboundDocSubmissionDeferredRequest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/StandardInboundDocSubmissionDeferredRequest.java
@@ -49,15 +49,16 @@ public class StandardInboundDocSubmissionDeferredRequest extends AbstractInbound
 
     private static final Logger LOG = Logger.getLogger(StandardInboundDocSubmissionDeferredRequest.class);
 
-    private XDRPolicyChecker policyChecker = new XDRPolicyChecker();
-    private PropertyAccessor propertyAccessor = PropertyAccessor.getInstance();
-    private AdapterDocSubmissionDeferredRequestErrorProxyObjectFactory errorAdapterFactory = new AdapterDocSubmissionDeferredRequestErrorProxyObjectFactory();
+    private XDRPolicyChecker policyChecker;
+    private PropertyAccessor propertyAccessor;
+    private AdapterDocSubmissionDeferredRequestErrorProxyObjectFactory errorAdapterFactory;
 
     /**
      * Constructor.
      */
     public StandardInboundDocSubmissionDeferredRequest() {
-        super(new AdapterDocSubmissionDeferredRequestProxyObjectFactory(), new XDRAuditLogger());
+        this(new AdapterDocSubmissionDeferredRequestProxyObjectFactory(), new XDRPolicyChecker(), PropertyAccessor
+                .getInstance(), new XDRAuditLogger(), new AdapterDocSubmissionDeferredRequestErrorProxyObjectFactory());
     }
 
     /**

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/AbstractInboundDocSubmissionDeferredResponse.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/AbstractInboundDocSubmissionDeferredResponse.java
@@ -29,6 +29,8 @@ package gov.hhs.fha.nhinc.docsubmission.inbound.deferred.response;
 import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
+import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.response.proxy.AdapterDocSubmissionDeferredResponseProxy;
+import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.response.proxy.AdapterDocSubmissionDeferredResponseProxyObjectFactory;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DeferredResponseDescriptionBuilder;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionArgTransformerBuilder;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
@@ -39,8 +41,15 @@ public abstract class AbstractInboundDocSubmissionDeferredResponse implements In
 
     abstract XDRAcknowledgementType processDocSubmissionResponse(RegistryResponseType body, AssertionType assertion);
 
-    protected XDRAuditLogger auditLogger = new XDRAuditLogger();
+    private XDRAuditLogger auditLogger;
+    private AdapterDocSubmissionDeferredResponseProxyObjectFactory adapterFactory;
 
+    public AbstractInboundDocSubmissionDeferredResponse(
+            AdapterDocSubmissionDeferredResponseProxyObjectFactory adapterFactory, XDRAuditLogger auditLogger) {
+        this.adapterFactory = adapterFactory;
+        this.auditLogger = auditLogger;
+    }
+    
     @InboundProcessingEvent(beforeBuilder = DeferredResponseDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
             serviceType = "Document Submission Deferred Response", version = "")
@@ -54,12 +63,26 @@ public abstract class AbstractInboundDocSubmissionDeferredResponse implements In
 
         return response;
     }
+    
+    protected XDRAcknowledgementType sendToAdapter(RegistryResponseType body, AssertionType assertion) {
+        AdapterDocSubmissionDeferredResponseProxy proxy = adapterFactory.getAdapterDocSubmissionDeferredResponseProxy();
+        return proxy.provideAndRegisterDocumentSetBResponse(body, assertion);
+    }
 
-    private void auditRequestFromNhin(RegistryResponseType body, AssertionType assertion) {
+    protected void auditRequestToAdapter(RegistryResponseType body, AssertionType assertion) {
+        auditLogger.auditAdapterXDRResponse(body, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
+    }
+
+    protected void auditResponseFromAdapter(XDRAcknowledgementType response, AssertionType assertion) {
+        auditLogger.auditAdapterAcknowledgement(response, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
+                NhincConstants.XDR_RESPONSE_ACTION);
+    }
+
+    protected void auditRequestFromNhin(RegistryResponseType body, AssertionType assertion) {
         auditLogger.auditNhinXDRResponse(body, assertion, null, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, false);
     }
 
-    private void auditResponseToNhin(XDRAcknowledgementType response, AssertionType assertion) {
+    protected void auditResponseToNhin(XDRAcknowledgementType response, AssertionType assertion) {
         auditLogger.auditAcknowledgement(response, assertion, null, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
                 NhincConstants.XDR_RESPONSE_ACTION);
     }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/PassthroughInboundDocSubmissionDeferredResponse.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/PassthroughInboundDocSubmissionDeferredResponse.java
@@ -42,7 +42,7 @@ public class PassthroughInboundDocSubmissionDeferredResponse extends AbstractInb
      * Constructor.
      */
     public PassthroughInboundDocSubmissionDeferredResponse() {
-        super(new AdapterDocSubmissionDeferredResponseProxyObjectFactory(), new XDRAuditLogger());
+        this(new AdapterDocSubmissionDeferredResponseProxyObjectFactory(), new XDRAuditLogger());
     }
 
     /**

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/PassthroughInboundDocSubmissionDeferredResponse.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/PassthroughInboundDocSubmissionDeferredResponse.java
@@ -28,9 +28,7 @@ package gov.hhs.fha.nhinc.docsubmission.inbound.deferred.response;
 
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
-import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.response.proxy.AdapterDocSubmissionDeferredResponseProxy;
 import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.response.proxy.AdapterDocSubmissionDeferredResponseProxyObjectFactory;
-import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.healthit.nhin.XDRAcknowledgementType;
 import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
 
@@ -40,39 +38,26 @@ import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
  */
 public class PassthroughInboundDocSubmissionDeferredResponse extends AbstractInboundDocSubmissionDeferredResponse {
 
-    private AdapterDocSubmissionDeferredResponseProxyObjectFactory adapterFactory = new AdapterDocSubmissionDeferredResponseProxyObjectFactory();
-
+    /**
+     * Constructor.
+     */
     public PassthroughInboundDocSubmissionDeferredResponse() {
-        super();
+        super(new AdapterDocSubmissionDeferredResponseProxyObjectFactory(), new XDRAuditLogger());
     }
 
+    /**
+     * Constructor with dependency injection of strategy components.
+     * 
+     * @param adapterFactory
+     * @param auditLogger
+     */
     public PassthroughInboundDocSubmissionDeferredResponse(
             AdapterDocSubmissionDeferredResponseProxyObjectFactory adapterFactory, XDRAuditLogger auditLogger) {
-        this.adapterFactory = adapterFactory;
-        this.auditLogger = auditLogger;
+        super(adapterFactory, auditLogger);
     }
 
     @Override
     XDRAcknowledgementType processDocSubmissionResponse(RegistryResponseType body, AssertionType assertion) {
         return sendToAdapter(body, assertion);
-    }
-
-    private XDRAcknowledgementType sendToAdapter(RegistryResponseType body, AssertionType assertion) {
-        auditRequestToAdapter(body, assertion);
-
-        AdapterDocSubmissionDeferredResponseProxy proxy = adapterFactory.getAdapterDocSubmissionDeferredResponseProxy();
-        XDRAcknowledgementType response = proxy.provideAndRegisterDocumentSetBResponse(body, assertion);
-
-        auditResponseFromAdapter(response, assertion);
-        return response;
-    }
-
-    private void auditRequestToAdapter(RegistryResponseType body, AssertionType assertion) {
-        auditLogger.auditAdapterXDRResponse(body, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
-    }
-
-    private void auditResponseFromAdapter(XDRAcknowledgementType response, AssertionType assertion) {
-        auditLogger.auditAdapterAcknowledgement(response, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
-                NhincConstants.XDR_RESPONSE_ACTION);
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/StandardInboundDocSubmissionDeferredResponse.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/StandardInboundDocSubmissionDeferredResponse.java
@@ -47,15 +47,16 @@ import org.apache.log4j.Logger;
 public class StandardInboundDocSubmissionDeferredResponse extends AbstractInboundDocSubmissionDeferredResponse {
 
     private static final Logger LOG = Logger.getLogger(StandardInboundDocSubmissionDeferredResponse.class);
-    private XDRPolicyChecker policyChecker = new XDRPolicyChecker();
-    private PropertyAccessor propertyAccessor = PropertyAccessor.getInstance();
     private MessageGeneratorUtils msgUtils = MessageGeneratorUtils.getInstance();
-
+    private XDRPolicyChecker policyChecker;
+    private PropertyAccessor propertyAccessor;
+    
     /**
      * Constructor.
      */
     public StandardInboundDocSubmissionDeferredResponse() {
-        super(new AdapterDocSubmissionDeferredResponseProxyObjectFactory(), new XDRAuditLogger());
+        this(new AdapterDocSubmissionDeferredResponseProxyObjectFactory(), new XDRPolicyChecker(), PropertyAccessor
+                .getInstance(), new XDRAuditLogger());
     }
 
     /**

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/StandardInboundDocSubmissionDeferredResponse.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/StandardInboundDocSubmissionDeferredResponse.java
@@ -26,18 +26,19 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.inbound.deferred.response;
 
-import org.apache.log4j.Logger;
-
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docsubmission.MessageGeneratorUtils;
 import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
 import gov.hhs.fha.nhinc.docsubmission.XDRPolicyChecker;
+import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.response.proxy.AdapterDocSubmissionDeferredResponseProxyObjectFactory;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import gov.hhs.fha.nhinc.properties.PropertyAccessException;
 import gov.hhs.fha.nhinc.properties.PropertyAccessor;
 import gov.hhs.healthit.nhin.XDRAcknowledgementType;
 import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
+
+import org.apache.log4j.Logger;
 
 /**
  * @author akong
@@ -46,36 +47,49 @@ import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
 public class StandardInboundDocSubmissionDeferredResponse extends AbstractInboundDocSubmissionDeferredResponse {
 
     private static final Logger LOG = Logger.getLogger(StandardInboundDocSubmissionDeferredResponse.class);
-    private PassthroughInboundDocSubmissionDeferredResponse passthroughDocSubmission = new PassthroughInboundDocSubmissionDeferredResponse();
     private XDRPolicyChecker policyChecker = new XDRPolicyChecker();
     private PropertyAccessor propertyAccessor = PropertyAccessor.getInstance();
     private MessageGeneratorUtils msgUtils = MessageGeneratorUtils.getInstance();
 
+    /**
+     * Constructor.
+     */
     public StandardInboundDocSubmissionDeferredResponse() {
-        super();
+        super(new AdapterDocSubmissionDeferredResponseProxyObjectFactory(), new XDRAuditLogger());
     }
 
+    /**
+     * Constructor with dependency injection of strategy components.
+     * 
+     * @param adapterFactory
+     * @param policyChecker
+     * @param propertyAccessor
+     * @param auditLogger
+     */
     public StandardInboundDocSubmissionDeferredResponse(
-            PassthroughInboundDocSubmissionDeferredResponse passthroughDocSubmission, XDRPolicyChecker policyChecker,
+            AdapterDocSubmissionDeferredResponseProxyObjectFactory adapterFactory, XDRPolicyChecker policyChecker,
             PropertyAccessor propertyAccessor, XDRAuditLogger auditLogger) {
-        this.passthroughDocSubmission = passthroughDocSubmission;
+        super(adapterFactory, auditLogger);
         this.policyChecker = policyChecker;
-        this.propertyAccessor = propertyAccessor;
-        this.auditLogger = auditLogger;   
+        this.propertyAccessor = propertyAccessor;  
     }
 
     @Override
     XDRAcknowledgementType processDocSubmissionResponse(RegistryResponseType body, AssertionType assertion) {
         XDRAcknowledgementType response;
 
+        auditRequestToAdapter(body, assertion);
+        
         String localHCID = getLocalHCID();
         if (isPolicyValid(body, assertion, localHCID)) {
             LOG.debug("Policy Check Succeeded");
-            response = passthroughDocSubmission.processDocSubmissionResponse(body, assertion);
+            response = sendToAdapter(body, assertion);
         } else {
             LOG.error("Policy Check Failed");
             response = msgUtils.createFailedPolicyCheckXDRAcknowledgementType();
         }
+        
+        auditResponseFromAdapter(response, assertion);
 
         return response;
     }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/request/PassthroughOutboundDocSubmissionDeferredRequest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/request/PassthroughOutboundDocSubmissionDeferredRequest.java
@@ -33,20 +33,17 @@ import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.common.nhinccommon.UrlInfoType;
 import gov.hhs.fha.nhinc.common.nhinccommonproxy.RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType;
 import gov.hhs.fha.nhinc.docsubmission.MessageGeneratorUtils;
-import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionArgTransformerBuilder;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionBaseEventDescriptionBuilder;
 import gov.hhs.fha.nhinc.docsubmission.entity.deferred.request.OutboundDocSubmissionDeferredRequestDelegate;
 import gov.hhs.fha.nhinc.docsubmission.entity.deferred.request.OutboundDocSubmissionDeferredRequestOrchestratable;
-import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.healthit.nhin.XDRAcknowledgementType;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 
 public class PassthroughOutboundDocSubmissionDeferredRequest implements OutboundDocSubmissionDeferredRequest {
-    private XDRAuditLogger auditLogger = null;
 
     public PassthroughOutboundDocSubmissionDeferredRequest() {
-        auditLogger = getXDRAuditLogger();
+        
     }
     
     @OutboundProcessingEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
@@ -62,15 +59,11 @@ public class PassthroughOutboundDocSubmissionDeferredRequest implements Outbound
         RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request = createRequestForInternalProcessing(
                 body, targetSystem);
 
-        auditRequestToNhin(request, assertion, request.getNhinTargetSystem());
-
         OutboundDocSubmissionDeferredRequestDelegate delegate = getOutboundDocSubmissionDeferredRequestDelegate();
         OutboundDocSubmissionDeferredRequestOrchestratable dsOrchestratable = createOrchestratable(delegate, request,
                 assertion);
         XDRAcknowledgementType response = ((OutboundDocSubmissionDeferredRequestOrchestratable) delegate
                 .process(dsOrchestratable)).getResponse();
-
-        auditResponseFromNhin(response, assertion, request.getNhinTargetSystem());
 
         return response;
     }
@@ -95,24 +88,8 @@ public class PassthroughOutboundDocSubmissionDeferredRequest implements Outbound
 
         return request;
     }
-
-    private void auditRequestToNhin(RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request,
-            AssertionType assertion, NhinTargetSystemType target) {
-        auditLogger.auditXDR(request, assertion, target, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
-    }
-
-    private void auditResponseFromNhin(XDRAcknowledgementType response, AssertionType assertion,
-            NhinTargetSystemType target) {
-        auditLogger.auditAcknowledgement(response, assertion, target, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
-                NhincConstants.XDR_REQUEST_ACTION);
-    }
-
+    
     protected OutboundDocSubmissionDeferredRequestDelegate getOutboundDocSubmissionDeferredRequestDelegate() {
         return new OutboundDocSubmissionDeferredRequestDelegate();
     }
-
-    protected XDRAuditLogger getXDRAuditLogger() {
-        return new XDRAuditLogger();
-    }
-
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/PassthroughInboundDocSubmissionTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/PassthroughInboundDocSubmissionTest.java
@@ -47,10 +47,13 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -84,11 +87,11 @@ public class PassthroughInboundDocSubmissionTest {
 
         assertSame(expectedResponse, actualResponse);
 
-        verify(auditLogger)
-                .auditAdapterXDR(eq(request), eq(assertion), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION));
+        verify(auditLogger, never()).auditAdapterXDR(any(ProvideAndRegisterDocumentSetRequestType.class),
+                any(AssertionType.class), anyString());
 
-        verify(auditLogger).auditAdapterXDRResponse(eq(actualResponse), eq(assertion),
-                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
+        verify(auditLogger, never()).auditAdapterXDRResponse(any(RegistryResponseType.class), any(AssertionType.class),
+                anyString());
 
         verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), isNull(NhinTargetSystemType.class),
                 eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/StandardInboundDocSubmissionTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/StandardInboundDocSubmissionTest.java
@@ -29,19 +29,15 @@ package gov.hhs.fha.nhinc.docsubmission.inbound;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.mockito.Matchers.isNull;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.lang.reflect.Method;
-
 import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
-import gov.hhs.fha.nhinc.docsubmission.DocSubmissionUtils;
 import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
 import gov.hhs.fha.nhinc.docsubmission.XDRPolicyChecker;
 import gov.hhs.fha.nhinc.docsubmission.adapter.proxy.AdapterDocSubmissionProxy;
@@ -51,6 +47,9 @@ import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.properties.PropertyAccessException;
 import gov.hhs.fha.nhinc.properties.PropertyAccessor;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
+
+import java.lang.reflect.Method;
+
 import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
 
 import org.junit.Test;
@@ -74,14 +73,10 @@ public class StandardInboundDocSubmissionTest {
         AdapterDocSubmissionProxyObjectFactory adapterFactory = mock(AdapterDocSubmissionProxyObjectFactory.class);
         AdapterDocSubmissionProxy adapterProxy = mock(AdapterDocSubmissionProxy.class);
         XDRAuditLogger auditLogger = mock(XDRAuditLogger.class);
-        DocSubmissionUtils dsUtils = mock(DocSubmissionUtils.class);
 
         when(adapterFactory.getAdapterDocSubmissionProxy()).thenReturn(adapterProxy);
 
         when(adapterProxy.provideAndRegisterDocumentSetB(request, assertion)).thenReturn(expectedResponse);
-
-        PassthroughInboundDocSubmission passthroughDocSubmission = new PassthroughInboundDocSubmission(adapterFactory,
-                auditLogger, dsUtils);
 
         PropertyAccessor propertyAccessor = mock(PropertyAccessor.class);
         XDRPolicyChecker policyChecker = mock(XDRPolicyChecker.class);
@@ -92,7 +87,7 @@ public class StandardInboundDocSubmissionTest {
         when(policyChecker.checkXDRRequestPolicy(request, assertion, senderHCID, localHCID, 
                 NhincConstants.POLICYENGINE_INBOUND_DIRECTION)).thenReturn(true);
 
-        StandardInboundDocSubmission standardDocSubmission = new StandardInboundDocSubmission(passthroughDocSubmission,
+        StandardInboundDocSubmission standardDocSubmission = new StandardInboundDocSubmission(adapterFactory,
                 policyChecker, propertyAccessor, auditLogger);
 
         RegistryResponseType actualResponse = standardDocSubmission.documentRepositoryProvideAndRegisterDocumentSetB(
@@ -121,8 +116,8 @@ public class StandardInboundDocSubmissionTest {
         AssertionType assertion = new AssertionType();
         assertion.setHomeCommunity(new HomeCommunityType());
         assertion.getHomeCommunity().setHomeCommunityId(senderHCID);
-
-        PassthroughInboundDocSubmission passthroughDocSubmission = mock(PassthroughInboundDocSubmission.class);
+        
+        AdapterDocSubmissionProxyObjectFactory adapterFactory = mock(AdapterDocSubmissionProxyObjectFactory.class);
         PropertyAccessor propertyAccessor = mock(PropertyAccessor.class);
         XDRPolicyChecker policyChecker = mock(XDRPolicyChecker.class);
         XDRAuditLogger auditLogger = mock(XDRAuditLogger.class);
@@ -133,7 +128,7 @@ public class StandardInboundDocSubmissionTest {
         when(policyChecker.checkXDRRequestPolicy(request, assertion, senderHCID, localHCID,
                 NhincConstants.POLICYENGINE_INBOUND_DIRECTION)).thenReturn(false);
 
-        StandardInboundDocSubmission standardDocSubmission = new StandardInboundDocSubmission(passthroughDocSubmission,
+        StandardInboundDocSubmission standardDocSubmission = new StandardInboundDocSubmission(adapterFactory,
                 policyChecker, propertyAccessor, auditLogger);
 
         RegistryResponseType actualResponse = standardDocSubmission.documentRepositoryProvideAndRegisterDocumentSetB(
@@ -157,12 +152,12 @@ public class StandardInboundDocSubmissionTest {
         ProvideAndRegisterDocumentSetRequestType request = new ProvideAndRegisterDocumentSetRequestType();
         AssertionType assertion = new AssertionType();
 
-        PassthroughInboundDocSubmission passthroughDocSubmission = mock(PassthroughInboundDocSubmission.class);
+        AdapterDocSubmissionProxyObjectFactory adapterFactory = mock(AdapterDocSubmissionProxyObjectFactory.class);
         PropertyAccessor propertyAccessor = mock(PropertyAccessor.class);
         XDRPolicyChecker policyChecker = mock(XDRPolicyChecker.class);
         XDRAuditLogger auditLogger = mock(XDRAuditLogger.class);
 
-        StandardInboundDocSubmission standardDocSubmission = new StandardInboundDocSubmission(passthroughDocSubmission,
+        StandardInboundDocSubmission standardDocSubmission = new StandardInboundDocSubmission(adapterFactory,
                 policyChecker, propertyAccessor, auditLogger);
 
         RegistryResponseType actualResponse = standardDocSubmission.documentRepositoryProvideAndRegisterDocumentSetB(

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/PassthroughInboundDocSubmissionDeferredRequestTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/PassthroughInboundDocSubmissionDeferredRequestTest.java
@@ -29,10 +29,13 @@ package gov.hhs.fha.nhinc.docsubmission.inbound.deferred.request;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -83,11 +86,11 @@ public class PassthroughInboundDocSubmissionDeferredRequestTest {
 
         assertSame(expectedResponse, actualResponse);
 
-        verify(auditLogger)
-                .auditAdapterXDR(eq(request), eq(assertion), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION));
+        verify(auditLogger, never()).auditAdapterXDR(any(ProvideAndRegisterDocumentSetRequestType.class),
+                any(AssertionType.class), anyString());
 
-        verify(auditLogger).auditAdapterAcknowledgement(eq(actualResponse), eq(assertion),
-                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.XDR_REQUEST_ACTION));
+        verify(auditLogger, never()).auditAdapterAcknowledgement(any(XDRAcknowledgementType.class),
+                any(AssertionType.class), anyString(), anyString());
 
         verify(auditLogger).auditNhinXDR(eq(request), eq(assertion), isNull(NhinTargetSystemType.class),
                 eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/StandardInboundDocSubmissionDeferredRequestTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/StandardInboundDocSubmissionDeferredRequestTest.java
@@ -35,14 +35,10 @@ import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.lang.reflect.Method;
-
 import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
-import gov.hhs.fha.nhinc.docsubmission.DocSubmissionUtils;
 import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
 import gov.hhs.fha.nhinc.docsubmission.XDRPolicyChecker;
 import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.request.error.proxy.AdapterDocSubmissionDeferredRequestErrorProxy;
@@ -56,6 +52,8 @@ import gov.hhs.fha.nhinc.properties.PropertyAccessException;
 import gov.hhs.fha.nhinc.properties.PropertyAccessor;
 import gov.hhs.healthit.nhin.XDRAcknowledgementType;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
+
+import java.lang.reflect.Method;
 
 import org.junit.Test;
 
@@ -78,14 +76,10 @@ public class StandardInboundDocSubmissionDeferredRequestTest {
         AdapterDocSubmissionDeferredRequestProxyObjectFactory adapterFactory = mock(AdapterDocSubmissionDeferredRequestProxyObjectFactory.class);
         AdapterDocSubmissionDeferredRequestProxy adapterProxy = mock(AdapterDocSubmissionDeferredRequestProxy.class);
         XDRAuditLogger auditLogger = mock(XDRAuditLogger.class);
-        DocSubmissionUtils dsUtils = mock(DocSubmissionUtils.class);
 
         when(adapterFactory.getAdapterDocSubmissionDeferredRequestProxy()).thenReturn(adapterProxy);
 
         when(adapterProxy.provideAndRegisterDocumentSetBRequest(request, assertion)).thenReturn(expectedResponse);
-
-        PassthroughInboundDocSubmissionDeferredRequest passthroughDocSubmission = new PassthroughInboundDocSubmissionDeferredRequest(
-                adapterFactory, auditLogger, dsUtils);
 
         PropertyAccessor propertyAccessor = mock(PropertyAccessor.class);
         XDRPolicyChecker policyChecker = mock(XDRPolicyChecker.class);
@@ -98,7 +92,7 @@ public class StandardInboundDocSubmissionDeferredRequestTest {
                 NhincConstants.POLICYENGINE_INBOUND_DIRECTION)).thenReturn(true);
 
         StandardInboundDocSubmissionDeferredRequest standardDocSubmission = new StandardInboundDocSubmissionDeferredRequest(
-                passthroughDocSubmission, policyChecker, propertyAccessor, auditLogger, errorAdapterFactory);
+                adapterFactory, policyChecker, propertyAccessor, auditLogger, errorAdapterFactory);
 
         XDRAcknowledgementType actualResponse = standardDocSubmission.provideAndRegisterDocumentSetBRequest(request,
                 assertion);
@@ -128,7 +122,7 @@ public class StandardInboundDocSubmissionDeferredRequestTest {
         assertion.getHomeCommunity().setHomeCommunityId(senderHCID);
         XDRAcknowledgementType expectedResponse = new XDRAcknowledgementType();
 
-        PassthroughInboundDocSubmissionDeferredRequest passthroughDocSubmission = mock(PassthroughInboundDocSubmissionDeferredRequest.class);
+        AdapterDocSubmissionDeferredRequestProxyObjectFactory adapterFactory = mock(AdapterDocSubmissionDeferredRequestProxyObjectFactory.class);
         PropertyAccessor propertyAccessor = mock(PropertyAccessor.class);
         XDRPolicyChecker policyChecker = mock(XDRPolicyChecker.class);
         XDRAuditLogger auditLogger = mock(XDRAuditLogger.class);
@@ -147,7 +141,7 @@ public class StandardInboundDocSubmissionDeferredRequestTest {
                 .thenReturn(expectedResponse);
 
         StandardInboundDocSubmissionDeferredRequest standardDocSubmission = new StandardInboundDocSubmissionDeferredRequest(
-                passthroughDocSubmission, policyChecker, propertyAccessor, auditLogger, errorAdapterFactory);
+                adapterFactory, policyChecker, propertyAccessor, auditLogger, errorAdapterFactory);
 
         XDRAcknowledgementType actualResponse = standardDocSubmission.provideAndRegisterDocumentSetBRequest(request,
                 assertion);
@@ -168,7 +162,7 @@ public class StandardInboundDocSubmissionDeferredRequestTest {
         AssertionType assertion = new AssertionType();
         XDRAcknowledgementType expectedResponse = new XDRAcknowledgementType();
 
-        PassthroughInboundDocSubmissionDeferredRequest passthroughDocSubmission = mock(PassthroughInboundDocSubmissionDeferredRequest.class);
+        AdapterDocSubmissionDeferredRequestProxyObjectFactory adapterFactory = mock(AdapterDocSubmissionDeferredRequestProxyObjectFactory.class);
         PropertyAccessor propertyAccessor = mock(PropertyAccessor.class);
         XDRPolicyChecker policyChecker = mock(XDRPolicyChecker.class);
         XDRAuditLogger auditLogger = mock(XDRAuditLogger.class);
@@ -181,7 +175,7 @@ public class StandardInboundDocSubmissionDeferredRequestTest {
                 .thenReturn(expectedResponse);
         
         StandardInboundDocSubmissionDeferredRequest standardDocSubmission = new StandardInboundDocSubmissionDeferredRequest(
-                passthroughDocSubmission, policyChecker, propertyAccessor, auditLogger, errorAdapterFactory);
+                adapterFactory, policyChecker, propertyAccessor, auditLogger, errorAdapterFactory);
 
         XDRAcknowledgementType actualResponse = standardDocSubmission.provideAndRegisterDocumentSetBRequest(request,
                 assertion);

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/PassthroughInboundDocSubmissionDeferredResponseTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/PassthroughInboundDocSubmissionDeferredResponseTest.java
@@ -29,9 +29,12 @@ package gov.hhs.fha.nhinc.docsubmission.inbound.deferred.response;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
@@ -79,11 +82,11 @@ public class PassthroughInboundDocSubmissionDeferredResponseTest {
 
         assertSame(expectedResponse, actualResponse);
 
-        verify(auditLogger).auditAdapterXDRResponse(eq(regResponse), eq(assertion),
-                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
+        verify(auditLogger, never()).auditAdapterXDRResponse(any(RegistryResponseType.class), any(AssertionType.class),
+                anyString());
 
-        verify(auditLogger).auditAdapterAcknowledgement(eq(actualResponse), eq(assertion),
-                eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.XDR_RESPONSE_ACTION));
+        verify(auditLogger, never()).auditAdapterAcknowledgement(any(XDRAcknowledgementType.class),
+                any(AssertionType.class), anyString(), anyString());
 
         verify(auditLogger).auditNhinXDRResponse(eq(regResponse), eq(assertion), isNull(NhinTargetSystemType.class),
                 eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(false));

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/StandardInboundDocSubmissionDeferredResponseTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/StandardInboundDocSubmissionDeferredResponseTest.java
@@ -79,9 +79,6 @@ public class StandardInboundDocSubmissionDeferredResponseTest {
 
         when(adapterProxy.provideAndRegisterDocumentSetBResponse(regResponse, assertion)).thenReturn(expectedResponse);
 
-        PassthroughInboundDocSubmissionDeferredResponse passthroughDocSubmission = new PassthroughInboundDocSubmissionDeferredResponse(
-                adapterFactory, auditLogger);
-
         PropertyAccessor propertyAccessor = mock(PropertyAccessor.class);
         XDRPolicyChecker policyChecker = mock(XDRPolicyChecker.class);
 
@@ -94,7 +91,7 @@ public class StandardInboundDocSubmissionDeferredResponseTest {
                         NhincConstants.POLICYENGINE_INBOUND_DIRECTION)).thenReturn(true);
 
         StandardInboundDocSubmissionDeferredResponse standardDocSubmission = new StandardInboundDocSubmissionDeferredResponse(
-                passthroughDocSubmission, policyChecker, propertyAccessor, auditLogger);
+                adapterFactory, policyChecker, propertyAccessor, auditLogger);
 
         XDRAcknowledgementType actualResponse = standardDocSubmission.provideAndRegisterDocumentSetBResponse(
                 regResponse, assertion);
@@ -123,7 +120,7 @@ public class StandardInboundDocSubmissionDeferredResponseTest {
         assertion.setHomeCommunity(new HomeCommunityType());
         assertion.getHomeCommunity().setHomeCommunityId(senderHCID);
 
-        PassthroughInboundDocSubmissionDeferredResponse passthroughDocSubmission = mock(PassthroughInboundDocSubmissionDeferredResponse.class);
+        AdapterDocSubmissionDeferredResponseProxyObjectFactory adapterFactory = mock(AdapterDocSubmissionDeferredResponseProxyObjectFactory.class);
         PropertyAccessor propertyAccessor = mock(PropertyAccessor.class);
         XDRPolicyChecker policyChecker = mock(XDRPolicyChecker.class);
         XDRAuditLogger auditLogger = mock(XDRAuditLogger.class);
@@ -137,7 +134,7 @@ public class StandardInboundDocSubmissionDeferredResponseTest {
                         NhincConstants.POLICYENGINE_INBOUND_DIRECTION)).thenReturn(false);
 
         StandardInboundDocSubmissionDeferredResponse standardDocSubmission = new StandardInboundDocSubmissionDeferredResponse(
-                passthroughDocSubmission, policyChecker, propertyAccessor, auditLogger);
+                adapterFactory, policyChecker, propertyAccessor, auditLogger);
 
         XDRAcknowledgementType actualResponse = standardDocSubmission.provideAndRegisterDocumentSetBResponse(
                 regResponse, assertion);
@@ -161,13 +158,13 @@ public class StandardInboundDocSubmissionDeferredResponseTest {
         RegistryResponseType regResponse = new RegistryResponseType();
         AssertionType assertion = new AssertionType();
 
-        PassthroughInboundDocSubmissionDeferredResponse passthroughDocSubmission = mock(PassthroughInboundDocSubmissionDeferredResponse.class);
+        AdapterDocSubmissionDeferredResponseProxyObjectFactory adapterFactory = mock(AdapterDocSubmissionDeferredResponseProxyObjectFactory.class);
         PropertyAccessor propertyAccessor = mock(PropertyAccessor.class);
         XDRPolicyChecker policyChecker = mock(XDRPolicyChecker.class);
         XDRAuditLogger auditLogger = mock(XDRAuditLogger.class);
 
         StandardInboundDocSubmissionDeferredResponse standardDocSubmission = new StandardInboundDocSubmissionDeferredResponse(
-                passthroughDocSubmission, policyChecker, propertyAccessor, auditLogger);
+                adapterFactory, policyChecker, propertyAccessor, auditLogger);
 
         XDRAcknowledgementType actualResponse = standardDocSubmission.provideAndRegisterDocumentSetBResponse(
                 regResponse, assertion);

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/request/PassthroughOutboundDocSubmissionDeferredRequestTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/request/PassthroughOutboundDocSubmissionDeferredRequestTest.java
@@ -29,13 +29,9 @@ package gov.hhs.fha.nhinc.docsubmission.outbound.deferred.request;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-
-import java.lang.reflect.Method;
-
 import gov.hhs.fha.nhinc.aspect.OutboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
-import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.common.nhinccommon.UrlInfoType;
 import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionArgTransformerBuilder;
@@ -45,6 +41,9 @@ import gov.hhs.fha.nhinc.docsubmission.entity.deferred.request.OutboundDocSubmis
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.healthit.nhin.XDRAcknowledgementType;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
+
+import java.lang.reflect.Method;
+
 import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
 
 import org.jmock.Expectations;
@@ -68,7 +67,6 @@ public class PassthroughOutboundDocSubmissionDeferredRequestTest {
     
     @Test
     public void testProvideAndRegisterDocumentSetB() {
-        expect2MockAudits();
         expectMockDelegateProcessAndReturnValidResponse();
         
         XDRAcknowledgementType response = runProvideAndRegisterDocumentSetBRequest();
@@ -82,7 +80,6 @@ public class PassthroughOutboundDocSubmissionDeferredRequestTest {
         PassthroughOutboundDocSubmissionDeferredRequest passthruOrch = new PassthroughOutboundDocSubmissionDeferredRequest();
         
         assertNotNull(passthruOrch.getOutboundDocSubmissionDeferredRequestDelegate());
-        assertNotNull(passthruOrch.getXDRAuditLogger());
     }
     
     private XDRAcknowledgementType runProvideAndRegisterDocumentSetBRequest() {
@@ -92,20 +89,6 @@ public class PassthroughOutboundDocSubmissionDeferredRequestTest {
         
         PassthroughOutboundDocSubmissionDeferredRequest passthruOrch = createPassthruDocSubmissionDeferredRequestOrchImpl();
         return passthruOrch.provideAndRegisterDocumentSetBAsyncRequest(request, assertion, targetCommunities, null);       
-    }
-    
-    private void expect2MockAudits() {
-        context.checking(new Expectations() {
-            {
-                oneOf(mockXDRLog)
-                        .auditXDR(
-                                with(any(gov.hhs.fha.nhinc.common.nhinccommonproxy.RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType.class)),
-                                with(any(AssertionType.class)), with(any(NhinTargetSystemType.class)), with(any(String.class)));
-
-                oneOf(mockXDRLog).auditAcknowledgement(with(any(XDRAcknowledgementType.class)),
-                        with(any(AssertionType.class)), with(any(NhinTargetSystemType.class)), with(any(String.class)), with(any(String.class)));
-            }
-        });
     }
     
     private void expectMockDelegateProcessAndReturnValidResponse() {
@@ -131,11 +114,7 @@ public class PassthroughOutboundDocSubmissionDeferredRequestTest {
     }
     
     private PassthroughOutboundDocSubmissionDeferredRequest createPassthruDocSubmissionDeferredRequestOrchImpl() {
-        return new PassthroughOutboundDocSubmissionDeferredRequest() {
-            protected XDRAuditLogger getXDRAuditLogger() {
-                return mockXDRLog;
-            }
-            
+        return new PassthroughOutboundDocSubmissionDeferredRequest() {            
             protected OutboundDocSubmissionDeferredRequestDelegate getOutboundDocSubmissionDeferredRequestDelegate() {
                 return mockDelegate;
             }


### PR DESCRIPTION
For inbound:

Moved the sendToAdapter() code from passthrough to the abstract parent class.  Removed the audits in that method to make passthrough not audit.  Added audits in the standard and made it call sendToAdapter()

For outbound:
Removed the audits from the passthrough code.
