### PR TITLE
Fixes addressing Wiki Admin GUI Improvements

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/direct.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/direct.xhtml
@@ -45,7 +45,7 @@
 				<div class="nav-section-tabs tabs-purple" id="nav-section-tabs">
 					<div class="navbar" role="navigation">
 						<ul class="nav nav-tabs">
-							<li class="active"><a href="#domains" data-toggle="tab" title="Manage Domains">Manage Domains</a></li>
+							<li class="active"><a href="#domains" data-toggle="tab" title="Domains">Domains</a></li>
 							<li><a href="#agent" data-toggle="tab" title="Agent Settings">Agent Settings</a></li>
 							<li><a href="#certs" data-toggle="tab" title="Certificates">Certificates</a></li>
 							<li><a href="#trust" data-toggle="tab" title="Trust Bundles">Trust Bundles</a></li>
@@ -66,7 +66,7 @@
 								<div class="table-responsive">
 									<div class="table-button-row">
 										<!--<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#modal-createdomain"><i class="glyphicon glyphicon-plus-sign"></i> Create New Domain</button>-->
-										<a href="direct_domains_create.xhtml"><button type="button" class="btn btn-primary"><i class="glyphicon glyphicon-plus-sign"></i> Create New Domain</button></a>
+										<a href="direct_domains_create.xhtml#tab_domains"><button type="button" class="btn btn-primary"><i class="glyphicon glyphicon-plus-sign"></i> Create New Domain</button></a>
 										<button type="button" class="btn btn-default"><i class="glyphicon glyphicon-refresh"></i> Refresh List</button>
 									</div>
 									<table class="table table-striped tablesorter table-domains">
@@ -83,19 +83,19 @@
 										<tbody>
 											<tr>
 												<td><input name="" type="checkbox" value="" /></td>
-												<td><span class="enabled">Enabled</span></td>
+												<td class="nowrap"><span class="enabled">Enabled</span></td>
 												<td><a href="#">connectdirect.connect.org</a></td>
 												<td>postmaster@connectdirect.connect.org</td>
-												<td></td>
-												<td>04/10/2014, 02:53</td>
+												<td class="nowrap"></td>
+												<td class="nowrap">04/10/2014, 02:53</td>
 											</tr>
 											<tr>
 												<td><input name="" type="checkbox" value="" /></td>
-												<td><span class="enabled">Enabled</span></td>
+												<td class="nowrap"><span class="enabled">Enabled</span></td>
 												<td><a href="#">connectdirectri-update.org</a></td>
 												<td>postmaster@connectdirectri.org</td>
-												<td></td>
-												<td>04/30/2014, 01:57</td>
+												<td class="nowrap"></td>
+												<td class="nowrap">04/30/2014, 01:57</td>
 											</tr>
 										</tbody>
 									</table>
@@ -197,7 +197,7 @@
 								<div class="table-responsive">
 									<div class="table-button-row">
 										<!--<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#modal-createdomain"><i class="glyphicon glyphicon-plus-sign"></i> Create New Domain</button>-->
-										<a href="#" data-toggle="modal" data-target="#modal-certs"><button type="button" class="btn btn-primary"><i class="glyphicon glyphicon-plus-sign"></i> Add New Certificate</button></a>
+										<a href="#" data-toggle="modal" data-target="#modal-certs"><button type="button" class="btn btn-primary"><i class="glyphicon glyphicon-plus-sign"></i> Add Certificate</button></a>
 										<button type="button" class="btn btn-default"><i class="glyphicon glyphicon-refresh"></i> Refresh List</button>
 									</div>
 									<table class="table table-striped tablesorter table-certs">
@@ -216,63 +216,63 @@
 										<tbody>
 											<tr>
 												<td><input name="" type="checkbox" value="" /></td>
-												<td><span class="enabled">Enabled</span></td>
+												<td class="nowrap"><span class="enabled">Enabled</span></td>
 												<td>connectdirect.connect.org</td>
 												<td>No</td>
 												<td>33b0a7f37dc0f8c3a6c0902bc3736aa35744fa58</td>
