### PR TITLE
FHAC-20

### DIFF
--- a/Product/Production/Deploy/ear-dependencies/pom.xml
+++ b/Product/Production/Deploy/ear-dependencies/pom.xml
@@ -192,19 +192,6 @@
         removed from the WAR's WEB-INF/lib -->
         <dependency>
             <groupId>org.connectopensource</groupId>
-            <artifactId>DirectCore</artifactId>
-            <version>${project.parent.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.connectopensource</groupId>
-            <artifactId>Direct</artifactId>
-            <version>${project.parent.version}</version>
-            <type>war</type>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.connectopensource</groupId>
             <artifactId>CONNECTAdminGUI</artifactId>
             <version>${project.parent.version}</version>
             <type>war</type>

--- a/pom.xml
+++ b/pom.xml
@@ -19,11 +19,11 @@ By advancing the adoption of interoperable health IT systems and health informat
         <connection>scm:git:git@github.com:${git.username}/CONNECT.git</connection>
         <developerConnection>scm:git:git@github.com:${git.username}/CONNECT.git</developerConnection>
         <url>https://github.com/${git.username}/CONNECT</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
     <modules>
-    	<module>ThirdParty</module>
-    	<module>Product</module>
+        <module>ThirdParty</module>
+        <module>Product</module>
     </modules>
     <licenses>
         <license>
@@ -32,7 +32,7 @@ By advancing the adoption of interoperable health IT systems and health informat
         </license>
     </licenses>
     <prerequisites>
-       <maven>3.0.4</maven>
+        <maven>3.0.4</maven>
     </prerequisites>
     <distributionManagement>
         <site>
@@ -52,9 +52,9 @@ By advancing the adoption of interoperable health IT systems and health informat
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                <version>2.4</version>
-        </plugin>
-           <plugin>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
                     <version>2.5</version>
@@ -74,7 +74,7 @@ By advancing the adoption of interoperable health IT systems and health informat
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>2.4</version>
                 </plugin>
-                 <plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>2.2.1</version>
@@ -94,16 +94,22 @@ By advancing the adoption of interoperable health IT systems and health informat
                     <artifactId>maven-war-plugin</artifactId>
                     <version>2.3</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <!-- Skipping 1.2.7 due to CPEAnalyzer ClassCastException bug -->
+                    <version>1.2.6</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
             <plugin>
-             <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-release-plugin</artifactId>
-              <configuration>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
                     <pushChanges>false</pushChanges>
-              </configuration>
-          </plugin>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
@@ -163,8 +169,8 @@ By advancing the adoption of interoperable health IT systems and health informat
                             <groupId>org.codehaus.mojo</groupId>
                             <artifactId>findbugs-maven-plugin</artifactId>
                             <version>2.5.2</version>
-			    <configuration>
-			        <plugins>
+                            <configuration>
+                                <plugins>
                                     <plugin>
                                         <groupId>com.h3xstream.findsecbugs</groupId>
                                         <artifactId>plugin</artifactId>
@@ -172,6 +178,20 @@ By advancing the adoption of interoperable health IT systems and health informat
                                     </plugin>
                                 </plugins>
                             </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.owasp</groupId>
+                            <artifactId>dependency-check-maven</artifactId>
+                            <configuration>
+                                <aggregate>true</aggregate>
+                            </configuration>
+                            <reportSets>
+                                <reportSet>
+                                    <reports>
+                                        <report>check</report>
+                                    </reports>
+                                </reportSet>
+                            </reportSets>
                         </plugin>
                     </reportPlugins>
                 </configuration>


### PR DESCRIPTION
- Added OWASP Dependency Check plugin to POM
- Removed DirectCore dependencies from non-Direct profile due to reporting failure with fresh .m2 repository
