### PR TITLE
Replace copyright HTML code in copyright file

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/copyright.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/copyright.xhtml
@@ -1,5 +1,5 @@
 <ui:composition xmlns:h="http://java.sun.com/jsf/html" xmlns:ui="http://java.sun.com/jsf/facelets" xmlns="http://www.w3.org/1999/xhtml">
-<p>Copyright &copy; 2009-2014, United States Government, as represented by the Secretary of Health and Human Services.</p>
+<p>Copyright &#169; 2009-2014, United States Government, as represented by the Secretary of Health and Human Services.</p>
 <p>All rights reserved.</p>
 <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:</p>
 <ul>


### PR DESCRIPTION
XHTML:
- Changed copyright symbol code in copyright.xhtml file.

Notes:
- Using HTML Name "&copy;" was causing errors.
- Changed to HTML Number "&#169;" to fix.
