### PR TITLE
CONN-1224: Remove Scroller from Login Sidebar

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/BaseTemplate.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/BaseTemplate.xhtml
@@ -11,7 +11,7 @@
 		<title><ui:insert name="title">Connect Administration</ui:insert></title>
         <ui:insert name="metatag"></ui:insert>
 		
-		<link rel="shortcut icon" href="#{resource['images/favicon-admingui.ico']}" type="image/x-icon" />
+        <link rel="shortcut icon" href="#{resource['images/favicon-admingui.ico']}" type="image/x-icon" />
         
 		<h:outputStylesheet library="css" name="bootstrap.css.map" />
         <h:outputStylesheet library="css" name="bootstrap.min.css" />
@@ -30,21 +30,14 @@
             <div class="container-fluid" style="height:100%;">
                 <div class="row" style="height: 100%;">
                     <!-- BEGIN: LEFT COLUMN - SIDEBAR NAVIGATION -->
-                    <div class="col-xs-2 sidebar sidebar-scroll">
-                        <ui:insert name="menu">
-                            <ui:include src="/resources/Templates/SidebarPaneForBaseTemplate.xhtml" />
-                        </ui:insert>
-                        <div class="copyright">
-                            <ui:insert name="footer">
-                                <ui:include src="/resources/Templates/FooterForBaseTemplate.xhtml" />
-                            </ui:insert>
-                        </div>
-                    </div>
+                    <ui:insert name="menu">
+                        <ui:include src="/resources/Templates/SidebarPaneForBaseTemplate.xhtml" />
+                    </ui:insert>
                     <!-- END: LEFT COLUMN - SIDEBAR NAVIGATION -->
 					
                     <!-- BEGIN: RIGHT COLUMN - Primary content is located here -->
                     <div class="col-xs-offset-2 col-xs-10 main">
-                        <!-- BEGIN: UTILITY BAR -->
+                        <!-- BEGIN: UTILITY BAR - "Header" -->
                         <ui:insert name="foradmin">
                             <div class="navbar nav-utility" role="navigation">
                                 <ui:insert name="header">
@@ -52,7 +45,7 @@
                                 </ui:insert>
                             </div>
                         </ui:insert>
-                        <!-- END: UTILITY BAR -->
+                        <!-- END: UTILITY BAR - "Header" -->
 						
                         <!-- BEGIN: MAIN CONTENT SECTION -->
                         <div class="main-content">

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/BaseTemplatePrime.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/BaseTemplatePrime.xhtml
@@ -9,15 +9,16 @@
 			<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 		</f:facet>
         <title><ui:insert name="title">Connect Administration</ui:insert></title>
-        <ui:insert name="metatag">
-        </ui:insert>
-        <h:outputStylesheet library="css" name="bootstrap.css" />
+        <ui:insert name="metatag"></ui:insert>
+        
+        <link rel="shortcut icon" href="#{resource['images/favicon-admingui.ico']}" type="image/x-icon" />
+
         <h:outputStylesheet library="css" name="bootstrap.css.map" />
         <h:outputStylesheet library="css" name="bootstrap.min.css" />
-        <h:outputStylesheet library="css" name="bootstrap-theme.css" />
         <h:outputStylesheet library="css" name="bootstrap-theme.css.map" />
         <h:outputStylesheet library="css" name="bootstrap-theme.min.css" />
         <h:outputStylesheet library="css" name="dashboard.css" />
+        
         <ui:insert name="morejs"></ui:insert>
     </h:head>
     <h:body>
@@ -25,22 +26,15 @@
         <f:view>
             <div class="container-fluid" style="height: 100%;">
                 <div class="row" style="height: 100%;">
-                    <!-- left side div -->
-                    <div class="col-xs-2 sidebar sidebar-scroll">
-                        <ui:insert name="menu">
-
-                            <ui:include src="/resources/Templates/SidebarPaneForBaseTemplatePrime.xhtml" />
-                        </ui:insert>
-                        <div class="copyright">
-                            <ui:insert name="footer">
-                                <ui:include src="/resources/Templates/FooterForBaseTemplatePrime.xhtml" />
-                            </ui:insert>
-                        </div>
-                    </div>
-                    <!-- end of left side div -->
-                    <!-- right side div with content -->
+                    <!-- BEGIN: LEFT COLUMN - SIDEBAR NAVIGATION -->
+                    <ui:insert name="menu">
+                        <ui:include src="/resources/Templates/SidebarPaneForBaseTemplatePrime.xhtml" />
+                    </ui:insert>
+                    <!-- END: LEFT COLUMN - SIDEBAR NAVIGATION -->
+					
+                    <!-- BEGIN: RIGHT COLUMN - Primary content is located here -->
                     <div class="col-xs-offset-2 col-xs-10 main">