-												<td>10/17/2013, 11:50</td>
-												<td>10/17/2013, 09:55</td>
-												<td>10/15/2023, 09:55</td>
+												<td class="nowrap">10/17/2013, 11:50</td>
+												<td class="nowrap">10/17/2013, 09:55</td>
+												<td class="nowrap">10/15/2023, 09:55</td>
 											</tr>
 											<tr>
 												<td><input name="" type="checkbox" value="" /></td>
-												<td><span class="enabled">Enabled</span></td>
+												<td class="nowrap"><span class="enabled">Enabled</span></td>
 												<td>connectdirect.connect.org Root CA</td>
 												<td>No</td>
 												<td>b145e498144454c16e9b9aff60b93e2f0e9839f3</td>
-												<td>10/17/2013, 11:50</td>
-												<td>10/17/2013, 09:54</td>
-												<td>10/15/2023, 09:54</td>
+												<td class="nowrap">10/17/2013, 11:50</td>
+												<td class="nowrap">10/17/2013, 09:54</td>
+												<td class="nowrap">10/15/2023, 09:54</td>
 											</tr>
 											<tr>
 												<td><input name="" type="checkbox" value="" /></td>
-												<td><span class="enabled">Enabled</span></td>
+												<td class="nowrap"><span class="enabled">Enabled</span></td>
 												<td>connectdirectri.org Root CA</td>
 												<td>No</td>
 												<td>5adb8bef9a562659550f96ea5684979eb820c314</td>
-												<td>10/17/2013, 11:50</td>
-												<td>10/11/2013, 03:59</td>
-												<td>10/11/2014, 03:59</td>
+												<td class="nowrap">10/17/2013, 11:50</td>
+												<td class="nowrap">10/11/2013, 03:59</td>
+												<td class="nowrap">10/11/2014, 03:59</td>
 											</tr>
 											<tr>
 												<td><input name="" type="checkbox" value="" /></td>
-												<td><span class="enabled">Enabled</span></td>
+												<td class="nowrap"><span class="enabled">Enabled</span></td>
 												<td>connectdirectri.org</td>
 												<td>No</td>
 												<td>90867ce50c18e2a290321f7d28a937f9945549b5</td>
-												<td>10/11/2013, 04:32</td>
-												<td>10/11/2013, 04:00</td>
-												<td>10/11/2014, 04:00</td>
+												<td class="nowrap">10/11/2013, 04:32</td>
+												<td class="nowrap">10/11/2013, 04:00</td>
+												<td class="nowrap">10/11/2014, 04:00</td>
 											</tr>
 											<tr>
 												<td><input name="" type="checkbox" value="" /></td>
-												<td>New</td>
+												<td class="nowrap">New</td>
 												<td>directri.connect.org</td>
 												<td>Yes</td>
 												<td>de2cf30af97b73f69bd71d5a0fad5de5d8363cfe</td>
-												<td>05/01/2014, 04:17</td>
-												<td>11/20/2013, 03:46</td>
-												<td>11/18/2023, 03:46</td>
+												<td class="nowrap">05/01/2014, 04:17</td>
+												<td class="nowrap">11/20/2013, 03:46</td>
+												<td class="nowrap">11/18/2023, 03:46</td>
 											</tr>
 											<tr>
 												<td><input name="" type="checkbox" value="" /></td>
-												<td>New</td>
+												<td class="nowrap">New</td>
 												<td>directri.connect.org</td>
 												<td>Yes</td>
 												<td>de2cf30af97b73f69bd71d5a0fad5de5d8363cfe</td>
-												<td>05/01/2014, 04:59</td>
-												<td>11/20/2013, 03:46</td>
-												<td>11/18/2023, 03:46</td>
+												<td class="nowrap">05/01/2014, 04:59</td>
+												<td class="nowrap">11/20/2013, 03:46</td>
+												<td class="nowrap">11/18/2023, 03:46</td>
 											</tr>
 										</tbody>
 									</table>
@@ -319,9 +319,9 @@
 			                                    	<a href="https://secure.bluebuttontrust.org/p7b.ashx?id=cb300117-3a4a-e211-8bc3-78e3b5114607" target="_blank">https://secure.bluebuttontrust.org/p7b.ashx?id=cb300117-3a4a-e211-8bc3-78e3b5114607</a>
 			                                    </td>
 			                                    <td>8d9121401ba2abcb16d16cb5195c360e84abedb6</td>
