### PR TITLE
CONN-1259: Button and Modal Fixes in Direct Pages in AdminGUI -- DELETE ME

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/directPrime.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/directPrime.xhtml
@@ -45,10 +45,7 @@
                     <div class="content-block">
 						<h2 class="subsection-header">Domain List</h2>
 						<div class="table-responsive">
-							<h:form id="domain-form">                                    
-								<p:panelGrid columns="1" styleClass="ui-panelgrid-domain">
-									<p:commandButton value="Create New Domain" type="button" onclick="PF('domainDlg').show();" styleClass="add-button pull-right" icon="ui-icon-circle-plus" />
-								</p:panelGrid>
+							<h:form id="domain-form">
 								<p:dataTable id="domainDataTable" var="domain" value="#{directDomainBean.domains}" selection="#{directDomainBean.selectedDomain}" rowKey="#{domain.domainName}" styleClass="table table-striped table-domains">
 									<p:column headerText="Delete" selectionMode="single" />
 									<p:column headerText="Status" sortBy="status">
@@ -72,8 +69,11 @@
 										<p:column>
 											<p:commandButton value="Delete" actionListener="#{directDomainBean.deleteDomain()}" update="domainDataTable" styleClass="delete-button" icon="ui-icon-closethick" />
 										</p:column>
-										<p:column styleClass="ui-button-rightmost">
+										<p:column>
 											<p:commandButton value="Edit Domain" actionListener="#{directDomainBean.showEdit()}" styleClass="edit-button" icon="ui-icon-pencil" />
+										</p:column>
+										<p:column styleClass="ui-button-rightmost">
+											<p:commandButton value="Create New Domain" type="button" onclick="PF('domainDlg').show();" styleClass="add-button pull-right" icon="ui-icon-circle-plus" />
 										</p:column>
 									</p:row>
 								</p:panelGrid>
@@ -85,10 +85,7 @@
                     <div class="content-block">
 						<h2 class="subsection-header">Agent Settings</h2>
 						<div class="table-responsive">
-							<h:form id="agent-form">                                    
-								<p:panelGrid columns="1" styleClass="ui-panelgrid-domain">
-									<p:commandButton value="Add New Agent Setting" type="button" onclick="PF('agentDlg').show();" icon="ui-icon-circle-plus" styleClass="add-button pull-right" />
-								</p:panelGrid>
+							<h:form id="agent-form">
 								<p:dataTable id="agentDataTable" var="agent" value="#{directAgentBean.agents}" selection="#{directAgentBean.selectedAgent}" rowKey="#{agent.agentName}" styleClass="table table-striped table-domains">
 								   <p:column headerText="Delete" selectionMode="single" />
 								   <p:column headerText="Name" sortBy="name">
@@ -98,8 +95,15 @@
 									   <h:outputText value="#{agent.agentValue}" />
 								   </p:column>
 								</p:dataTable>                                    
-								<p:panelGrid columns="1" styleClass="ui-panelgrid-domain ui-panelgrid-domain-bottom">
-									<p:commandButton update="agentDataTable" value="Delete" action="#{directAgentBean.deleteAgent()}" styleClass="delete-button" icon="ui-icon-closethick"/>
+								<p:panelGrid styleClass="ui-panelgrid-domain ui-panelgrid-domain-bottom">
+                                    <p:row>
+                                        <p:column>
+                                            <p:commandButton update="agentDataTable" value="Delete" action="#{directAgentBean.deleteAgent()}" styleClass="delete-button" icon="ui-icon-closethick"/>
+                                        </p:column>
+                                        <p:column styleClass="ui-button-rightmost">
+                                            <p:commandButton value="Add New Agent Setting" type="button" onclick="PF('agentDlg').show();" icon="ui-icon-circle-plus" styleClass="add-button pull-right" />
+                                        </p:column>
+                                    </p:row>
 								</p:panelGrid>
 							</h:form>
 						</div>
@@ -109,10 +113,7 @@
                     <div class="content-block">
 						<h2 class="subsection-header">Certificates</h2>
                         <div class="table-responsive">
-							<h:form id="cert-form">                                    
-								<p:panelGrid columns="1" styleClass="ui-panelgrid-domain">
-									<p:commandButton value="Add New Certificate" type="button" onclick="PF('certDlg').show();" icon="ui-icon-circle-plus" styleClass="add-button pull-right" />
-								</p:panelGrid>
+							<h:form id="cert-form">
 								<p:dataTable id="certDataTable" var="cert" value="#{directCertBean.certificates}" selection="#{directCertBean.selectedCert}" rowKey="#{cert.certThumb}" styleClass="table table-striped table-domains">
 									<p:column headerText="Delete" selectionMode="single" />
 									<p:column headerText="Status" sortBy="status">
