### PR TITLE
Conn 1390:Fix for not allowing to add duplicate domain

### DIFF
--- a/Product/DBScripts/configdb/configdb.sql
+++ b/Product/DBScripts/configdb/configdb.sql
@@ -8,7 +8,7 @@ CREATE DATABASE configdb;
 CREATE TABLE IF NOT EXISTS configdb.domain (
     id SERIAL PRIMARY KEY,
     postmasterAddressId BIGINT,
-    domainName VARCHAR(255) NOT NULL,
+    domainName VARCHAR(255) NOT NULL UNIQUE,
     status INTEGER DEFAULT 0,
     createTime DATETIME NOT NULL,
     updateTime DATETIME

--- a/Product/DBScripts/nhincdb/nhincdb.sql
+++ b/Product/DBScripts/nhincdb/nhincdb.sql
@@ -48,7 +48,7 @@ CREATE DATABASE configdb;
 CREATE TABLE IF NOT EXISTS configdb.domain (
     id SERIAL PRIMARY KEY,
     postmasterAddressId BIGINT,
-    domainName VARCHAR(255) NOT NULL,
+    domainName VARCHAR(255) NOT NULL UNIQUE,
     status INTEGER DEFAULT 0,
     createTime DATETIME NOT NULL,
     updateTime DATETIME

--- a/Product/DBScripts/nhincdb/nhincdb_oracle.sql
+++ b/Product/DBScripts/nhincdb/nhincdb_oracle.sql
@@ -386,3 +386,7 @@
     (ID, SALT, SHA1, USERNAME)
   VALUES
     (1, "ABCD", "TxMu4SPUdek0XU5NovS9U2llt3Q=", "CONNECTAdmin");
+--------------------------------------------------------
+--  Constraints for Table DOMAIN
+--------------------------------------------------------
+  ALTER TABLE "NHINCUSER"."DOMAIN" ADD CONSTRAINT DOMAIN UNIQUE (DOMAINNAME) ENABLE;

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/direct/DirectDomainBean.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/direct/DirectDomainBean.java
@@ -30,7 +30,7 @@ import gov.hhs.fha.nhinc.admingui.managed.direct.helpers.CertContainer;
 import gov.hhs.fha.nhinc.admingui.model.direct.DirectAnchor;
 import gov.hhs.fha.nhinc.admingui.model.direct.DirectTrustBundle;
 import gov.hhs.fha.nhinc.admingui.services.DirectService;
-import gov.hhs.fha.nhinc.admingui.services.exception.CreateDomainException;
+import gov.hhs.fha.nhinc.admingui.services.exception.DomainException;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import java.util.ArrayList;
 import java.util.List;
@@ -142,7 +142,7 @@ public class DirectDomainBean {
         try {
             directService.addDomain(addDomain);
             refreshDomains();
-        } catch (CreateDomainException domainException) {
+        } catch (DomainException domainException) {
             FacesContext.getCurrentInstance().validationFailed();
             FacesContext.getCurrentInstance().addMessage("domainAddErrors",
                 new FacesMessage(FacesMessage.SEVERITY_ERROR, "Can not add domain: " + domainException.getLocalizedMessage(), ""));
@@ -174,7 +174,7 @@ public class DirectDomainBean {
             directService.updateDomain(updateDomain);
             selectedDomain = null;
             refreshDomains();
-        } catch (CreateDomainException domainException) {
+        } catch (DomainException domainException) {
             FacesContext.getCurrentInstance().validationFailed();
             FacesContext.getCurrentInstance().addMessage("domainEditErrors",
                 new FacesMessage(FacesMessage.SEVERITY_ERROR, "Can not update domain: " + domainException.getLocalizedMessage(), ""));
@@ -211,7 +211,7 @@ public class DirectDomainBean {
             updateDomain.setDomain(selectedDomain);
             try {
                 directService.updateDomain(updateDomain);
-            } catch (CreateDomainException domainException) {
+            } catch (DomainException domainException) {
                 LOG.error("Error updating to domain: " + domainException.getMessage());
             }
         }

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/direct/DirectDomainBean.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/direct/DirectDomainBean.java
@@ -1,22 +1,28 @@
-/**
- * Copyright (c) 2009-2014, United States Government, as represented by the Secretary of Health and Human Services. All
- * rights reserved.
+/*
+ *  Copyright (c) 2009-2014, United States Government, as represented by the Secretary of Health and Human Services.
+ *  All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
- * following conditions are met: Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation and/or other materials provided with the
- * distribution. Neither the name of the United States Government nor the names of its contributors may be used to
- * endorse or promote products derived from this software without specific prior written permission.
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *      * Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following disclaimer.
+ *      * Redistributions in binary form must reproduce the above copyright
+ *        notice, this list of conditions and the following disclaimer in the documentation
+ *        and/or other materials provided with the distribution.
+ *      * Neither the name of the United States Government nor the
+ *        names of its contributors may be used to endorse or promote products
+ *        derived from this software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ *  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package gov.hhs.fha.nhinc.admingui.managed.direct;
 
@@ -27,9 +33,7 @@ import gov.hhs.fha.nhinc.admingui.services.DirectService;
 import gov.hhs.fha.nhinc.admingui.services.exception.CreateDomainException;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
 import javax.faces.application.FacesMessage;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/proxy/DirectConfigProxy.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/proxy/DirectConfigProxy.java
@@ -20,7 +20,7 @@
  */
 package gov.hhs.fha.nhinc.admingui.proxy;
 
-import gov.hhs.fha.nhinc.admingui.services.exception.CreateDomainException;
+import gov.hhs.fha.nhinc.admingui.services.exception.DomainException;
 import java.util.List;
 import org.nhind.config.AddAnchor;
 import org.nhind.config.AddCertificates;
@@ -58,9 +58,9 @@ public interface DirectConfigProxy {
      *
      * @param domain
      * @throws Exception
-     * @throws CreateDomainException
+     * @throws DomainException
      */
-    public void addDomain(AddDomain domain) throws CreateDomainException;
+    public void addDomain(AddDomain domain) throws DomainException;
 
     /**
      * Direct Config proxy call to get all direct domains.
@@ -76,9 +76,9 @@ public interface DirectConfigProxy {
      * @param updateDomain
      * @return
      * @throws Exception
-     * @throws CreateDomainException
+     * @throws DomainException
      */
-    public UpdateDomainResponse updateDomain(UpdateDomain updateDomain) throws CreateDomainException;
+    public UpdateDomainResponse updateDomain(UpdateDomain updateDomain) throws DomainException;
 
     /**
      * Direct Config proxy call to delete direct domain with given name.

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/proxy/DirectConfigProxy.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/proxy/DirectConfigProxy.java
@@ -20,6 +20,7 @@
  */
 package gov.hhs.fha.nhinc.admingui.proxy;
 
+import gov.hhs.fha.nhinc.admingui.services.exception.CreateDomainException;
 import java.util.List;
 import org.nhind.config.AddAnchor;
 import org.nhind.config.AddCertificates;
@@ -45,6 +46,7 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to get direct domain with given ID.
+     *
      * @param id
      * @return
      * @throws Exception
@@ -53,13 +55,16 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to add given direct domain.
+     *
      * @param domain
      * @throws Exception
+     * @throws CreateDomainException
      */
-    public void addDomain(AddDomain domain) throws Exception;
+    public void addDomain(AddDomain domain) throws CreateDomainException;
 
     /**
      * Direct Config proxy call to get all direct domains.
+     *
      * @return
      * @throws Exception
      */
@@ -67,14 +72,17 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to update given direct domain.
+     *
      * @param updateDomain
      * @return
      * @throws Exception
+     * @throws CreateDomainException
      */
-    public UpdateDomainResponse updateDomain(UpdateDomain updateDomain) throws Exception;
+    public UpdateDomainResponse updateDomain(UpdateDomain updateDomain) throws CreateDomainException;
 
     /**
      * Direct Config proxy call to delete direct domain with given name.
+     *
      * @param name
      * @throws Exception
      */
@@ -82,6 +90,7 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to add given direct anchor.
+     *
      * @param addAnchor
      * @throws Exception
      */
@@ -89,6 +98,7 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to delete given anchors.
+     *
      * @param removeAnchors
      * @throws Exception
      */
@@ -96,6 +106,7 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to get direct anchors for given owner.
+     *
      * @param getAnchorsForOwner
      * @return
      * @throws Exception
@@ -104,6 +115,7 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to add a direct setting with given key value pair.
+     *
      * @param name
      * @param Value
      * @throws Exception
@@ -112,6 +124,7 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to get all direct settings.
+     *
      * @return
      * @throws Exception
      */
@@ -119,6 +132,7 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to delete all direct settings with given names.
+     *
      * @param deleteNames
      * @throws Exception
      */
@@ -126,6 +140,7 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to add given direct certificates.
+     *
      * @param certificate
      * @throws Exception
      */
@@ -133,6 +148,7 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to remove given direct certificate.
+     *
      * @param cert
      * @throws Exception
      */
@@ -140,6 +156,7 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to get all direct certificates from given criteria.
+     *
      * @param listCert
      * @return
      * @throws Exception
@@ -148,6 +165,7 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to get all direct trust bundles with option of including anchors.
+     *
      * @param fetchAnchors
      * @return
      * @throws Exception
@@ -156,6 +174,7 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to get all direct trust bundles for given domain with the option of including anchors.
+     *
      * @param domainId
      * @param fetchAnchors
      * @return
@@ -165,6 +184,7 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to get a direct trust bundle with the given name.
+     *
      * @param bundleName
      * @return
      * @throws Exception
@@ -173,6 +193,7 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to add the given direct trust bundle.
+     *
      * @param b
      * @throws Exception
      */
@@ -180,6 +201,7 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to associate a direct trust bundle with a direct domain.
+     *
      * @param domainId
      * @param trustBundleId
      * @param incoming
@@ -190,14 +212,16 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to delete direct trust bundles with the given IDs.
+     *
      * @param ids
      * @throws Exception
      */
     public void deleteTrustBundles(List<Long> ids) throws Exception;
 
     /**
-     * Direct Config proxy call to disassociate the direct trust bundle with the given ID from
-     * the direct domain with the other given ID.
+     * Direct Config proxy call to disassociate the direct trust bundle with the given ID from the direct domain with
+     * the other given ID.
+     *
      * @param domainId
      * @param trustBundleId
      * @throws Exception
@@ -206,6 +230,7 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to disassociate the direct trust bundle with the given ID from all domains.
+     *
      * @param trustBundleId
      * @throws Exception
      */
@@ -213,6 +238,7 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to disassociate all direct trust bundles from the domain with the given ID.
+     *
      * @param domainId
      * @throws Exception
      */
@@ -220,6 +246,7 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to refresh the given direct trust bundle.
+     *
      * @param id
      * @throws Exception
      */
@@ -227,6 +254,7 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to update a direct trust bundle with the given parameters.
+     *
      * @param trustBundleId
      * @param trustBundleName
      * @param trustBundleURL
@@ -239,6 +267,7 @@ public interface DirectConfigProxy {
 
     /**
      * Direct Config proxy call to delete a direct domain address.
+     *
      * @param addressEmail
      * @throws Exception
      */

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/proxy/DirectConfigProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/proxy/DirectConfigProxyWebServiceUnsecuredImpl.java
@@ -21,6 +21,7 @@
 package gov.hhs.fha.nhinc.admingui.proxy;
 
 import gov.hhs.fha.nhinc.admingui.proxy.service.DirectConfigUnsecuredServicePortDescriptor;
+import gov.hhs.fha.nhinc.admingui.services.exception.CreateDomainException;
 import gov.hhs.fha.nhinc.messaging.client.CONNECTCXFClientFactory;
 import gov.hhs.fha.nhinc.messaging.client.CONNECTClient;
 import gov.hhs.fha.nhinc.messaging.service.port.ServicePortDescriptor;
@@ -59,7 +60,7 @@ public class DirectConfigProxyWebServiceUnsecuredImpl implements DirectConfigPro
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#getDomain(int)
      */
     @Override
@@ -69,39 +70,47 @@ public class DirectConfigProxyWebServiceUnsecuredImpl implements DirectConfigPro
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#addDomain(org.nhind.config.AddDomain)
      */
     @Override
-    public void addDomain(AddDomain domain) throws Exception {
-        getClient().invokePort(directConfigClazz, DirectConfigConstants.DIRECT_CONFIG_ADD_DOMAIN, domain);
+    public void addDomain(AddDomain domain) throws CreateDomainException {
+        try {
+            getClient().invokePort(directConfigClazz, DirectConfigConstants.DIRECT_CONFIG_ADD_DOMAIN, domain);
+        } catch (Exception e) {
+            throw new CreateDomainException("Could not create new domain " + domain.getDomain().getDomainName(), e);
+        }
     }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#listDomains()
      */
     @Override
     public List<Domain> listDomains() throws Exception {
         return (List<Domain>) getClient().invokePort(directConfigClazz,
-                DirectConfigConstants.DIRECT_CONFIG_LIST_DOMAINS, null, 0);
+            DirectConfigConstants.DIRECT_CONFIG_LIST_DOMAINS, null, 0);
     }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#updateDomain(org.nhind.config.UpdateDomain)
      */
     @Override
-    public UpdateDomainResponse updateDomain(UpdateDomain updateDomain) throws Exception {
-        return (UpdateDomainResponse) getClient().invokePort(directConfigClazz,
+    public UpdateDomainResponse updateDomain(UpdateDomain updateDomain) throws CreateDomainException {
+        try {
+            return (UpdateDomainResponse) getClient().invokePort(directConfigClazz,
                 DirectConfigConstants.DIRECT_CONFIG_UPDATE_DOMAIN, updateDomain);
+        } catch (Exception e) {
+            throw new CreateDomainException("Could not update domain " + updateDomain.getDomain().getDomainName(), e);
+        }
     }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#deleteDomain(String)
      */
     @Override
@@ -111,7 +120,7 @@ public class DirectConfigProxyWebServiceUnsecuredImpl implements DirectConfigPro
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#addAnchor(org.nhind.config.AddAnchor)
      */
     @Override
@@ -122,7 +131,7 @@ public class DirectConfigProxyWebServiceUnsecuredImpl implements DirectConfigPro
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#removeAnchors(org.nhind.config.RemoveAnchors)
      */
     @Override
@@ -133,7 +142,7 @@ public class DirectConfigProxyWebServiceUnsecuredImpl implements DirectConfigPro
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#getAnchorsForOwner(org.nhind.config.GetAnchorsForOwner)
      */
     @Override
@@ -145,7 +154,7 @@ public class DirectConfigProxyWebServiceUnsecuredImpl implements DirectConfigPro
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#addCertificates(org.nhind.config.AddCertificates)
      */
     @Override
@@ -156,31 +165,31 @@ public class DirectConfigProxyWebServiceUnsecuredImpl implements DirectConfigPro
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#removeCertificate(org.nhind.config.RemoveCertificates)
      */
     @Override
     public void removeCertificate(RemoveCertificates certificate) throws Exception {
         getClient().invokePort(directConfigClazz, DirectConfigConstants.DIRECT_CONFIG_DELETE_CERT,
-                certificate.getCertificateIds());
+            certificate.getCertificateIds());
 
     }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#listCertificates(org.nhind.config.ListCertificates)
      */
     @Override
     public List<Certificate> listCertificates(ListCertificates listCert) throws Exception {
         return (List<Certificate>) getClient().invokePort(directConfigClazz,
-                DirectConfigConstants.DIRECT_CONFIG_LIST_CERTS, listCert.getLastCertificateId(),
-                listCert.getMaxResutls(), listCert.getOptions());
+            DirectConfigConstants.DIRECT_CONFIG_LIST_CERTS, listCert.getLastCertificateId(),
+            listCert.getMaxResutls(), listCert.getOptions());
     }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#addSetting(String, String)
      */
     @Override
@@ -190,7 +199,7 @@ public class DirectConfigProxyWebServiceUnsecuredImpl implements DirectConfigPro
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#getSetting()
      */
     @Override
@@ -201,7 +210,7 @@ public class DirectConfigProxyWebServiceUnsecuredImpl implements DirectConfigPro
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#deleteSetting(List<String>)
      */
     @Override
@@ -211,7 +220,7 @@ public class DirectConfigProxyWebServiceUnsecuredImpl implements DirectConfigPro
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#addTrustBundle(org.nhind.config.TrustBundle)
      */
     @Override
@@ -232,7 +241,7 @@ public class DirectConfigProxyWebServiceUnsecuredImpl implements DirectConfigPro
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#getTrustBundleByName(String)
      */
     @Override
@@ -242,7 +251,7 @@ public class DirectConfigProxyWebServiceUnsecuredImpl implements DirectConfigPro
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#getTrustBundleByDomain(long, boolean)
      */
     @Override
@@ -252,7 +261,7 @@ public class DirectConfigProxyWebServiceUnsecuredImpl implements DirectConfigPro
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#associateTrustBundleToDomain(long, long, boolean, boolean)
      */
     @Override
@@ -262,7 +271,7 @@ public class DirectConfigProxyWebServiceUnsecuredImpl implements DirectConfigPro
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#updateTrustBundleAttributes(long, String, String, org.nhind.config.Certificate, int)
      */
     @Override
@@ -275,7 +284,7 @@ public class DirectConfigProxyWebServiceUnsecuredImpl implements DirectConfigPro
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#refreshTrustBundle(int)
      */
     @Override
@@ -285,7 +294,7 @@ public class DirectConfigProxyWebServiceUnsecuredImpl implements DirectConfigPro
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#disassociateTrustBundleFromDomain(long, long)
      */
     @Override
@@ -295,7 +304,7 @@ public class DirectConfigProxyWebServiceUnsecuredImpl implements DirectConfigPro
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#disassociateTrustBundleFromDomains(long)
      */
     @Override
@@ -305,7 +314,7 @@ public class DirectConfigProxyWebServiceUnsecuredImpl implements DirectConfigPro
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#disassociateTrustBundlesFromDomain(long)
      */
     @Override
@@ -322,26 +331,26 @@ public class DirectConfigProxyWebServiceUnsecuredImpl implements DirectConfigPro
     public void deleteTrustBundles(List<Long> ids) throws Exception {
         getClient().invokePort(directConfigClazz, DirectConfigConstants.DIRECT_CONFIG_DELETE_TRUST_BUNDLE, ids);
     }
-    
+
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#removeAddress(String)
      */
     @Override
-    public void removeAddress(String addressEmail) throws Exception{
+    public void removeAddress(String addressEmail) throws Exception {
         getClient().invokePort(directConfigClazz, DirectConfigConstants.DIRECT_CONFIG_REMOVE_ADDRESS, addressEmail);
     }
-    
+
     private CONNECTClient<ConfigurationService> getClient() throws Exception {
 
         String url = oProxyHelper
-                .getAdapterEndPointFromConnectionManager(DirectConfigConstants.DIRECT_CONFIG_SERVICE_NAME);
+            .getAdapterEndPointFromConnectionManager(DirectConfigConstants.DIRECT_CONFIG_SERVICE_NAME);
 
         ServicePortDescriptor<ConfigurationService> portDescriptor = new DirectConfigUnsecuredServicePortDescriptor();
 
         CONNECTClient<ConfigurationService> client = CONNECTCXFClientFactory.getInstance().getCONNECTClientUnsecured(
-                portDescriptor, url, null);
+            portDescriptor, url, null);
 
         return client;
     }

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/proxy/DirectConfigProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/proxy/DirectConfigProxyWebServiceUnsecuredImpl.java
@@ -21,7 +21,7 @@
 package gov.hhs.fha.nhinc.admingui.proxy;
 
 import gov.hhs.fha.nhinc.admingui.proxy.service.DirectConfigUnsecuredServicePortDescriptor;
-import gov.hhs.fha.nhinc.admingui.services.exception.CreateDomainException;
+import gov.hhs.fha.nhinc.admingui.services.exception.DomainException;
 import gov.hhs.fha.nhinc.messaging.client.CONNECTCXFClientFactory;
 import gov.hhs.fha.nhinc.messaging.client.CONNECTClient;
 import gov.hhs.fha.nhinc.messaging.service.port.ServicePortDescriptor;
@@ -74,11 +74,11 @@ public class DirectConfigProxyWebServiceUnsecuredImpl implements DirectConfigPro
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#addDomain(org.nhind.config.AddDomain)
      */
     @Override
-    public void addDomain(AddDomain domain) throws CreateDomainException {
+    public void addDomain(AddDomain domain) throws DomainException {
         try {
             getClient().invokePort(directConfigClazz, DirectConfigConstants.DIRECT_CONFIG_ADD_DOMAIN, domain);
         } catch (Exception e) {
-            throw new CreateDomainException("Could not create new domain " + domain.getDomain().getDomainName(), e);
+            throw new DomainException("Could not create new domain " + domain.getDomain().getDomainName(), e);
         }
     }
 
@@ -99,12 +99,12 @@ public class DirectConfigProxyWebServiceUnsecuredImpl implements DirectConfigPro
      * @see gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy#updateDomain(org.nhind.config.UpdateDomain)
      */
     @Override
-    public UpdateDomainResponse updateDomain(UpdateDomain updateDomain) throws CreateDomainException {
+    public UpdateDomainResponse updateDomain(UpdateDomain updateDomain) throws DomainException {
         try {
             return (UpdateDomainResponse) getClient().invokePort(directConfigClazz,
                 DirectConfigConstants.DIRECT_CONFIG_UPDATE_DOMAIN, updateDomain);
         } catch (Exception e) {
-            throw new CreateDomainException("Could not update domain " + updateDomain.getDomain().getDomainName(), e);
+            throw new DomainException("Could not update domain " + updateDomain.getDomain().getDomainName(), e);
         }
     }
 

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/DirectService.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/DirectService.java
@@ -20,7 +20,7 @@
  */
 package gov.hhs.fha.nhinc.admingui.services;
 
-import gov.hhs.fha.nhinc.admingui.services.exception.CreateDomainException;
+import gov.hhs.fha.nhinc.admingui.services.exception.DomainException;
 import java.util.List;
 import org.nhind.config.AddAnchor;
 import org.nhind.config.AddCertificates;
@@ -54,16 +54,16 @@ public interface DirectService {
      * Update a direct domain.
      *
      * @param domain
-     * @throws CreateDomainException
+     * @throws DomainException
      */
-    public void updateDomain(UpdateDomain domain) throws CreateDomainException;
+    public void updateDomain(UpdateDomain domain) throws DomainException;
 
     /**
      *
      * @param domain
-     * @throws CreateDomainException
+     * @throws DomainException
      */
-    public void addDomain(AddDomain domain) throws CreateDomainException;
+    public void addDomain(AddDomain domain) throws DomainException;
 
     /**
      * Delete the provided direct domain.

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/DirectService.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/DirectService.java
@@ -20,6 +20,7 @@
  */
 package gov.hhs.fha.nhinc.admingui.services;
 
+import gov.hhs.fha.nhinc.admingui.services.exception.CreateDomainException;
 import java.util.List;
 import org.nhind.config.AddAnchor;
 import org.nhind.config.AddCertificates;
@@ -44,24 +45,29 @@ public interface DirectService {
 
     /**
      * Get a list of all direct domains.
+     *
      * @return
      */
     public List<Domain> getDomains();
 
     /**
      * Update a direct domain.
+     *
      * @param domain
+     * @throws CreateDomainException
      */
-    public void updateDomain(UpdateDomain domain);
+    public void updateDomain(UpdateDomain domain) throws CreateDomainException;
 
     /**
      *
      * @param domain
+     * @throws CreateDomainException
      */
-    public void addDomain(AddDomain domain);
+    public void addDomain(AddDomain domain) throws CreateDomainException;
 
     /**
      * Delete the provided direct domain.
+     *
      * @param domain
      */
     public void deleteDomain(Domain domain);
@@ -74,6 +80,7 @@ public interface DirectService {
 
     /**
      * Get all direct anchors for the given owner.
+     *
      * @param getAnchorsForOwner
      * @return
      */
@@ -81,18 +88,21 @@ public interface DirectService {
 
     /**
      * Delete the given list of direct anchors.
+     *
      * @param removeAnchors
      */
     public void deleteAnchor(RemoveAnchors removeAnchors);
 
     /**
      * Get all direct settings.
+     *
      * @return
      */
     public List<Setting> getSetting();
 
     /**
      * Add the given key value pair as a direct setting.
+     *
      * @param name
      * @param value
      * @throws Exception
@@ -101,24 +111,28 @@ public interface DirectService {
 
     /**
      * Delete the given direct settings with the given names.
+     *
      * @param deleteNames
      */
     public void deleteSetting(List<String> deleteNames);
 
     /**
      * Add the given direct certificates.
+     *
      * @param addcert
      */
     public void addCertificate(AddCertificates addcert);
 
     /**
      * Remove the given direct certificates.
+     *
      * @param removeCert
      */
     public void deleteCertificate(RemoveCertificates removeCert);
 
     /**
      * Get all direct certificates for the given certificate criteria.
+     *
      * @param listCert
      * @return
      */
@@ -126,6 +140,7 @@ public interface DirectService {
 
     /**
      * Get all direct trust bundles with the option of including anchors.
+     *
      * @param fetchAnchors
      * @return
      */
@@ -133,6 +148,7 @@ public interface DirectService {
 
     /**
      * Get direct trust bundle for the given name.
+     *
      * @param bundleName
      * @return
      */
@@ -140,6 +156,7 @@ public interface DirectService {
 
     /**
      * Get all direct trust bundles for the given domain with the option of including anchors.
+     *
      * @param domainId
      * @param fetchAnchors
      * @return
@@ -148,6 +165,7 @@ public interface DirectService {
 
     /**
      * Add the given direct trust bundle.
+     *
      * @param b
      */
     public void addTrustBundle(TrustBundle b);
@@ -160,6 +178,7 @@ public interface DirectService {
 
     /**
      * Update a direct trust bundle with the given fields.
+     *
      * @param trustBundleId
      * @param trustBundleName
      * @param trustBundleURL
@@ -171,12 +190,14 @@ public interface DirectService {
 
     /**
      * Refresh the given direct trust bundle by ID.
+     *
      * @param id
      */
     public void refreshTrustBundle(long id);
 
     /**
      * Associate the given direct trust bundle to the given direct domain.
+     *
      * @param domainId
      * @param trustBundleId
      * @param incoming
@@ -186,6 +207,7 @@ public interface DirectService {
 
     /**
      * Disassociate the given direct trust bundle to the given direct domain.
+     *
      * @param domainId
      * @param trustBundleId
      */
@@ -193,18 +215,21 @@ public interface DirectService {
 
     /**
      * Disassociate the given direct trust bundle to all domains.
+     *
      * @param trustBundleId
      */
     public void disassociateTrustBundleFromDomains(long trustBundleId);
 
     /**
      * Disassociate all direct trust bundles to the given domain.
+     *
      * @param domainId
      */
     public void disassociateTrustBundlesFromDomain(long domainId);
 
     /**
      * Delete given domain address.
+     *
      * @param addressEmail
      * @return
      */

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/exception/CreateDomainException.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/exception/CreateDomainException.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2009-2014, United States Government, as represented by the Secretary of Health and Human Services.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *      * Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following disclaimer.
+ *      * Redistributions in binary form must reproduce the above copyright
+ *        notice, this list of conditions and the following disclaimer in the documentation
+ *        and/or other materials provided with the distribution.
+ *      * Neither the name of the United States Government nor the
+ *        names of its contributors may be used to endorse or promote products
+ *        derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ *  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.admingui.services.exception;
+
+/**
+ *
+ * @author sadusumilli
+ */
+public class CreateDomainException extends Exception {
+
+    /**
+     * The Constant serialVersionUID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Instantiates a new create domain exception.
+     *
+     * @param message the message
+     * @param cause the cause
+     */
+    public CreateDomainException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/exception/DomainException.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/exception/DomainException.java
@@ -30,7 +30,7 @@ package gov.hhs.fha.nhinc.admingui.services.exception;
  *
  * @author sadusumilli
  */
-public class CreateDomainException extends Exception {
+public class DomainException extends Exception {
 
     /**
      * The Constant serialVersionUID.
@@ -43,7 +43,7 @@ public class CreateDomainException extends Exception {
      * @param message the message
      * @param cause the cause
      */
-    public CreateDomainException(String message, Throwable cause) {
+    public DomainException(String message, Throwable cause) {
         super(message, cause);
     }
 

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/impl/direct/DirectServiceImpl.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/impl/direct/DirectServiceImpl.java
@@ -22,7 +22,7 @@ package gov.hhs.fha.nhinc.admingui.services.impl.direct;
 
 import gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy;
 import gov.hhs.fha.nhinc.admingui.services.DirectService;
-import gov.hhs.fha.nhinc.admingui.services.exception.CreateDomainException;
+import gov.hhs.fha.nhinc.admingui.services.exception.DomainException;
 import java.util.List;
 import org.apache.log4j.Logger;
 import org.nhind.config.AddAnchor;
@@ -72,28 +72,28 @@ public class DirectServiceImpl implements DirectService {
     /**
      *
      * @param domain
-     * @throws CreateDomainException
+     * @throws DomainException
      */
     @Override
-    public void updateDomain(UpdateDomain domain) throws CreateDomainException {
+    public void updateDomain(UpdateDomain domain) throws DomainException {
         try {
             directProxy.updateDomain(domain);
         } catch (Exception ex) {
-            throw new CreateDomainException("Duplicate Domain: " + domain.getDomain().getDomainName(), ex);
+            throw new DomainException("Unable to update Domain: " + domain.getDomain().getDomainName(), ex);
         }
     }
 
     /**
      *
      * @param domain
-     * @throws CreateDomainException
+     * @throws DomainException
      */
     @Override
-    public void addDomain(AddDomain domain) throws CreateDomainException {
+    public void addDomain(AddDomain domain) throws DomainException {
         try {
             directProxy.addDomain(domain);
         } catch (Exception ex) {
-            throw new CreateDomainException("Duplicate Domain: " + domain.getDomain().getDomainName(), ex);
+            throw new DomainException("Unable to add new Domain: " + domain.getDomain().getDomainName(), ex);
         }
     }
 

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/impl/direct/DirectServiceImpl.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/impl/direct/DirectServiceImpl.java
@@ -22,6 +22,7 @@ package gov.hhs.fha.nhinc.admingui.services.impl.direct;
 
 import gov.hhs.fha.nhinc.admingui.proxy.DirectConfigProxy;
 import gov.hhs.fha.nhinc.admingui.services.DirectService;
+import gov.hhs.fha.nhinc.admingui.services.exception.CreateDomainException;
 import java.util.List;
 import org.apache.log4j.Logger;
 import org.nhind.config.AddAnchor;
@@ -71,26 +72,28 @@ public class DirectServiceImpl implements DirectService {
     /**
      *
      * @param domain
+     * @throws CreateDomainException
      */
     @Override
-    public void updateDomain(UpdateDomain domain) {
+    public void updateDomain(UpdateDomain domain) throws CreateDomainException {
         try {
             directProxy.updateDomain(domain);
         } catch (Exception ex) {
-            LOG.error("Unable to update domain: " + domain.getDomain().getDomainName(), ex);
+            throw new CreateDomainException("Duplicate Domain: " + domain.getDomain().getDomainName(), ex);
         }
     }
 
     /**
      *
      * @param domain
+     * @throws CreateDomainException
      */
     @Override
-    public void addDomain(AddDomain domain) {
+    public void addDomain(AddDomain domain) throws CreateDomainException {
         try {
             directProxy.addDomain(domain);
         } catch (Exception ex) {
-            LOG.error("Unable to add new domain: " + domain.getDomain().getDomainName(), ex);
+            throw new CreateDomainException("Duplicate Domain: " + domain.getDomain().getDomainName(), ex);
         }
     }
 
@@ -402,14 +405,14 @@ public class DirectServiceImpl implements DirectService {
             LOG.error("Unable to remove anchor", ex);
         }
     }
-    
+
     /**
      *
      * @param addressEmail
      * @return
      */
     @Override
-    public boolean removeAddress(String addressEmail){
+    public boolean removeAddress(String addressEmail) {
         boolean removed = true;
         try {
             directProxy.removeAddress(addressEmail);

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/domainCreateDialog.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/domainCreateDialog.xhtml
@@ -6,8 +6,9 @@
             <div class="content">
                 <h3>Add New Domain to HISP</h3>
                 <p class="instructions">Enter the requested information below to add a new domain to configure.</p>
-                <div class="form-block center-block">
-                    <h:form id="domainDlgForm" class="form form-horizontal">
+                <div class="form-block center-block">                    
+                    <h:form id="domainDlgForm" class="form form-horizontal" >
+                        <p:messages id="domainAddErrors" autoUpdate="true" closable="true" redisplay="false"/> 
                         <div class="form-group">
                             <h:outputLabel for="input-domain" class="col-sm-3 control-label" id="input-domainLbl" value="Domain Name:" />
                             <div class="col-sm-9">
@@ -19,12 +20,11 @@
                             <div class="col-sm-9">
                                 <p:inputText styleClass="form-control" id="input-email" maxlength="255" required="true" requiredMessage="Postmaster address required." value="#{directDomainBean.domainPostmaster}"/>
                             </div>
-                        </div>
-                        
+                        </div>                        
                         <div class="form-group">
                             <div class="col-sm-12">
                                 <div class="form-button-row">
-                                    <p:commandButton id="submit" ajax="true" styleClass="btn btn-primary" value="Submit" actionListener="#{directDomainBean.addDomain}" update=":tabview:domain-form" oncomplete="PF('domainDlg').hide()" />
+                                    <p:commandButton id="submit" ajax="true" styleClass="btn btn-primary" value="Submit" actionListener="#{directDomainBean.addDomain}" update=":tabview:domain-form,domainDlgForm" oncomplete="PF('domainDlg').hide()" />
                                 </div>
                             </div>
                         </div>

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/domainEditDialog.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/domainEditDialog.xhtml
@@ -10,6 +10,7 @@
                 <p:tabView id="domainEditTabview" effect="fade" effectDuration="normal" dynamic="true" activeIndex="0">
                     <p:tab title="Domain Name">
                         <h:form id="domainEditDlgForm" class="form form-horizontal">
+                            <p:messages id="domainEditErrors" autoUpdate="true" closable="true" redisplay="false"/> 
                             <div class="form-group">
                                 <h:outputLabel for="input-edit-domain" class="col-sm-3 control-label" id="input-edit-domainLbl" value="Domain Name:" />
                                 <div class="col-sm-9">


### PR DESCRIPTION
1. Added logic for not to allow adding / updating duplicate domains.Updated related DirectDomainBean.java and other related DAO's and Impl files.
2. Created CreateDomainException class to Instantiate new create domain exception.
3. Updated domaincreatedialog.xhtml, domaineditdialog.xhtml to fix dialogue window refresh issue.
4. Updated configdb.sql,nhincdb.sql and nhincdb_oracle.sql to add unique constraint on domain name in domain table.
