### PR TITLE
CONN-1166 Direct Admin GUI not displayed if no DirectConfig

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/display/DirectDisplayController.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/display/DirectDisplayController.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2009-2014, United States Government, as represented by the Secretary of Health and Human Services. All
+ * rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met: Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or other materials provided with the
+ * distribution. Neither the name of the United States Government nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package gov.hhs.fha.nhinc.admingui.display;
+
+import gov.hhs.fha.nhinc.admingui.proxy.DirectConfigConstants;
+import gov.hhs.fha.nhinc.admingui.proxy.service.DirectConfigUnsecuredServicePortDescriptor;
+import gov.hhs.fha.nhinc.messaging.client.CONNECTCXFClientFactory;
+import gov.hhs.fha.nhinc.messaging.client.CONNECTClient;
+import gov.hhs.fha.nhinc.messaging.service.port.ServicePortDescriptor;
+import gov.hhs.fha.nhinc.nhinclib.NullChecker;
+import gov.hhs.fha.nhinc.webserviceproxy.WebServiceProxyHelper;
+import java.util.List;
+import org.apache.log4j.Logger;
+import org.nhind.config.ConfigurationService;
+import org.nhind.config.Domain;
+
+/**
+ *
+ * @author jsmith
+ */
+public class DirectDisplayController {
+
+    private final WebServiceProxyHelper oProxyHelper = new WebServiceProxyHelper();
+
+    private static final Logger LOG = Logger.getLogger(DirectDisplayController.class);
+
+    public void checkDirectDisplay() {
+        DisplayHolder.getInstance().setDirectEnabled(directConfigEnabled());
+    }
+
+    private boolean directConfigEnabled() {
+        boolean result;
+        try {
+            String url = oProxyHelper
+                    .getAdapterEndPointFromConnectionManager(DirectConfigConstants.DIRECT_CONFIG_SERVICE_NAME);
+            if (NullChecker.isNullish(url)) {
+                result = false;
+            } else {
+                result = pingDirectConfig(url);
+            }
+        } catch (Exception ex) {
+            result = false;
+            LOG.error(ex.getLocalizedMessage(), ex);
+        }
+
+        return result;
+    }
+
+    private boolean pingDirectConfig(String url) throws Exception {
+        ServicePortDescriptor<ConfigurationService> portDescriptor = new DirectConfigUnsecuredServicePortDescriptor();
+
+        CONNECTClient<ConfigurationService> client = CONNECTCXFClientFactory.getInstance().getCONNECTClientUnsecured(
+                portDescriptor, url, null);
+        List<Domain> domains = (List<Domain>) client.invokePort(ConfigurationService.class, DirectConfigConstants.DIRECT_CONFIG_LIST_DOMAINS, null, 0);
+        return domains != null;
+    }
+    
+}

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/display/DisplayHolder.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/display/DisplayHolder.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2009-2014, United States Government, as represented by the Secretary of Health and Human Services. All
+ * rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met: Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or other materials provided with the
+ * distribution. Neither the name of the United States Government nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package gov.hhs.fha.nhinc.admingui.display;
+
+/**
+ *
+ * @author jsmith
+ */
+public class DisplayHolder {
+
+    private static DisplayHolder INSTANCE;
+    
+    private DisplayHolder(){
+    }
+    
+    public static DisplayHolder getInstance(){
+        if(INSTANCE == null){
+            INSTANCE = new DisplayHolder();
+        }
+        return INSTANCE;
+    }
+    
+    private boolean directEnabled = true;
+
+    public boolean isDirectEnabled() {
+        return directEnabled;
+    }
+
+    public void setDirectEnabled(boolean directEnabled) {
+        this.directEnabled = directEnabled;
+    }
+    
+}

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/jee/jsf/UserAuthorizationListener.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/jee/jsf/UserAuthorizationListener.java
@@ -26,21 +26,19 @@
  */
 package gov.hhs.fha.nhinc.admingui.jee.jsf;
 
+import gov.hhs.fha.nhinc.admingui.display.DisplayHolder;
 import gov.hhs.fha.nhinc.admingui.services.RoleService;
 import gov.hhs.fha.nhinc.admingui.services.RoleServiceImpl;
 import gov.hhs.fha.nhinc.admingui.services.persistence.jpa.entity.UserLogin;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.faces.application.NavigationHandler;
 import javax.faces.context.FacesContext;
 import javax.faces.event.PhaseEvent;
 import javax.faces.event.PhaseId;
 import javax.faces.event.PhaseListener;
 import javax.servlet.http.HttpSession;