@@ -137,8 +138,15 @@
 										<h:outputText value="#{cert.certEnd}" styleClass="nowrap" />
 									</p:column>
 								</p:dataTable>
-								<p:panelGrid columns="1" styleClass="ui-panelgrid-domain ui-panelgrid-domain-bottom">
-									<p:commandButton update="certDataTable" value="Delete" action="#{directCertBean.deleteCertificate()}" styleClass="delete-button" icon="ui-icon-closethick"/>
+								<p:panelGrid styleClass="ui-panelgrid-domain ui-panelgrid-domain-bottom">
+                                    <p:row>
+                                        <p:column>
+                                            <p:commandButton update="certDataTable" value="Delete" action="#{directCertBean.deleteCertificate()}" styleClass="delete-button" icon="ui-icon-closethick"/>
+                                        </p:column>
+                                        <p:column styleClass="ui-button-rightmost">
+                                            <p:commandButton value="Add New Certificate" type="button" onclick="PF('certDlg').show();" icon="ui-icon-circle-plus" styleClass="add-button pull-right" />
+                                        </p:column>
+                                    </p:row>
 								</p:panelGrid>                                    
 							</h:form>
                         </div>
@@ -148,10 +156,7 @@
                     <div class="content-block">
 						<h2 class="subsection-header">Trust Bundles</h2>
                         <div class="table-responsive">
-							<h:form id="tb-form">                                    
-								<p:panelGrid columns="1" styleClass="ui-panelgrid-domain">
-									<p:commandButton value="Add New Trust Bundle" type="button" onclick="PF('tbDlg').show();" icon="ui-icon-circle-plus" styleClass="add-button pull-right" />
-								</p:panelGrid>
+							<h:form id="tb-form">
 								<p:dataTable id="tbDataTable" var="tb" value="#{directTrustBundleBean.trustBundles}" selection="#{directTrustBundleBean.selectedTb}" rowKey="#{tb.tbName}" styleClass="table table-striped table-domains">
 									<p:column headerText="Delete" selectionMode="single" />
 									<p:column headerText="Bundle Name" sortBy="bundle_name">
@@ -181,8 +186,11 @@
 										<p:column>
 											<p:commandButton value="Delete" update="tbDataTable" action="#{directTrustBundleBean.showDelConfirm()}" icon="ui-icon-closethick" styleClass="delete-button" />
 										</p:column>
-										<p:column styleClass="ui-button-rightmost">
+										<p:column>
 											<p:commandButton value="Edit Trust Bundle" actionListener="#{directTrustBundleBean.showEdit()}" icon="ui-icon-pencil" styleClass="edit-button" />
+										</p:column>
+										<p:column styleClass="ui-button-rightmost">
+											<p:commandButton value="Add New Trust Bundle" type="button" onclick="PF('tbDlg').show();" icon="ui-icon-circle-plus" styleClass="add-button pull-right" />
 										</p:column>
 									</p:row>
 								</p:panelGrid>

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/css/pf-override.css
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/css/pf-override.css
@@ -639,8 +639,11 @@ body {
     background-color: inherit;
 }
 .ui-panelgrid-domain.ui-panelgrid td {
-	padding:10px 0px;
+	padding:10px 0px 0px 10px;
 	text-align:left;
+}
+.ui-panelgrid-domain.ui-panelgrid td:first-child {
+	padding-left:0px;
 }
 .ui-panelgrid-domain td.ui-button-rightmost {
 	width:100%;
@@ -755,6 +758,9 @@ body {
 
 
 /* -- DOMAIN CONFIG MODAL STYLES -- CREATE DOMAIN / EDIT DOMAIN -- */
+#domainEditDlg {
+	top:50px !important;
+}
 #domainCreateDlg .ui-widget-header,
 #domainEditDlg .ui-widget-header {
 	/*


### PR DESCRIPTION
This PR includes UI fixes that are related to the AdminGUI Direct pages, and referenced in CONN-1259 (https://connectopensource.atlassian.net/browse/CONN-1259).

CSS:
- pf-override.css -- moodified CSS rules for buttons in Direct pages, as well as Edit Domain modal position.

XHTML:
- directPrime.xhtml -- changed button placements.