-			                                    <td>10/09/2013 03:11</td>
-			                                    <td>05/09/2014 06:51</td>
-			                                    <td>05/13/2014 09:51</td>
+			                                    <td class="nowrap">10/09/2013 03:11</td>
+			                                    <td class="nowrap">05/09/2014 06:51</td>
+			                                    <td class="nowrap">05/13/2014 09:51</td>
 			                                    <td>72</td> 
 											</tr>
 											<tr>
@@ -331,9 +331,9 @@
 			                                    </td>
 			                                    <td><a href="http://thisisnotavalidtrustbundle.link/noseriously.p7b" target="_blank">http://thisisnotavalidtrustbundle.link/noseriously.p7b</a></td>
 			                                    <td></td>
-			                                    <td>04/10/2014 04:12</td>
-			                                    <td></td>
-			                                    <td>05/13/2014 09:51</td>
+			                                    <td class="nowrap">04/10/2014 04:12</td>
+			                                    <td class="nowrap"></td>
+			                                    <td class="nowrap">05/13/2014 09:51</td>
 			                                    <td>1</td>  
 											</tr>
 										</tbody>
@@ -360,7 +360,7 @@
 	<div class="modal-dialog">
 		<div class="modal-content">
 			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
 				<h4 class="modal-title" id="modal-createdomain-label">CREATE NEW DOMAIN</h4>
 			</div>
 			<div class="modal-body">
@@ -420,7 +420,7 @@
 	<div class="modal-dialog">
 		<div class="modal-content">
 			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
 				<h4 class="modal-title" id="modal-agent-label">ADD NEW AGENT SETTING</h4>
 			</div>
 			<div class="modal-body">
@@ -442,8 +442,7 @@
 							<div class="form-group">
 								<div class="col-sm-12">
 									<div class="form-button-row">
-										<button type="submit" class="btn btn-default">Add Setting</button>
-										<button type="reset" class="btn btn-primary">Cancel</button>
+										<button type="submit" class="btn btn-primary">Add Setting</button>
 									</div>
 								</div>
 							</div>
@@ -461,7 +460,7 @@
 	<div class="modal-dialog">
 		<div class="modal-content">
 			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
 				<h4 class="modal-title" id="modal-certs-label">ADD NEW CERTIFICATE</h4>
 			</div>
 			<div class="modal-body">
@@ -507,7 +506,7 @@
 	<div class="modal-dialog">
 		<div class="modal-content">
 			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
 				<h4 class="modal-title" id="modal-trust-bundle-label">ADD NEW TRUST BUNDLE</h4>
 			</div>
 			<div class="modal-body">
@@ -562,7 +561,7 @@
 	<div class="modal-dialog modal-lg">
 		<div class="modal-content">
 			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
 				<h4 class="modal-title" id="modal-anchor1-label">Anchor List</h4>
 			</div>
 			<div class="modal-body">
@@ -578,7 +577,7 @@
 	<div class="modal-dialog modal-lg">
 		<div class="modal-content">
 			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
 				<h4 class="modal-title" id="modal-anchor2-label">Anchor List</h4>
 			</div>
 			<div class="modal-body">

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/direct_domains_create.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/direct_domains_create.xhtml
@@ -45,7 +45,7 @@
 				<div class="nav-section-tabs tabs-purple" id="nav-section-tabs">
 					<div class="navbar" role="navigation">
 						<ul class="nav nav-tabs">
-							<li class="active"><a href="#domains" data-toggle="tab" title="Manage Domains">Manage Domains</a></li>
+							<li class="active"><a href="#domains" data-toggle="tab" title="Domains">Domains</a></li>
 							<li><a href="#agent" data-toggle="tab" title="Agent Settings">Agent Settings</a></li>
 							<li><a href="#certs" data-toggle="tab" title="Certificates">Certificates</a></li>
 							<li><a href="#trust" data-toggle="tab" title="Trust Bundles">Trust Bundles</a></li>
@@ -192,7 +192,7 @@
 													<tbody>
 														<tr>
 															<td><input name="" type="checkbox" value="" /></td>
-															<td><span class="enabled">Enabled</span></td>
+															<td class="nowrap"><span class="enabled">Enabled</span></td>
 															<td><a href="#">postmaster@connectdirect.connect.org</a></td>
 															<td>Postmaster</td>
 															<td></td>
