### PR TITLE
CONN-853 Fixed ImapMailReceiverTest for further coverage

### DIFF
--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/mail/ImapMailReceiver.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/mail/ImapMailReceiver.java
@@ -157,7 +157,7 @@ public class ImapMailReceiver extends AbstractMailClient implements MailReceiver
         return inbox;
     }
     
-    private Store getImapsStore() throws MailClientException {
+    Store getImapsStore() throws MailClientException {
         try {
             return getMailSession().getStore("imaps");
         } catch (NoSuchProviderException e) {


### PR DESCRIPTION
Added further coverage by including a protected method that was overridden before and adding an exception use case.
