### PR TITLE
Gateway-3400 Warning for DQ passthrough too many targets

### DIFF
--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/outbound/PassthroughOutboundDocQueryTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/outbound/PassthroughOutboundDocQueryTest.java
@@ -31,10 +31,13 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import gov.hhs.fha.nhinc.aspect.OutboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunityType;
 import gov.hhs.fha.nhinc.docquery.aspect.AdhocQueryRequestDescriptionBuilder;
 import gov.hhs.fha.nhinc.docquery.aspect.AdhocQueryResponseDescriptionBuilder;
 import gov.hhs.fha.nhinc.docquery.entity.OutboundDocQueryDelegate;
@@ -45,7 +48,9 @@ import java.lang.reflect.Method;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryResponse;
 
+import org.apache.log4j.Logger;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 /**
  * @author akong
@@ -86,5 +91,58 @@ public class PassthroughOutboundDocQueryTest {
 
         assertSame(expectedResponse, actualResponse);
 
+    }
+    
+    @Test
+    public void passthroughOutboundDocQueryTooManyTargets() {
+    	final String HCID1 = "1.1";
+    	final String HCID2 = "2.2";
+    	
+    	final Logger mockLogger = mock(Logger.class);
+    	ArgumentCaptor<Logger> loggerCaptor = ArgumentCaptor.forClass(Logger.class);
+    		
+    	final String compareOutput = "Multiple targets in request message in passthrough mode." +
+    			"  Only sending to target HCID: " + HCID1 + ".  Not sending request to: " + HCID2 + ".";
+    	
+    	OutboundDocQueryDelegate mockDelegate = mock(OutboundDocQueryDelegate.class);
+
+        AdhocQueryResponse expectedResponse = new AdhocQueryResponse();
+        OutboundDocQueryOrchestratable orchestratableResponse = new OutboundDocQueryOrchestratable();
+        orchestratableResponse.setResponse(expectedResponse);
+
+        when(mockDelegate.process(any(OutboundDocQueryOrchestratable.class))).thenReturn(orchestratableResponse);
+
+        AdhocQueryRequest request = new AdhocQueryRequest();
+        AssertionType assertion = new AssertionType();
+        NhinTargetCommunitiesType targets = new NhinTargetCommunitiesType();
+        
+        NhinTargetCommunityType target1 = new NhinTargetCommunityType();
+        HomeCommunityType homeCommunity1 = new HomeCommunityType();
+        homeCommunity1.setHomeCommunityId(HCID1);
+        target1.setHomeCommunity(homeCommunity1);
+        
+        NhinTargetCommunityType target2 = new NhinTargetCommunityType();
+        HomeCommunityType homeCommunity2 = new HomeCommunityType();
+        homeCommunity2.setHomeCommunityId(HCID2);
+        target2.setHomeCommunity(homeCommunity2);
+        
+        targets.getNhinTargetCommunity().add(target1);
+        targets.getNhinTargetCommunity().add(target2);
+
+
+        PassthroughOutboundDocQuery passthroughDocQuery = new PassthroughOutboundDocQuery(mockDelegate){
+        	@Override
+        	protected void logWarning(String warning){
+        		mockLogger.warn(warning);
+        	}
+        };
+        
+        AdhocQueryResponse actualResponse = passthroughDocQuery.respondingGatewayCrossGatewayQuery(request, assertion,
+                targets);
+
+        verify(mockLogger).warn(loggerCaptor.capture());    	
+        assertSame(expectedResponse, actualResponse);
+        assertEquals(compareOutput, loggerCaptor.getValue());
+        
     }
 }


### PR DESCRIPTION
- Checks passthrough outbound for more targets than one and then warns that it only sends to the first target.
- Created unit test case for warning.