@@ -200,7 +200,7 @@
 														</tr>
 														<tr>
 															<td><input name="" type="checkbox" value="" /></td>
-															<td><span>Disabled</span></td>
+															<td class="nowrap"><span>Disabled</span></td>
 															<td><a href="#">webmaster@connectdirect.connect.org</a></td>
 															<td>Webmaster</td>
 															<td></td>
@@ -283,14 +283,14 @@
 													<tbody>
 														<tr>
 															<td><input name="" type="checkbox" value="" /></td>
-															<td><span class="enabled">Enabled</span></td>
+															<td class="nowrap"><span class="enabled">Enabled</span></td>
 															<td>bluebutton-providerstest</td>
 															<td><input name="" type="checkbox" value="" checked="checked" /></td>
 															<td><input name="" type="checkbox" value="" checked="checked" /></td>
 														</tr>
 														<tr>
 															<td><input name="" type="checkbox" value="" /></td>
-															<td><span>Disabled</span></td>
+															<td class="nowrap"><span>Disabled</span></td>
 															<td>DELETEME</td>
 															<td><input name="" type="checkbox" value="" checked="checked" /></td>
 															<td><input name="" type="checkbox" value="" checked="checked" /></td>
@@ -424,63 +424,63 @@
 										<tbody>
 											<tr>
 												<td><input name="" type="checkbox" value="" /></td>
-												<td><span class="enabled">Enabled</span></td>
+												<td class="nowrap"><span class="enabled">Enabled</span></td>
 												<td>connectdirect.connect.org</td>
 												<td>No</td>
 												<td>33b0a7f37dc0f8c3a6c0902bc3736aa35744fa58</td>
-												<td>10/17/2013, 11:50</td>
-												<td>10/17/2013, 09:55</td>
-												<td>10/15/2023, 09:55</td>
+												<td class="nowrap">10/17/2013, 11:50</td>
+												<td class="nowrap">10/17/2013, 09:55</td>
+												<td class="nowrap">10/15/2023, 09:55</td>
 											</tr>
 											<tr>
 												<td><input name="" type="checkbox" value="" /></td>
-												<td><span class="enabled">Enabled</span></td>
+												<td class="nowrap"><span class="enabled">Enabled</span></td>
 												<td>connectdirect.connect.org Root CA</td>
 												<td>No</td>
 												<td>b145e498144454c16e9b9aff60b93e2f0e9839f3</td>
-												<td>10/17/2013, 11:50</td>
-												<td>10/17/2013, 09:54</td>
-												<td>10/15/2023, 09:54</td>
+												<td class="nowrap">10/17/2013, 11:50</td>
+												<td class="nowrap">10/17/2013, 09:54</td>
+												<td class="nowrap">10/15/2023, 09:54</td>
 											</tr>
 											<tr>
 												<td><input name="" type="checkbox" value="" /></td>
-												<td><span class="enabled">Enabled</span></td>
+												<td class="nowrap"><span class="enabled">Enabled</span></td>
 												<td>connectdirectri.org Root CA</td>
 												<td>No</td>
 												<td>5adb8bef9a562659550f96ea5684979eb820c314</td>
-												<td>10/17/2013, 11:50</td>
-												<td>10/11/2013, 03:59</td>
-												<td>10/11/2014, 03:59</td>
+												<td class="nowrap">10/17/2013, 11:50</td>
+												<td class="nowrap">10/11/2013, 03:59</td>
+												<td class="nowrap">10/11/2014, 03:59</td>
 											</tr>
 											<tr>
 												<td><input name="" type="checkbox" value="" /></td>
-												<td><span class="enabled">Enabled</span></td>
+												<td class="nowrap"><span class="enabled">Enabled</span></td>
 												<td>connectdirectri.org</td>
 												<td>No</td>
 												<td>90867ce50c18e2a290321f7d28a937f9945549b5</td>
-												<td>10/11/2013, 04:32</td>
-												<td>10/11/2013, 04:00</td>
-												<td>10/11/2014, 04:00</td>
+												<td class="nowrap">10/11/2013, 04:32</td>
+												<td class="nowrap">10/11/2013, 04:00</td>
+												<td class="nowrap">10/11/2014, 04:00</td>
 											</tr>
 											<tr>
 												<td><input name="" type="checkbox" value="" /></td>
