### PR TITLE
Gateway-3469: Fixed DS large payload save for standard

### DIFF
--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/StandardInboundDocSubmissionTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/StandardInboundDocSubmissionTest.java
@@ -38,6 +38,7 @@ import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.docsubmission.DocSubmissionUtils;
 import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
 import gov.hhs.fha.nhinc.docsubmission.XDRPolicyChecker;
 import gov.hhs.fha.nhinc.docsubmission.adapter.proxy.AdapterDocSubmissionProxy;
@@ -87,8 +88,15 @@ public class StandardInboundDocSubmissionTest {
         when(policyChecker.checkXDRRequestPolicy(request, assertion, senderHCID, localHCID, 
                 NhincConstants.POLICYENGINE_INBOUND_DIRECTION)).thenReturn(true);
 
+        final DocSubmissionUtils mockDocSubmissionUtils = mock(DocSubmissionUtils.class);
+        
         StandardInboundDocSubmission standardDocSubmission = new StandardInboundDocSubmission(adapterFactory,
-                policyChecker, propertyAccessor, auditLogger);
+                policyChecker, propertyAccessor, auditLogger){
+        	@Override
+        	public DocSubmissionUtils getDocSubmissionUtils(){
+        		return mockDocSubmissionUtils;
+        	}
+        };
 
         RegistryResponseType actualResponse = standardDocSubmission.documentRepositoryProvideAndRegisterDocumentSetB(
                 request, assertion);

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/StandardInboundDocSubmissionDeferredRequestTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/StandardInboundDocSubmissionDeferredRequestTest.java
@@ -39,6 +39,7 @@ import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.docsubmission.DocSubmissionUtils;
 import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
 import gov.hhs.fha.nhinc.docsubmission.XDRPolicyChecker;
 import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.request.error.proxy.AdapterDocSubmissionDeferredRequestErrorProxy;
@@ -91,8 +92,15 @@ public class StandardInboundDocSubmissionDeferredRequestTest {
         when(policyChecker.checkXDRRequestPolicy(request, assertion, senderHCID, localHCID,
                 NhincConstants.POLICYENGINE_INBOUND_DIRECTION)).thenReturn(true);
 
+        final DocSubmissionUtils mockDocSubmissionUtils = mock(DocSubmissionUtils.class);
+        
         StandardInboundDocSubmissionDeferredRequest standardDocSubmission = new StandardInboundDocSubmissionDeferredRequest(
-                adapterFactory, policyChecker, propertyAccessor, auditLogger, errorAdapterFactory);
+                adapterFactory, policyChecker, propertyAccessor, auditLogger, errorAdapterFactory){
+        	@Override
+        	public DocSubmissionUtils getDocSubmissionUtils(){
+        		return mockDocSubmissionUtils;
+        	}
+        };
 
         XDRAcknowledgementType actualResponse = standardDocSubmission.provideAndRegisterDocumentSetBRequest(request,
                 assertion);


### PR DESCRIPTION
DS is not passing the reference and saving the file for standard mode.  Added the logic back in.
