### PR TITLE
the gui need their own web contexts

### DIFF
--- a/Product/Production/Deploy/ear/pom.xml
+++ b/Product/Production/Deploy/ear/pom.xml
@@ -613,13 +613,13 @@
                             <webModule>
                                 <groupId>org.connectopensource</groupId>
                                 <artifactId>CONNECTConsumerPreferencesProfileGUI</artifactId>
-                                <contextRoot>/</contextRoot>
+                                <contextRoot>/gui/consumerPreferencesProfile</contextRoot>
                                 <excluded>${gui.excluded}</excluded>
                             </webModule>
                             <webModule>
                                 <groupId>org.connectopensource</groupId>
                                 <artifactId>CONNECTDeferredQueueManagerGUI</artifactId>
-                                <contextRoot>/</contextRoot>
+                                <contextRoot>/gui/deferredQueueManager</contextRoot>
                                 <excluded>${gui.excluded}</excluded>
                             </webModule>
                         </modules>


### PR DESCRIPTION
added distinct context roots for: CONNECTConsumerPreferencesProfileGUI and CONNECTDeferredQueueManagerGUI. Without this the ear fails to deploy when the GUI profile is enabled.