-												<td>New</td>
+												<td class="nowrap">New</td>
 												<td>directri.connect.org</td>
 												<td>Yes</td>
 												<td>de2cf30af97b73f69bd71d5a0fad5de5d8363cfe</td>
-												<td>05/01/2014, 04:17</td>
-												<td>11/20/2013, 03:46</td>
-												<td>11/18/2023, 03:46</td>
+												<td class="nowrap">05/01/2014, 04:17</td>
+												<td class="nowrap">11/20/2013, 03:46</td>
+												<td class="nowrap">11/18/2023, 03:46</td>
 											</tr>
 											<tr>
 												<td><input name="" type="checkbox" value="" /></td>
-												<td>New</td>
+												<td class="nowrap">New</td>
 												<td>directri.connect.org</td>
 												<td>Yes</td>
 												<td>de2cf30af97b73f69bd71d5a0fad5de5d8363cfe</td>
-												<td>05/01/2014, 04:59</td>
-												<td>11/20/2013, 03:46</td>
-												<td>11/18/2023, 03:46</td>
+												<td class="nowrap">05/01/2014, 04:59</td>
+												<td class="nowrap">11/20/2013, 03:46</td>
+												<td class="nowrap">11/18/2023, 03:46</td>
 											</tr>
 										</tbody>
 									</table>
@@ -527,9 +527,9 @@
 			                                    	<a href="https://secure.bluebuttontrust.org/p7b.ashx?id=cb300117-3a4a-e211-8bc3-78e3b5114607" target="_blank">https://secure.bluebuttontrust.org/p7b.ashx?id=cb300117-3a4a-e211-8bc3-78e3b5114607</a>
 			                                    </td>
 			                                    <td>8d9121401ba2abcb16d16cb5195c360e84abedb6</td>
-			                                    <td>10/09/2013 03:11</td>
-			                                    <td>05/09/2014 06:51</td>
-			                                    <td>05/13/2014 09:51</td>
+			                                    <td class="nowrap">10/09/2013 03:11</td>
+			                                    <td class="nowrap">05/09/2014 06:51</td>
+			                                    <td class="nowrap">05/13/2014 09:51</td>
 			                                    <td>72</td> 
 											</tr>
 											<tr>
@@ -539,9 +539,9 @@
 			                                    </td>
 			                                    <td><a href="http://thisisnotavalidtrustbundle.link/noseriously.p7b" target="_blank">http://thisisnotavalidtrustbundle.link/noseriously.p7b</a></td>
 			                                    <td></td>
-			                                    <td>04/10/2014 04:12</td>
-			                                    <td></td>
-			                                    <td>05/13/2014 09:51</td>
+			                                    <td class="nowrap">04/10/2014 04:12</td>
+			                                    <td class="nowrap"></td>
+			                                    <td class="nowrap">05/13/2014 09:51</td>
 			                                    <td>1</td>  
 											</tr>
 										</tbody>
@@ -568,7 +568,7 @@
 	<div class="modal-dialog">
 		<div class="modal-content">
 			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
 				<h4 class="modal-title" id="modal-trustbundle-label">ADD A TRUST BUNDLE</h4>
 			</div>
 			<div class="modal-body">
@@ -616,7 +616,7 @@
 	<div class="modal-dialog">
 		<div class="modal-content">
 			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
 				<h4 class="modal-title" id="modal-domain-address-label">ADD A NEW ADDRESS</h4>
 			</div>
 			<div class="modal-body">
@@ -669,7 +669,7 @@
 	<div class="modal-dialog">
 		<div class="modal-content">
 			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
 				<h4 class="modal-title" id="modal-agent-label">ADD NEW AGENT SETTING</h4>
 			</div>
 			<div class="modal-body">
@@ -692,8 +692,7 @@
 							<div class="form-group">
 								<div class="col-sm-12">
 									<div class="form-button-row">
-										<button type="submit" class="btn btn-default">Add Setting</button>
-										<button type="reset" class="btn btn-primary">Cancel</button>
+										<button type="submit" class="btn btn-primary">Add Setting</button>
 									</div>
 								</div>
 							</div>
