### PR TITLE
CONN-677

### DIFF
--- a/Product/Production/Adapters/GenericFileTransfer/FTATransferAdapterEJB/src/main/java/gov/hhs/fha/nhinc/fta/NotificationImpl.java
+++ b/Product/Production/Adapters/GenericFileTransfer/FTATransferAdapterEJB/src/main/java/gov/hhs/fha/nhinc/fta/NotificationImpl.java
@@ -121,10 +121,19 @@ public class NotificationImpl {
 
         Writer output = null;
         f.createNewFile();
-        output = new BufferedWriter(new FileWriter(f));
-        output.write(fileContents);
-        output.close();
-
+		
+	    try {
+            output = new BufferedWriter(new FileWriter(f));
+            output.write(fileContents);
+        } finally {
+            if (output != null) {
+                try {
+                    output.close();
+                } catch (Exception e) {
+                    LOG.error("Failed to close file : " + fileName + " : " + e.getMessage());
+                }
+            }
+        }
     }
 
     private static String generateUID() {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/largefile/LargeFileUtils.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/largefile/LargeFileUtils.java
@@ -251,10 +251,20 @@ public class LargeFileUtils {
         InputStream is = dh.getInputStream();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        int read = 0;
-        byte[] bytes = new byte[1024];
-        while ((read = is.read(bytes)) != -1) {
-            baos.write(bytes, 0, read);
+        try {
+            int read = 0;
+            byte[] bytes = new byte[1024];
+            while ((read = is.read(bytes)) != -1) {
+                baos.write(bytes, 0, read);
+            }
+        } finally {
+            if (is != null) {
+                try {
+                    is.close();
+                } catch (Exception e) {
+                    LOG.error("Could not close input stream : " + e.getMessage());
+                }
+            }
         }
 
         return baos.toByteArray();

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/largefile/LargeFileUtils.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/largefile/LargeFileUtils.java
@@ -206,10 +206,7 @@ public class LargeFileUtils {
                             + file.getAbsolutePath());
         }
 
-        FileInputStream fis = new FileInputStream(file);
-        StreamDataSource sds = new StreamDataSource("application/octet-stream", fis);
-
-        return new DataHandler(sds);
+        return new DataHandler(file.toURI().toURL());
     }
 
     /**

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/largefile/LargeFileUtils.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/largefile/LargeFileUtils.java
@@ -42,6 +42,7 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 
 import javax.activation.DataHandler;
 
@@ -206,6 +207,18 @@ public class LargeFileUtils {
                             + file.getAbsolutePath());
         }
 
+        URI fileURI = file.toURI();
+        URL fileURL = null;
+        
+        if (fileURI != null) {
+            fileURL = fileURI.toURL();
+        }
+
+        // Not nested to cover the cases where a) URI is null b) URI is not null, but URL is null
+        if (fileURL == null) {
+            throw new IOException ("Could not get URL for : " + file.getAbsolutePath());
+        }
+        
         return new DataHandler(file.toURI().toURL());
     }
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/largefile/LargeFileUtils.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/largefile/LargeFileUtils.java
@@ -219,7 +219,7 @@ public class LargeFileUtils {
             throw new IOException ("Could not get URL for : " + file.getAbsolutePath());
         }
         
-        return new DataHandler(file.toURI().toURL());
+        return new DataHandler(fileURL);
     }
 
     /**

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/largefile/LargeFileUtils.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/largefile/LargeFileUtils.java
@@ -207,7 +207,7 @@ public class LargeFileUtils {
         }
 
         FileInputStream fis = new FileInputStream(file);
-        StreamDataSource sds = new StreamDataSource("application/octect-stream", fis);
+        StreamDataSource sds = new StreamDataSource("application/octet-stream", fis);
 
         return new DataHandler(sds);
     }

--- a/Product/Production/Services/PolicyEngineCore/src/main/java/gov/hhs/fha/nhinc/policyengine/adapter/pip/PatientConsentDocumentBuilderHelper.java
+++ b/Product/Production/Services/PolicyEngineCore/src/main/java/gov/hhs/fha/nhinc/policyengine/adapter/pip/PatientConsentDocumentBuilderHelper.java
@@ -1015,33 +1015,6 @@ public class PatientConsentDocumentBuilderHelper {
         return intStr;
     }
 
-    /*protected synchronized String getOidFromProperty(String sPropertyName) {
-        String sUniqueId = "";
-        try {
-            Properties tempProp = new Properties();
-            InputStream propsInFile = new FileInputStream(sPropertyFile);
-            tempProp.load(propsInFile);
-            propsInFile.close();
-            sUniqueId = tempProp.getProperty(sPropertyName);
-            String sFirstPart = sUniqueId.substring(0, sUniqueId.lastIndexOf("."));
-            String sDotString = sUniqueId.substring(sUniqueId.lastIndexOf("."));
-            sDotString = sDotString.substring(1);
-            int iSUniqueId = Integer.parseInt(sDotString);
-            iSUniqueId = iSUniqueId + 1;
-            String sNewId = sFirstPart + "." + iSUniqueId;
-            tempProp.setProperty(sPropertyName, sNewId);
-            OutputStream propsOutFile = new FileOutputStream(sPropertyFile);
-            tempProp.store(propsOutFile, "Update property file with new sequence");
-            propsOutFile.close();
-        } catch (Exception ex) {
-            ex.printStackTrace();
-        }
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Generated unique id: " + sUniqueId);
-        }
-        return sUniqueId;
-    }*/
-
     private String extractAddressFromPatInfo(PolicyPatientInfoType patInfo) {
         StringBuffer sAddr = new StringBuffer();
         if (patInfo != null) {


### PR DESCRIPTION
*\* FIXES **

Converted DataHandler to use URL instead of FileInputStream:
CONNECTCoreLib
    gov.hhs.fha.nhinc.largefile.LargeFileUtils, line 209

Fixed by calling "free()" for Blob in a finally block in the parent function:
AuditRepositoryCore
    gov.hhs.fha.nhinc.auditrepository.nhinc.AuditRepositoryOrchImpl, line 297

Fixed by calling "close()" for InputStream in a finally block:
CONNECTCoreLib
    gov.hhs.fha.nhinc.largefile.LargeFileUtils, line 251

Fixed by calling "close()" for Writer in a finally block:
FTATransferAdapterEJB
    gov.hhs.fha.nhinc.fta.NotificationImpl, line 124

Deleted a commented-out function that covered the following lines:
PolicyEngineCore
    gov.hhs.fha.nhinc.policyengine.adapter.pip.PatientConsentDocumentBuilderHelper, line 1033
    gov.hhs.fha.nhinc.policyengine.adapter.pip.PatientConsentDocumentBuilderHelper, line 1022

*\* NON-FIXES **

The following instances were flagged incorrectly (they are closing the stream as expected):
CONNECTCoreLib
    gov.hhs.fha.nhinc.properties.PropertyFileDAO, line 80
    gov.hhs.fha.nhinc.properties.PropertyFileManager, line 68
    gov.hhs.fha.nhinc.properties.PropertyAccessorFileUtilities, line 122
    gov.hhs.fha.nhinc.util.StringUtil, line 55

The following instance is intended to be used with SOAP requests, where any stream would be closed before calling this function (at the moment, it is only used in test classes, where the "stream" is either null or a String):
DirectCore
    gov.hhs.fha.nhinc.direct.MimeMessageBuilder, line 211