-
 import org.apache.log4j.Logger;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 // TODO: Auto-generated Javadoc
@@ -108,8 +106,11 @@ public class UserAuthorizationListener implements PhaseListener {
             LOG.debug("Current User does not have permission for page, redirecting to status page.");
             NavigationHandler nh = facesContext.getApplication().getNavigationHandler();
             nh.handleNavigation(facesContext, null, STATUS_PAGE_NAV_OUTCOME);
+        } else if(!canAccessDirect(currentPage)){
+            LOG.debug("Direct configuration is not available.");
+            NavigationHandler nh = facesContext.getApplication().getNavigationHandler();
+            nh.handleNavigation(facesContext, null, STATUS_PAGE_NAV_OUTCOME);
         }
-
     }
 
     /*
@@ -138,6 +139,11 @@ public class UserAuthorizationListener implements PhaseListener {
         }else {
             return pageName.toLowerCase();
         }
+    }
+
+    private boolean canAccessDirect(String currentPage) {
+        return !formatPageName(currentPage).equalsIgnoreCase("directprime.xhtml") || 
+                DisplayHolder.getInstance().isDirectEnabled();
     }
 
 }

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/ApplicationBean.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/ApplicationBean.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2009-2014, United States Government, as represented by the Secretary of Health and Human Services. All
+ * rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met: Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or other materials provided with the
+ * distribution. Neither the name of the United States Government nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package gov.hhs.fha.nhinc.admingui.managed;
+
+import gov.hhs.fha.nhinc.admingui.display.DisplayHolder;
+import javax.faces.bean.ApplicationScoped;
+import javax.faces.bean.ManagedBean;
+
+/**
+ *
+ * @author jsmith
+ */
+@ManagedBean(name = "applicationBean")
+@ApplicationScoped
+public class ApplicationBean {
+    
+   public boolean isDirectEnabled(){
+        return DisplayHolder.getInstance().isDirectEnabled();
+    }
+
+}

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/LoginBean.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/LoginBean.java
@@ -27,6 +27,7 @@
 package gov.hhs.fha.nhinc.admingui.managed;
 
 import gov.hhs.fha.nhinc.admingui.constant.NavigationConstant;
+import gov.hhs.fha.nhinc.admingui.display.DirectDisplayController;
 import gov.hhs.fha.nhinc.admingui.jee.jsf.UserAuthorizationListener;
 import gov.hhs.fha.nhinc.admingui.model.Login;
 import gov.hhs.fha.nhinc.admingui.services.LoginService;
@@ -63,6 +64,8 @@ public class LoginBean {
 
     /** The is correct. */
     public Boolean isCorrect = false;
+    
+    private static boolean firstTimeLogged = true; 
 
     /** The login service. */
     @Autowired
@@ -159,10 +162,20 @@ public class LoginBean {
                 FacesContext facesContext = FacesContext.getCurrentInstance();
                 HttpSession session = (HttpSession) facesContext.getExternalContext().getSession(false);
                 session.setAttribute(UserAuthorizationListener.USER_INFO_SESSION_ATTRIBUTE, user);
+                checkDisplays();
             }
         } catch (UserLoginException e) {
             LOG.error(e, e);
         }
         return loggedIn;
     }
+    
+    private void checkDisplays() {
+        if(firstTimeLogged){
+            new DirectDisplayController().checkDirectDisplay();
+            // can add additional checks for enable / disable other displays in the future
+            firstTimeLogged = false;
+        }
+    }
+    
 }

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/ManageRoleBean.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/ManageRoleBean.java
@@ -26,6 +26,7 @@
  */
 package gov.hhs.fha.nhinc.admingui.managed;
 
+import gov.hhs.fha.nhinc.admingui.display.DisplayHolder;
 import static gov.hhs.fha.nhinc.admingui.jee.jsf.UserAuthorizationListener.USER_INFO_SESSION_ATTRIBUTE;
 import gov.hhs.fha.nhinc.admingui.services.RoleService;
 import gov.hhs.fha.nhinc.admingui.services.persistence.jpa.entity.RolePreference;
