### PR TITLE
CONN-1191

### DIFF
--- a/Product/Production/Deploy/ear/weblogic/src/main/application/META-INF/weblogic-application.xml
+++ b/Product/Production/Deploy/ear/weblogic/src/main/application/META-INF/weblogic-application.xml
@@ -27,7 +27,6 @@
         <package-name>javax.faces.*</package-name>
         <package-name>com.sun.faces.*</package-name>
         <package-name>com.bea.faces.*</package-name>
-        <package-name>com.sun.xml.*</package-name>
     </prefer-application-packages>
     <prefer-application-resources>
         <resource-name>javax.faces.*</resource-name>


### PR DESCRIPTION
Removed com.sun.xml.\* from WebLogic classloader filtering to fix JAXB exception during CONNECTDirectConfig deploy.