-                        <!--header  -->
+                        <!-- BEGIN: UTILITY BAR - "Header" -->
                         <ui:insert name="foradmin">
                             <div class="navbar nav-utility" role="navigation">
                                 <ui:insert name="header">
@@ -48,18 +42,22 @@
                                 </ui:insert>
                             </div>
                         </ui:insert>
-                        <!-- content navigation -->
+                        <!-- END: UTILITY BAR - "Header" -->
+						
+                        <!-- BEGIN: MAIN CONTENT SECTION -->
                         <div class="main-content">
                             <ui:insert name="content">
 
                             </ui:insert>
                         </div>
+                        <!-- END: MAIN CONTENT SECTION -->
                     </div>
-                    <!--end of right side div  -->
+                    <!-- END: RIGHT COLUMN - Primary content is located here -->
                 </div>
             </div>
-			<ui:include src="copyright-modal-prime.xhtml" />
-			<h:outputScript library="js" name="sidebar.js" />
+            <ui:include src="copyright-modal-prime.xhtml" />
+            
+            <h:outputScript library="js" name="sidebar.js" />
         </f:view>
     </h:body>
 </html>

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/SidebarForLogin.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/SidebarForLogin.xhtml
@@ -34,11 +34,13 @@
       xmlns:ui="http://java.sun.com/jsf/facelets"
       xmlns:f="http://java.sun.com/jsf/core">
     <body>
-		<ui:composition>
+    <ui:composition>
+        <div class="col-xs-2 sidebar">
             <h1 class="page-header">Gateway Administrative Console</h1>
             <div align="center" class="sidebar-gfx">
                 <img src="resources/images/gfx-consoleiconic.png" class="img-responsive" />
             </div>
-		</ui:composition>
+        </div>
+    </ui:composition>
     </body>
 </html>

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/SidebarPaneForBaseTemplate.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/SidebarPaneForBaseTemplate.xhtml
@@ -34,7 +34,8 @@
       xmlns:f="http://java.sun.com/jsf/core">
 
     <body>
-		<ui:composition xmlns:h="http://java.sun.com/jsf/html" xmlns:ui="http://java.sun.com/jsf/facelets" xmlns="http://www.w3.org/1999/xhtml">
+    <ui:composition xmlns:h="http://java.sun.com/jsf/html" xmlns:ui="http://java.sun.com/jsf/facelets" xmlns="http://www.w3.org/1999/xhtml">
+        <div class="col-xs-2 sidebar sidebar-scroll">
 			<h1 class="page-header">Gateway Administrative Console</h1>
 	
 			<div id="sidenav-status">
@@ -91,6 +92,13 @@
 					<li><a href="acctmanage.xhtml#tab_certificate"><i class="glyphicon glyphicon-lock"></i> Certificate Management</a></li>
 				</ul>
 			</div>
-		</ui:composition>
+            
+            <div class="copyright">
+                <ui:insert name="footer">
+                    <ui:include src="/resources/Templates/FooterForBaseTemplate.xhtml" />
+                </ui:insert>
+            </div>
+        </div>
+    </ui:composition>
     </body>
 </html>

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/SidebarPaneForBaseTemplatePrime.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/SidebarPaneForBaseTemplatePrime.xhtml
@@ -34,28 +34,39 @@
       xmlns:f="http://java.sun.com/jsf/core"
       xmlns:p="http://primefaces.org/ui">
     <body>
