### PR TITLE
Fix for pulling dependencies from https repos (CGI network doesn't like)...

### DIFF
--- a/Product/pom.xml
+++ b/Product/pom.xml
@@ -483,7 +483,7 @@
             <id>jboss</id>
             <name>JBoss</name>
             <layout>default</layout>
-            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+            <url>http://repository.jboss.org/nexus/content/groups/public/</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -497,7 +497,7 @@
         </repository>
         <repository>
             <id>sonatype-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <url>http://oss.sonatype.org/content/repositories/snapshots/</url>
         </repository>
     </repositories>
     <profiles>


### PR DESCRIPTION
.... It appears that the CGI Federal CA certificate issue is also present when downloading dependencies from https repos. The same repos are available using http so I think we are fine to use http.
