### PR TITLE
FHAC-64:Remove OWASP dependency issue jars

### DIFF
--- a/Product/Production/Adapters/General/CONNECTDirectConfig/pom.xml
+++ b/Product/Production/Adapters/General/CONNECTDirectConfig/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>General</artifactId>
@@ -87,7 +87,7 @@
                 </exclusion>
                 <exclusion>
                     <!-- exclude and use <artifactId>cglib-nodep</artifactId>
-                        to include the asm it needs in a private package space. -->
+                    to include the asm it needs in a private package space. -->
                     <groupId>cglib</groupId>
                     <artifactId>cglib</artifactId>
                 </exclusion>
@@ -117,7 +117,7 @@
 
         <dependency>
             <!-- Used to include the asm it needs in a private package
-                space. -->
+            space. -->
             <groupId>cglib</groupId>
             <artifactId>cglib-nodep</artifactId>
             <version>2.2</version>
@@ -197,6 +197,10 @@
                     <groupId>bouncycastle</groupId>
                     <artifactId>bcprov-jdk15</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.mail</groupId>
+                    <artifactId>mail</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -204,6 +208,12 @@
             <groupId>org.nhind</groupId>
             <artifactId>direct-common</artifactId>
             <version>1.2.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.mail</groupId>
+                    <artifactId>mail</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -264,6 +274,12 @@
             <groupId>org.apache.james</groupId>
             <artifactId>apache-mailet-base</artifactId>
             <version>1.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.mail</groupId>
+                    <artifactId>mail</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Testing -->

--- a/Product/Production/Services/DirectCore/pom.xml
+++ b/Product/Production/Services/DirectCore/pom.xml
@@ -18,11 +18,23 @@
             <groupId>org.nhind</groupId>
             <artifactId>gateway</artifactId>
             <version>3.0.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.mail</groupId>
+                    <artifactId>mail</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.nhind</groupId>
             <artifactId>xd-common</artifactId>
             <version>1.2-CONNECT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.mail</groupId>
+                    <artifactId>mail</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -47,20 +59,32 @@
                     <groupId>bouncycastle</groupId>
                     <artifactId>bcprov-jdk15</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.mail</groupId>
+                    <artifactId>mail</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.nhind</groupId>
             <artifactId>direct-common</artifactId>
             <version>1.2.1</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.mail</groupId>
+                    <artifactId>mail</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>mail</artifactId>
+            <version>1.4.4</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
             <groupId>org.connectopensource</groupId>

--- a/Product/pom.xml
+++ b/Product/pom.xml
@@ -53,6 +53,25 @@
                         <groupId>org.apache.santuario</groupId>
                         <artifactId>xmlsec</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.geronimo.specs</groupId>
+                        <artifactId>geronimo-jaxws_2.2_spec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.geronimo.specs</groupId>
+                        <artifactId>geronimo-javamail_1.4_spec</artifactId>
+
+                    </exclusion>
+
+                    <exclusion>
+                        <groupId>org.apache.geronimo.specs</groupId>
+                        <artifactId>geronimo-servlet_3.0_spec</artifactId>
+
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.geronimo.specs</groupId>
+                        <artifactId>geronimo-jms_1.1_spec</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -264,11 +283,6 @@
                 <version>1.3.1b-mbaechler</version>
                 <scope>test</scope>
             </dependency>
-            <dependency>
-                <groupId>javax.mail</groupId>
-                <artifactId>mail</artifactId>
-                <version>1.4.4</version>
-            </dependency>
 
             <dependency>
                 <groupId>javax.activation</groupId>
@@ -281,6 +295,12 @@
                 <groupId>com.sun.faces.extensions</groupId>
                 <artifactId>jsf-extensions-dynamic-faces</artifactId>
                 <version>0.1</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jvnet.wagon-svn</groupId>
+                        <artifactId>wagon-svn</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.sun.faces.extensions</groupId>


### PR DESCRIPTION
Remove the following jars which are vulnerable and reported by OWASP scan
1. geronimo-jaxws_2.2_spec-1.1.jar
2. geronimo-javamail_1.4_spec-1.7.1.jar
3. geronimo-servlet_3.0_spec-1.0.jar
4. geronimo-jms_1.1_spec-1.1.1.jar
5. wagon-svn-1.8.jar
6. mail-1.4.4.jar
