### PR TITLE
No ticket: adding jetty container support for quickly checking ui change...

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/pom.xml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/pom.xml
@@ -194,6 +194,11 @@
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>5.1.23</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -219,6 +224,18 @@
                     </archive>
                 </configuration>
             </plugin>
-        </plugins>
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>9.0.0.RC0</version>
+                <dependencies>
+        <dependency>
+            <groupId>org.apache.myfaces.core</groupId>
+            <artifactId>myfaces-bundle</artifactId>
+            <version>2.1.15</version>
+        </dependency>
+                </dependencies>
+            </plugin>
+</plugins>
     </build>
 </project>

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/WEB-INF/jetty-env.xml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/WEB-INF/jetty-env.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//DTD Configure//EN" "http://jetty.mortbay.org/configure.dtd">
+
+<Configure id='wac_admingui' class="org.eclipse.jetty.webapp.WebAppContext">
+    <New id="adminguidb_datasource" class="org.eclipse.jetty.plus.jndi.Resource">
+        <Arg>jdbc/adminguidb_datasource</Arg>
+        <Arg>
+            <New class="com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource">
+                <Set name="Url">jdbc:mysql://localhost:3306/adminguidb</Set>
+                <Set name="User">nhincuser</Set>
+                <Set name="Password">nhincpass</Set>
+            </New>
+        </Arg>
+    </New>
+    <New id="eventdb_datasource" class="org.eclipse.jetty.plus.jndi.Resource">
+        <Arg>jdbc/eventdb_datasource</Arg>
+        <Arg>
+            <New class="com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource">
+                <Set name="Url">jdbc:mysql://localhost:3306/eventdb</Set>
+                <Set name="User">nhincuser</Set>
+                <Set name="Password">nhincpass</Set>
+            </New>
+        </Arg>
+    </New>
+</Configure>


### PR DESCRIPTION
...s.

mvn clean install jetty:run and this will deploy the admingui war to a jetty instance to allow for testing of ui components.

The jetty container will be looking for the admingui and eventdb data sources, I'm not sure what will happen if they aren't there.