@@ -35,7 +36,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
-
 import javax.faces.application.FacesMessage;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.RequestScoped;
@@ -76,34 +76,34 @@ public class ManageRoleBean {
      */
     public void accessLevelChanged(final AjaxBehaviorEvent event) {
         RolePreference preference = pagesModel.getRowData().getPreference();
-        
+
         int prefAccess = -1;
         String selectedAccess = pagesModel.getRowData().getSelectedAccessLevel();
-        
-        if(selectedAccess.equals(PageAccessMapping.NO_ACCESS)){
+
+        if (selectedAccess.equals(PageAccessMapping.NO_ACCESS)) {
             prefAccess = -1;
-        }else if(selectedAccess.equals(PageAccessMapping.READ_ONLY)){
+        } else if (selectedAccess.equals(PageAccessMapping.READ_ONLY)) {
             prefAccess = 0;
-        }else if(selectedAccess.equals(PageAccessMapping.READ_WRITE)){
+        } else if (selectedAccess.equals(PageAccessMapping.READ_WRITE)) {
             prefAccess = 1;
         }
-        
+
         preference.setAccess(prefAccess);
-        
+
         boolean updated = roleService.updatePreference(preference);
-        
-        if(updated){
+
+        if (updated) {
             UserRole userRole = getCurrentUser().getUserRole();
-            if(preference.getUserRole().getRoleName().equals(userRole.getRoleName())){
-                for(RolePreference currPref : userRole.getPreferences()){
-                    if(currPref.getPageName().equals(preference.getPageName())){
+            if (preference.getUserRole().getRoleName().equals(userRole.getRoleName())) {
+                for (RolePreference currPref : userRole.getPreferences()) {
+                    if (currPref.getPageName().equals(preference.getPageName())) {
                         currPref.setAccess(prefAccess);
                         break;
                     }
                 }
             }
             FacesContext.getCurrentInstance().addMessage(null,
-                new FacesMessage(FacesMessage.SEVERITY_INFO, "INFO", "Access Level Changed."));
+                    new FacesMessage(FacesMessage.SEVERITY_INFO, "INFO", "Access Level Changed."));
         }
     }
 
@@ -156,6 +156,10 @@ public class ManageRoleBean {
         List<RolePreference> preferences = roleService.getPreferences(role);
         List<PageAccessMapping> mappings = new ArrayList<PageAccessMapping>();
         for (RolePreference preference : preferences) {
+            if (!DisplayHolder.getInstance().isDirectEnabled()
+                    && preference.getPageName().toLowerCase().contains("direct")) {
+                continue;
+            }
             mappings.add(new PageAccessMapping(preference, this));
         }
         pagesModel = new ListDataModel<PageAccessMapping>(mappings);

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/direct/DirectDomainBean.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/direct/DirectDomainBean.java
@@ -29,9 +29,11 @@ import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import javax.faces.application.FacesMessage;
 
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
+import javax.faces.context.FacesContext;
 
 import org.nhind.config.AddAnchor;
 import org.nhind.config.AddDomain;
@@ -100,10 +102,15 @@ public class DirectDomainBean {
     }
 
     public void deleteDomain() {
-        directService.disassociateTrustBundlesFromDomain(selectedDomain.getId());
-        directService.deleteDomain(selectedDomain);
+        if(domains.size() > 1){
+            directService.disassociateTrustBundlesFromDomain(selectedDomain.getId());
+            directService.deleteDomain(selectedDomain);
+            refreshDomains();
+        }else {
+            FacesContext.getCurrentInstance().addMessage("domainDeleteError",
+                new FacesMessage(FacesMessage.SEVERITY_ERROR, "ERROR", "Delete Denied. Must always have one active domain."));
+        }
         selectedDomain = null;
-        refreshDomains();
     }
 
     public void addDomain() {

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/proxy/DirectConfigConstants.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/proxy/DirectConfigConstants.java
@@ -26,39 +26,39 @@ package gov.hhs.fha.nhinc.admingui.proxy;
  */
 public class DirectConfigConstants {
 
-    static final String DIRECT_CONFIG_SERVICE_NAME = "directconfig";
+    public static final String DIRECT_CONFIG_SERVICE_NAME = "directconfig";
 
-    static final String DIRECT_CONFIG_GET_DOMAIN = "getDomain";
-    static final String DIRECT_CONFIG_ADD_DOMAIN = "addDomain";
-    static final String DIRECT_CONFIG_LIST_DOMAINS = "listDomains";
-    static final String DIRECT_CONFIG_UPDATE_DOMAIN = "updateDomain";
-    static final String DIRECT_CONFIG_DELETE_DOMAIN = "removeDomain";
+    public static final String DIRECT_CONFIG_GET_DOMAIN = "getDomain";
+    public static final String DIRECT_CONFIG_ADD_DOMAIN = "addDomain";
+    public static final String DIRECT_CONFIG_LIST_DOMAINS = "listDomains";
+    public static final String DIRECT_CONFIG_UPDATE_DOMAIN = "updateDomain";
+    public static final String DIRECT_CONFIG_DELETE_DOMAIN = "removeDomain";
 
-    static final String DIRECT_CONFIG_ADD_ANCHOR = "addAnchor";
-    static final String DIRECT_CONFIG_DELETE_ANCHOR = "removeAnchors";
-    static final String DIRECT_CONFIG_GET_ANCHORS_FOR_OWNER = "getAnchorsForOwner";
+    public static final String DIRECT_CONFIG_ADD_ANCHOR = "addAnchor";
+    public static final String DIRECT_CONFIG_DELETE_ANCHOR = "removeAnchors";
+    public static final String DIRECT_CONFIG_GET_ANCHORS_FOR_OWNER = "getAnchorsForOwner";
 
-    static final String DIRECT_CONFIG_DELETE_ADDRESS = "removeAddress";
+    public static final String DIRECT_CONFIG_DELETE_ADDRESS = "removeAddress";
 
-    static final String DIRECT_CONFIG_ADD_SETTING = "addSetting";
-    static final String DIRECT_CONFIG_DELETE_SETTING = "deleteSetting";
-    static final String DIRECT_CONFIG_LIST_SETTINGS = "getAllSettings";
+    public static final String DIRECT_CONFIG_ADD_SETTING = "addSetting";
+    public static final String DIRECT_CONFIG_DELETE_SETTING = "deleteSetting";
+    public static final String DIRECT_CONFIG_LIST_SETTINGS = "getAllSettings";
 
-    static final String DIRECT_CONFIG_ADD_CERT = "addCertificates";
-    static final String DIRECT_CONFIG_DELETE_CERT = "removeCertificates";
-    static final String DIRECT_CONFIG_GET_CERTS_FOR_OWNER = "getCertificatesForOwner";
-    static final String DIRECT_CONFIG_LIST_CERTS = "listCertificates";
+    public static final String DIRECT_CONFIG_ADD_CERT = "addCertificates";
+    public static final String DIRECT_CONFIG_DELETE_CERT = "removeCertificates";
+    public static final String DIRECT_CONFIG_GET_CERTS_FOR_OWNER = "getCertificatesForOwner";
+    public static final String DIRECT_CONFIG_LIST_CERTS = "listCertificates";
 
-    static final String DIRECT_CONFIG_ADD_TRUST_BUNDLE = "addTrustBundle";
-    static final String DIRECT_CONFIG_DELETE_TRUST_BUNDLE = "deleteTrustBundles";
-    static final String DIRECT_CONFIG_GET_TRUST_BUNDLES = "getTrustBundles";
-    static final String DIRECT_CONFIG_GET_TRUST_BUNDLE_BY_NAME = "getTrustBundleByName";
-    static final String DIRECT_CONFIG_GET_TRUST_BUNDLES_BY_DOMAIN = "getTrustBundlesByDomain";
-    static final String DIRECT_CONFIG_ASSOCIATE_TRUST_BUNDLE_TO_DOMAIN = "associateTrustBundleToDomain";
-    static final String DIRECT_CONFIG_DISASSOCIATE_TRUST_BUNDLE_FROM_DOMAIN = "disassociateTrustBundleFromDomain";
-    static final String DIRECT_CONFIG_DISASSOCIATE_TRUST_BUNDLE_FROM_DOMAINS = "disassociateTrustBundleFromDomains";
-    static final String DIRECT_CONFIG_DISASSOCIATE_TRUST_BUNDLES_FROM_DOMAIN = "disassociateTrustBundlesFromDomain";
-    static final String DIRECT_CONFIG_UPDATE_TRUST_BUNDLE_ATTRIBUTES = "updateTrustBundleAttributes";
-    static final String DIRECT_CONFIG_REFRESH_TRUST_BUNDLE = "refreshTrustBundle";
-    static final String DIRECT_CONFIG_REMOVE_ADDRESS = "removeAddress";
+    public static final String DIRECT_CONFIG_ADD_TRUST_BUNDLE = "addTrustBundle";
+    public static final String DIRECT_CONFIG_DELETE_TRUST_BUNDLE = "deleteTrustBundles";
+    public static final String DIRECT_CONFIG_GET_TRUST_BUNDLES = "getTrustBundles";
+    public static final String DIRECT_CONFIG_GET_TRUST_BUNDLE_BY_NAME = "getTrustBundleByName";
+    public static final String DIRECT_CONFIG_GET_TRUST_BUNDLES_BY_DOMAIN = "getTrustBundlesByDomain";
+    public static final String DIRECT_CONFIG_ASSOCIATE_TRUST_BUNDLE_TO_DOMAIN = "associateTrustBundleToDomain";
+    public static final String DIRECT_CONFIG_DISASSOCIATE_TRUST_BUNDLE_FROM_DOMAIN = "disassociateTrustBundleFromDomain";
+    public static final String DIRECT_CONFIG_DISASSOCIATE_TRUST_BUNDLE_FROM_DOMAINS = "disassociateTrustBundleFromDomains";
+    public static final String DIRECT_CONFIG_DISASSOCIATE_TRUST_BUNDLES_FROM_DOMAIN = "disassociateTrustBundlesFromDomain";
+    public static final String DIRECT_CONFIG_UPDATE_TRUST_BUNDLE_ATTRIBUTES = "updateTrustBundleAttributes";
+    public static final String DIRECT_CONFIG_REFRESH_TRUST_BUNDLE = "refreshTrustBundle";
+    public static final String DIRECT_CONFIG_REMOVE_ADDRESS = "removeAddress";
 }

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/directPrime.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/directPrime.xhtml
@@ -78,6 +78,7 @@
                                         </p:column>
                                     </p:row>
                                 </p:panelGrid>
+                                <p:messages id="domainDeleteError" globalOnly="false" showDetail="true" autoUpdate="true" closable="true" />
                             </h:form>
                         </div>
                     </div>

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/SidebarPaneForBaseTemplatePrime.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/SidebarPaneForBaseTemplatePrime.xhtml
@@ -45,7 +45,7 @@
                         <p:menuitem value="Performance Statistics" action="#{tabBean.setDashboardTabIndexNavigate(1)}" styleClass="glyphicon glyphicon-stats" />
                         <p:menuitem value="Remote Gateway List" action="#{tabBean.setDashboardTabIndexNavigate(2)}" styleClass="glyphicon glyphicon-list" />
                     </p:submenu>
-                    <p:submenu label="Direct Configuration" styleClass="sidebar-purple">
+                    <p:submenu rendered="#{applicationBean.isDirectEnabled()}" label="Direct Configuration" styleClass="sidebar-purple">
                         <p:menuitem value="Domains" action="#{tabBean.setDirectTabIndexNavigate(0)}" styleClass="glyphicon glyphicon-globe" />
                         <p:menuitem value="Agent Settings" action="#{tabBean.setDirectTabIndexNavigate(1)}" styleClass="glyphicon glyphicon-cog" />
                         <p:menuitem value="Certificates" action="#{tabBean.setDirectTabIndexNavigate(2)}" styleClass="glyphicon glyphicon-list-alt" />


### PR DESCRIPTION
Configured AdminGui to not display direct if not connected to the DirectConfig.

Logic:  Doesn't show direct views if configDir url not found and if lookup on domains is unsuccessful (either by not returning any or by exception).

Includes:
- Does not render view for left menu bar for direct.
- Does not display direct page preferences for role admin.
- Can not directly navigate to direct page by entering in url.
- Also, no longer allows user to delete domain, if there is only 1 domain remaining (needs 1 active domain).
