### PR TITLE
GATEWAY-3447: DQ aggregate error - don't lose error in mixed result.

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/gateway/executorservice/ExecutorServiceHelper.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/gateway/executorservice/ExecutorServiceHelper.java
@@ -26,13 +26,14 @@
  */
 package gov.hhs.fha.nhinc.gateway.executorservice;
 
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.properties.PropertyAccessor;
-import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+
 import java.io.CharArrayWriter;
 import java.io.PrintWriter;
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.log4j.Logger;
 
@@ -73,7 +74,7 @@ public class ExecutorServiceHelper {
     private ExecutorServiceHelper() {
         try {
             PropertyAccessor propertyAccessor = PropertyAccessor.getInstance();
-            
+
             // get executor service pool sizes
             String concurrentPoolSizeStr = propertyAccessor.getProperty(NhincConstants.GATEWAY_PROPERTY_FILE,
                     NhincConstants.CONCURRENT_POOL_SIZE);
@@ -134,7 +135,8 @@ public class ExecutorServiceHelper {
      * Used to determine if a task should be executed using the large job executor service. If targetListCount >=
      * largejobSizePercent * concurrentPoolSize then it is a large job.
      * 
-     * @param targetListCount is the fan-out count for the task
+     * @param targetListCount
+     *            is the fan-out count for the task
      * @return boolean true if task should be run using large job executor service
      */
     public static boolean checkExecutorTaskIsLarge(int targetListCount) {
@@ -167,21 +169,11 @@ public class ExecutorServiceHelper {
      * @param ex
      */
     public static String getFormattedExceptionInfo(Exception ex, NhinTargetSystemType target, String serviceName) {
-        String err = "EXCEPTION: " + ex.getClass().getCanonicalName() + "\r\n";
+        String err = "EXCEPTION: " + ex.getClass().getCanonicalName() + "\r\nEXCEPTION Cause Message: "
+                + ex.getMessage() + "\r\n";
         Throwable cause = ex.getCause();
         if (cause != null) {
             err += "EXCEPTION Cause: " + cause.getClass().getCanonicalName() + "\r\n";
-            /*if (cause instanceof com.sun.xml.ws.client.ClientTransportException) {
-                try {
-                	NhinEndpointManager nem = new NhinEndpointManager();
-                    NhincConstants.GATEWAY_API_LEVEL apiLevel = nem.getApiVersion(
-                            target.getHomeCommunity().getHomeCommunityId(), serviceName);
-                    String url = (new WebServiceProxyHelper()).getUrlFromTargetSystemByGatewayAPILevel(target,
-                            serviceName, apiLevel);
-                    err += "EXCEPTION Message: Unable to connect to endpoint url=" + url + "\r\n";
-                } catch (Exception e) {
-                }
-            }*/
             err += "EXCEPTION Cause Message: " + cause.getMessage();
         }
         return err;

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/gateway/executorservice/NhinCallableRequest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/gateway/executorservice/NhinCallableRequest.java
@@ -26,13 +26,15 @@
  */
 package gov.hhs.fha.nhinc.gateway.executorservice;
 
+import gov.hhs.fha.nhinc.orchestration.OutboundDelegate;
+import gov.hhs.fha.nhinc.orchestration.OutboundOrchestratableMessage;
+import gov.hhs.fha.nhinc.orchestration.OutboundResponseProcessor;
+
 import java.util.concurrent.Callable;
 
 import org.apache.log4j.Logger;
 
-import gov.hhs.fha.nhinc.orchestration.OutboundOrchestratableMessage;
-import gov.hhs.fha.nhinc.orchestration.OutboundDelegate;
-import gov.hhs.fha.nhinc.orchestration.OutboundResponseProcessor;
+import com.google.common.base.Preconditions;
 
 /**
  * CallableRequest is basically what is executed (i.e. the Runnable) Uses generics for Response (which represents object
@@ -46,13 +48,14 @@ import gov.hhs.fha.nhinc.orchestration.OutboundResponseProcessor;
 public class NhinCallableRequest<Response extends OutboundOrchestratableMessage> implements Callable<Response> {
 
     private OutboundDelegate client = null;
-    private OutboundResponseProcessor processor = null;
+    private OutboundResponseProcessor processor;
     private OutboundOrchestratableMessage entityRequest = null;
     private static final Logger LOG = Logger.getLogger(NhinCallableRequest.class);
-    
+
     public NhinCallableRequest(OutboundOrchestratableMessage orch) {
+        Preconditions.checkArgument(orch.getResponseProcessor().isPresent());
         this.client = orch.getDelegate();
-        this.processor = orch.getResponseProcessor();
+        this.processor = orch.getResponseProcessor().get();
         this.entityRequest = orch;
     }
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/gateway/executorservice/NhinTaskExecutor.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/gateway/executorservice/NhinTaskExecutor.java
@@ -26,18 +26,20 @@
  */
 package gov.hhs.fha.nhinc.gateway.executorservice;
 
-import java.util.List;
+import gov.hhs.fha.nhinc.orchestration.OutboundOrchestratableMessage;
+import gov.hhs.fha.nhinc.orchestration.OutboundResponseProcessor;
+
 import java.util.ArrayList;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorCompletionService;
+import java.util.List;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.Future;
 
-import gov.hhs.fha.nhinc.orchestration.OutboundResponseProcessor;
-import gov.hhs.fha.nhinc.orchestration.OutboundOrchestratableMessage;
-
 import org.apache.log4j.Logger;
+
+import com.google.common.base.Optional;
 
 /**
  * Main unit of execution Executes a DQ or PD request currently, but could be used to execute any of the Nhin
@@ -112,7 +114,12 @@ public class NhinTaskExecutor<CumulativeResponse extends OutboundOrchestratableM
                         IndividualResponse r = (IndividualResponse) future.get();
                         if (r != null) {
                             // process response
-                            OutboundResponseProcessor processor = r.getResponseProcessor();
+                            Optional<OutboundResponseProcessor> optionalProcessor = r.getResponseProcessor();
+                            if (!optionalProcessor.isPresent()) {
+                                throw new IllegalArgumentException(
+                                        "IndividualResponse.getResponseProcessor returned null");
+                            }
+                            OutboundResponseProcessor processor = optionalProcessor.get();
                             cumulativeResponse = (CumulativeResponse) processor.processNhinResponse(r,
                                     cumulativeResponse);
                         } else {

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/gateway/executorservice/ExecutorServiceHelperTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/gateway/executorservice/ExecutorServiceHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, United States Government, as represented by the Secretary of Health and Human Services. 
+ * Copyright (c) 2009-2013, United States Government, as represented by the Secretary of Health and Human Services. 
  * All rights reserved. 
  *
  * Redistribution and use in source and binary forms, with or without 
@@ -24,17 +24,22 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
-package gov.hhs.fha.nhinc.orchestration;
+package gov.hhs.fha.nhinc.gateway.executorservice;
 
-import com.google.common.base.Optional;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-/**
- * Used for concurrent task executor based orchestrator implementations
- * 
- * @author paul.eftis
- */
-public interface OutboundOrchestratableMessage extends OutboundOrchestratable {
+import org.junit.Test;
 
-    public Optional<OutboundResponseProcessor> getResponseProcessor();
+public class ExecutorServiceHelperTest {
 
+    @Test
+    public void formattedExceptionIncludesMessage() {
+        Exception e = mock(Exception.class);
+        when(e.getMessage()).thenReturn("message");
+
+        String result = ExecutorServiceHelper.getFormattedExceptionInfo(e, null, null);
+        assertTrue(result.contains("message"));
+    }
 }

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/OutboundDocQueryOrchestratable.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/OutboundDocQueryOrchestratable.java
@@ -26,29 +26,27 @@
  */
 package gov.hhs.fha.nhinc.docquery.entity;
 
-import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
-import gov.hhs.fha.nhinc.orchestration.OutboundOrchestratableMessage;
-import gov.hhs.fha.nhinc.orchestration.OutboundDelegate;
-import gov.hhs.fha.nhinc.orchestration.NhinAggregator;
-import gov.hhs.fha.nhinc.orchestration.OutboundResponseProcessor;
-import gov.hhs.fha.nhinc.orchestration.AuditTransformer;
-import gov.hhs.fha.nhinc.orchestration.PolicyTransformer;
-
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
-
+import gov.hhs.fha.nhinc.orchestration.AuditTransformer;
+import gov.hhs.fha.nhinc.orchestration.NhinAggregator;
+import gov.hhs.fha.nhinc.orchestration.OutboundDelegate;
+import gov.hhs.fha.nhinc.orchestration.OutboundOrchestratableMessage;
+import gov.hhs.fha.nhinc.orchestration.OutboundResponseProcessor;
+import gov.hhs.fha.nhinc.orchestration.PolicyTransformer;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryResponse;
 
+import com.google.common.base.Optional;
+
 /**
  * Doc Query implementation of OutboundOrchestratableMessage.
- *
+ * 
  * @author paul.eftis
  */
 public class OutboundDocQueryOrchestratable implements OutboundOrchestratableMessage {
 
     private OutboundDelegate delegate = null;
-    private OutboundResponseProcessor processor = null;
     private AuditTransformer auditTransformer = null;
     private PolicyTransformer policyTransformer = null;
     private AssertionType assertion = null;
@@ -60,7 +58,6 @@ public class OutboundDocQueryOrchestratable implements OutboundOrchestratableMes
     private AdhocQueryResponse response = null;
     private NhinAggregator aggregator = null;
 
-
     /**
      * Default Constructor.
      */
@@ -68,29 +65,36 @@ public class OutboundDocQueryOrchestratable implements OutboundOrchestratableMes
     }
 
     /**
-     * @param delegate DocQuery Delegate.
+     * @param delegate
+     *            DocQuery Delegate.
      */
     public OutboundDocQueryOrchestratable(OutboundDelegate delegate) {
         this.delegate = delegate;
     }
 
-    /** Constructor.
-     * @param d Delegate.
-     * @param p outboundResponseProcessor.
-     * @param at AuditTransformer.
-     * @param pt PolicyTransformer.
-     * @param a assertion.
-     * @param name serviceName.
-     * @param t target.
-     * @param r AdhocQUery Request.
+    /**
+     * Constructor.
+     * 
+     * @param d
+     *            Delegate.
+     * @param at
+     *            AuditTransformer.
+     * @param pt
+     *            PolicyTransformer.
+     * @param a
+     *            assertion.
+     * @param name
+     *            serviceName.
+     * @param t
+     *            target.
+     * @param r
+     *            AdhocQUery Request.
      */
-    //CHECKSTYLE:OFF
-    public OutboundDocQueryOrchestratable(OutboundDelegate d, OutboundResponseProcessor p, AuditTransformer at,
-            PolicyTransformer pt, AssertionType a, String name, NhinTargetSystemType t, AdhocQueryRequest r) {
-    //CHECKSTYLE:ON
-
+    // CHECKSTYLE:OFF
+    public OutboundDocQueryOrchestratable(OutboundDelegate d, AuditTransformer at, PolicyTransformer pt,
+            AssertionType a, String name, NhinTargetSystemType t, AdhocQueryRequest r) {
+        // CHECKSTYLE:ON
         this.delegate = d;
-        this.processor = p;
         this.auditTransformer = at;
         this.policyTransformer = pt;
         this.assertion = a;
@@ -98,34 +102,37 @@ public class OutboundDocQueryOrchestratable implements OutboundOrchestratableMes
         this.target = t;
         this.request = r;
     }
-    
-    public OutboundDocQueryOrchestratable(OutboundDelegate d, AssertionType a, String name, NhinTargetSystemType t, AdhocQueryRequest r) {
-        this(d, null, null, null, a, name,  t, r);
+
+    public OutboundDocQueryOrchestratable(OutboundDelegate d, AssertionType a, String name, NhinTargetSystemType t,
+            AdhocQueryRequest r) {
+        this(d, null, null, a, name, t, r);
     }
 
     public OutboundDocQueryOrchestratable(NhinAggregator agg, AssertionType a, String name, AdhocQueryRequest r) {
-    //CHECKSTYLE:ON
-        this(null, null, null, null, a, name, null, r);
+        // CHECKSTYLE:ON
+        this(null, null, null, a, name, null, r);
         this.aggregator = agg;
     }
-    
-    
+
     /**
-     * @param assertion Assertion received.
+     * @param assertion
+     *            Assertion received.
      */
     public void setAssertion(AssertionType assertion) {
         this.assertion = assertion;
     }
 
     /**
-     * @param request AdhocQUery Request.
+     * @param request
+     *            AdhocQUery Request.
      */
     public void setRequest(AdhocQueryRequest request) {
         this.request = request;
     }
 
     /**
-     * @param target NhinTarget info.
+     * @param target
+     *            NhinTarget info.
      */
     public void setTarget(NhinTargetSystemType target) {
         this.target = target;
@@ -139,7 +146,8 @@ public class OutboundDocQueryOrchestratable implements OutboundOrchestratableMes
     }
 
     /**
-     * @param r AdhocQuery Response.
+     * @param r
+     *            AdhocQuery Response.
      */
     public void setResponse(AdhocQueryResponse r) {
         response = r;
@@ -152,7 +160,9 @@ public class OutboundDocQueryOrchestratable implements OutboundOrchestratableMes
         return delegate;
     }
 
-    /**This is not used.
+    /**
+     * This is not used.
+     * 
      * @return Null.
      */
     public NhinAggregator getAggregator() {
@@ -160,10 +170,10 @@ public class OutboundDocQueryOrchestratable implements OutboundOrchestratableMes
     }
 
     /**
-     * @return processor that execute the Response.
+     * @return absent processor. Does not exists for DQ.
      */
-    public OutboundResponseProcessor getResponseProcessor() {
-        return processor;
+    public Optional<OutboundResponseProcessor> getResponseProcessor() {
+        return Optional.absent();
     }
 
     /**
@@ -214,8 +224,5 @@ public class OutboundDocQueryOrchestratable implements OutboundOrchestratableMes
     public boolean isPassthru() {
         return false;
     }
-
-    
-
 
 }

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/OutboundDocQueryOrchestratable_a0.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/OutboundDocQueryOrchestratable_a0.java
@@ -26,26 +26,23 @@
  */
 package gov.hhs.fha.nhinc.docquery.entity;
 
-import gov.hhs.fha.nhinc.orchestration.OutboundDelegate;
-import gov.hhs.fha.nhinc.orchestration.OutboundResponseProcessor;
-import gov.hhs.fha.nhinc.orchestration.AuditTransformer;
-import gov.hhs.fha.nhinc.orchestration.PolicyTransformer;
-
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
-
+import gov.hhs.fha.nhinc.orchestration.AuditTransformer;
+import gov.hhs.fha.nhinc.orchestration.OutboundDelegate;
+import gov.hhs.fha.nhinc.orchestration.PolicyTransformer;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryResponse;
 
 /**
  * OutboundDocQueryOrchestratable_a0 returns the response for the a0 specification Note that for DocQuery, the
  * individual response is a AdhocQueryResponse and the cumulative response is also a AdhocQueryResponse.
- *
+ * 
  * @author paul.eftis
  */
-//CHECKSTYLE:OFF
+// CHECKSTYLE:OFF
 public class OutboundDocQueryOrchestratable_a0 extends OutboundDocQueryOrchestratable {
-//CHECKSTYLE:ON
+    // CHECKSTYLE:ON
 
     private AdhocQueryResponse cumulativeResponse = null;
 
@@ -56,22 +53,30 @@ public class OutboundDocQueryOrchestratable_a0 extends OutboundDocQueryOrchestra
         super();
     }
 
-    /** Override SuperClass Constructor.
-     * @param d Delegate.
-     * @param p outboundResponseProcessor.
-     * @param at AuditTransformer.
-     * @param pt PolicyTransformer.
-     * @param a assertion.
-     * @param name serviceName.
-     * @param t target.
-     * @param req AdhocQUery Request.
+    /**
+     * Override SuperClass Constructor.
+     * 
+     * @param d
+     *            Delegate.
+     * @param at
+     *            AuditTransformer.
+     * @param pt
+     *            PolicyTransformer.
+     * @param a
+     *            assertion.
+     * @param name
+     *            serviceName.
+     * @param t
+     *            target.
+     * @param req
+     *            AdhocQUery Request.
      */
-    //CHECKSTYLE:OFF
-    public OutboundDocQueryOrchestratable_a0(OutboundDelegate d, OutboundResponseProcessor p, AuditTransformer at,
-            PolicyTransformer pt, AssertionType a, String name, NhinTargetSystemType t, AdhocQueryRequest req) {
-    //CHECKSTYLE:ON
+    // CHECKSTYLE:OFF
+    public OutboundDocQueryOrchestratable_a0(OutboundDelegate d, AuditTransformer at, PolicyTransformer pt,
+            AssertionType a, String name, NhinTargetSystemType t, AdhocQueryRequest req) {
+        // CHECKSTYLE:ON
 
-        super(d, p, at, pt, a, name, t, req);
+        super(d, at, pt, a, name, t, req);
     }
 
     // OutboundDocQueryOrchestratable objects are run by the nhin delegate
@@ -90,7 +95,8 @@ public class OutboundDocQueryOrchestratable_a0 extends OutboundDocQueryOrchestra
     }
 
     /**
-     * @param r cumulativeResponse passed.
+     * @param r
+     *            cumulativeResponse passed.
      */
     public void setCumulativeResponse(AdhocQueryResponse r) {
         cumulativeResponse = r;

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/OutboundDocQueryOrchestratable_a1.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/OutboundDocQueryOrchestratable_a1.java
@@ -26,14 +26,11 @@
  */
 package gov.hhs.fha.nhinc.docquery.entity;
 
-import gov.hhs.fha.nhinc.orchestration.OutboundDelegate;
-import gov.hhs.fha.nhinc.orchestration.OutboundResponseProcessor;
-import gov.hhs.fha.nhinc.orchestration.AuditTransformer;
-import gov.hhs.fha.nhinc.orchestration.PolicyTransformer;
-
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
-
+import gov.hhs.fha.nhinc.orchestration.AuditTransformer;
+import gov.hhs.fha.nhinc.orchestration.OutboundDelegate;
+import gov.hhs.fha.nhinc.orchestration.PolicyTransformer;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryResponse;
 
@@ -41,12 +38,12 @@ import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryResponse;
  * OutboundDocQueryOrchestratable_a1 returns the response for the a1 specification Note that for DocQuery, the
  * individual response is a AdhocQueryResponse and the cumulative response is also a AdhocQueryResponse Currently, a0
  * and a1 specs are same for Doc Query.
- *
+ * 
  * @author paul.eftis
  */
-//CHECKSTYLE:OFF
+// CHECKSTYLE:OFF
 public class OutboundDocQueryOrchestratable_a1 extends OutboundDocQueryOrchestratable {
-//CHECKSTYLE:ON
+    // CHECKSTYLE:ON
 
     private AdhocQueryResponse cumulativeResponse = null;
 
@@ -57,21 +54,29 @@ public class OutboundDocQueryOrchestratable_a1 extends OutboundDocQueryOrchestra
         super();
     }
 
-    /** Override SuperClass Constructor.
-     * @param d Delegate.
-     * @param p outboundResponseProcessor.
-     * @param at AuditTransformer.
-     * @param pt PolicyTransformer.
-     * @param a assertion.
-     * @param name serviceName.
-     * @param t target.
-     * @param req AdhocQUery Request.
+    /**
+     * Override SuperClass Constructor.
+     * 
+     * @param d
+     *            Delegate.
+     * @param at
+     *            AuditTransformer.
+     * @param pt
+     *            PolicyTransformer.
+     * @param a
+     *            assertion.
+     * @param name
+     *            serviceName.
+     * @param t
+     *            target.
+     * @param req
+     *            AdhocQUery Request.
      */
-    //CHECKSTYLE:OFF
-    public OutboundDocQueryOrchestratable_a1(OutboundDelegate d, OutboundResponseProcessor p, AuditTransformer at,
-            PolicyTransformer pt, AssertionType a, String name, NhinTargetSystemType t, AdhocQueryRequest req) {
-    //CHECKSTYLE:ON
-        super(d, p, at, pt, a, name, t, req);
+    // CHECKSTYLE:OFF
+    public OutboundDocQueryOrchestratable_a1(OutboundDelegate d, AuditTransformer at, PolicyTransformer pt,
+            AssertionType a, String name, NhinTargetSystemType t, AdhocQueryRequest req) {
+        // CHECKSTYLE:ON
+        super(d, at, pt, a, name, t, req);
     }
 
     // OutboundDocQueryOrchestratable objects are run by the nhin delegate
@@ -81,7 +86,7 @@ public class OutboundDocQueryOrchestratable_a1 extends OutboundDocQueryOrchestra
     public OutboundDelegate getDelegate() {
         return null;
     }
-    
+
     /**
      * @return AdhocQueryResponse which is cumulativeResponse.
      */
@@ -90,7 +95,8 @@ public class OutboundDocQueryOrchestratable_a1 extends OutboundDocQueryOrchestra
     }
 
     /**
-     * @param r cumulativeResponse passed.
+     * @param r
+     *            cumulativeResponse passed.
      */
     public void setCumulativeResponse(AdhocQueryResponse r) {
         cumulativeResponse = r;

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/OutboundDocQueryOrchestrationContextBuilder.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/OutboundDocQueryOrchestrationContextBuilder.java
@@ -29,17 +29,19 @@ package gov.hhs.fha.nhinc.docquery.entity;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.orchestration.AuditTransformer;
-import gov.hhs.fha.nhinc.orchestration.OutboundDelegate;
-import gov.hhs.fha.nhinc.orchestration.OutboundResponseProcessor;
 import gov.hhs.fha.nhinc.orchestration.OrchestrationContext;
 import gov.hhs.fha.nhinc.orchestration.OrchestrationContextBuilder;
+import gov.hhs.fha.nhinc.orchestration.OutboundDelegate;
+import gov.hhs.fha.nhinc.orchestration.OutboundResponseProcessor;
 import gov.hhs.fha.nhinc.orchestration.PolicyTransformer;
-
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 
 /**
  * @author bhumphrey/paul
- *
+ * 
  */
 public abstract class OutboundDocQueryOrchestrationContextBuilder implements OrchestrationContextBuilder {
 
@@ -49,7 +51,7 @@ public abstract class OutboundDocQueryOrchestrationContextBuilder implements Orc
     private PolicyTransformer policyTransformer = null;
     private AuditTransformer auditTransformer = null;
     private OutboundDelegate nhinDelegate = null;
-    private OutboundResponseProcessor nhinProcessor = null;
+    private Optional<OutboundResponseProcessor> nhinProcessor = Optional.absent();
     private String serviceName = "";
 
     @Override
@@ -65,10 +67,11 @@ public abstract class OutboundDocQueryOrchestrationContextBuilder implements Orc
     /**
      * @return OutboundDocQueryStrategy based on specLevel
      */
-     protected abstract OutboundDocQueryStrategy getStrategy();
+    protected abstract OutboundDocQueryStrategy getStrategy();
 
     /**
-     * @param t NhinTarget community passed.
+     * @param t
+     *            NhinTarget community passed.
      */
     public void setTarget(NhinTargetSystemType t) {
         this.target = t;
@@ -82,7 +85,8 @@ public abstract class OutboundDocQueryOrchestrationContextBuilder implements Orc
     }
 
     /**
-     * @param dqRequest AdhocQUery Request received.
+     * @param dqRequest
+     *            AdhocQUery Request received.
      */
     public void setRequest(AdhocQueryRequest dqRequest) {
         this.request = dqRequest;
@@ -103,7 +107,8 @@ public abstract class OutboundDocQueryOrchestrationContextBuilder implements Orc
     }
 
     /**
-     * @param assertionType Assertion received.
+     * @param assertionType
+     *            Assertion received.
      */
     public void setAssertionType(AssertionType assertionType) {
         this.assertionType = assertionType;
@@ -117,7 +122,8 @@ public abstract class OutboundDocQueryOrchestrationContextBuilder implements Orc
     }
 
     /**
-     * @param policyTransformer policyTransformer received.
+     * @param policyTransformer
+     *            policyTransformer received.
      */
     public void setPolicyTransformer(PolicyTransformer policyTransformer) {
         this.policyTransformer = policyTransformer;
@@ -131,7 +137,8 @@ public abstract class OutboundDocQueryOrchestrationContextBuilder implements Orc
     }
 
     /**
-     * @param auditTransformer AuditTransformer to audit.
+     * @param auditTransformer
+     *            AuditTransformer to audit.
      */
     public void setAuditTransformer(AuditTransformer auditTransformer) {
         this.auditTransformer = auditTransformer;
@@ -145,7 +152,8 @@ public abstract class OutboundDocQueryOrchestrationContextBuilder implements Orc
     }
 
     /**
-     * @param nhinDelegate nhinDelegate received.
+     * @param nhinDelegate
+     *            nhinDelegate received.
      */
     public void setNhinDelegate(OutboundDelegate nhinDelegate) {
         this.nhinDelegate = nhinDelegate;
@@ -154,29 +162,33 @@ public abstract class OutboundDocQueryOrchestrationContextBuilder implements Orc
     /**
      * @return outboundDocQueryProcessor.
      */
-    protected OutboundResponseProcessor getAggregator() {
+    protected Optional<OutboundResponseProcessor> getAggregator() {
         return nhinProcessor;
     }
 
     /**
-     * @param processor DocQueryProcessor.
+     * @param processor
+     *            DocQueryProcessor.
      */
-    public void setAggregator(OutboundResponseProcessor processor) {
+    public void setAggregator(Optional<OutboundResponseProcessor> processor) {
+        Preconditions.checkNotNull(processor);
         nhinProcessor = processor;
     }
 
     /**
      * @return outboundDocQueryProcessor.
      */
-    protected OutboundResponseProcessor getProcessor() {
+    protected Optional<OutboundResponseProcessor> getProcessor() {
         return nhinProcessor;
     }
 
     /**
-     * @param processor outboundReponseProcessor.
+     * @param processor
+     *            outboundReponseProcessor.
      */
-    public void setProcessor(OutboundResponseProcessor processor) {
-        this.nhinProcessor = processor;
+    public void setProcessor(Optional<OutboundResponseProcessor> processor) {
+        Preconditions.checkNotNull(processor);
+        nhinProcessor = processor;
     }
 
     /**
@@ -187,7 +199,8 @@ public abstract class OutboundDocQueryOrchestrationContextBuilder implements Orc
     }
 
     /**
-     * @param name ServiceName DocQuery.
+     * @param name
+     *            ServiceName DocQuery.
      */
     public void setServiceName(String name) {
         this.serviceName = name;

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/OutboundDocQueryOrchestrationContextBuilder_g0.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/OutboundDocQueryOrchestrationContextBuilder_g0.java
@@ -28,12 +28,12 @@ package gov.hhs.fha.nhinc.docquery.entity;
 
 /**
  * DocQuery OrchestrationContext for g0 endpoint.
- *
+ * 
  * @author paul.eftis
  */
-//CHECKSTYLE:OFF
+// CHECKSTYLE:OFF
 public class OutboundDocQueryOrchestrationContextBuilder_g0 extends OutboundDocQueryOrchestrationContextBuilder {
-//CHECKSTYLE:ON
+    // CHECKSTYLE:ON
     /**
      * @return strategy for g0
      */
@@ -48,7 +48,7 @@ public class OutboundDocQueryOrchestrationContextBuilder_g0 extends OutboundDocQ
     @Override
     protected OutboundDocQueryOrchestratable getOrchestratable() {
         OutboundDocQueryOrchestratable_a0 orcha0 = new OutboundDocQueryOrchestratable_a0(getNhinDelegate(),
-                getProcessor(), getAuditTransformer(), getPolicyTransformer(), getAssertionType(), getServiceName(),
+                getAuditTransformer(), getPolicyTransformer(), getAssertionType(), getServiceName(),
                 getTargetSystemType(), getRequest());
         return orcha0;
     }

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/OutboundDocQueryOrchestrationContextBuilder_g1.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/OutboundDocQueryOrchestrationContextBuilder_g1.java
@@ -28,12 +28,12 @@ package gov.hhs.fha.nhinc.docquery.entity;
 
 /**
  * DocQuery OrchestrationContext for g0 endpoint.
- *
+ * 
  * @author paul.eftis
  */
-//CHECKSTYLE:OFF
+// CHECKSTYLE:OFF
 public class OutboundDocQueryOrchestrationContextBuilder_g1 extends OutboundDocQueryOrchestrationContextBuilder {
-//CHECKSTYLE:ON
+    // CHECKSTYLE:ON
     /**
      * @return strategy for g1
      */
@@ -48,7 +48,7 @@ public class OutboundDocQueryOrchestrationContextBuilder_g1 extends OutboundDocQ
     @Override
     protected OutboundDocQueryOrchestratable getOrchestratable() {
         OutboundDocQueryOrchestratable_a1 orcha1 = new OutboundDocQueryOrchestratable_a1(getNhinDelegate(),
-                getProcessor(), getAuditTransformer(), getPolicyTransformer(), getAssertionType(), getServiceName(),
+                getAuditTransformer(), getPolicyTransformer(), getAssertionType(), getServiceName(),
                 getTargetSystemType(), getRequest());
         return orcha1;
     }

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/outbound/StandardOutboundDocQuery.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/outbound/StandardOutboundDocQuery.java
@@ -76,13 +76,18 @@ public class StandardOutboundDocQuery implements OutboundDocQuery {
 
     /**
      * 
-     * @param adhocQueryRequest The AdhocQueryRequest message received.
-     * @param assertion Assertion received.
-     * @param targets Target to send request.
+     * @param adhocQueryRequest
+     *            The AdhocQueryRequest message received.
+     * @param assertion
+     *            Assertion received.
+     * @param targets
+     *            Target to send request.
      * @return AdhocQueryResponse from Entity Interface.
      */
     @Override
-    @OutboundProcessingEvent(beforeBuilder = AdhocQueryRequestDescriptionBuilder.class, afterReturningBuilder = AdhocQueryResponseDescriptionBuilder.class, serviceType = "Document Query", version = "")
+    @OutboundProcessingEvent(beforeBuilder = AdhocQueryRequestDescriptionBuilder.class,
+            afterReturningBuilder = AdhocQueryResponseDescriptionBuilder.class, serviceType = "Document Query",
+            version = "")
     public AdhocQueryResponse respondingGatewayCrossGatewayQuery(AdhocQueryRequest adhocQueryRequest,
             AssertionType assertion, NhinTargetCommunitiesType targets) {
         LOG.trace("EntityDocQueryOrchImpl.respondingGatewayCrossGatewayQuery...");
@@ -129,8 +134,10 @@ public class StandardOutboundDocQuery implements OutboundDocQuery {
     /**
      * This method returns Response with RegistryErrorList if there is any failure.
      * 
-     * @param errorCode The ErrorCode that needs to be set to the AdhocQueryResponse (Errorcodes are defined in spec).
-     * @param codeContext The codecontext defines the reason of failure of AdhocQueryRequest.
+     * @param errorCode
+     *            The ErrorCode that needs to be set to the AdhocQueryResponse (Errorcodes are defined in spec).
+     * @param codeContext
+     *            The codecontext defines the reason of failure of AdhocQueryRequest.
      * @return AdhocQueryResponse.
      */
     private AdhocQueryResponse createErrorResponse(String errorCode, String codeContext) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/entity/AbstractOutboundPatientDiscoveryOrchestrationContextBuilder.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/entity/AbstractOutboundPatientDiscoveryOrchestrationContextBuilder.java
@@ -26,23 +26,26 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.entity;
 
-import org.hl7.v3.PRPAIN201305UV02;
-
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.orchestration.AuditTransformer;
-import gov.hhs.fha.nhinc.orchestration.OutboundDelegate;
-import gov.hhs.fha.nhinc.orchestration.OutboundResponseProcessor;
 import gov.hhs.fha.nhinc.orchestration.OrchestrationContext;
 import gov.hhs.fha.nhinc.orchestration.OrchestrationContextBuilder;
+import gov.hhs.fha.nhinc.orchestration.OutboundDelegate;
+import gov.hhs.fha.nhinc.orchestration.OutboundResponseProcessor;
 import gov.hhs.fha.nhinc.orchestration.PolicyTransformer;
+
+import org.hl7.v3.PRPAIN201305UV02;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 
 /**
  * @author bhumphrey/paul
  * 
  */
-public abstract class AbstractOutboundPatientDiscoveryOrchestrationContextBuilder implements 
-                                    OrchestrationContextBuilder {
+public abstract class AbstractOutboundPatientDiscoveryOrchestrationContextBuilder implements
+        OrchestrationContextBuilder {
 
     private NhinTargetSystemType target = null;
     private PRPAIN201305UV02 request = null;
@@ -50,7 +53,7 @@ public abstract class AbstractOutboundPatientDiscoveryOrchestrationContextBuilde
     private PolicyTransformer policyTransformer = null;
     private AuditTransformer auditTransformer = null;
     private OutboundDelegate nhinDelegate = null;
-    private OutboundResponseProcessor nhinProcessor = null;
+    private Optional<OutboundResponseProcessor> nhinProcessor = Optional.absent();
     private String serviceName = "";
 
     @Override
@@ -110,20 +113,22 @@ public abstract class AbstractOutboundPatientDiscoveryOrchestrationContextBuilde
         this.nhinDelegate = nhinDelegate;
     }
 
-    protected OutboundResponseProcessor getAggregator() {
+    protected Optional<OutboundResponseProcessor> getAggregator() {
         return nhinProcessor;
     }
 
-    public void setAggregator(OutboundResponseProcessor processor) {
+    public void setAggregator(Optional<OutboundResponseProcessor> processor) {
+        Preconditions.checkNotNull(processor);
         nhinProcessor = processor;
     }
 
-    protected OutboundResponseProcessor getProcessor() {
+    protected Optional<OutboundResponseProcessor> getProcessor() {
         return nhinProcessor;
     }
 
-    public void setProcessor(OutboundResponseProcessor processor) {
-        this.nhinProcessor = processor;
+    public void setProcessor(Optional<OutboundResponseProcessor> processor) {
+        Preconditions.checkNotNull(processor);
+        nhinProcessor = processor;
     }
 
     protected String getServiceName() {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/entity/OutboundPatientDiscoveryOrchestratable.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/entity/OutboundPatientDiscoveryOrchestratable.java
@@ -39,6 +39,9 @@ import org.hl7.v3.PRPAIN201305UV02;
 import org.hl7.v3.PRPAIN201306UV02;
 import org.hl7.v3.RespondingGatewayPRPAIN201306UV02ResponseType;
 
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+
 /**
  * Patient Discovery implementation of OutboundOrchestratableMessage
  * 
@@ -47,7 +50,7 @@ import org.hl7.v3.RespondingGatewayPRPAIN201306UV02ResponseType;
 public class OutboundPatientDiscoveryOrchestratable implements OutboundOrchestratableMessage {
 
     private OutboundDelegate delegate = null;
-    private OutboundResponseProcessor processor = null;
+    private Optional<OutboundResponseProcessor> processor = Optional.absent();
     private AuditTransformer auditTransformer = null;
     private PolicyTransformer policyTransformer = null;
     private AssertionType assertion = null;
@@ -60,9 +63,10 @@ public class OutboundPatientDiscoveryOrchestratable implements OutboundOrchestra
     public OutboundPatientDiscoveryOrchestratable() {
     }
 
-    public OutboundPatientDiscoveryOrchestratable(OutboundDelegate d, OutboundResponseProcessor p, AuditTransformer at,
-            PolicyTransformer pt, AssertionType a, String name, NhinTargetSystemType t, PRPAIN201305UV02 r) {
-
+    public OutboundPatientDiscoveryOrchestratable(OutboundDelegate d, Optional<OutboundResponseProcessor> p,
+            AuditTransformer at, PolicyTransformer pt, AssertionType a, String name, NhinTargetSystemType t,
+            PRPAIN201305UV02 r) {
+        Preconditions.checkNotNull(p);
         this.delegate = d;
         this.processor = p;
         this.auditTransformer = at;
@@ -81,7 +85,7 @@ public class OutboundPatientDiscoveryOrchestratable implements OutboundOrchestra
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
-    public OutboundResponseProcessor getResponseProcessor() {
+    public Optional<OutboundResponseProcessor> getResponseProcessor() {
         return processor;
     }
 
@@ -112,7 +116,7 @@ public class OutboundPatientDiscoveryOrchestratable implements OutboundOrchestra
     public boolean isPassthru() {
         return false;
     }
-    
+
     public PRPAIN201306UV02 getResponse() {
         return response;
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscovery.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscovery.java
@@ -71,6 +71,8 @@ import org.hl7.v3.PRPAMT201306UV02QueryByParameter;
 import org.hl7.v3.RespondingGatewayPRPAIN201305UV02RequestType;
 import org.hl7.v3.RespondingGatewayPRPAIN201306UV02ResponseType;
 
+import com.google.common.base.Optional;
+
 public class StandardOutboundPatientDiscovery implements OutboundPatientDiscovery {
 
     private static final Logger LOG = Logger.getLogger(StandardOutboundPatientDiscovery.class);
@@ -165,8 +167,7 @@ public class StandardOutboundPatientDiscovery implements OutboundPatientDiscover
             if (NullChecker.isNullish(urlInfoList)) {
                 throw new Exception("No target endpoints were found for the Patient Discovery Request.");
             } else {
-                List<NhinCallableRequest<OutboundPatientDiscoveryOrchestratable>> callableList =
-                    new ArrayList<NhinCallableRequest<OutboundPatientDiscoveryOrchestratable>>();
+                List<NhinCallableRequest<OutboundPatientDiscoveryOrchestratable>> callableList = new ArrayList<NhinCallableRequest<OutboundPatientDiscoveryOrchestratable>>();
                 String transactionId = (UUID.randomUUID()).toString();
 
                 // we hold the error messages for any failed policy checks in policyErrList
@@ -185,15 +186,16 @@ public class StandardOutboundPatientDiscovery implements OutboundPatientDiscover
 
                         logTransaction(assertion.getMessageId(), newRequest.getAssertion().getMessageId());
 
-                        OutboundPatientDiscoveryOrchestratable message =
-                            createOrchestratable(newRequest.getPRPAIN201305UV02(), newRequest.getAssertion(), target, gatewayLevel);
+                        OutboundPatientDiscoveryOrchestratable message = createOrchestratable(
+                                newRequest.getPRPAIN201305UV02(), newRequest.getAssertion(), target, gatewayLevel);
                         callableList.add(new NhinCallableRequest<OutboundPatientDiscoveryOrchestratable>(message));
 
-                        LOG.debug("Added NhinCallableRequest" + " for hcid=" + target.getHomeCommunity().getHomeCommunityId());
+                        LOG.debug("Added NhinCallableRequest" + " for hcid="
+                                + target.getHomeCommunity().getHomeCommunityId());
                     } else {
                         LOG.debug("Policy Check Failed for homeId=" + urlInfo.getHcid());
-                        CommunityPRPAIN201306UV02ResponseType communityResponse =
-                            createFailedPolicyCommunityResponseFromRequest(request.getPRPAIN201305UV02(), urlInfo.getHcid());
+                        CommunityPRPAIN201306UV02ResponseType communityResponse = createFailedPolicyCommunityResponseFromRequest(
+                                request.getPRPAIN201305UV02(), urlInfo.getHcid());
 
                         policyErrList.add(communityResponse);
                     }
@@ -254,8 +256,8 @@ public class StandardOutboundPatientDiscovery implements OutboundPatientDiscover
             AssertionType assertion, NhinTargetSystemType target, NhincConstants.GATEWAY_API_LEVEL gatewayLevel) {
         OutboundDelegate nd = new OutboundPatientDiscoveryDelegate();
         OutboundResponseProcessor np = new OutboundPatientDiscoveryProcessor(gatewayLevel);
-        OutboundPatientDiscoveryOrchestratable orchestratable = new OutboundPatientDiscoveryOrchestratable(nd, np,
-                null, null, assertion, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, target, message);
+        OutboundPatientDiscoveryOrchestratable orchestratable = new OutboundPatientDiscoveryOrchestratable(nd,
+                Optional.of(np), null, null, assertion, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, target, message);
 
         return orchestratable;
     }
@@ -268,8 +270,8 @@ public class StandardOutboundPatientDiscovery implements OutboundPatientDiscover
         home.setHomeCommunityId(hcid);
         tc.setHomeCommunity(home);
         communityResponse.setNhinTargetCommunity(tc);
-        communityResponse.setPRPAIN201306UV02((new HL7PRPA201306Transforms())
-                .createPRPA201306ForErrors(message, "Policy Check Failed for homeId=" + hcid));
+        communityResponse.setPRPAIN201306UV02((new HL7PRPA201306Transforms()).createPRPA201306ForErrors(message,
+                "Policy Check Failed for homeId=" + hcid));
 
         return communityResponse;
     }
@@ -299,10 +301,14 @@ public class StandardOutboundPatientDiscovery implements OutboundPatientDiscover
      * original. This request will have a cloned assertion with the same message id if numTargets == 1 and a new message
      * id otherwise.
      * 
-     * @param request the request to be cloned
-     * @param assertion the assertion to be cloned
-     * @param urlInfo the url info to use
-     * @param numTargets the number of total outbound targets of the originating request
+     * @param request
+     *            the request to be cloned
+     * @param assertion
+     *            the assertion to be cloned
+     * @param urlInfo
+     *            the url info to use
+     * @param numTargets
+     *            the number of total outbound targets of the originating request
      * @return new RespondingGatewayPRPAIN201305UV02RequestType
      */
     protected RespondingGatewayPRPAIN201305UV02RequestType createNewRequest(
@@ -321,11 +327,14 @@ public class StandardOutboundPatientDiscovery implements OutboundPatientDiscover
 
     /**
      * Create a new RespondingGatewayPRPAIN201305UV02RequestType which has a new PRPAIN201305UV02 cloned from the
-     * original.  This call will NOT clone the passed in assertion and instead will use it immediately for the request.
+     * original. This call will NOT clone the passed in assertion and instead will use it immediately for the request.
      * 
-     * @param request the request to be cloned
-     * @param assertion the assertion to be used to the request
-     * @param urlInfo the url info to use
+     * @param request
+     *            the request to be cloned
+     * @param assertion
+     *            the assertion to be used to the request
+     * @param urlInfo
+     *            the url info to use
      * @return new RespondingGatewayPRPAIN201305UV02RequestType
      */
     private RespondingGatewayPRPAIN201305UV02RequestType createNewRequest(
@@ -360,8 +369,10 @@ public class StandardOutboundPatientDiscovery implements OutboundPatientDiscover
     /**
      * Log the transaction of the new request message id, but only if it's not the same as the related message id.
      * 
-     * @param relatedMessageId the message id of a previous transaction that the request message id should be a part of
-     * @param requestMessageId the message id to be logged
+     * @param relatedMessageId
+     *            the message id of a previous transaction that the request message id should be a part of
+     * @param requestMessageId
+     *            the message id to be logged
      */
     private void logTransaction(String relatedMessageId, String requestMessageId) {
         if (!relatedMessageId.equals(requestMessageId)) {
@@ -391,8 +402,7 @@ public class StandardOutboundPatientDiscovery implements OutboundPatientDiscover
         return sHomeCommunity;
     }
 
-    protected void auditRequestFromAdapter(RespondingGatewayPRPAIN201305UV02RequestType request,
-            AssertionType assertion) {
+    protected void auditRequestFromAdapter(RespondingGatewayPRPAIN201305UV02RequestType request, AssertionType assertion) {
         getNewPatientDiscoveryAuditLogger().auditEntity201305(request, assertion,
                 NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
     }


### PR DESCRIPTION
DQ response processor does not exist.  Removed incorrect usages, and
forced explicit null handling through use of Optional typing.
Improved error message display itself to include exception cause.
