### PR TITLE
Gateway-3437:Fix missed requirements mentioned in Gateway-3437

### DIFF
--- a/Product/Production/Adapters/General/CONNECTUniversalClientGUI/src/main/java/universalclientgui/Page2.java
+++ b/Product/Production/Adapters/General/CONNECTUniversalClientGUI/src/main/java/universalclientgui/Page2.java
@@ -444,6 +444,7 @@ public class Page2 extends AbstractPageBean {
         this.firstNameField.setText("");
         this.lastNameField.setText("");
         this.lastNameField.clearInitialState();
+        this.patientInfo.setText("");
         return null;
     }
 
@@ -618,6 +619,7 @@ public class Page2 extends AbstractPageBean {
                 getSessionBean1().setFoundPatient(testPatient);
                 foundPatient = testPatient;
 
+                discoverInfoBuf.append("Patient Information Query: ");
                 discoverInfoBuf.append("Name: ");
                 if (!foundPatient.getLastName().isEmpty()) {
                     discoverInfoBuf.append(foundPatient.getLastName() + ", ");
@@ -811,7 +813,7 @@ public class Page2 extends AbstractPageBean {
 
         this.errorMessage.setText("");
         this.getSessionBean1().getPatientCorrelationList().clear();
-
+        this.patientInfo.setText("");
         SearchData searchData = (SearchData) getBean("SearchData");
 
         PatientSearchData currentPatient = null;
@@ -846,25 +848,6 @@ public class Page2 extends AbstractPageBean {
         return null;
     }
 
-    private boolean isDocumentSearchCriteriaValid() {
-        StringBuffer message = new StringBuffer();
-        boolean isValid = true;
-
-        if (this.creationFromDate == null || this.creationToDate == null) {
-            message.append("Earliest Date and Most Recent Date should not be null");
-            isValid = false;
-        } else if (this.creationFromDate.getSelectedDate() == null || this.getCreationToDate().getSelectedDate() == null) {
-            message.append("Earliest Date and Most Recent Date should not be null");
-            isValid = false;
-        } else if (this.creationFromDate.getSelectedDate().after(this.getCreationToDate().getSelectedDate())) {
-            message.append("Earliest Date should not be after Most Recent Date");
-            isValid = false;
-        }
-
-        errors = message.toString();
-
-        return isValid;
-    }
 
     public String displayDocument() throws Exception {
 

--- a/Product/Production/Adapters/General/CONNECTUniversalClientGUI/src/main/webapp/Page2.jsp
+++ b/Product/Production/Adapters/General/CONNECTUniversalClientGUI/src/main/webapp/Page2.jsp
@@ -77,7 +77,7 @@
                                 <webuijsf:panelLayout id="subjectDiscoveryLayoutPanel" style="height: 534px; position: relative; width: 100%; -rave-layout: grid">
                                     <webuijsf:staticText binding="#{Page2.subjectDiscoveryResultsInfo}" id="subjectDiscoveryResultsInfo" style="color: black; font-family: 'Times New Roman','Times',serif; font-size: 14px; font-weight: bold; left: 24px; top: 24px; position: absolute"/>
                                     <webuijsf:button actionExpression="#{Page2.broadcastSubjectDiscoveryButton_action}" id="broadcastSubjectDiscoveryButton"
-                                        style="font-family: 'Times New Roman','Times',serif; font-size: 14px; left: 23px; top: 72px; position: absolute" text="Discover Patients"/>
+                                        style="font-family: 'Times New Roman','Times',serif; font-size: 14px; left: 23px; top: 72px; position: absolute" text="Discover Patient"/>
                                     <webuijsf:label id="searchPatientDiscovery"
                                         style="font-family: 'Times New Roman','Times',serif; font-size: 14px; left: 24px; top: 95px; position: absolute" text="Click to send a patient discovery message to systems in your UDDI (and/or uddiConnectionInfo.xml file)."/>   
                                     <webuijsf:table augmentTitle="false" id="subjectDiscoveryCoorelationTable" paginateButton="true" paginationControls="true"


### PR DESCRIPTION
Fix Button in PatientCorrelation tab to Discover Patient.
Add missed Requirement Patient information Query: to the info displayed on the top of the page when PatientCorrelation tab is active.
Fix missed clean-up displayed info when switch tab to PatientCorrelation and PatientSearch. 
