### PR TITLE
creationTime should have correct format.

### DIFF
--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/mpi/adapter/component/hl7parsers/HL7DbParser201306.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/mpi/adapter/component/hl7parsers/HL7DbParser201306.java
@@ -90,6 +90,10 @@ import gov.hhs.fha.nhinc.transform.subdisc.HL7Constants;
 import gov.hhs.fha.nhinc.transform.subdisc.HL7DataTransformHelper;
 import gov.hhs.fha.nhinc.util.HomeCommunityMap;
 import gov.hhs.fha.nhinc.util.format.UTCDateUtil;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
 
 /**
  *
@@ -129,7 +133,7 @@ public class HL7DbParser201306 {
         id.setExtension(MessageIdGenerator.generateMessageId());
         msg.setId(id);
         TSExplicit creationTime = new TSExplicit();
-        creationTime.setValue(buildCreationTimeString(new Date()));
+        creationTime.setValue(buildCreationTimeString());
         msg.setCreationTime(creationTime);
 
         II interactionId = new II();
@@ -163,8 +167,8 @@ public class HL7DbParser201306 {
         return msg;
     }
 
-    static String buildCreationTimeString(Date date) {
-        return new SimpleDateFormat("yyyyMMddHHmmss").format(date);
+    static String buildCreationTimeString() {
+        return DateTimeFormat.forPattern("yyyyMMddHHmmss").print(new DateTime(DateTimeZone.UTC));
     }
 
     private static PRPAIN201306UV02MFMIMT700711UV01ControlActProcess createControlActProcess(List<Patient> patients,

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/mpi/adapter/component/hl7parsers/HL7DbParser201306.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/mpi/adapter/component/hl7parsers/HL7DbParser201306.java
@@ -27,6 +27,8 @@
 package gov.hhs.fha.nhinc.mpi.adapter.component.hl7parsers;
 
 import java.math.BigInteger;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.TimeZone;
@@ -126,26 +128,8 @@ public class HL7DbParser201306 {
         }
         id.setExtension(MessageIdGenerator.generateMessageId());
         msg.setId(id);
-
-        // Set up the creation time string
-        String timestamp = "";
-        try {
-            GregorianCalendar today = new GregorianCalendar(TimeZone.getTimeZone("GMT"));
-
-            timestamp =
-                String.valueOf(today.get(GregorianCalendar.YEAR))
-                + String.valueOf(today.get(GregorianCalendar.MONTH) + 1)
-                + String.valueOf(today.get(GregorianCalendar.DAY_OF_MONTH))
-                + String.valueOf(today.get(GregorianCalendar.HOUR_OF_DAY))
-                + String.valueOf(today.get(GregorianCalendar.MINUTE))
-                + String.valueOf(today.get(GregorianCalendar.SECOND));
-        } catch (Exception e) {
-            LOG.error("Exception when creating XMLGregorian Date");
-            LOG.error(" message: " + e.getMessage());
-        }
-
         TSExplicit creationTime = new TSExplicit();
-        creationTime.setValue(timestamp);
+        creationTime.setValue(buildCreationTimeString(new Date()));
         msg.setCreationTime(creationTime);
 
         II interactionId = new II();
@@ -177,6 +161,10 @@ public class HL7DbParser201306 {
 
         LOG.trace("Exiting HL7Parser201306.BuildMessageFromMpiPatient method...");
         return msg;
+    }
+
+    static String buildCreationTimeString(Date date) {
+        return new SimpleDateFormat("yyyyMMddHHmmss").format(date);
     }
 
     private static PRPAIN201306UV02MFMIMT700711UV01ControlActProcess createControlActProcess(List<Patient> patients,

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/mpi/adapter/component/hl7parsers/HL7DbParser201306Test.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/mpi/adapter/component/hl7parsers/HL7DbParser201306Test.java
@@ -1,3 +1,29 @@
+/*
+ * Copyright (c) 2012, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package gov.hhs.fha.nhinc.mpi.adapter.component.hl7parsers;
 
 import org.joda.time.DateTime;

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/mpi/adapter/component/hl7parsers/HL7DbParser201306Test.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/mpi/adapter/component/hl7parsers/HL7DbParser201306Test.java
@@ -1,0 +1,18 @@
+package gov.hhs.fha.nhinc.mpi.adapter.component.hl7parsers;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class HL7DbParser201306Test {
+
+    //see http://connect-forums.3294226.n2.nabble.com/NwHIN-PD-can-have-invalid-creation-time-td7579571.html#a7579572
+    @Test
+    public void creationTimeShouldHaveCorrectFormat() {
+        DateTime creationTimeDate = new DateTime(2014, 5, 14, 1, 15, 30, 2);
+        assertEquals("20140514011530", HL7DbParser201306.buildCreationTimeString(creationTimeDate.toDate()));
+    }
+
+
+}

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/mpi/adapter/component/hl7parsers/HL7DbParser201306Test.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/mpi/adapter/component/hl7parsers/HL7DbParser201306Test.java
@@ -1,17 +1,31 @@
 package gov.hhs.fha.nhinc.mpi.adapter.component.hl7parsers;
 
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.joda.time.DateTimeZone;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 
 public class HL7DbParser201306Test {
 
+    @Before
+    public void setUp() throws Exception {
+        DateTime testCurrentTime = new DateTime(2014, 5, 13, 14, 15, 30, 2, DateTimeZone.forOffsetHours(-7));
+        DateTimeUtils.setCurrentMillisFixed(testCurrentTime.getMillis());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        DateTimeUtils.setCurrentMillisSystem();
+    }
+
     //see http://connect-forums.3294226.n2.nabble.com/NwHIN-PD-can-have-invalid-creation-time-td7579571.html#a7579572
     @Test
     public void creationTimeShouldHaveCorrectFormat() {
-        DateTime creationTimeDate = new DateTime(2014, 5, 14, 1, 15, 30, 2);
-        assertEquals("20140514011530", HL7DbParser201306.buildCreationTimeString(creationTimeDate.toDate()));
+        assertEquals("20140513211530", HL7DbParser201306.buildCreationTimeString());
     }
 
 


### PR DESCRIPTION
Context: http://connect-forums.3294226.n2.nabble.com/NwHIN-PD-can-have-invalid-creation-time-td7579571.html#a7579572

This is from the CONNECT 4.2 branch