-        <ui:composition>
-		<h1 class="page-header">Gateway Administrative Console</h1>
-        <h:form>
-        <p:panelMenu style="width:100%">
-            <p:submenu label="Gateway Status" styleClass="sidebar-orange">
-                <p:menuitem value="Dashboard" action="#{tabBean.setDashboardTabIndexNavigate(0)}" styleClass="glyphicon glyphicon-dashboard" />
-                <p:menuitem value="Performance Statistics" action="#{tabBean.setDashboardTabIndexNavigate(1)}" styleClass="glyphicon glyphicon-stats" />
-                <p:menuitem value="Remote Gateway List" action="#{tabBean.setDashboardTabIndexNavigate(2)}" styleClass="glyphicon glyphicon-list" />
-            </p:submenu>
-            <p:submenu label="Direct Configuration" styleClass="sidebar-purple">
-                <p:menuitem value="Domains" action="#{tabBean.setDirectTabIndexNavigate(0)}" styleClass="glyphicon glyphicon-globe" />
-                <p:menuitem value="Agent Settings" action="#{tabBean.setDirectTabIndexNavigate(1)}" styleClass="glyphicon glyphicon-cog" />
-                <p:menuitem value="Certificates" action="#{tabBean.setDirectTabIndexNavigate(2)}" styleClass="glyphicon glyphicon-list-alt" />
-                <p:menuitem value="Trust Bundles" action="#{tabBean.setDirectTabIndexNavigate(3)}" styleClass="glyphicon glyphicon-briefcase" />			
-            </p:submenu>
-			<p:submenu label="Account Management" styleClass="sidebar-blue">
-                <p:menuitem value="User Accounts" action="#{tabBean.setAdminTabIndexNavigate(0)}" styleClass="glyphicon glyphicon-user" />
-                <p:menuitem value="Certificate Management" action="#{tabBean.setAdminTabIndexNavigate(1)}" styleClass="glyphicon glyphicon-lock" />
-				<p:menuitem value="Manage User Roles" url="ManageRole.xhtml" styleClass="glyphicon glyphicon-lock" />
-            </p:submenu>
-        </p:panelMenu>
-        </h:form>
-		</ui:composition>
+    <ui:composition>
+        <div class="col-xs-2 sidebar sidebar-scroll">
+            
+                <h1 class="page-header">Gateway Administrative Console</h1>
+                
+                <h:form>
+                    <p:panelMenu style="width:100%">
+                        <p:submenu label="Gateway Status" styleClass="sidebar-orange">
+                            <p:menuitem value="Dashboard" action="#{tabBean.setDashboardTabIndexNavigate(0)}" styleClass="glyphicon glyphicon-dashboard" />
+                            <p:menuitem value="Performance Statistics" action="#{tabBean.setDashboardTabIndexNavigate(1)}" styleClass="glyphicon glyphicon-stats" />
+                            <p:menuitem value="Remote Gateway List" action="#{tabBean.setDashboardTabIndexNavigate(2)}" styleClass="glyphicon glyphicon-list" />
+                        </p:submenu>
+                        <p:submenu label="Direct Configuration" styleClass="sidebar-purple">
+                            <p:menuitem value="Domains" action="#{tabBean.setDirectTabIndexNavigate(0)}" styleClass="glyphicon glyphicon-globe" />
+                            <p:menuitem value="Agent Settings" action="#{tabBean.setDirectTabIndexNavigate(1)}" styleClass="glyphicon glyphicon-cog" />
+                            <p:menuitem value="Certificates" action="#{tabBean.setDirectTabIndexNavigate(2)}" styleClass="glyphicon glyphicon-list-alt" />
+                            <p:menuitem value="Trust Bundles" action="#{tabBean.setDirectTabIndexNavigate(3)}" styleClass="glyphicon glyphicon-briefcase" />			
+                        </p:submenu>
+                        <p:submenu label="Account Management" styleClass="sidebar-blue">
+                            <p:menuitem value="User Accounts" action="#{tabBean.setAdminTabIndexNavigate(0)}" styleClass="glyphicon glyphicon-user" />
+                            <p:menuitem value="Certificate Management" action="#{tabBean.setAdminTabIndexNavigate(1)}" styleClass="glyphicon glyphicon-lock" />
+                            <p:menuitem value="Manage User Roles" url="ManageRole.xhtml" styleClass="glyphicon glyphicon-lock" />
+                        </p:submenu>
+                    </p:panelMenu>
+                </h:form>
+                
+                <div class="copyright">
+                    <ui:insert name="footer">
+                        <ui:include src="/resources/Templates/FooterForBaseTemplatePrime.xhtml" />
+                    </ui:insert>
+                </div>
+            
+        </div>
+    </ui:composition>
     </body>
 </html>

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/css/pf-override.css
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/css/pf-override.css
@@ -135,7 +135,7 @@ body {
 	border-bottom:1px solid #283b53;
 	font-size:14px;
 }
-.sidebar .ui-widget-content a:hover {
+.sidebar .ui-widget-content a:hover, .sidebar .ui-widget-content a.ui-state-hover {
 	background:#0c1c2f;
 	color:#ffffff;
 	box-shadow:none;


### PR DESCRIPTION
This PR updates one visible item: (1) The scroller is removed from the sidebar on the Login page.

Side Note: This PR also addresses the newly missing favicon as noted in Visual Defects 5 of the AdminGUI Improvements Wiki (https://connectopensource.atlassian.net/wiki/pages/viewpage.action?spaceKey=FCPT&title=Admin+GUI+Improvements). Also did some minor reformatting.

CSS:
- pf-override.css -- corrected hover state CSS for sidebar.

XHTML:
- BaseTemplate.xhtml -- restructured the HTML, moving all sidebar elements to sidebar file.
- BaseTemplatePrime.xhtml -- restructured the HTML, moving all sidebar elements to sidebar file.
- SidebarForLogin.xhtml -- restructured with newly moved elements.
- SidebarPaneForBaseTemplate.xhtml -- restructured with newly moved elements.
- SidebarPaneForBaseTemplatePrime.xhtml -- restructured with newly moved elements.