@@ -711,7 +710,7 @@
 	<div class="modal-dialog">
 		<div class="modal-content">
 			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
 				<h4 class="modal-title" id="modal-certs-label">ADD NEW CERTIFICATE</h4>
 			</div>
 			<div class="modal-body">
@@ -757,7 +756,7 @@
 	<div class="modal-dialog">
 		<div class="modal-content">
 			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
 				<h4 class="modal-title" id="modal-trust-bundle-label">ADD NEW TRUST BUNDLE</h4>
 			</div>
 			<div class="modal-body">
@@ -812,7 +811,7 @@
 	<div class="modal-dialog modal-lg">
 		<div class="modal-content">
 			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
 				<h4 class="modal-title" id="modal-anchor1-label">Anchor List</h4>
 			</div>
 			<div class="modal-body">
@@ -828,7 +827,7 @@
 	<div class="modal-dialog modal-lg">
 		<div class="modal-content">
 			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
 				<h4 class="modal-title" id="modal-anchor2-label">Anchor List</h4>
 			</div>
 			<div class="modal-body">

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/BaseTemplate.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/BaseTemplate.xhtml
@@ -36,8 +36,11 @@
     <h:head>
         <title><ui:insert name="title">Connect Administration</ui:insert></title>
         <ui:insert name="metatag">
-        </ui:insert>    
-        <h:outputStylesheet library="css" name="bootstrap.css.map" />
+        </ui:insert>
+		
+		<link rel="shortcut icon" href="#{resource['images/favicon-admingui.ico']}" type="image/x-icon" />
+        
+		<h:outputStylesheet library="css" name="bootstrap.css.map" />
         <h:outputStylesheet library="css" name="bootstrap.min.css" />
         <h:outputStylesheet library="css" name="bootstrap-theme.css.map" />
         <h:outputStylesheet library="css" name="bootstrap-theme.min.css" />
@@ -85,6 +88,7 @@
                     <!--end of right side div  -->
                 </div>
             </div>
+			<ui:include src="copyright-modal.xhtml" />
         </f:view>
     </body>
 </html>

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/FooterForBaseTemplate.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/FooterForBaseTemplate.xhtml
@@ -32,25 +32,8 @@
     <body>
         <ui:composition>
 
-            <footer id="footer"> Copyright &copy; 2009-2014, United
-                States Government. All rights reserved. <a href="#"
-                                                           data-toggle="modal" data-target="#modal-copyright">MORE <i
-                        class="glyphicon glyphicon-new-window"></i></a> </footer>
-            <!-- BEGIN: MODAL - COPYRIGHT -->
-            <div class="modal fade" id="modal-copyright" tabindex="-1" role="dialog" aria-labelledby="modal-copyright-label" aria-hidden="true">
-                <div class="modal-dialog modal-lg">
-                    <div class="modal-content">
-                        <div class="modal-header">
-                            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                            <h4 class="modal-title" id="modal-copyright-label">COPYRIGHT STATEMENT</h4>
-                        </div>
-                        <div class="modal-body">
-                            <ui:include src="copyright.xhtml" />
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <!-- END: MODAL - COPYRIGHT -->
+            <footer id="footer"> Copyright &#169; 2009-2014, United States Government. All rights reserved. <a href="#" data-toggle="modal" data-target="#modal-copyright">MORE <i class="glyphicon glyphicon-new-window"></i></a> </footer>
+
         </ui:composition>
     </body>
 </html>

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/SidebarPaneForBaseTemplate.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/SidebarPaneForBaseTemplate.xhtml
@@ -34,7 +34,7 @@
       xmlns:f="http://java.sun.com/jsf/core">
 
     <body>
-		
+		<ui:composition xmlns:h="http://java.sun.com/jsf/html" xmlns:ui="http://java.sun.com/jsf/facelets" xmlns="http://www.w3.org/1999/xhtml">
 			<h1 class="page-header">Gateway Administrative Console</h1>
 	
 			<div id="sidenav-status">
@@ -75,7 +75,7 @@
 					Direct Configuration
 				</h2>
 				<ul class="nav nav-sidebar sidebar-purple">
