### PR TITLE
CONN-676: Addressed Null Dereferences identified by Fortify scan

### DIFF
--- a/Product/Production/Adapters/General/CONNECTUniversalClientGUI/src/main/java/universalclientgui/Page2.java
+++ b/Product/Production/Adapters/General/CONNECTUniversalClientGUI/src/main/java/universalclientgui/Page2.java
@@ -709,8 +709,10 @@ public class Page2 extends AbstractPageBean {
 
         SearchData searchData = (SearchData) getBean("SearchData");
 
-        searchData.setPatientID(foundPatient.getPatientId());
-
+        if (foundPatient != null) {
+            searchData.setPatientID(foundPatient.getPatientId());
+        }
+        
         return null;
     }
 

--- a/Product/Production/Adapters/GenericFileTransfer/FTATransferAdapterEJB/src/main/java/gov/hhs/fha/nhinc/fta/Util.java
+++ b/Product/Production/Adapters/GenericFileTransfer/FTATransferAdapterEJB/src/main/java/gov/hhs/fha/nhinc/fta/Util.java
@@ -84,6 +84,7 @@ public class Util {
 
     public static org.w3c.dom.Element marshalPayload(String contents) {
         org.w3c.dom.Document doc = null;
+        Element docElement = null;
 
         try {
             JAXBContextHandler oHandler = new JAXBContextHandler();
@@ -100,11 +101,13 @@ public class Util {
 
             marshaller.marshal(payload, doc);
             LOG.info(doc.getNodeValue());
+			
+            docElement = doc.getDocumentElement();
         } catch (Exception ex) {
             LOG.error(ex.getMessage(), ex);
         }
-        return doc.getDocumentElement();
 
+        return docElement;
     }
 
     public static org.w3c.dom.Element marshalTopic(String topic, String dialect) {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/transform/policy/AdhocQueryTransformHelper.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/transform/policy/AdhocQueryTransformHelper.java
@@ -182,7 +182,8 @@ public class AdhocQueryTransformHelper {
 
         if (event != null && InboundOutboundChecker.isOutbound(event.getDirection())) {
             request.setAction(ActionHelper.actionFactory(ACTIONVALUEOUT));
-            if ((assertion.getUniquePatientId() != null) && (assertion.getUniquePatientId().size() > 0)) {
+            if ((assertion != null) && (assertion.getUniquePatientId() != null)
+                    && (assertion.getUniquePatientId().size() > 0)) {
                 aaId = PatientIdFormatUtil.parseCommunityId(assertion.getUniquePatientId().get(0));
                 sStrippedPatientId = PatientIdFormatUtil.parsePatientId(assertion.getUniquePatientId().get(0));
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/webserviceproxy/WebServiceProxyHelper.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/webserviceproxy/WebServiceProxyHelper.java
@@ -392,7 +392,7 @@ public class WebServiceProxyHelper {
             int iRetryDelay, Method oMethod) throws Exception {
         Object oResponse = null;
         int i = 1;
-        Exception eCatchExp = null;
+        Exception eCatchExp = new Exception();
         String sExceptionText = getExceptionText();
         while (i <= iRetryCount) {
             try {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/xmlCommon/XmlUtility.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/xmlCommon/XmlUtility.java
@@ -194,15 +194,17 @@ public class XmlUtility {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         DocumentBuilder builder = null;
         Document document = null;
+        Element docElement = null;
+        
         try {
             builder = factory.newDocumentBuilder();
             document = builder.newDocument();
+            docElement = document.createElement("init");
         } catch (ParserConfigurationException e) {
             LOG.error("Error creating dom document builder", e);
         }
 
-        return document.createElement("init");
-
+        return docElement;
     }
 
     private static Element convertXmlToElementWorker(String xml) throws Exception {

--- a/Product/Production/Gateway/HIEM_20/src/main/java/gov/hhs/fha/nhinc/hiem/_20/unsubscribe/passthru/ProxyHiemUnsubscribeImpl.java
+++ b/Product/Production/Gateway/HIEM_20/src/main/java/gov/hhs/fha/nhinc/hiem/_20/unsubscribe/passthru/ProxyHiemUnsubscribeImpl.java
@@ -76,7 +76,7 @@ public class ProxyHiemUnsubscribeImpl {
     public UnsubscribeResponse unsubscribe(
             gov.hhs.fha.nhinc.common.nhinccommonproxy.UnsubscribeRequestSecuredType unsubscribeRequest,
             WebServiceContext context) throws UnableToDestroySubscriptionFault {
-        UnsubscribeResponse response = null;
+        UnsubscribeResponse response = new UnsubscribeResponse();
         LOG.debug("Entering ProxyHiemUnsubscribeImpl.unsubscribe...");
         Unsubscribe unsubscribe = unsubscribeRequest.getUnsubscribe();
         NhinTargetSystemType target = unsubscribeRequest.getNhinTargetSystem();
@@ -90,11 +90,10 @@ public class ProxyHiemUnsubscribeImpl {
             response = proxy
                     .unsubscribe(unsubscribe, soapHeaderElements, assertion, target, getSubscriptionId(context));
         } catch (UnableToDestroySubscriptionFault e) {
-            LOG.error("error occurred", e);
-            response = new UnsubscribeResponse();
+            LOG.error("Error occurred: " + e.getMessage(), e);
             response.getAny().add(e);
         } catch (Exception e) {
-            LOG.error("exception occured: " + e.getMessage());
+            LOG.error("Exception occurred: " + e.getMessage(), e);
             response.getAny().add(e);
         }
         LOG.debug("Exiting ProxyHiemUnsubscribeImpl.unsubscribe...");

--- a/Product/Production/Services/HIEMCore/src/main/java/gov/hhs/fha/nhinc/hiem/dte/marshallers/TopicMarshaller.java
+++ b/Product/Production/Services/HIEMCore/src/main/java/gov/hhs/fha/nhinc/hiem/dte/marshallers/TopicMarshaller.java
@@ -60,16 +60,18 @@ public class TopicMarshaller {
     private Element convertStringToElement(String xml) {
         javax.xml.parsers.DocumentBuilderFactory dbf;
         org.w3c.dom.Document doc = null;
-
+        Element docElement = null;
+        
         try {
             dbf = javax.xml.parsers.DocumentBuilderFactory.newInstance();
             dbf.setNamespaceAware(true);
 
             doc = dbf.newDocumentBuilder().parse(new InputSource(new StringReader(xml)));
+            docElement = doc.getDocumentElement();
         } catch (Exception ex) {
 
         }
 
-        return doc.getDocumentElement();
+        return docElement;
     }
 }

--- a/Product/Production/Services/HIEMCore/src/main/java/gov/hhs/fha/nhinc/subscription/repository/dialectalgorithms/concrete/ConcreteDialectRootTopicExtractor.java
+++ b/Product/Production/Services/HIEMCore/src/main/java/gov/hhs/fha/nhinc/subscription/repository/dialectalgorithms/concrete/ConcreteDialectRootTopicExtractor.java
@@ -40,7 +40,7 @@ import org.w3c.dom.Node;
 public class ConcreteDialectRootTopicExtractor implements IRootTopicExtractionStrategy {
 
     public String extractRootTopicFromTopicExpressionNode(Node topicExpression) throws SubscriptionRepositoryException {
-        String rootTopic = null;
+        String rootTopic = "";
         String topicValue = XmlUtility.getNodeValue(topicExpression);
 
         String[] topicParts = topicValue.split("/");
@@ -48,9 +48,7 @@ public class ConcreteDialectRootTopicExtractor implements IRootTopicExtractionSt
         for (String topicPart : topicParts) {
             String cleanedTopicPart = RootTopicExtractorHelper.ReplaceNamespacePrefixesWithNamespaces(topicPart,
                     topicExpression);
-            if (NullChecker.isNullish(rootTopic)) {
-                rootTopic = "";
-            } else {
+            if (NullChecker.isNotNullish(rootTopic)) {
                 rootTopic = rootTopic.concat("/");
             }
             rootTopic = rootTopic.concat(cleanedTopicPart);

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/queue/AdapterPatientDiscoveryDeferredReqQueueOrchImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/queue/AdapterPatientDiscoveryDeferredReqQueueOrchImpl.java
@@ -149,19 +149,19 @@ public class AdapterPatientDiscoveryDeferredReqQueueOrchImpl {
 
         if (targets != null) {
             urlInfoList = getTargetEndpoints(targets);
+
+            if (NullChecker.isNotNullish(urlInfoList) && urlInfoList.get(0) != null
+                    && NullChecker.isNotNullish(urlInfoList.get(0).getUrl())) {
+
+                EntityPatientDiscoveryDeferredResponseProxyObjectFactory patientDiscoveryFactory = new EntityPatientDiscoveryDeferredResponseProxyObjectFactory();
+                EntityPatientDiscoveryDeferredResponseProxy proxy = patientDiscoveryFactory.getNhincPatientDiscoveryProxy();
+
+                resp = proxy.processPatientDiscoveryAsyncResp(respMsg, assertion, targets);
+            } else {
+                LOG.error("Failed to send response to the Nhin as no target endpoints can be found.");
+            }
         }
-
-        if (NullChecker.isNotNullish(urlInfoList) && urlInfoList.get(0) != null
-                && NullChecker.isNotNullish(urlInfoList.get(0).getUrl())) {
-
-            EntityPatientDiscoveryDeferredResponseProxyObjectFactory patientDiscoveryFactory = new EntityPatientDiscoveryDeferredResponseProxyObjectFactory();
-            EntityPatientDiscoveryDeferredResponseProxy proxy = patientDiscoveryFactory.getNhincPatientDiscoveryProxy();
-
-            resp = proxy.processPatientDiscoveryAsyncResp(respMsg, assertion, targets);
-        } else {
-            LOG.error("Failed to send response to the Nhin as no target endpoints can be found.");
-        }
-
+        
         return resp;
     }
 


### PR DESCRIPTION
Null Dereferences identified by Fortify scan addressed by:

1) Short-circuit logic for checking for nulls before dereferencing
2) Using intermediate variables so that when exceptions are thrown and caught, a null is returned instead of attempting to dereference a null variable.
