### PR TITLE
CONN-682

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/gateway/executorservice/ExecutorServiceHelper.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/gateway/executorservice/ExecutorServiceHelper.java
@@ -82,6 +82,11 @@ public class ExecutorServiceHelper {
             // get large job percentage
             String largejobSizePercentStr = propertyAccessor.getProperty(NhincConstants.GATEWAY_PROPERTY_FILE,
                     NhincConstants.LARGEJOB_SIZE_PERCENT);
+            
+            if (largejobSizePercentStr.length() > 3) {
+                largejobSizePercentStr = largejobSizePercentStr.substring(0, 3);
+            }
+            
             largejobSizePercent = Double.parseDouble(largejobSizePercentStr);
         } catch (Exception e) {
             LOG.error("ExecutorServiceHelper exception loading config properties so using default values");


### PR DESCRIPTION
Addressed Denial of Service (parseDouble) Fortify scan results by truncating the String passed to parseDouble to a length of three, the number represented by it cannot be in the range that causes the JVM to hang.