-					<li><a href="direct.xhtml#tab_domains"><i class="glyphicon glyphicon-cog"></i> Manage Domains</a></li>
+					<li><a href="direct.xhtml#tab_domains"><i class="glyphicon glyphicon-cog"></i> Domains</a></li>
 					<li><a href="direct.xhtml#tab_agent"><i class="glyphicon glyphicon-cog"></i> Agent Settings</a></li>
 					<li><a href="direct.xhtml#tab_certs"><i class="glyphicon glyphicon-cog"></i> Certificates</a></li>
 					<li><a href="direct.xhtml#tab_trust"><i class="glyphicon glyphicon-cog"></i> Trust Bundles</a></li>
@@ -91,6 +91,6 @@
 					<li><a href="acctmanage.xhtml#tab_certificate"><i class="glyphicon glyphicon-lock"></i> Certificate Management</a></li>
 				</ul>
 			</div>
-		
+		</ui:composition>
     </body>
 </html>

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/copyright-modal.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/copyright-modal.xhtml
@@ -1,0 +1,29 @@
+<ui:composition xmlns:h="http://java.sun.com/jsf/html" xmlns:ui="http://java.sun.com/jsf/facelets" xmlns="http://www.w3.org/1999/xhtml">
+
+<!-- BEGIN: MODAL - COPYRIGHT -->
+<div class="modal fade" id="modal-copyright" tabindex="-1" role="dialog" aria-labelledby="modal-copyright-label" aria-hidden="true">
+	<div class="modal-dialog modal-lg">
+		<div class="modal-content">
+			<div class="modal-header">
+				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+				<h4 class="modal-title" id="modal-copyright-label">COPYRIGHT STATEMENT</h4>
+			</div>
+			<div class="modal-body">
+				
+				<p>Copyright &#169; 2009-2014, United States Government, as represented by the Secretary of Health and Human Services.</p>
+				<p>All rights reserved.</p>
+				<p>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:</p>
+				<ul>
+					<li>Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.</li>
+					<li>Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.</li>
+					<li>Neither the name of the United States Government nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.</li>
+				</ul>
+				<p>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
+				
+			</div>
+		</div>
+	</div>
+</div>
+<!-- END: MODAL - COPYRIGHT -->
+
+</ui:composition>

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/css/dashboard.css
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/css/dashboard.css
@@ -45,6 +45,7 @@ html, body {
 body {
 	background:#e3ebf5; /* #10253f */
 }
+
 a {
 	outline:none !important;
 }
@@ -63,7 +64,7 @@ a {
 	padding-left:0px;
 	padding-right:0px;
 	padding-bottom:30px;
-	background:#10253f;
+	background:#10253f; /* 212c65 */
 	position:absolute;
 }
 .sidebar h1.page-header {
@@ -570,6 +571,14 @@ span.enabled {
 	margin-top:10px;
 }
 
+.main-content table[class*="table-"] td {  /* table[class$="table-"] */
+	word-wrap: break-word;
+	word-break: break-all;
+}.main-content table[class*="table-"] td.nowrap {  /* table[class$="table-"] */
+	word-wrap: break-word;
+	word-break: normal;
+}
+
 /* -- SERVER STATUS KPI STYLES -----------------------------------------------*/
 .kpi-block {
 	margin-bottom:20px;
@@ -586,13 +595,6 @@ span.enabled {
 	font-size:24px;
 	font-weight:normal;
 }
-
-.kpi-value-c {
-    padding:0px 15px 5px;
-    font-size:18px;
-    font-weight:normal;
-}
-
 .kpi-footer {
 	padding:5px 15px;
 	border-top:1px solid #e3ebf5;
@@ -675,6 +677,9 @@ span.enabled {
 	}
 	.main h2.subsection-header {
 		padding:12px;
+	}
+	.main-content table[class*="table-"] td {
+		font-size:14px;
 	}
 }
 @media (max-width: 800px) {

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/js/admingui.js
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/js/admingui.js
@@ -12,9 +12,6 @@ $(document).ready(function() {
 		$(movethis).insertAfter("h1.page-header"); // MOVE SIDEBAR MENU SECTION MATCHING SELECTED TAB TO TOP OF SIDEBAR
 	}
 	else {
-		//var showTab = $('.nav-section-tabs li.active').find('a').attr('href');
-		//console.log(showTab);
-		//$('#nav-section-tabs a[href='+showTab+']').tab('show');
 		var movethis = $('.nav-sidebar li.active').closest('div[id^="sidenav-"]'); // FIND ID OF SIDEBAR MENU'S CONTAINING DIV THAT HAS THE ACTIVE LINK
 		$(movethis).insertAfter("h1.page-header"); // MOVE SIDEBAR MENU SECTION CONTAINING ACTIVE LINK TO TOP OF SIDEBAR
 	};
@@ -27,11 +24,8 @@ $(document).ready(function() {
 		$(showActivebar).addClass('active'); // ADD ACTIVE CLASS TO NEWLY SELECTED LINK LI
 	
 		var urlFull = $(this).find('a').attr('href'); // CATCH HREF FROM SIDEBAR LINK
-		//console.log(urlFull);
 		var url = urlFull.substring(urlFull.indexOf("#")); // GET JUST THE URL STRING STARTING AT THE HASH MARK
-		//console.log(url);
 		if (url.match('#')) {
-			//console.log(url);
 			$('.nav-section-tabs a[href='+url.replace(prefix,"")+']').tab('show') ; // REMOVE PREFIX and CHANGE TAB TO MATCH SELECTED SIDEBAR LINK
 		}
 	});

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/js/admingui.js
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/js/admingui.js
@@ -27,9 +27,9 @@ $(document).ready(function() {
 		$(showActivebar).addClass('active'); // ADD ACTIVE CLASS TO NEWLY SELECTED LINK LI
 	
 		var urlFull = $(this).find('a').attr('href'); // CATCH HREF FROM SIDEBAR LINK
-		console.log(urlFull);
+		//console.log(urlFull);
 		var url = urlFull.substring(urlFull.indexOf("#")); // GET JUST THE URL STRING STARTING AT THE HASH MARK
-		console.log(url);
+		//console.log(url);
 		if (url.match('#')) {
 			//console.log(url);
 			$('.nav-section-tabs a[href='+url.replace(prefix,"")+']').tab('show') ; // REMOVE PREFIX and CHANGE TAB TO MATCH SELECTED SIDEBAR LINK
@@ -38,7 +38,13 @@ $(document).ready(function() {
 	
 	// FUNCTION FOR TABBED NAV IN MAIN CONTENT AREA - CHANGE SELECTED SIDEBAR LINK
 	$('.nav-section-tabs a').click(function () {
-		var url = $(this).attr('href').replace("#","#tab_"); // CATCH HREF FROM SELECTED TAB and ADD PREFIX TO FIND CORRECT SIDEBAR LINK
+		var urlTest = $(this).attr('href').replace("#","#tab_"); // CATCH HREF FROM SELECTED TAB and ADD PREFIX TO FIND CORRECT SIDEBAR LINK
+		if (urlTest.indexOf('domain-') >= 0) {
+			var url = "#tab_domains";
+		}
+		else {
+			var url = urlTest;
+		}
 		SidebarNavStyle(url);
 	});
 	


### PR DESCRIPTION
This PR addresses some of the notes found in the "Admin GUI Improvements" Wiki, found here:
https://connectopensource.atlassian.net/wiki/display/FCPT/Admin+GUI+Improvements

<b>SPECIFICALLY:</b>
- Change "Add New Certificate" to "Add Certificate" - Since we an add certificates with status NEW/DISABLED/ENABLED, it is better we can call the button as "Add Certificate".  <b>Text changed.</b>
- All the tab names/menu items under Direct are without the "Manage" word except for Domains. It is better we say "Domains" instead of "Manage Domains".  <b>All instances changed.</b>
- The content of Trust Bundles go beyond the frame.  This may occur with other tables when the browser window is shrunk.  <b>The fix is via CSS word-wrap and word-break properties.</b>
- XHTML is not displaying text symbols that use HTML entity names.  <b>The fix is to change the problematic code snippets to use HTML entity numbers instead.  For instance, replace "&times;" with "&#215;". </b>
- Currently, the copyright modal box pops-up behind the page content layer.  <b>The fix is to move the copyright code to the bottom of the page code; this should address the layering issues. </b>
- On the Direct screens, in the "Agent Settings" modal pop-up, the buttons are in the wrong order and need the CSS classes switched between them, and remove "Cancel" button, for consistency with other screens.  <b>Fixed as noted.</b>
- Favicon is missing.  <b>Fix is to add the link reference in the head section of the base template.</b>
