### PR TITLE
CONN-678 Removed empty password and throw expected exception.

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/TLSClientParametersFactory.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/TLSClientParametersFactory.java
@@ -103,10 +103,10 @@ public class TLSClientParametersFactory {
         return tlsCP;
     }
 
-    private char[] getKeystorePassword() {
+    private char[] getKeystorePassword() throws UnrecoverableKeyException {
         String keystorePassword = System.getProperty("javax.net.ssl.keyStorePassword");
-        if (keystorePassword == null) {
-            keystorePassword = "";
+        if (keystorePassword == null || keystorePassword.isEmpty()) {
+            throw new UnrecoverableKeyException("Password for key is null or empty.");
         }
 
         return keystorePassword.toCharArray();


### PR DESCRIPTION
Reasoning behind code change over documentation for this issue:
1.  Get rid of fortify issue.
2.  The exception that is thrown is the same that would be thrown after further processing by the KeyManagerFactory upon calling init(keystore, keystorePassword).  The init throws the UnrecoverableKeyException upon not finding a match which is what would happen with a password of "".  We're just catching the issue earlier with this change.
