### PR TITLE
Gateway 3443

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/BaseEventAdviceDelegate.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/BaseEventAdviceDelegate.java
@@ -94,11 +94,12 @@ public abstract class BaseEventAdviceDelegate implements EventAdviceDelegate {
     @Override
     public void begin(Object[] args, String serviceType, String version,
             Class<? extends EventDescriptionBuilder> eventDescriptionbuilderClass) {
+        if (eventRecorder != null && eventRecorder.isRecordEventEnabled()) {
+            EventDescriptionBuilder eventDescriptionBuilder = createAndInitializeEventDecriptionBuilder(args,
+                    createEventContextAccessor(serviceType, version), eventDescriptionbuilderClass, null);
 
-        EventDescriptionBuilder eventDescriptionBuilder = createAndInitializeEventDecriptionBuilder(args,
-                createEventContextAccessor(serviceType, version), eventDescriptionbuilderClass, null);
-
-        createAndRecordEvent(getBeginEventBuilder(eventDescriptionBuilder));
+            createAndRecordEvent(getBeginEventBuilder(eventDescriptionBuilder));
+        }
     }
 
     /**
@@ -121,9 +122,11 @@ public abstract class BaseEventAdviceDelegate implements EventAdviceDelegate {
     @Override
     public void end(Object[] args, String serviceType, String version,
             Class<? extends EventDescriptionBuilder> eventDescriptionbuilderClass, Object returnValue) {
-        EventDescriptionBuilder eventDescriptionBuilder = createAndInitializeEventDecriptionBuilder(args,
-                createEventContextAccessor(serviceType, version), eventDescriptionbuilderClass, returnValue);
-        createAndRecordEvent(getEndEventBuilder(eventDescriptionBuilder));
+        if (eventRecorder != null && eventRecorder.isRecordEventEnabled()) {
+            EventDescriptionBuilder eventDescriptionBuilder = createAndInitializeEventDecriptionBuilder(args,
+                    createEventContextAccessor(serviceType, version), eventDescriptionbuilderClass, returnValue);
+            createAndRecordEvent(getEndEventBuilder(eventDescriptionBuilder));
+        }
     }
 
     /*
@@ -133,9 +136,11 @@ public abstract class BaseEventAdviceDelegate implements EventAdviceDelegate {
      */
     @Override
     public void fail(Object[] arguments, Throwable throwable) {
-        ErrorEventBuilder builder = new ErrorEventBuilder();
-        builder.setThrowable(throwable);
-        createAndRecordEvent(builder);
+        if (eventRecorder != null && eventRecorder.isRecordEventEnabled()) {
+            ErrorEventBuilder builder = new ErrorEventBuilder();
+            builder.setThrowable(throwable);
+            createAndRecordEvent(builder);
+        }
     }
 
     /**

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/async/AsyncMessageIdExtractor.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/async/AsyncMessageIdExtractor.java
@@ -36,6 +36,7 @@ import javax.xml.ws.handler.MessageContext;
 
 import org.apache.cxf.binding.soap.SoapHeader;
 import org.apache.cxf.headers.Header;
+import org.springframework.util.CollectionUtils;
 import org.w3c.dom.Element;
 
 /**
@@ -44,24 +45,33 @@ import org.w3c.dom.Element;
  */
 public class AsyncMessageIdExtractor {
 
-    public Element getSoapHeaderElement(WebServiceContext context, String headerName) {
-        Element element = null;
+    protected Element getSoapHeaderElement(WebServiceContext context, String headerName) {
+        if (context == null) {
+            return null;
+        }
 
         MessageContext mContext = context.getMessageContext();
-        if (context != null && mContext != null) {
-            @SuppressWarnings("unchecked")
-            List<Header> headers = (List<Header>) mContext.get(Header.HEADER_LIST);
+        if (mContext == null) {
+            return null;
+        }
 
-            if (headers != null) {
-                for (Header header : headers) {
-                    if (header.getName().getLocalPart().equalsIgnoreCase(headerName)) {
-                        element = (Element) ((SoapHeader) header).getObject();
-                    }
-                }
+        return getSoapHeaderFromContext(headerName, mContext);
+    }
+
+    private Element getSoapHeaderFromContext(String headerName, MessageContext mContext) {
+        @SuppressWarnings("unchecked")
+        List<Header> headers = (List<Header>) mContext.get(Header.HEADER_LIST);
+        if (CollectionUtils.isEmpty(headers)) {
+            return null;
+        }
+
+        for (Header header : headers) {
+            if (header.getName().getLocalPart().equalsIgnoreCase(headerName)) {
+                return (Element) ((SoapHeader) header).getObject();
             }
         }
 
-        return element;
+        return null;
     }
 
     public String getMessageId(WebServiceContext context) {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/event/EventRecorder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/event/EventRecorder.java
@@ -2,6 +2,17 @@ package gov.hhs.fha.nhinc.event;
 
 public interface EventRecorder {
 
-    public abstract void recordEvent(Event event);
+    /**
+     * Records an event. May be a no-op (discoverable via {@link #isRecordEventEnabled()}.
+     * 
+     * @param event
+     *            event to record
+     */
+    void recordEvent(Event event);
 
+    /**
+     * @return true if calls to {@link #recordEvent(Event)} will be recorded somewhere. Useful if creating an event is
+     *         expensive. Similar to @{link Logger.isDebugEnabled()}
+     */
+    boolean isRecordEventEnabled();
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/aspect/BaseEventAdviceDelegateTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/aspect/BaseEventAdviceDelegateTest.java
@@ -1,0 +1,96 @@
+/**
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2009-2013, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *  
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above
+ *     copyright notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   * Neither the name of the United States Government nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ *DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.aspect;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import gov.hhs.fha.nhinc.event.Event;
+import gov.hhs.fha.nhinc.event.EventDescriptionBuilder;
+import gov.hhs.fha.nhinc.event.EventRecorder;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class BaseEventAdviceDelegateTest {
+
+    @Test
+    public void beginNoEventRecorder() {
+        BaseEventAdviceDelegate delegate = createAdviceDelegate(null);
+        delegate.begin(new Object[] {}, "", "", EventDescriptionBuilder.class);
+    }
+
+    @Test
+    public void beginShouldntCallRecordIfEventRecorderNotEnabled() {
+        EventRecorder mockEventRecorder = mock(EventRecorder.class);
+        BaseEventAdviceDelegate delegate = createAdviceDelegate(mockEventRecorder);
+        delegate.begin(new Object[] {}, "", "", EventDescriptionBuilder.class);
+        assertEventRecorderInteractions(mockEventRecorder);
+    }
+
+    @Test
+    public void endNoEventRecorder() {
+        BaseEventAdviceDelegate delegate = createAdviceDelegate(null);
+        delegate.end(new Object[] {}, "", "", EventDescriptionBuilder.class, null);
+    }
+
+    @Test
+    public void endShouldntCallRecordIfEventRecorderNotEnabled() {
+        EventRecorder mockEventRecorder = mock(EventRecorder.class);
+        BaseEventAdviceDelegate delegate = createAdviceDelegate(mockEventRecorder);
+        delegate.end(new Object[] {}, "", "", EventDescriptionBuilder.class, null);
+        assertEventRecorderInteractions(mockEventRecorder);
+    }
+
+    @Test
+    public void failNoEventRecorder() {
+        BaseEventAdviceDelegate delegate = createAdviceDelegate(null);
+        delegate.fail(new Object[] {}, mock(Throwable.class));
+    }
+
+    @Test
+    public void failShouldntCallRecordIfEventRecorderNotEnabled() {
+        EventRecorder mockEventRecorder = mock(EventRecorder.class);
+        BaseEventAdviceDelegate delegate = createAdviceDelegate(mockEventRecorder);
+        delegate.fail(new Object[] {}, mock(Throwable.class));
+        assertEventRecorderInteractions(mockEventRecorder);
+    }
+
+    private BaseEventAdviceDelegate createAdviceDelegate(EventRecorder mockEventRecorder) {
+        BaseEventAdviceDelegate delegate = mock(BaseEventAdviceDelegate.class, Mockito.CALLS_REAL_METHODS);
+        delegate.setEventRecorder(mockEventRecorder);
+        return delegate;
+    }
+
+    private void assertEventRecorderInteractions(EventRecorder mockEventRecorder) {
+        verify(mockEventRecorder).isRecordEventEnabled();
+        verify(mockEventRecorder, times(0)).recordEvent(any(Event.class));
+    }
+}

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/aspect/EventAdviceDelegateTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/aspect/EventAdviceDelegateTest.java
@@ -57,6 +57,7 @@ import gov.hhs.fha.nhinc.event.responder.EndInboundProcessingEvent;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 
 import org.json.JSONException;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
@@ -68,6 +69,11 @@ public class EventAdviceDelegateTest {
     private static final String DS_SERVICE_TYPE = "Document Submission";
     private static final String DS_VERISON = "2.0";
     private EventFactory eventFactory = new EventFactory();
+
+    @Before
+    public void before() {
+        when(eventRecorder.isRecordEventEnabled()).thenReturn(true);
+    }
 
     @Test
     public void inboundMessageAdviceDelegate() {

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/async/AsyncMessageIdExtractorTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/async/AsyncMessageIdExtractorTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2009-2013, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.async;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.namespace.QName;
+import javax.xml.ws.WebServiceContext;
+import javax.xml.ws.handler.MessageContext;
+
+import org.apache.cxf.binding.soap.SoapHeader;
+import org.apache.cxf.headers.Header;
+import org.junit.Test;
+import org.w3c.dom.Element;
+
+public class AsyncMessageIdExtractorTest {
+
+    @Test
+    public void pullsFirstSoapHeader() {
+        List<Header> headers = new ArrayList<Header>();
+        Element mockElement = addHeader(headers, "local");
+        addHeader(headers, "local"); // 2nd add, shouldn't be returned
+
+        WebServiceContext mockServiceContext = createContextWithHeaders(headers);
+
+        AsyncMessageIdExtractor extractor = new AsyncMessageIdExtractor();
+
+        Element extractedElement = extractor.getSoapHeaderElement(mockServiceContext, "local");
+        assertSame(mockElement, extractedElement);
+    }
+
+    private WebServiceContext createContextWithHeaders(List<Header> headers) {
+        MessageContext mockMessageContext = mock(MessageContext.class);
+        when(mockMessageContext.get(anyObject())).thenReturn(headers);
+
+        WebServiceContext mockServiceContext = mock(WebServiceContext.class);
+        when(mockServiceContext.getMessageContext()).thenReturn(mockMessageContext);
+
+        return mockServiceContext;
+    }
+
+    private Element addHeader(List<Header> headers, String localHeaderName) {
+        QName mockQName = mock(QName.class);
+        when(mockQName.getLocalPart()).thenReturn(localHeaderName);
+
+        Element mockElement = mock(Element.class);
+
+        SoapHeader header = mock(SoapHeader.class);
+        when(header.getName()).thenReturn(mockQName);
+        when(header.getObject()).thenReturn(mockElement);
+
+        headers.add(header);
+
+        return mockElement;
+    }
+}

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/event/EventManagerTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/event/EventManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, United States Government, as represented by the Secretary of Health and Human Services.
+ * Copyright (c) 2009-2013, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,9 +30,16 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class EventManagerTest {
+
+    @Before
+    public void before() {
+        // Other tests add observers, and our tests need a clean slate.
+        EventManager.getInstance().deleteObservers();
+    }
 
     @Test
     public void noRegisteredLoggerDisablesRecording() {

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/event/EventManagerTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/event/EventManagerTest.java
@@ -26,38 +26,26 @@
  */
 package gov.hhs.fha.nhinc.event;
 
-import java.util.Observable;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
-/**
- * @author zmelnick
- * 
- */
-public class EventManager extends Observable implements EventRecorder, EventLoggerRegistrar {
+import org.junit.Test;
 
-    private EventManager() {
+public class EventManagerTest {
+
+    @Test
+    public void noRegisteredLoggerDisablesRecording() {
+        EventRecorder eventRecorder = EventManager.getInstance();
+        assertFalse(eventRecorder.isRecordEventEnabled());
     }
 
-    private static class EventManagerHolder {
-        public static final EventManager INSTANCE = new EventManager();
-    }
+    @Test
+    public void oneRegisteredLoggerEnabledRecording() {
+        EventLogger mockEventLogger = mock(EventLogger.class);
+        EventManager eventManager = EventManager.getInstance();
+        eventManager.registerLogger(mockEventLogger);
 
-    public static EventManager getInstance() {
-        return EventManagerHolder.INSTANCE;
-    }
-
-    @Override
-    public void recordEvent(Event event) {
-        setChanged();
-        notifyObservers(event);
-    }
-
-    @Override
-    public void registerLogger(EventLogger eventLogger) {
-        addObserver(eventLogger);
-    }
-
-    @Override
-    public boolean isRecordEventEnabled() {
-        return countObservers() > 0;
+        assertTrue(eventManager.isRecordEventEnabled());
     }
 }


### PR DESCRIPTION
Improves performance in two distinct ways:
- As soon as a matching soap header is found, return it.  Old implementation continued to iterate through all headers, even after a match was found.
- In event logging, only construct the event (which is expensive) if it going to be logged somewhere.
