### PR TITLE
Gateway 3364

### DIFF
--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/xdr/SoapDirectEdgeOrchestration.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/xdr/SoapDirectEdgeOrchestration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, United States Government, as represented by the Secretary of Health and Human Services.
+ * Copyright (c) 2009-2013, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -43,6 +43,7 @@ import javax.mail.Address;
 
 import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.nhindirect.xd.common.DirectDocuments;
 import org.nhindirect.xd.transform.XdsDirectDocumentsTransformer;
 import org.nhindirect.xd.transform.exception.TransformationException;
@@ -50,15 +51,18 @@ import org.nhindirect.xd.transform.impl.DefaultXdsDirectDocumentsTransformer;
 
 public class SoapDirectEdgeOrchestration {
 
-    private XdsDirectDocumentsTransformer xdsDirectDocumentsTransformer = null;
-    private DirectSender directSender = null;
-    private SoapEdgeAuditor auditor = null;
+    private XdsDirectDocumentsTransformer xdsDirectDocumentsTransformer = new DefaultXdsDirectDocumentsTransformer();
+    private DirectSender directSender = new DirectAdapterFactory().getDirectSender();
+    private SoapEdgeAuditor auditor = new SoapEdgeAuditorFactory().getAuditor();
+    private ToAddressParser toParser = new ToAddressParserFactory().getToParser();
 
     /**
      * Handle an incoming ProvideAndRegisterDocumentSetRequestType object and transform to XDM.
      * 
-     * @param prdst The incoming ProvideAndRegisterDocumentSetRequestType object
-     * @param context The values of the ws headers
+     * @param prdst
+     *            The incoming ProvideAndRegisterDocumentSetRequestType object
+     * @param context
+     *            The values of the ws headers
      * @return a RegistryResponseType object
      * @throws Exception
      */
@@ -66,66 +70,46 @@ public class SoapDirectEdgeOrchestration {
             throws Exception {
         RegistryResponseType resp = null;
 
-        getAuditor().audit(SoapEdgeAuditor.PRINCIPAL, SoapEdgeAuditor.REQUESTRECIEVED_CATEGORY,
+        auditor.audit(SoapEdgeAuditor.PRINCIPAL, SoapEdgeAuditor.REQUESTRECIEVED_CATEGORY,
                 SoapEdgeAuditor.REQUESTRECIEVED_MESSAGE, context);
 
         resp = sendMessage(prdst, context);
 
-        getAuditor().audit(SoapEdgeAuditor.PRINCIPAL, SoapEdgeAuditor.RESPONSERETURNED_CATEGORY,
+        auditor.audit(SoapEdgeAuditor.PRINCIPAL, SoapEdgeAuditor.RESPONSERETURNED_CATEGORY,
                 SoapEdgeAuditor.RESPONSERETURNED_MESSAGE, context);
 
         return resp;
     }
 
     /**
-     * @param prdst XDR message to be sent to direct
+     * @param prdst
+     *            XDR message to be sent to direct
      * @return Status of success or failure + error list
      * @throws TransformationException
      */
     protected RegistryResponseType sendMessage(ProvideAndRegisterDocumentSetRequestType prdst, SoapEdgeContext context)
             throws TransformationException {
-        DirectDocuments documents = getDefaultXdsDirectDocumentsTransformer().transform(prdst);
+        DirectDocuments documents = xdsDirectDocumentsTransformer.transform(prdst);
 
-        ToAddressParser toParser = new ToAddressParserFactory().getToParser();
         Set<Address> addressTo = toParser.parse(context.getDirectTo(), documents);
+        if (CollectionUtils.isEmpty(addressTo)) {
+            throw new TransformationException("No 'To' addresses in soap context.", null);
+        }
 
         FromAddressParser fromParser = new FromAddressParserFactory().getFromParser();
         Address addressFrom = fromParser.parse(context.getDirectFrom(), documents);
 
-        getDirectSender().sendOutboundDirect(addressFrom, addressTo.toArray(new Address[0]), documents,
+        directSender.sendOutboundDirect(addressFrom, addressTo.toArray(new Address[0]), documents,
                 context.getMessageId());
 
         return new XDCommonResponseHelper().createSuccess();
     }
 
-    /**
-     * @return The DirectClient impl
-     */
-    private DirectSender getDirectSender() {
-        if (directSender == null) {
-            directSender = new DirectAdapterFactory().getDirectSender();
-        }
-        return directSender;
+    protected void setDocumentsTransformer(XdsDirectDocumentsTransformer docTransformer) {
+        xdsDirectDocumentsTransformer = docTransformer;
     }
 
-    /**
-     * @return The XdsDirectDocumentsTransformer impl
-     */
-    private XdsDirectDocumentsTransformer getDefaultXdsDirectDocumentsTransformer() {
-        if (xdsDirectDocumentsTransformer == null) {
-            xdsDirectDocumentsTransformer = new DefaultXdsDirectDocumentsTransformer();
-        }
-        return xdsDirectDocumentsTransformer;
+    public void setToAddressParser(ToAddressParser toParser) {
+        this.toParser = toParser;
     }
-
-    /**
-     * @return The SoapEdgeAuditor impl
-     */
-    private SoapEdgeAuditor getAuditor() {
-        if (auditor == null) {
-            auditor = new SoapEdgeAuditorFactory().getAuditor();
-        }
-        return auditor;
-    }
-
 }

--- a/Product/Production/Services/DirectCore/src/test/java/gov/hhs/fha/nhinc/direct/xdr/SoapDirectEdgeOrchestrationTest.java
+++ b/Product/Production/Services/DirectCore/src/test/java/gov/hhs/fha/nhinc/direct/xdr/SoapDirectEdgeOrchestrationTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2009-2013, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.direct.xdr;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import gov.hhs.fha.nhinc.direct.addressparsing.ToAddressParser;
+import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
+
+import java.util.Collections;
+import java.util.Set;
+
+import javax.mail.Address;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.nhindirect.xd.common.DirectDocuments;
+import org.nhindirect.xd.transform.XdsDirectDocumentsTransformer;
+import org.nhindirect.xd.transform.exception.TransformationException;
+
+public class SoapDirectEdgeOrchestrationTest {
+    private SoapDirectEdgeOrchestration orch;
+    private XdsDirectDocumentsTransformer mockDocTransformer;
+    private ToAddressParser mockToParser;
+    private ProvideAndRegisterDocumentSetRequestType mockRequest;
+    private SoapEdgeContext mockContext;
+
+    @Before
+    public void before() {
+        orch = new SoapDirectEdgeOrchestration();
+        mockDocTransformer = mock(XdsDirectDocumentsTransformer.class);
+        mockToParser = mock(ToAddressParser.class);
+        mockRequest = mock(ProvideAndRegisterDocumentSetRequestType.class);
+        mockContext = mock(SoapEdgeContext.class);
+    }
+
+    @Test(expected = TransformationException.class)
+    public void sendMessageNullToAddresses() throws TransformationException {
+        sendWithToParserResult(null);
+    }
+
+    @Test(expected = TransformationException.class)
+    public void sendMessageEmptyToAddresses() throws TransformationException {
+        Set<Address> emptyAddresses = Collections.emptySet();
+        sendWithToParserResult(emptyAddresses);
+    }
+
+    private void sendWithToParserResult(Set<Address> addresses) throws TransformationException {
+        when(mockToParser.parse(anyString(), any(DirectDocuments.class))).thenReturn(addresses);
+
+        orch.setDocumentsTransformer(mockDocTransformer);
+        orch.setToAddressParser(mockToParser);
+
+        orch.sendMessage(mockRequest, mockContext);
+    }
+}


### PR DESCRIPTION
With regards to the completion criteria:
- improved the reported error message by correctly doing the logical toString on the stack trace
- detected the missing/empty to addresses.  
- unconfigured to addresses will result in a less friendly error.  Confirmed with weaver that this is ok.
