### PR TITLE
FHAC-246: Fixes for HIMSS Universal Client

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/event/model/Document.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/event/model/Document.java
@@ -26,8 +26,9 @@
  */
 package gov.hhs.fha.nhinc.admingui.event.model;
 
+import java.text.DecimalFormat;
+import java.text.SimpleDateFormat;
 import java.util.Date;
-import org.apache.commons.codec.binary.Base64;
 
 /**
  * POJO class to render the results back to the UI
@@ -46,7 +47,8 @@ public class Document {
     private String legalAuthenticator;
     private Date serviceStartTime;
     private Date serviceStopTime;
-    private int size;
+    //private int size;
+    private double size;
     private String sourcePatientId;
     //not sure if we need this
     private String sourcePatientInfo;
@@ -62,18 +64,25 @@ public class Document {
     private String authorSpecialty;
     private String codingScheme;
     private String codingSchemeName;
-    //unique ID from document 
+    //unique ID from document
     private String documentId;
     private String patientId;
 
     private byte[] documentContent;
     private boolean documentRetrieved;
-    
+
     private String document;
 
     private String contentType;
     // document content type PDF, XLSX, TXT, XML
     private String documentType;
+
+    private String confidentialityCode;
+    private String entryUUID;
+    private String healthcareFacilityTypeCode;
+    private String documentTypeCode;
+    private String documentClassCode;
+    private String documentFormatCode;
 
     public Document() {
         this.documentRetrieved = false;
@@ -84,6 +93,7 @@ public class Document {
      */
     public Date getCreationTime() {
         return creationTime;
+
     }
 
     /**
@@ -91,6 +101,20 @@ public class Document {
      */
     public void setCreationTime(Date creationTime) {
         this.creationTime = creationTime;
+    }
+
+    /**
+     *
+     * @return the formattedDate
+     */
+    public String getCreationTimeUiDisplay() {
+        String formattedDate = null;
+        if (this.getCreationTime() != null) {
+            Date currentDate = this.getCreationTime();
+            SimpleDateFormat dateformat = new SimpleDateFormat("MM/dd/yyyy");
+            formattedDate = dateformat.format(currentDate);
+        }
+        return formattedDate;
     }
 
     /**
@@ -180,14 +204,14 @@ public class Document {
     /**
      * @return the size
      */
-    public int getSize() {
-        return size;
+    public double getSize() {
+        return Double.parseDouble(new DecimalFormat("##.##").format(size / 1024));
     }
 
     /**
      * @param size the size to set
      */
-    public void setSize(int size) {
+    public void setSize(double size) {
         this.size = size;
     }
 
@@ -463,6 +487,54 @@ public class Document {
      */
     public void setDocumentIndex(int documentIndex) {
         this.documentIndex = documentIndex;
+    }
+
+    public String getConfidentialityCode() {
+        return confidentialityCode;
+    }
+
+    public void setConfidentialityCode(String confidentialityCode) {
+        this.confidentialityCode = confidentialityCode;
+    }
+
+    public String getEntryUUID() {
+        return entryUUID;
+    }
+
+    public void setEntryUUID(String entryUUID) {
+        this.entryUUID = entryUUID;
+    }
+
+    public String getHealthcareFacilityTypeCode() {
+        return healthcareFacilityTypeCode;
+    }
+
+    public void setHealthcareFacilityTypeCode(String healthcareFacilityTypeCode) {
+        this.healthcareFacilityTypeCode = healthcareFacilityTypeCode;
+    }
+
+    public String getDocumentTypeCode() {
+        return documentTypeCode;
+    }
+
+    public void setDocumentTypeCode(String documentTypeCode) {
+        this.documentTypeCode = documentTypeCode;
+    }
+
+    public String getDocumentClassCode() {
+        return documentClassCode;
+    }
+
+    public void setDocumentClassCode(String documentClassCode) {
+        this.documentClassCode = documentClassCode;
+    }
+
+    public String getDocumentFormatCode() {
+        return documentFormatCode;
+    }
+
+    public void setDocumentFormatCode(String documentFormatCode) {
+        this.documentFormatCode = documentFormatCode;
     }
 
 }

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/event/model/Patient.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/event/model/Patient.java
@@ -33,14 +33,14 @@ import java.util.List;
 /**
  *
  * POJO class used by the UI to render the data
- * 
+ *
  * @author Naresh Subramanyan
  */
 public class Patient {
-    
-   //used in the UI
+
+    //used in the UI
     private int patientIndex;
-    
+
     private String firstName;
     private String lastName;
     private Date dateOfBirth;
@@ -61,13 +61,12 @@ public class Patient {
     private String drivinglicense;
     private String assigningAuthorityId;
     private String domain;
-    
+
     private List<Document> documentList;
 
     public Patient() {
         this.documentList = new ArrayList<Document>();
     }
-
 
     /**
      * @return the firstName
@@ -159,7 +158,7 @@ public class Patient {
      * @return the name
      */
     public String getName() {
-        return firstName + " "+lastName;
+        return firstName + " " + lastName;
     }
 
     /**
@@ -175,10 +174,10 @@ public class Patient {
     public void setPatientId(String patientId) {
         this.patientId = patientId;
     }
-    
-    public void clearAll(){
+
+    public void clearAll() {
         //clear the patient info
-        
+
         //clear the document info
     }
 
@@ -342,5 +341,5 @@ public class Patient {
     public void setDomain(String domain) {
         this.domain = domain;
     }
-    
+
 }

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/PatientSearchBean.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/PatientSearchBean.java
@@ -33,12 +33,19 @@ import gov.hhs.fha.nhinc.admingui.services.GatewayService;
 import gov.hhs.fha.nhinc.connectmgr.ConnectionManagerCache;
 import gov.hhs.fha.nhinc.connectmgr.ConnectionManagerCacheHelper;
 import gov.hhs.fha.nhinc.connectmgr.ConnectionManagerException;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.properties.PropertyAccessException;
+import gov.hhs.fha.nhinc.properties.PropertyAccessor;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.SessionScoped;
 import javax.faces.model.SelectItem;
@@ -87,6 +94,7 @@ public class PatientSearchBean {
     private boolean renderDocumentPdf;
     private boolean renderDocumentText;
     private boolean renderDcoumentNotSupported;
+    private String displayOrganizationName;
 
     //For Lookup..should be moved to a different managed bean
     private List<SelectItem> documentTypeList;
@@ -159,14 +167,16 @@ public class PatientSearchBean {
     /**
      * Action method called when user clicks the Document View.
      *
+     * @throws java.io.IOException
      */
-    public void retrieveDocument() {
+    public void retrieveDocument() throws IOException {
         //check to make sure if the Document Retrieve is already done
         if (this.getDocumentList().get(getSelectedDocument()).isDocumentRetrieved()) {
             return;
         }
         //Call the NwHIN RD to get the documents
         documentFound = GatewayService.getInstance().retrieveDocument(this);
+
     }
 
     /**
@@ -479,11 +489,14 @@ public class PatientSearchBean {
                     }
                     //add it to the organizationList
                     localOrganizationList.put(homeCommunityName, homeCommunityId);
+                    //added to display orgnaization name in UI
+                    displayOrganizationName = homeCommunityName;
                 }
             }
         } catch (ConnectionManagerException ex) {
             LOG.error("Failed to retrieve Business Entities from UDDI file.");
         }
+        LOG.info("Organization name to display in ui:" + homeCommunityName);
         return localOrganizationList;
     }
 
@@ -506,9 +519,17 @@ public class PatientSearchBean {
      */
     private List<SelectItem> populateDocumentTypes() {
         List<SelectItem> localDocumentTypeList = new ArrayList<SelectItem>();
-        localDocumentTypeList.add(new SelectItem("Prescription", "Prescription"));
-        localDocumentTypeList.add(new SelectItem("Discharge Summary", "Discharge Summary"));
-        localDocumentTypeList.add(new SelectItem("Transfer of care referral note", "Transfer of care referral note"));
+
+        try {
+            //Load the documentType.properties file
+            Properties localDocumentTypeProperties = PropertyAccessor.getInstance().getProperties(NhincConstants.DOCUMET_TYPE_PROPERTY_FILE);
+            for (Iterator<Entry<Object, Object>> it = localDocumentTypeProperties.entrySet().iterator(); it.hasNext();) {
+                Entry<Object, Object> property = it.next();
+                localDocumentTypeList.add(new SelectItem((String) property.getKey(), (String) property.getValue()));
+            }
+        } catch (PropertyAccessException ex) {
+            LOG.error("Not able to load the document types from the property file:" + ex.getMessage());
+        }
         return localDocumentTypeList;
     }
 
@@ -603,4 +624,21 @@ public class PatientSearchBean {
     public boolean isRenderDcoumentNotSupported() {
         return !(isRenderDocumentPdf() || isRenderDocumentText() || isRenderDocumentimage());
     }
+
+    /**
+     *
+     * @return
+     */
+    public String getDisplayOrganizationName() {
+        return displayOrganizationName;
+    }
+
+    /**
+     *
+     * @param displayOrganizationName
+     */
+    public void setDisplayOrganizationName(String displayOrganizationName) {
+        this.displayOrganizationName = displayOrganizationName;
+    }
+
 }

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/GatewayService.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/GatewayService.java
@@ -42,8 +42,15 @@ import gov.hhs.fha.nhinc.docretrieve.model.DocumentRetrieve;
 import gov.hhs.fha.nhinc.docretrieve.model.DocumentRetrieveResults;
 import gov.hhs.fha.nhinc.patientdiscovery.model.PatientSearchResults;
 import gov.hhs.fha.nhinc.util.format.UTCDateUtil;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import javax.faces.context.FacesContext;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
 import org.apache.log4j.Logger;
 
 /**
@@ -130,9 +137,11 @@ public class GatewayService {
         //and end time
         DocumentMetadata document = new DocumentMetadata();
         //document type
-        //document.setDocumentType("");
-        //document.setStartTime(null);
-        //document.setEndTime(null);
+        document.setDocumentType(patientQuerySearch.getQueryDocuments());
+        //set the document range from date
+        document.setStartTime(patientQuerySearch.getDocumentRangeFrom());
+        //set the document range to date
+        document.setEndTime(patientQuerySearch.getDocumentRangeTo());
         //set the organization
         document.setOrganization(patientQuerySearch.getSelectedCurrentPatient().getOrganization());
         //set the Patient Id
@@ -165,8 +174,9 @@ public class GatewayService {
      * @param patientQuerySearch
      *
      * @return true if the document retrieval is successful else false
+     * @throws java.io.IOException
      */
-    public boolean retrieveDocument(PatientSearchBean patientQuerySearch) {
+    public boolean retrieveDocument(PatientSearchBean patientQuerySearch) throws IOException {
         //set the document retrieve request values document id, organization and respository id
         DocumentRetrieve docRetrieve = new DocumentRetrieve();
         docRetrieve.setDocumentId(patientQuerySearch.getSelectedCurrentDocument().getDocumentId());
@@ -175,15 +185,43 @@ public class GatewayService {
 
         //Call the NwHIN service to retrieve the document
         DocumentRetrieveResults response = documentRetrieveService.retrieveDocuments(docRetrieve);
-        //set the retrieved document to the UI patient bean 
+
+        //set the retrieved document to the UI patient bean
         if (response.getDocument() != null) {
-            //patientQuerySearch.getSelectedCurrentDocument().setContentType(response.getContentType());
-            patientQuerySearch.getSelectedCurrentDocument().setDocumentContent(response.getDocument());
+            if (response.getContentType().contains("text/xml")) {
+                InputStream xsl = FacesContext.getCurrentInstance().getExternalContext().getResourceAsStream("/WEB-INF/CDA.xsl");
+                InputStream xml = new ByteArrayInputStream(response.getDocument());
+                byte[] convertXmlToHtml = null;
+                if (xsl != null) {
+                    convertXmlToHtml = convertXMLToHTML(xml, xsl);
+                    xsl.close();
+                }
+                patientQuerySearch.getSelectedCurrentDocument().setDocumentContent(convertXmlToHtml);
+            } else {
+                patientQuerySearch.getSelectedCurrentDocument().setDocumentContent(response.getDocument());
+            }
             patientQuerySearch.getSelectedCurrentDocument().setDocumentRetrieved(true);
             LOG.debug("Successfully retrieved the content of document with documentid:" + response.getContentType());
             return true;
         }
         return false;
+    }
+
+    private byte[] convertXMLToHTML(InputStream xml, InputStream xsl) {
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        try {
+            TransformerFactory tFactory = TransformerFactory.newInstance();
+            Transformer transformer = tFactory.newTransformer(new javax.xml.transform.stream.StreamSource(xsl));
+            transformer.transform(new javax.xml.transform.stream.StreamSource(xml),
+                new javax.xml.transform.stream.StreamResult(output));
+
+        } catch (Exception e) {
+            LOG.error("Exception in transforming xml to html", e);
+        }
+
+        return output.toByteArray();
     }
 
     /**

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/WEB-INF/CDA.xsl
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/WEB-INF/CDA.xsl
@@ -1,0 +1,2289 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Title: CDA XSL StyleSheet
+  Original Filename: cda.xsl 
+  Version: 3.0
+  Revision History: 08/12/08 Jingdong Li updated
+  Revision History: 12/11/09 KH updated 
+  Revision History:  03/30/10 Jingdong Li updated.
+  Revision History:  08/25/10 Jingdong Li updated
+  Revision History:  09/17/10 Jingdong Li updated
+  Revision History:  01/05/11 Jingdong Li updated
+  Specification: ANSI/HL7 CDAR2  
+  The current version and documentation are available at http://www.lantanagroup.com/resources/tools/. 
+  We welcome feedback and contributions to tools@lantanagroup.com
+  The stylesheet is the cumulative work of several developers; the most significant prior milestones were the foundation work from HL7 
+  Germany and Finland (Tyylitiedosto) and HL7 US (Calvin Beebe), and the presentation approach from Tony Schaller, medshare GmbH provided at IHIC 2009. 
+-->
+<!-- LICENSE INFORMATION
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 
+-->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:n1="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <xsl:output method="html" indent="yes" version="4.01" encoding="ISO-8859-1" doctype-system="http://www.w3.org/TR/html4/strict.dtd" doctype-public="-//W3C//DTD HTML 4.01//EN"/>
+   <!-- global variable title -->
+   <xsl:variable name="title">
+      <xsl:choose>
+         <xsl:when test="string-length(/n1:ClinicalDocument/n1:title)  &gt;= 1">
+            <xsl:value-of select="/n1:ClinicalDocument/n1:title"/>
+         </xsl:when>
+         <xsl:when test="/n1:ClinicalDocument/n1:code/@displayName">
+            <xsl:value-of select="/n1:ClinicalDocument/n1:code/@displayName"/>
+         </xsl:when>
+         <xsl:otherwise>
+            <xsl:text>Clinical Document</xsl:text>
+         </xsl:otherwise>
+      </xsl:choose>
+   </xsl:variable>
+   <!-- Main -->
+   <xsl:template match="/">
+      <xsl:apply-templates select="n1:ClinicalDocument"/>
+   </xsl:template>
+   <!-- produce browser rendered, human readable clinical document -->
+   <xsl:template match="n1:ClinicalDocument">
+      <html>
+         <head>
+            <xsl:comment> Do NOT edit this HTML directly: it was generated via an XSLT transformation from a CDA Release 2 XML document. </xsl:comment>
+            <title>
+               <xsl:value-of select="$title"/>
+            </title>
+            <xsl:call-template name="addCSS"/>
+         </head>
+         <body>
+            <h1 class="h1center">
+               <xsl:value-of select="$title"/>
+            </h1>
+            <!-- START display top portion of clinical document -->
+            <xsl:call-template name="recordTarget"/>
+            <xsl:call-template name="documentGeneral"/>
+            <xsl:call-template name="documentationOf"/>
+            <xsl:call-template name="author"/>
+            <xsl:call-template name="componentof"/>
+            <xsl:call-template name="participant"/>
+            <xsl:call-template name="dataEnterer"/>
+            <xsl:call-template name="authenticator"/>
+            <xsl:call-template name="informant"/>
+            <xsl:call-template name="informationRecipient"/>
+            <xsl:call-template name="legalAuthenticator"/>
+            <xsl:call-template name="custodian"/>
+            <!-- END display top portion of clinical document -->
+            <!-- produce table of contents -->
+            <xsl:if test="not(//n1:nonXMLBody)">
+               <xsl:if test="count(/n1:ClinicalDocument/n1:component/n1:structuredBody/n1:component[n1:section]) &gt; 1">
+                  <xsl:call-template name="make-tableofcontents"/>
+               </xsl:if>
+            </xsl:if>
+            <hr align="left" color="teal" size="2" width="80%"/>
+            <!-- produce human readable document content -->
+            <xsl:apply-templates select="n1:component/n1:structuredBody|n1:component/n1:nonXMLBody"/>
+            <br/>
+            <br/>
+         </body>
+      </html>
+   </xsl:template>
+   <!-- generate table of contents -->
+   <xsl:template name="make-tableofcontents">
+      <h2>
+         <a name="toc">Table of Contents</a>
+      </h2>
+      <ul>
+         <xsl:for-each select="n1:component/n1:structuredBody/n1:component/n1:section/n1:title">
+            <li>
+               <a href="#{generate-id(.)}">
+                  <xsl:value-of select="."/>
+               </a>
+            </li>
+         </xsl:for-each>
+      </ul>
+   </xsl:template>
+   <!-- header elements -->
+   <xsl:template name="documentGeneral">
+      <table class="header_table">
+         <tbody>
+            <tr>
+               <td width="20%" bgcolor="#3399ff">
+                  <span class="td_label">
+                     <xsl:text>Document Id</xsl:text>
+                  </span>
+               </td>
+               <td width="80%">
+                  <xsl:call-template name="show-id">
+                     <xsl:with-param name="id" select="n1:id"/>
+                  </xsl:call-template>
+               </td>
+            </tr>
+            <tr>
+               <td width="20%" bgcolor="#3399ff">
+                  <span class="td_label">
+                     <xsl:text>Document Created:</xsl:text>
+                  </span>
+               </td>
+               <td width="80%">
+                  <xsl:call-template name="show-time">
+                     <xsl:with-param name="datetime" select="n1:effectiveTime"/>
+                  </xsl:call-template>
+               </td>
+            </tr>
+         </tbody>
+      </table>
+   </xsl:template>
+   <!-- confidentiality -->
+   <xsl:template name="confidentiality">
+      <table class="header_table">
+         <tbody>
+            <td width="20%" bgcolor="#3399ff">
+               <xsl:text>Confidentiality</xsl:text>
+            </td>
+            <td width="80%">
+               <xsl:choose>
+                  <xsl:when test="n1:confidentialityCode/@code  = &apos;N&apos;">
+                     <xsl:text>Normal</xsl:text>
+                  </xsl:when>
+                  <xsl:when test="n1:confidentialityCode/@code  = &apos;R&apos;">
+                     <xsl:text>Restricted</xsl:text>
+                  </xsl:when>
+                  <xsl:when test="n1:confidentialityCode/@code  = &apos;V&apos;">
+                     <xsl:text>Very restricted</xsl:text>
+                  </xsl:when>
+               </xsl:choose>
+               <xsl:if test="n1:confidentialityCode/n1:originalText">
+                  <xsl:text> </xsl:text>
+                  <xsl:value-of select="n1:confidentialityCode/n1:originalText"/>
+               </xsl:if>
+            </td>
+         </tbody>
+      </table>
+   </xsl:template>
+   <!-- author -->
+   <xsl:template name="author">
+      <xsl:if test="n1:author">
+         <table class="header_table">
+            <tbody>
+               <xsl:for-each select="n1:author/n1:assignedAuthor">
+                  <tr>
+                     <td width="20%" bgcolor="#3399ff">
+                        <span class="td_label">
+                           <xsl:text>Author</xsl:text>
+                        </span>
+                     </td>
+                     <td width="80%">
+                        <xsl:choose>
+                           <xsl:when test="n1:assignedPerson/n1:name">
+                              <xsl:call-template name="show-name">
+                                 <xsl:with-param name="name" select="n1:assignedPerson/n1:name"/>
+                              </xsl:call-template>
+                              <xsl:if test="n1:representedOrganization">
+                                 <xsl:text>, </xsl:text>
+                                 <xsl:call-template name="show-name">
+                                    <xsl:with-param name="name" select="n1:representedOrganization/n1:name"/>
+                                 </xsl:call-template>
+                              </xsl:if>
+                           </xsl:when>
+                           <xsl:when test="n1:assignedAuthoringDevice/n1:softwareName">
+                              <xsl:value-of select="n1:assignedAuthoringDevice/n1:softwareName"/>
+                           </xsl:when>
+                           <xsl:when test="n1:representedOrganization">
+                              <xsl:call-template name="show-name">
+                                 <xsl:with-param name="name" select="n1:representedOrganization/n1:name"/>
+                              </xsl:call-template>
+                           </xsl:when>
+                           <xsl:otherwise>
+                              <xsl:for-each select="n1:id">
+                                 <xsl:call-template name="show-id"/>
+                                 <br/>
+                              </xsl:for-each>
+                           </xsl:otherwise>
+                        </xsl:choose>
+                     </td>
+                  </tr>
+                  <xsl:if test="n1:addr | n1:telecom">
+                     <tr>
+                        <td bgcolor="#3399ff">
+                           <span class="td_label">
+                              <xsl:text>Contact info</xsl:text>
+                           </span>
+                        </td>
+                        <td>
+                           <xsl:call-template name="show-contactInfo">
+                              <xsl:with-param name="contact" select="."/>
+                           </xsl:call-template>
+                        </td>
+                     </tr>
+                  </xsl:if>
+               </xsl:for-each>
+            </tbody>
+         </table>
+      </xsl:if>
+   </xsl:template>
+   <!--  authenticator -->
+   <xsl:template name="authenticator">
+      <xsl:if test="n1:authenticator">
+         <table class="header_table">
+            <tbody>
+               <tr>
+                  <xsl:for-each select="n1:authenticator">
+                     <tr>
+                        <td width="20%" bgcolor="#3399ff">
+                           <span class="td_label">
+                              <xsl:text>Signed </xsl:text>
+                           </span>
+                        </td>
+                        <td width="80%">
+                           <xsl:call-template name="show-name">
+                              <xsl:with-param name="name" select="n1:assignedEntity/n1:assignedPerson/n1:name"/>
+                           </xsl:call-template>
+                           <xsl:text> at </xsl:text>
+                           <xsl:call-template name="show-time">
+                              <xsl:with-param name="date" select="n1:time"/>
+                           </xsl:call-template>
+                        </td>
+                     </tr>
+                     <xsl:if test="n1:assignedEntity/n1:addr | n1:assignedEntity/n1:telecom">
+                        <tr>
+                           <td bgcolor="#3399ff">
+                              <span class="td_label">
+                                 <xsl:text>Contact info</xsl:text>
+                              </span>
+                           </td>
+                           <td width="80%">
+                              <xsl:call-template name="show-contactInfo">
+                                 <xsl:with-param name="contact" select="n1:assignedEntity"/>
+                              </xsl:call-template>
+                           </td>
+                        </tr>
+                     </xsl:if>
+                  </xsl:for-each>
+               </tr>
+            </tbody>
+         </table>
+      </xsl:if>
+   </xsl:template>
+   <!-- legalAuthenticator -->
+   <xsl:template name="legalAuthenticator">
+      <xsl:if test="n1:legalAuthenticator">
+         <table class="header_table">
+            <tbody>
+               <tr>
+                  <td width="20%" bgcolor="#3399ff">
+                     <span class="td_label">
+                        <xsl:text>Legal authenticator</xsl:text>
+                     </span>
+                  </td>
+                  <td width="80%">
+                     <xsl:call-template name="show-assignedEntity">
+                        <xsl:with-param name="asgnEntity" select="n1:legalAuthenticator/n1:assignedEntity"/>
+                     </xsl:call-template>
+                     <xsl:text> </xsl:text>
+                     <xsl:call-template name="show-sig">
+                        <xsl:with-param name="sig" select="n1:legalAuthenticator/n1:signatureCode"/>
+                     </xsl:call-template>
+                     <xsl:if test="n1:legalAuthenticator/n1:time/@value">
+                        <xsl:text> at </xsl:text>
+                        <xsl:call-template name="show-time">
+                           <xsl:with-param name="datetime" select="n1:legalAuthenticator/n1:time"/>
+                        </xsl:call-template>
+                     </xsl:if>
+                  </td>
+               </tr>
+               <xsl:if test="n1:legalAuthenticator/n1:assignedEntity/n1:addr | n1:legalAuthenticator/n1:assignedEntity/n1:telecom">
+                  <tr>
+                     <td bgcolor="#3399ff">
+                        <span class="td_label">
+                           <xsl:text>Contact info</xsl:text>
+                        </span>
+                     </td>
+                     <td>
+                        <xsl:call-template name="show-contactInfo">
+                           <xsl:with-param name="contact" select="n1:legalAuthenticator/n1:assignedEntity"/>
+                        </xsl:call-template>
+                     </td>
+                  </tr>
+               </xsl:if>
+            </tbody>
+         </table>
+      </xsl:if>
+   </xsl:template>
+   <!-- dataEnterer -->
+   <xsl:template name="dataEnterer">
+      <xsl:if test="n1:dataEnterer">
+         <table class="header_table">
+            <tbody>
+               <tr>
+                  <td width="20%" bgcolor="#3399ff">
+                     <span class="td_label">
+                        <xsl:text>Entered by</xsl:text>
+                     </span>
+                  </td>
+                  <td width="80%">
+                     <xsl:call-template name="show-assignedEntity">
+                        <xsl:with-param name="asgnEntity" select="n1:dataEnterer/n1:assignedEntity"/>
+                     </xsl:call-template>
+                  </td>
+               </tr>
+               <xsl:if test="n1:dataEnterer/n1:assignedEntity/n1:addr | n1:dataEnterer/n1:assignedEntity/n1:telecom">
+                  <tr>
+                     <td bgcolor="#3399ff">
+                        <span class="td_label">
+                           <xsl:text>Contact info</xsl:text>
+                        </span>
+                     </td>
+                     <td>
+                        <xsl:call-template name="show-contactInfo">
+                           <xsl:with-param name="contact" select="n1:dataEnterer/n1:assignedEntity"/>
+                        </xsl:call-template>
+                     </td>
+                  </tr>
+               </xsl:if>
+            </tbody>
+         </table>
+      </xsl:if>
+   </xsl:template>
+   <!-- componentOf -->
+   <xsl:template name="componentof">
+      <xsl:if test="n1:componentOf">
+         <table class="header_table">
+            <tbody>
+               <xsl:for-each select="n1:componentOf/n1:encompassingEncounter">
+                  <xsl:if test="n1:id">
+                     <tr>
+                        <xsl:choose>
+                           <xsl:when test="n1:code">
+                              <td width="20%" bgcolor="#3399ff">
+                                 <span class="td_label">
+                                    <xsl:text>Encounter Id</xsl:text>
+                                 </span>
+                              </td>
+                              <td width="30%">
+                                 <xsl:call-template name="show-id">
+                                    <xsl:with-param name="id" select="n1:id"/>
+                                 </xsl:call-template>
+                              </td>
+                              <td width="15%" bgcolor="#3399ff">
+                                 <span class="td_label">
+                                    <xsl:text>Encounter Type</xsl:text>
+                                 </span>
+                              </td>
+                              <td>
+                                 <xsl:call-template name="show-code">
+                                    <xsl:with-param name="code" select="n1:code"/>
+                                 </xsl:call-template>
+                              </td>
+                           </xsl:when>
+                           <xsl:otherwise>
+                              <td width="20%" bgcolor="#3399ff">
+                                 <span class="td_label">
+                                    <xsl:text>Encounter Id</xsl:text>
+                                 </span>
+                              </td>
+                              <td>
+                                 <xsl:call-template name="show-id">
+                                    <xsl:with-param name="id" select="n1:id"/>
+                                 </xsl:call-template>
+                              </td>
+                           </xsl:otherwise>
+                        </xsl:choose>
+                     </tr>
+                  </xsl:if>
+                  <tr>
+                     <td width="20%" bgcolor="#3399ff">
+                        <span class="td_label">
+                           <xsl:text>Encounter Date</xsl:text>
+                        </span>
+                     </td>
+                     <td colspan="3">
+                        <xsl:if test="n1:effectiveTime">
+                           <xsl:choose>
+                              <xsl:when test="n1:effectiveTime/@value">
+                                 <xsl:text>&#160;at&#160;</xsl:text>
+                                 <xsl:call-template name="show-time">
+                                    <xsl:with-param name="datetime" select="n1:effectiveTime"/>
+                                 </xsl:call-template>
+                              </xsl:when>
+                              <xsl:when test="n1:effectiveTime/n1:low">
+                                 <xsl:text>&#160;From&#160;</xsl:text>
+                                 <xsl:call-template name="show-time">
+                                    <xsl:with-param name="datetime" select="n1:effectiveTime/n1:low"/>
+                                 </xsl:call-template>
+                                 <xsl:if test="n1:effectiveTime/n1:high">
+                                    <xsl:text> to </xsl:text>
+                                    <xsl:call-template name="show-time">
+                                       <xsl:with-param name="datetime" select="n1:effectiveTime/n1:high"/>
+                                    </xsl:call-template>
+                                 </xsl:if>
+                              </xsl:when>
+                           </xsl:choose>
+                        </xsl:if>
+                     </td>
+                  </tr>
+                  <xsl:if test="n1:location/n1:healthCareFacility">
+                     <tr>
+                        <td width="20%" bgcolor="#3399ff">
+                           <span class="td_label">
+                              <xsl:text>Encounter Location</xsl:text>
+                           </span>
+                        </td>
+                        <td colspan="3">
+                           <xsl:choose>
+                              <xsl:when test="n1:location/n1:healthCareFacility/n1:location/n1:name">
+                                 <xsl:call-template name="show-name">
+                                    <xsl:with-param name="name" select="n1:location/n1:healthCareFacility/n1:location/n1:name"/>
+                                 </xsl:call-template>
+                                 <xsl:for-each select="n1:location/n1:healthCareFacility/n1:serviceProviderOrganization/n1:name">
+                                    <xsl:text> of </xsl:text>
+                                    <xsl:call-template name="show-name">
+                                       <xsl:with-param name="name" select="n1:location/n1:healthCareFacility/n1:serviceProviderOrganization/n1:name"/>
+                                    </xsl:call-template>
+                                 </xsl:for-each>
+                              </xsl:when>
+                              <xsl:when test="n1:location/n1:healthCareFacility/n1:code">
+                                 <xsl:call-template name="show-code">
+                                    <xsl:with-param name="code" select="n1:location/n1:healthCareFacility/n1:code"/>
+                                 </xsl:call-template>
+                              </xsl:when>
+                              <xsl:otherwise>
+                                 <xsl:if test="n1:location/n1:healthCareFacility/n1:id">
+                                    <xsl:text>id: </xsl:text>
+                                    <xsl:for-each select="n1:location/n1:healthCareFacility/n1:id">
+                                       <xsl:call-template name="show-id">
+                                          <xsl:with-param name="id" select="."/>
+                                       </xsl:call-template>
+                                    </xsl:for-each>
+                                 </xsl:if>
+                              </xsl:otherwise>
+                           </xsl:choose>
+                        </td>
+                     </tr>
+                  </xsl:if>
+                  <xsl:if test="n1:responsibleParty">
+                     <tr>
+                        <td width="20%" bgcolor="#3399ff">
+                           <span class="td_label">
+                              <xsl:text>Responsible party</xsl:text>
+                           </span>
+                        </td>
+                        <td colspan="3">
+                           <xsl:call-template name="show-assignedEntity">
+                              <xsl:with-param name="asgnEntity" select="n1:responsibleParty/n1:assignedEntity"/>
+                           </xsl:call-template>
+                        </td>
+                     </tr>
+                  </xsl:if>
+                  <xsl:if test="n1:responsibleParty/n1:assignedEntity/n1:addr | n1:responsibleParty/n1:assignedEntity/n1:telecom">
+                     <tr>
+                        <td width="20%" bgcolor="#3399ff">
+                           <span class="td_label">
+                              <xsl:text>Contact info</xsl:text>
+                           </span>
+                        </td>
+                        <td colspan="3">
+                           <xsl:call-template name="show-contactInfo">
+                              <xsl:with-param name="contact" select="n1:responsibleParty/n1:assignedEntity"/>
+                           </xsl:call-template>
+                        </td>
+                     </tr>
+                  </xsl:if>
+               </xsl:for-each>
+            </tbody>
+         </table>
+      </xsl:if>
+   </xsl:template>
+   <!-- custodian -->
+   <xsl:template name="custodian">
+      <xsl:if test="n1:custodian">
+         <table class="header_table">
+            <tbody>
+               <tr>
+                  <td width="20%" bgcolor="#3399ff">
+                     <span class="td_label">
+                        <xsl:text>Document maintained by</xsl:text>
+                     </span>
+                  </td>
+                  <td width="80%">
+                     <xsl:choose>
+                        <xsl:when test="n1:custodian/n1:assignedCustodian/n1:representedCustodianOrganization/n1:name">
+                           <xsl:call-template name="show-name">
+                              <xsl:with-param name="name" select="n1:custodian/n1:assignedCustodian/n1:representedCustodianOrganization/n1:name"/>
+                           </xsl:call-template>
+                        </xsl:when>
+                        <xsl:otherwise>
+                           <xsl:for-each select="n1:custodian/n1:assignedCustodian/n1:representedCustodianOrganization/n1:id">
+                              <xsl:call-template name="show-id"/>
+                              <xsl:if test="position()!=last()">
+                                 <br/>
+                              </xsl:if>
+                           </xsl:for-each>
+                        </xsl:otherwise>
+                     </xsl:choose>
+                  </td>
+               </tr>
+               <xsl:if test="n1:custodian/n1:assignedCustodian/n1:representedCustodianOrganization/n1:addr |             n1:custodian/n1:assignedCustodian/n1:representedCustodianOrganization/n1:telecom">
+                  <tr>
+                     <td bgcolor="#3399ff">
+                        <span class="td_label">
+                           <xsl:text>Contact info</xsl:text>
+                        </span>
+                     </td>
+                     <td width="80%">
+                        <xsl:call-template name="show-contactInfo">
+                           <xsl:with-param name="contact" select="n1:custodian/n1:assignedCustodian/n1:representedCustodianOrganization"/>
+                        </xsl:call-template>
+                     </td>
+                  </tr>
+               </xsl:if>
+            </tbody>
+         </table>
+      </xsl:if>
+   </xsl:template>
+   <!-- documentationOf -->
+   <xsl:template name="documentationOf">
+      <xsl:if test="n1:documentationOf">
+         <table class="header_table">
+            <tbody>
+               <xsl:for-each select="n1:documentationOf">
+                  <xsl:if test="n1:serviceEvent/@classCode and n1:serviceEvent/n1:code">
+                     <xsl:variable name="displayName">
+                        <xsl:call-template name="show-actClassCode">
+                           <xsl:with-param name="clsCode" select="n1:serviceEvent/@classCode"/>
+                        </xsl:call-template>
+                     </xsl:variable>
+                     <xsl:if test="$displayName">
+                        <tr>
+                           <td width="20%" bgcolor="#3399ff">
+                              <span class="td_label">
+                                 <xsl:call-template name="firstCharCaseUp">
+                                    <xsl:with-param name="data" select="$displayName"/>
+                                 </xsl:call-template>
+                              </span>
+                           </td>
+                           <td width="80%" colspan="3">
+                              <xsl:call-template name="show-code">
+                                 <xsl:with-param name="code" select="n1:serviceEvent/n1:code"/>
+                              </xsl:call-template>
+                              <xsl:if test="n1:serviceEvent/n1:effectiveTime">
+                                 <xsl:choose>
+                                    <xsl:when test="n1:serviceEvent/n1:effectiveTime/@value">
+                                       <xsl:text>&#160;at&#160;</xsl:text>
+                                       <xsl:call-template name="show-time">
+                                          <xsl:with-param name="datetime" select="n1:serviceEvent/n1:effectiveTime"/>
+                                       </xsl:call-template>
+                                    </xsl:when>
+                                    <xsl:when test="n1:serviceEvent/n1:effectiveTime/n1:low">
+                                       <xsl:text>&#160;from&#160;</xsl:text>
+                                       <xsl:call-template name="show-time">
+                                          <xsl:with-param name="datetime" select="n1:serviceEvent/n1:effectiveTime/n1:low"/>
+                                       </xsl:call-template>
+                                       <xsl:if test="n1:serviceEvent/n1:effectiveTime/n1:high">
+                                          <xsl:text> to </xsl:text>
+                                          <xsl:call-template name="show-time">
+                                             <xsl:with-param name="datetime" select="n1:serviceEvent/n1:effectiveTime/n1:high"/>
+                                          </xsl:call-template>
+                                       </xsl:if>
+                                    </xsl:when>
+                                 </xsl:choose>
+                              </xsl:if>
+                           </td>
+                        </tr>
+                     </xsl:if>
+                  </xsl:if>
+                  <xsl:for-each select="n1:serviceEvent/n1:performer">
+                     <xsl:variable name="displayName">
+                        <xsl:call-template name="show-participationType">
+                           <xsl:with-param name="ptype" select="@typeCode"/>
+                        </xsl:call-template>
+                        <xsl:text> </xsl:text>
+                        <xsl:if test="n1:functionCode/@code">
+                           <xsl:call-template name="show-participationFunction">
+                              <xsl:with-param name="pFunction" select="n1:functionCode/@code"/>
+                           </xsl:call-template>
+                        </xsl:if>
+                     </xsl:variable>
+                     <tr>
+                        <td width="20%" bgcolor="#3399ff">
+                           <span class="td_label">
+                              <xsl:call-template name="firstCharCaseUp">
+                                 <xsl:with-param name="data" select="$displayName"/>
+                              </xsl:call-template>
+                           </span>
+                        </td>
+                        <td width="80%" colspan="3">
+                           <xsl:call-template name="show-assignedEntity">
+                              <xsl:with-param name="asgnEntity" select="n1:assignedEntity"/>
+                           </xsl:call-template>
+                        </td>
+                     </tr>
+                  </xsl:for-each>
+               </xsl:for-each>
+            </tbody>
+         </table>
+      </xsl:if>
+   </xsl:template>
+   <!-- inFulfillmentOf -->
+   <xsl:template name="inFulfillmentOf">
+      <xsl:if test="n1:infulfillmentOf">
+         <table class="header_table">
+            <tbody>
+               <xsl:for-each select="n1:inFulfillmentOf">
+                  <tr>
+                     <td width="20%" bgcolor="#3399ff">
+                        <span class="td_label">
+                           <xsl:text>In fulfillment of</xsl:text>
+                        </span>
+                     </td>
+                     <td width="80%">
+                        <xsl:for-each select="n1:order">
+                           <xsl:for-each select="n1:id">
+                              <xsl:call-template name="show-id"/>
+                           </xsl:for-each>
+                           <xsl:for-each select="n1:code">
+                              <xsl:text>&#160;</xsl:text>
+                              <xsl:call-template name="show-code">
+                                 <xsl:with-param name="code" select="."/>
+                              </xsl:call-template>
+                           </xsl:for-each>
+                           <xsl:for-each select="n1:priorityCode">
+                              <xsl:text>&#160;</xsl:text>
+                              <xsl:call-template name="show-code">
+                                 <xsl:with-param name="code" select="."/>
+                              </xsl:call-template>
+                           </xsl:for-each>
+                        </xsl:for-each>
+                     </td>
+                  </tr>
+               </xsl:for-each>
+            </tbody>
+         </table>
+      </xsl:if>
+   </xsl:template>
+   <!-- informant -->
+   <xsl:template name="informant">
+      <xsl:if test="n1:informant">
+         <table class="header_table">
+            <tbody>
+               <xsl:for-each select="n1:informant">
+                  <tr>
+                     <td width="20%" bgcolor="#3399ff">
+                        <span class="td_label">
+                           <xsl:text>Informant</xsl:text>
+                        </span>
+                     </td>
+                     <td width="80%">
+                        <xsl:if test="n1:assignedEntity">
+                           <xsl:call-template name="show-assignedEntity">
+                              <xsl:with-param name="asgnEntity" select="n1:assignedEntity"/>
+                           </xsl:call-template>
+                        </xsl:if>
+                        <xsl:if test="n1:relatedEntity">
+                           <xsl:call-template name="show-relatedEntity">
+                              <xsl:with-param name="relatedEntity" select="n1:relatedEntity"/>
+                           </xsl:call-template>
+                        </xsl:if>
+                     </td>
+                  </tr>
+                  <xsl:choose>
+                     <xsl:when test="n1:assignedEntity/n1:addr | n1:assignedEntity/n1:telecom">
+                        <tr>
+                           <td bgcolor="#3399ff">
+                              <span class="td_label">
+                                 <xsl:text>Contact info</xsl:text>
+                              </span>
+                           </td>
+                           <td>
+                              <xsl:if test="n1:assignedEntity">
+                                 <xsl:call-template name="show-contactInfo">
+                                    <xsl:with-param name="contact" select="n1:assignedEntity"/>
+                                 </xsl:call-template>
+                              </xsl:if>
+                           </td>
+                        </tr>
+                     </xsl:when>
+                     <xsl:when test="n1:relatedEntity/n1:addr | n1:relatedEntity/n1:telecom">
+                        <tr>
+                           <td bgcolor="#3399ff">
+                              <span class="td_label">
+                                 <xsl:text>Contact info</xsl:text>
+                              </span>
+                           </td>
+                           <td>
+                              <xsl:if test="n1:relatedEntity">
+                                 <xsl:call-template name="show-contactInfo">
+                                    <xsl:with-param name="contact" select="n1:relatedEntity"/>
+                                 </xsl:call-template>
+                              </xsl:if>
+                           </td>
+                        </tr>
+                     </xsl:when>
+                  </xsl:choose>
+               </xsl:for-each>
+            </tbody>
+         </table>
+      </xsl:if>
+   </xsl:template>
+   <!-- informantionRecipient -->
+   <xsl:template name="informationRecipient">
+      <xsl:if test="n1:informationRecipient">
+         <table class="header_table">
+            <tbody>
+               <xsl:for-each select="n1:informationRecipient">
+                  <tr>
+                     <td width="20%" bgcolor="#3399ff">
+                        <span class="td_label">
+                           <xsl:text>Information recipient:</xsl:text>
+                        </span>
+                     </td>
+                     <td width="80%">
+                        <xsl:choose>
+                           <xsl:when test="n1:intendedRecipient/n1:informationRecipient/n1:name">
+                              <xsl:for-each select="n1:intendedRecipient/n1:informationRecipient">
+                                 <xsl:call-template name="show-name">
+                                    <xsl:with-param name="name" select="n1:name"/>
+                                 </xsl:call-template>
+                                 <xsl:if test="position() != last()">
+                                    <br/>
+                                 </xsl:if>
+                              </xsl:for-each>
+                           </xsl:when>
+                           <xsl:otherwise>
+                              <xsl:for-each select="n1:intendedRecipient">
+                                 <xsl:for-each select="n1:id">
+                                    <xsl:call-template name="show-id"/>
+                                 </xsl:for-each>
+                                 <xsl:if test="position() != last()">
+                                    <br/>
+                                 </xsl:if>
+                                 <br/>
+                              </xsl:for-each>
+                           </xsl:otherwise>
+                        </xsl:choose>
+                     </td>
+                  </tr>
+                  <xsl:if test="n1:intendedRecipient/n1:addr | n1:intendedRecipient/n1:telecom">
+                     <tr>
+                        <td bgcolor="#3399ff">
+                           <span class="td_label">
+                              <xsl:text>Contact info</xsl:text>
+                           </span>
+                        </td>
+                        <td>
+                           <xsl:call-template name="show-contactInfo">
+                              <xsl:with-param name="contact" select="n1:intendedRecipient"/>
+                           </xsl:call-template>
+                        </td>
+                     </tr>
+                  </xsl:if>
+               </xsl:for-each>
+            </tbody>
+         </table>
+      </xsl:if>
+   </xsl:template>
+   <!-- participant -->
+   <xsl:template name="participant">
+      <xsl:if test="n1:participant">
+         <table class="header_table">
+            <tbody>
+               <xsl:for-each select="n1:participant">
+                  <tr>
+                     <td width="20%" bgcolor="#3399ff">
+                        <xsl:variable name="participtRole">
+                           <xsl:call-template name="translateRoleAssoCode">
+                              <xsl:with-param name="classCode" select="n1:associatedEntity/@classCode"/>
+                              <xsl:with-param name="code" select="n1:associatedEntity/n1:code"/>
+                           </xsl:call-template>
+                        </xsl:variable>
+                        <xsl:choose>
+                           <xsl:when test="$participtRole">
+                              <span class="td_label">
+                                 <xsl:call-template name="firstCharCaseUp">
+                                    <xsl:with-param name="data" select="$participtRole"/>
+                                 </xsl:call-template>
+                              </span>
+                           </xsl:when>
+                           <xsl:otherwise>
+                              <span class="td_label">
+                                 <xsl:text>Participant</xsl:text>
+                              </span>
+                           </xsl:otherwise>
+                        </xsl:choose>
+                     </td>
+                     <td width="80%">
+                        <xsl:if test="n1:functionCode">
+                           <xsl:call-template name="show-code">
+                              <xsl:with-param name="code" select="n1:functionCode"/>
+                           </xsl:call-template>
+                        </xsl:if>
+                        <xsl:call-template name="show-associatedEntity">
+                           <xsl:with-param name="assoEntity" select="n1:associatedEntity"/>
+                        </xsl:call-template>
+                        <xsl:if test="n1:time">
+                           <xsl:if test="n1:time/n1:low">
+                              <xsl:text> from </xsl:text>
+                              <xsl:call-template name="show-time">
+                                 <xsl:with-param name="datetime" select="n1:time/n1:low"/>
+                              </xsl:call-template>
+                           </xsl:if>
+                           <xsl:if test="n1:time/n1:high">
+                              <xsl:text> to </xsl:text>
+                              <xsl:call-template name="show-time">
+                                 <xsl:with-param name="datetime" select="n1:time/n1:high"/>
+                              </xsl:call-template>
+                           </xsl:if>
+                        </xsl:if>
+                        <xsl:if test="position() != last()">
+                           <br/>
+                        </xsl:if>
+                     </td>
+                  </tr>
+                  <xsl:if test="n1:associatedEntity/n1:addr | n1:associatedEntity/n1:telecom">
+                     <tr>
+                        <td bgcolor="#3399ff">
+                           <span class="td_label">
+                              <xsl:text>Contact info</xsl:text>
+                           </span>
+                        </td>
+                        <td>
+                           <xsl:call-template name="show-contactInfo">
+                              <xsl:with-param name="contact" select="n1:associatedEntity"/>
+                           </xsl:call-template>
+                        </td>
+                     </tr>
+                  </xsl:if>
+               </xsl:for-each>
+            </tbody>
+         </table>
+      </xsl:if>
+   </xsl:template>
+   <!-- recordTarget -->
+   <xsl:template name="recordTarget">
+      <table class="header_table">
+         <tbody>
+            <xsl:for-each select="/n1:ClinicalDocument/n1:recordTarget/n1:patientRole">
+               <xsl:if test="not(n1:id/@nullFlavor)">
+                  <tr>
+                     <td width="20%" bgcolor="#3399ff">
+                        <span class="td_label">
+                           <xsl:text>Patient</xsl:text>
+                        </span>
+                     </td>
+                     <td colspan="3">
+                        <xsl:call-template name="show-name">
+                           <xsl:with-param name="name" select="n1:patient/n1:name"/>
+                        </xsl:call-template>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td width="20%" bgcolor="#3399ff">
+                        <span class="td_label">
+                           <xsl:text>Date of birth</xsl:text>
+                        </span>
+                     </td>
+                     <td width="30%">
+                        <xsl:call-template name="show-time">
+                           <xsl:with-param name="datetime" select="n1:patient/n1:birthTime"/>
+                        </xsl:call-template>
+                     </td>
+                     <td width="15%" bgcolor="#3399ff">
+                        <span class="td_label">
+                           <xsl:text>Sex</xsl:text>
+                        </span>
+                     </td>
+                     <td>
+                        <xsl:for-each select="n1:patient/n1:administrativeGenderCode">
+                           <xsl:call-template name="show-gender"/>
+                        </xsl:for-each>
+                     </td>
+                  </tr>
+                  <xsl:if test="n1:patient/n1:raceCode | (n1:patient/n1:ethnicGroupCode)">
+                     <tr>
+                        <td width="20%" bgcolor="#3399ff">
+                           <span class="td_label">
+                              <xsl:text>Race</xsl:text>
+                           </span>
+                        </td>
+                        <td width="30%">
+                           <xsl:choose>
+                              <xsl:when test="n1:patient/n1:raceCode">
+                                 <xsl:for-each select="n1:patient/n1:raceCode">
+                                    <xsl:call-template name="show-race-ethnicity"/>
+                                 </xsl:for-each>
+                              </xsl:when>
+                              <xsl:otherwise>
+                                 <xsl:text>Information not available</xsl:text>
+                              </xsl:otherwise>
+                           </xsl:choose>
+                        </td>
+                        <td width="15%" bgcolor="#3399ff">
+                           <span class="td_label">
+                              <xsl:text>Ethnicity</xsl:text>
+                           </span>
+                        </td>
+                        <td>
+                           <xsl:choose>
+                              <xsl:when test="n1:patient/n1:ethnicGroupCode">
+                                 <xsl:for-each select="n1:patient/n1:ethnicGroupCode">
+                                    <xsl:call-template name="show-race-ethnicity"/>
+                                 </xsl:for-each>
+                              </xsl:when>
+                              <xsl:otherwise>
+                                 <xsl:text>Information not available</xsl:text>
+                              </xsl:otherwise>
+                           </xsl:choose>
+                        </td>
+                     </tr>
+                  </xsl:if>
+                  <tr>
+                     <td bgcolor="#3399ff">
+                        <span class="td_label">
+                           <xsl:text>Contact info</xsl:text>
+                        </span>
+                     </td>
+                     <td>
+                        <xsl:call-template name="show-contactInfo">
+                           <xsl:with-param name="contact" select="."/>
+                        </xsl:call-template>
+                     </td>
+                     <td bgcolor="#3399ff">
+                        <span class="td_label">
+                           <xsl:text>Patient IDs</xsl:text>
+                        </span>
+                     </td>
+                     <td>
+                        <xsl:for-each select="n1:id">
+                           <xsl:call-template name="show-id"/>
+                           <br/>
+                        </xsl:for-each>
+                     </td>
+                  </tr>
+               </xsl:if>
+            </xsl:for-each>
+         </tbody>
+      </table>
+   </xsl:template>
+   <!-- relatedDocument -->
+   <xsl:template name="relatedDocument">
+      <xsl:if test="n1:relatedDocument">
+         <table class="header_table">
+            <tbody>
+               <xsl:for-each select="n1:relatedDocument">
+                  <tr>
+                     <td width="20%" bgcolor="#3399ff">
+                        <span class="td_label">
+                           <xsl:text>Related document</xsl:text>
+                        </span>
+                     </td>
+                     <td width="80%">
+                        <xsl:for-each select="n1:parentDocument">
+                           <xsl:for-each select="n1:id">
+                              <xsl:call-template name="show-id"/>
+                              <br/>
+                           </xsl:for-each>
+                        </xsl:for-each>
+                     </td>
+                  </tr>
+               </xsl:for-each>
+            </tbody>
+         </table>
+      </xsl:if>
+   </xsl:template>
+   <!-- authorization (consent) -->
+   <xsl:template name="authorization">
+      <xsl:if test="n1:authorization">
+         <table class="header_table">
+            <tbody>
+               <xsl:for-each select="n1:authorization">
+                  <tr>
+                     <td width="20%" bgcolor="#3399ff">
+                        <span class="td_label">
+                           <xsl:text>Consent</xsl:text>
+                        </span>
+                     </td>
+                     <td width="80%">
+                        <xsl:choose>
+                           <xsl:when test="n1:consent/n1:code">
+                              <xsl:call-template name="show-code">
+                                 <xsl:with-param name="code" select="n1:consent/n1:code"/>
+                              </xsl:call-template>
+                           </xsl:when>
+                           <xsl:otherwise>
+                              <xsl:call-template name="show-code">
+                                 <xsl:with-param name="code" select="n1:consent/n1:statusCode"/>
+                              </xsl:call-template>
+                           </xsl:otherwise>
+                        </xsl:choose>
+                        <br/>
+                     </td>
+                  </tr>
+               </xsl:for-each>
+            </tbody>
+         </table>
+      </xsl:if>
+   </xsl:template>
+   <!-- setAndVersion -->
+   <xsl:template name="setAndVersion">
+      <xsl:if test="n1:setId and n1:versionNumber">
+         <table class="header_table">
+            <tbody>
+               <tr>
+                  <td width="20%">
+                     <xsl:text>SetId and Version</xsl:text>
+                  </td>
+                  <td colspan="3">
+                     <xsl:text>SetId: </xsl:text>
+                     <xsl:call-template name="show-id">
+                        <xsl:with-param name="id" select="n1:setId"/>
+                     </xsl:call-template>
+                     <xsl:text>  Version: </xsl:text>
+                     <xsl:value-of select="n1:versionNumber/@value"/>
+                  </td>
+               </tr>
+            </tbody>
+         </table>
+      </xsl:if>
+   </xsl:template>
+   <!-- show StructuredBody  -->
+   <xsl:template match="n1:component/n1:structuredBody">
+      <xsl:for-each select="n1:component/n1:section">
+         <xsl:call-template name="section"/>
+      </xsl:for-each>
+   </xsl:template>
+   <!-- show nonXMLBody -->
+   <xsl:template match='n1:component/n1:nonXMLBody'>
+      <xsl:choose>
+         <!-- if there is a reference, use that in an IFRAME -->
+         <xsl:when test='n1:text/n1:reference'>
+            <IFRAME name='nonXMLBody' id='nonXMLBody' WIDTH='80%' HEIGHT='600' src='{n1:text/n1:reference/@value}'/>
+         </xsl:when>
+         <xsl:when test='n1:text/@mediaType="text/plain"'>
+            <pre>
+               <xsl:value-of select='n1:text/text()'/>
+            </pre>
+         </xsl:when>
+         <xsl:otherwise>
+            <CENTER>Cannot display the text</CENTER>
+         </xsl:otherwise>
+      </xsl:choose>
+   </xsl:template>
+   <!-- top level component/section: display title and text,
+     and process any nested component/sections
+   -->
+   <xsl:template name="section">
+      <xsl:call-template name="section-title">
+         <xsl:with-param name="title" select="n1:title"/>
+      </xsl:call-template>
+      <xsl:call-template name="section-author"/>
+      <xsl:call-template name="section-text"/>
+      <xsl:for-each select="n1:component/n1:section">
+         <xsl:call-template name="nestedSection">
+            <xsl:with-param name="margin" select="2"/>
+         </xsl:call-template>
+      </xsl:for-each>
+   </xsl:template>
+   <!-- top level section title -->
+   <xsl:template name="section-title">
+      <xsl:param name="title"/>
+      <xsl:choose>
+         <xsl:when test="count(/n1:ClinicalDocument/n1:component/n1:structuredBody/n1:component[n1:section]) &gt; 1">
+            <h3>
+               <a name="{generate-id($title)}" href="#toc">
+                  <xsl:value-of select="$title"/>
+               </a>
+            </h3>
+         </xsl:when>
+         <xsl:otherwise>
+            <h3>
+               <xsl:value-of select="$title"/>
+            </h3>
+         </xsl:otherwise>
+      </xsl:choose>
+   </xsl:template>
+   <!-- section author -->
+   <xsl:template name="section-author">
+      <xsl:if test="count(n1:author)&gt;0">
+         <div style="margin-left : 2em;">
+            <b>
+               <xsl:text>Section Author: </xsl:text>
+            </b>
+            <xsl:for-each select="n1:author/n1:assignedAuthor">
+               <xsl:choose>
+                  <xsl:when test="n1:assignedPerson/n1:name">
+                     <xsl:call-template name="show-name">
+                        <xsl:with-param name="name" select="n1:assignedPerson/n1:name"/>
+                     </xsl:call-template>
+                     <xsl:if test="n1:representedOrganization">
+                        <xsl:text>, </xsl:text>
+                        <xsl:call-template name="show-name">
+                           <xsl:with-param name="name" select="n1:representedOrganization/n1:name"/>
+                        </xsl:call-template>
+                     </xsl:if>
+                  </xsl:when>
+                  <xsl:when test="n1:assignedAuthoringDevice/n1:softwareName">
+                     <xsl:value-of select="n1:assignedAuthoringDevice/n1:softwareName"/>
+                  </xsl:when>
+                  <xsl:otherwise>
+                     <xsl:for-each select="n1:id">
+                        <xsl:call-template name="show-id"/>
+                        <br/>
+                     </xsl:for-each>
+                  </xsl:otherwise>
+               </xsl:choose>
+            </xsl:for-each>
+            <br/>
+         </div>
+      </xsl:if>
+   </xsl:template>
+   <!-- top-level section Text   -->
+   <xsl:template name="section-text">
+      <div>
+         <xsl:apply-templates select="n1:text"/>
+      </div>
+   </xsl:template>
+   <!-- nested component/section -->
+   <xsl:template name="nestedSection">
+      <xsl:param name="margin"/>
+      <h4 style="margin-left : {$margin}em;">
+         <xsl:value-of select="n1:title"/>
+      </h4>
+      <div style="margin-left : {$margin}em;">
+         <xsl:apply-templates select="n1:text"/>
+      </div>
+      <xsl:for-each select="n1:component/n1:section">
+         <xsl:call-template name="nestedSection">
+            <xsl:with-param name="margin" select="2*$margin"/>
+         </xsl:call-template>
+      </xsl:for-each>
+   </xsl:template>
+   <!--   paragraph  -->
+   <xsl:template match="n1:paragraph">
+      <p>
+         <xsl:apply-templates/>
+      </p>
+   </xsl:template>
+   <!--   pre format  -->
+   <xsl:template match="n1:pre">
+      <pre>
+         <xsl:apply-templates/>
+      </pre>
+   </xsl:template>
+   <!--   Content w/ deleted text is hidden -->
+   <xsl:template match="n1:content[@revised='delete']"/>
+   <!--   content  -->
+   <xsl:template match="n1:content">
+      <xsl:apply-templates/>
+   </xsl:template>
+   <!-- line break -->
+   <xsl:template match="n1:br">
+      <xsl:element name='br'>
+         <xsl:apply-templates/>
+      </xsl:element>
+   </xsl:template>
+   <!--   list  -->
+   <xsl:template match="n1:list">
+      <xsl:if test="n1:caption">
+         <p>
+            <b>
+               <xsl:apply-templates select="n1:caption"/>
+            </b>
+         </p>
+      </xsl:if>
+      <ul>
+         <xsl:for-each select="n1:item">
+            <li>
+               <xsl:apply-templates/>
+            </li>
+         </xsl:for-each>
+      </ul>
+   </xsl:template>
+   <xsl:template match="n1:list[@listType='ordered']">
+      <xsl:if test="n1:caption">
+         <span style="font-weight:bold; ">
+            <xsl:apply-templates select="n1:caption"/>
+         </span>
+      </xsl:if>
+      <ol>
+         <xsl:for-each select="n1:item">
+            <li>
+               <xsl:apply-templates/>
+            </li>
+         </xsl:for-each>
+      </ol>
+   </xsl:template>
+   <!--   caption  -->
+   <xsl:template match="n1:caption">
+      <xsl:apply-templates/>
+      <xsl:text>: </xsl:text>
+   </xsl:template>
+   <!--  Tables   -->
+   <xsl:template match="n1:table/@*|n1:thead/@*|n1:tfoot/@*|n1:tbody/@*|n1:colgroup/@*|n1:col/@*|n1:tr/@*|n1:th/@*|n1:td/@*">
+      <xsl:copy>
+         <xsl:copy-of select="@*"/>
+         <xsl:apply-templates/>
+      </xsl:copy>
+   </xsl:template>
+   <xsl:template match="n1:table">
+      <table class="narr_table">
+         <xsl:copy-of select="@*"/>
+         <xsl:apply-templates/>
+      </table>
+   </xsl:template>
+   <xsl:template match="n1:thead">
+      <thead>
+         <xsl:copy-of select="@*"/>
+         <xsl:apply-templates/>
+      </thead>
+   </xsl:template>
+   <xsl:template match="n1:tfoot">
+      <tfoot>
+         <xsl:copy-of select="@*"/>
+         <xsl:apply-templates/>
+      </tfoot>
+   </xsl:template>
+   <xsl:template match="n1:tbody">
+      <tbody>
+         <xsl:copy-of select="@*"/>
+         <xsl:apply-templates/>
+      </tbody>
+   </xsl:template>
+   <xsl:template match="n1:colgroup">
+      <colgroup>
+         <xsl:copy-of select="@*"/>
+         <xsl:apply-templates/>
+      </colgroup>
+   </xsl:template>
+   <xsl:template match="n1:col">
+      <col>
+         <xsl:copy-of select="@*"/>
+         <xsl:apply-templates/>
+      </col>
+   </xsl:template>
+   <xsl:template match="n1:tr">
+      <tr class="narr_tr">
+         <xsl:copy-of select="@*"/>
+         <xsl:apply-templates/>
+      </tr>
+   </xsl:template>
+   <xsl:template match="n1:th">
+      <th class="narr_th">
+         <xsl:copy-of select="@*"/>
+         <xsl:apply-templates/>
+      </th>
+   </xsl:template>
+   <xsl:template match="n1:td">
+      <td>
+         <xsl:copy-of select="@*"/>
+         <xsl:apply-templates/>
+      </td>
+   </xsl:template>
+   <xsl:template match="n1:table/n1:caption">
+      <span style="font-weight:bold; ">
+         <xsl:apply-templates/>
+      </span>
+   </xsl:template>
+   <!--   RenderMultiMedia 
+    this currently only handles GIF's and JPEG's.  It could, however,
+    be extended by including other image MIME types in the predicate
+    and/or by generating <object> or <applet> tag with the correct
+    params depending on the media type  @ID  =$imageRef  referencedObject
+    -->
+   <xsl:template match="n1:renderMultiMedia">
+      <xsl:variable name="imageRef" select="@referencedObject"/>
+      <xsl:choose>
+         <xsl:when test="//n1:regionOfInterest[@ID=$imageRef]">
+            <!-- Here is where the Region of Interest image referencing goes -->
+            <xsl:if test="//n1:regionOfInterest[@ID=$imageRef]//n1:observationMedia/n1:value[@mediaType='image/gif' or
+ @mediaType='image/jpeg']">
+               <br clear="all"/>
+               <xsl:element name="img">
+                  <xsl:attribute name="src"><xsl:value-of select="//n1:regionOfInterest[@ID=$imageRef]//n1:observationMedia/n1:value/n1:reference/@value"/></xsl:attribute>
+               </xsl:element>
+            </xsl:if>
+         </xsl:when>
+         <xsl:otherwise>
+            <!-- Here is where the direct MultiMedia image referencing goes -->
+            <xsl:if test="//n1:observationMedia[@ID=$imageRef]/n1:value[@mediaType='image/gif' or @mediaType='image/jpeg']">
+               <br clear="all"/>
+               <xsl:element name="img">
+                  <xsl:attribute name="src"><xsl:value-of select="//n1:observationMedia[@ID=$imageRef]/n1:value/n1:reference/@value"/></xsl:attribute>
+               </xsl:element>
+            </xsl:if>
+         </xsl:otherwise>
+      </xsl:choose>
+   </xsl:template>
+   <!--    Stylecode processing   
+    Supports Bold, Underline and Italics display
+    -->
+   <xsl:template match="//n1:*[@styleCode]">
+      <xsl:if test="@styleCode='Bold'">
+         <xsl:element name="b">
+            <xsl:apply-templates/>
+         </xsl:element>
+      </xsl:if>
+      <xsl:if test="@styleCode='Italics'">
+         <xsl:element name="i">
+            <xsl:apply-templates/>
+         </xsl:element>
+      </xsl:if>
+      <xsl:if test="@styleCode='Underline'">
+         <xsl:element name="u">
+            <xsl:apply-templates/>
+         </xsl:element>
+      </xsl:if>
+      <xsl:if test="contains(@styleCode,'Bold') and contains(@styleCode,'Italics') and not (contains(@styleCode, 'Underline'))">
+         <xsl:element name="b">
+            <xsl:element name="i">
+               <xsl:apply-templates/>
+            </xsl:element>
+         </xsl:element>
+      </xsl:if>
+      <xsl:if test="contains(@styleCode,'Bold') and contains(@styleCode,'Underline') and not (contains(@styleCode, 'Italics'))">
+         <xsl:element name="b">
+            <xsl:element name="u">
+               <xsl:apply-templates/>
+            </xsl:element>
+         </xsl:element>
+      </xsl:if>
+      <xsl:if test="contains(@styleCode,'Italics') and contains(@styleCode,'Underline') and not (contains(@styleCode, 'Bold'))">
+         <xsl:element name="i">
+            <xsl:element name="u">
+               <xsl:apply-templates/>
+            </xsl:element>
+         </xsl:element>
+      </xsl:if>
+      <xsl:if test="contains(@styleCode,'Italics') and contains(@styleCode,'Underline') and contains(@styleCode, 'Bold')">
+         <xsl:element name="b">
+            <xsl:element name="i">
+               <xsl:element name="u">
+                  <xsl:apply-templates/>
+               </xsl:element>
+            </xsl:element>
+         </xsl:element>
+      </xsl:if>
+      <xsl:if test="not (contains(@styleCode,'Italics') or contains(@styleCode,'Underline') or contains(@styleCode, 'Bold'))">
+         <xsl:apply-templates/>
+      </xsl:if>
+   </xsl:template>
+   <!--    Superscript or Subscript   -->
+   <xsl:template match="n1:sup">
+      <xsl:element name="sup">
+         <xsl:apply-templates/>
+      </xsl:element>
+   </xsl:template>
+   <xsl:template match="n1:sub">
+      <xsl:element name="sub">
+         <xsl:apply-templates/>
+      </xsl:element>
+   </xsl:template>
+   <!-- show-signature -->
+   <xsl:template name="show-sig">
+      <xsl:param name="sig"/>
+      <xsl:choose>
+         <xsl:when test="$sig/@code =&apos;S&apos;">
+            <xsl:text>signed</xsl:text>
+         </xsl:when>
+         <xsl:when test="$sig/@code=&apos;I&apos;">
+            <xsl:text>intended</xsl:text>
+         </xsl:when>
+         <xsl:when test="$sig/@code=&apos;X&apos;">
+            <xsl:text>signature required</xsl:text>
+         </xsl:when>
+      </xsl:choose>
+   </xsl:template>
+   <!--  show-id -->
+   <xsl:template name="show-id">
+      <xsl:param name="id"/>
+      <xsl:choose>
+         <xsl:when test="not($id)">
+            <xsl:if test="not(@nullFlavor)">
+               <xsl:if test="@extension">
+                  <xsl:value-of select="@extension"/>
+               </xsl:if>
+               <xsl:text> </xsl:text>
+               <xsl:value-of select="@root"/>
+            </xsl:if>
+         </xsl:when>
+         <xsl:otherwise>
+            <xsl:if test="not($id/@nullFlavor)">
+               <xsl:if test="$id/@extension">
+                  <xsl:value-of select="$id/@extension"/>
+               </xsl:if>
+               <xsl:text> </xsl:text>
+               <xsl:value-of select="$id/@root"/>
+            </xsl:if>
+         </xsl:otherwise>
+      </xsl:choose>
+   </xsl:template>
+   <!-- show-name  -->
+   <xsl:template name="show-name">
+      <xsl:param name="name"/>
+      <xsl:choose>
+         <xsl:when test="$name/n1:family">
+            <xsl:if test="$name/n1:prefix">
+               <xsl:value-of select="$name/n1:prefix"/>
+               <xsl:text> </xsl:text>
+            </xsl:if>
+            <xsl:value-of select="$name/n1:given"/>
+            <xsl:text> </xsl:text>
+            <xsl:value-of select="$name/n1:family"/>
+            <xsl:if test="$name/n1:suffix">
+               <xsl:text>, </xsl:text>
+               <xsl:value-of select="$name/n1:suffix"/>
+            </xsl:if>
+         </xsl:when>
+         <xsl:otherwise>
+            <xsl:value-of select="$name"/>
+         </xsl:otherwise>
+      </xsl:choose>
+   </xsl:template>
+   <!-- show-gender  -->
+   <xsl:template name="show-gender">
+      <xsl:choose>
+         <xsl:when test="@code   = &apos;M&apos;">
+            <xsl:text>Male</xsl:text>
+         </xsl:when>
+         <xsl:when test="@code  = &apos;F&apos;">
+            <xsl:text>Female</xsl:text>
+         </xsl:when>
+         <xsl:when test="@code  = &apos;U&apos;">
+            <xsl:text>Undifferentiated</xsl:text>
+         </xsl:when>
+      </xsl:choose>
+   </xsl:template>
+   <!-- show-race-ethnicity  -->
+   <xsl:template name="show-race-ethnicity">
+      <xsl:choose>
+         <xsl:when test="@displayName">
+            <xsl:value-of select="@displayName"/>
+         </xsl:when>
+         <xsl:otherwise>
+            <xsl:value-of select="@code"/>
+         </xsl:otherwise>
+      </xsl:choose>
+   </xsl:template>
+   <!-- show-contactInfo -->
+   <xsl:template name="show-contactInfo">
+      <xsl:param name="contact"/>
+      <xsl:call-template name="show-address">
+         <xsl:with-param name="address" select="$contact/n1:addr"/>
+      </xsl:call-template>
+      <xsl:call-template name="show-telecom">
+         <xsl:with-param name="telecom" select="$contact/n1:telecom"/>
+      </xsl:call-template>
+   </xsl:template>
+   <!-- show-address -->
+   <xsl:template name="show-address">
+      <xsl:param name="address"/>
+      <xsl:choose>
+         <xsl:when test="$address">
+            <xsl:if test="$address/@use">
+               <xsl:text> </xsl:text>
+               <xsl:call-template name="translateTelecomCode">
+                  <xsl:with-param name="code" select="$address/@use"/>
+               </xsl:call-template>
+               <xsl:text>:</xsl:text>
+               <br/>
+            </xsl:if>
+            <xsl:for-each select="$address/n1:streetAddressLine">
+               <xsl:value-of select="."/>
+               <br/>
+            </xsl:for-each>
+            <xsl:if test="$address/n1:streetName">
+               <xsl:value-of select="$address/n1:streetName"/>
+               <xsl:text> </xsl:text>
+               <xsl:value-of select="$address/n1:houseNumber"/>
+               <br/>
+            </xsl:if>
+            <xsl:if test="string-length($address/n1:city)>0">
+               <xsl:value-of select="$address/n1:city"/>
+            </xsl:if>
+            <xsl:if test="string-length($address/n1:state)>0">
+               <xsl:text>,&#160;</xsl:text>
+               <xsl:value-of select="$address/n1:state"/>
+            </xsl:if>
+            <xsl:if test="string-length($address/n1:postalCode)>0">
+               <xsl:text>&#160;</xsl:text>
+               <xsl:value-of select="$address/n1:postalCode"/>
+            </xsl:if>
+            <xsl:if test="string-length($address/n1:country)>0">
+               <xsl:text>,&#160;</xsl:text>
+               <xsl:value-of select="$address/n1:country"/>
+            </xsl:if>
+         </xsl:when>
+         <xsl:otherwise>
+            <xsl:text>address not available</xsl:text>
+         </xsl:otherwise>
+      </xsl:choose>
+      <br/>
+   </xsl:template>
+   <!-- show-telecom -->
+   <xsl:template name="show-telecom">
+      <xsl:param name="telecom"/>
+      <xsl:choose>
+         <xsl:when test="$telecom">
+            <xsl:variable name="type" select="substring-before($telecom/@value, ':')"/>
+            <xsl:variable name="value" select="substring-after($telecom/@value, ':')"/>
+            <xsl:if test="$type">
+               <xsl:call-template name="translateTelecomCode">
+                  <xsl:with-param name="code" select="$type"/>
+               </xsl:call-template>
+               <xsl:if test="@use">
+                  <xsl:text> (</xsl:text>
+                  <xsl:call-template name="translateTelecomCode">
+                     <xsl:with-param name="code" select="@use"/>
+                  </xsl:call-template>
+                  <xsl:text>)</xsl:text>
+               </xsl:if>
+               <xsl:text>: </xsl:text>
+               <xsl:text> </xsl:text>
+               <xsl:value-of select="$value"/>
+            </xsl:if>
+         </xsl:when>
+         <xsl:otherwise>
+            <xsl:text>Telecom information not available</xsl:text>
+         </xsl:otherwise>
+      </xsl:choose>
+      <br/>
+   </xsl:template>
+   <!-- show-recipientType -->
+   <xsl:template name="show-recipientType">
+      <xsl:param name="typeCode"/>
+      <xsl:choose>
+         <xsl:when test="$typeCode='PRCP'">Primary Recipient:</xsl:when>
+         <xsl:when test="$typeCode='TRC'">Secondary Recipient:</xsl:when>
+         <xsl:otherwise>Recipient:</xsl:otherwise>
+      </xsl:choose>
+   </xsl:template>
+   <!-- Convert Telecom URL to display text -->
+   <xsl:template name="translateTelecomCode">
+      <xsl:param name="code"/>
+      <!--xsl:value-of select="document('voc.xml')/systems/system[@root=$code/@codeSystem]/code[@value=$code/@code]/@displayName"/-->
+      <!--xsl:value-of select="document('codes.xml')/*/code[@code=$code]/@display"/-->
+      <xsl:choose>
+         <!-- lookup table Telecom URI -->
+         <xsl:when test="$code='tel'">
+            <xsl:text>Tel</xsl:text>
+         </xsl:when>
+         <xsl:when test="$code='fax'">
+            <xsl:text>Fax</xsl:text>
+         </xsl:when>
+         <xsl:when test="$code='http'">
+            <xsl:text>Web</xsl:text>
+         </xsl:when>
+         <xsl:when test="$code='mailto'">
+            <xsl:text>Mail</xsl:text>
+         </xsl:when>
+         <xsl:when test="$code='H'">
+            <xsl:text>Home</xsl:text>
+         </xsl:when>
+         <xsl:when test="$code='HV'">
+            <xsl:text>Vacation Home</xsl:text>
+         </xsl:when>
+         <xsl:when test="$code='HP'">
+            <xsl:text>Pirmary Home</xsl:text>
+         </xsl:when>
+         <xsl:when test="$code='WP'">
+            <xsl:text>Work Place</xsl:text>
+         </xsl:when>
+         <xsl:when test="$code='PUB'">
+            <xsl:text>Pub</xsl:text>
+         </xsl:when>
+         <xsl:otherwise>
+            <xsl:text>{$code='</xsl:text>
+            <xsl:value-of select="$code"/>
+            <xsl:text>'?}</xsl:text>
+         </xsl:otherwise>
+      </xsl:choose>
+   </xsl:template>
+   <!-- convert RoleClassAssociative code to display text -->
+   <xsl:template name="translateRoleAssoCode">
+      <xsl:param name="classCode"/>
+      <xsl:param name="code"/>
+      <xsl:choose>
+         <xsl:when test="$classCode='AFFL'">
+            <xsl:text>affiliate</xsl:text>
+         </xsl:when>
+         <xsl:when test="$classCode='AGNT'">
+            <xsl:text>agent</xsl:text>
+         </xsl:when>
+         <xsl:when test="$classCode='ASSIGNED'">
+            <xsl:text>assigned entity</xsl:text>
+         </xsl:when>
+         <xsl:when test="$classCode='COMPAR'">
+            <xsl:text>commissioning party</xsl:text>
+         </xsl:when>
+         <xsl:when test="$classCode='CON'">
+            <xsl:text>contact</xsl:text>
+         </xsl:when>
+         <xsl:when test="$classCode='ECON'">
+            <xsl:text>emergency contact</xsl:text>
+         </xsl:when>
+         <xsl:when test="$classCode='NOK'">
+            <xsl:text>next of kin</xsl:text>
+         </xsl:when>
+         <xsl:when test="$classCode='SGNOFF'">
+            <xsl:text>signing authority</xsl:text>
+         </xsl:when>
+         <xsl:when test="$classCode='GUARD'">
+            <xsl:text>guardian</xsl:text>
+         </xsl:when>
+         <xsl:when test="$classCode='GUAR'">
+            <xsl:text>guardian</xsl:text>
+         </xsl:when>
+         <xsl:when test="$classCode='CIT'">
+            <xsl:text>citizen</xsl:text>
+         </xsl:when>
+         <xsl:when test="$classCode='COVPTY'">
+            <xsl:text>covered party</xsl:text>
+         </xsl:when>
+         <xsl:when test="$classCode='PRS'">
+            <xsl:text>personal relationship</xsl:text>
+         </xsl:when>
+         <xsl:when test="$classCode='CAREGIVER'">
+            <xsl:text>care giver</xsl:text>
+         </xsl:when>
+         <xsl:otherwise>
+            <xsl:text>{$classCode='</xsl:text>
+            <xsl:value-of select="$classCode"/>
+            <xsl:text>'?}</xsl:text>
+         </xsl:otherwise>
+      </xsl:choose>
+      <xsl:if test="($code/@code) and ($code/@codeSystem='2.16.840.1.113883.5.111')">
+         <xsl:text> </xsl:text>
+         <xsl:choose>
+            <xsl:when test="$code/@code='FTH'">
+               <xsl:text>(Father)</xsl:text>
+            </xsl:when>
+            <xsl:when test="$code/@code='MTH'">
+               <xsl:text>(Mother)</xsl:text>
+            </xsl:when>
+            <xsl:when test="$code/@code='NPRN'">
+               <xsl:text>(Natural parent)</xsl:text>
+            </xsl:when>
+            <xsl:when test="$code/@code='STPPRN'">
+               <xsl:text>(Step parent)</xsl:text>
+            </xsl:when>
+            <xsl:when test="$code/@code='SONC'">
+               <xsl:text>(Son)</xsl:text>
+            </xsl:when>
+            <xsl:when test="$code/@code='DAUC'">
+               <xsl:text>(Daughter)</xsl:text>
+            </xsl:when>
+            <xsl:when test="$code/@code='CHILD'">
+               <xsl:text>(Child)</xsl:text>
+            </xsl:when>
+            <xsl:when test="$code/@code='EXT'">
+               <xsl:text>(Extended family member)</xsl:text>
+            </xsl:when>
+            <xsl:when test="$code/@code='NBOR'">
+               <xsl:text>(Neighbor)</xsl:text>
+            </xsl:when>
+            <xsl:when test="$code/@code='SIGOTHR'">
+               <xsl:text>(Significant other)</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+               <xsl:text>{$code/@code='</xsl:text>
+               <xsl:value-of select="$code/@code"/>
+               <xsl:text>'?}</xsl:text>
+            </xsl:otherwise>
+         </xsl:choose>
+      </xsl:if>
+   </xsl:template>
+   <!-- show time -->
+   <xsl:template name="show-time">
+      <xsl:param name="datetime"/>
+      <xsl:choose>
+         <xsl:when test="not($datetime)">
+            <xsl:call-template name="formatDateTime">
+               <xsl:with-param name="date" select="@value"/>
+            </xsl:call-template>
+            <xsl:text> </xsl:text>
+         </xsl:when>
+         <xsl:otherwise>
+            <xsl:call-template name="formatDateTime">
+               <xsl:with-param name="date" select="$datetime/@value"/>
+            </xsl:call-template>
+            <xsl:text> </xsl:text>
+         </xsl:otherwise>
+      </xsl:choose>
+   </xsl:template>
+   <!-- paticipant facility and date -->
+   <xsl:template name="facilityAndDates">
+      <table class="header_table">
+         <tbody>
+            <!-- facility id -->
+            <tr>
+               <td width="20%" bgcolor="#3399ff">
+                  <span class="td_label">
+                     <xsl:text>Facility ID</xsl:text>
+                  </span>
+               </td>
+               <td colspan="3">
+                  <xsl:choose>
+                     <xsl:when test="count(/n1:ClinicalDocument/n1:participant
+                                      [@typeCode='LOC'][@contextControlCode='OP']
+                                      /n1:associatedEntity[@classCode='SDLOC']/n1:id)&gt;0">
+                        <!-- change context node -->
+                        <xsl:for-each select="/n1:ClinicalDocument/n1:participant
+                                      [@typeCode='LOC'][@contextControlCode='OP']
+                                      /n1:associatedEntity[@classCode='SDLOC']/n1:id">
+                           <xsl:call-template name="show-id"/>
+                           <!-- change context node again, for the code -->
+                           <xsl:for-each select="../n1:code">
+                              <xsl:text> (</xsl:text>
+                              <xsl:call-template name="show-code">
+                                 <xsl:with-param name="code" select="."/>
+                              </xsl:call-template>
+                              <xsl:text>)</xsl:text>
+                           </xsl:for-each>
+                        </xsl:for-each>
+                     </xsl:when>
+                     <xsl:otherwise>
+                 Not available
+                             </xsl:otherwise>
+                  </xsl:choose>
+               </td>
+            </tr>
+            <!-- Period reported -->
+            <tr>
+               <td width="20%" bgcolor="#3399ff">
+                  <span class="td_label">
+                     <xsl:text>First day of period reported</xsl:text>
+                  </span>
+               </td>
+               <td colspan="3">
+                  <xsl:call-template name="show-time">
+                     <xsl:with-param name="datetime" select="/n1:ClinicalDocument/n1:documentationOf
+                                      /n1:serviceEvent/n1:effectiveTime/n1:low"/>
+                  </xsl:call-template>
+               </td>
+            </tr>
+            <tr>
+               <td width="20%" bgcolor="#3399ff">
+                  <span class="td_label">
+                     <xsl:text>Last day of period reported</xsl:text>
+                  </span>
+               </td>
+               <td colspan="3">
+                  <xsl:call-template name="show-time">
+                     <xsl:with-param name="datetime" select="/n1:ClinicalDocument/n1:documentationOf
+                                      /n1:serviceEvent/n1:effectiveTime/n1:high"/>
+                  </xsl:call-template>
+               </td>
+            </tr>
+         </tbody>
+      </table>
+   </xsl:template>
+   <!-- show assignedEntity -->
+   <xsl:template name="show-assignedEntity">
+      <xsl:param name="asgnEntity"/>
+      <xsl:choose>
+         <xsl:when test="$asgnEntity/n1:assignedPerson/n1:name">
+            <xsl:call-template name="show-name">
+               <xsl:with-param name="name" select="$asgnEntity/n1:assignedPerson/n1:name"/>
+            </xsl:call-template>
+            <xsl:if test="$asgnEntity/n1:representedOrganization/n1:name">
+               <xsl:text> of </xsl:text>
+               <xsl:value-of select="$asgnEntity/n1:representedOrganization/n1:name"/>
+            </xsl:if>
+         </xsl:when>
+         <xsl:when test="$asgnEntity/n1:representedOrganization">
+            <xsl:value-of select="$asgnEntity/n1:representedOrganization/n1:name"/>
+         </xsl:when>
+         <xsl:otherwise>
+            <xsl:for-each select="$asgnEntity/n1:id">
+               <xsl:call-template name="show-id"/>
+               <xsl:choose>
+                  <xsl:when test="position()!=last()">
+                     <xsl:text>, </xsl:text>
+                  </xsl:when>
+                  <xsl:otherwise>
+                     <br/>
+                  </xsl:otherwise>
+               </xsl:choose>
+            </xsl:for-each>
+         </xsl:otherwise>
+      </xsl:choose>
+   </xsl:template>
+   <!-- show relatedEntity -->
+   <xsl:template name="show-relatedEntity">
+      <xsl:param name="relatedEntity"/>
+      <xsl:choose>
+         <xsl:when test="$relatedEntity/n1:relatedPerson/n1:name">
+            <xsl:call-template name="show-name">
+               <xsl:with-param name="name" select="$relatedEntity/n1:relatedPerson/n1:name"/>
+            </xsl:call-template>
+         </xsl:when>
+      </xsl:choose>
+   </xsl:template>
+   <!-- show associatedEntity -->
+   <xsl:template name="show-associatedEntity">
+      <xsl:param name="assoEntity"/>
+      <xsl:choose>
+         <xsl:when test="$assoEntity/n1:associatedPerson">
+            <xsl:for-each select="$assoEntity/n1:associatedPerson/n1:name">
+               <xsl:call-template name="show-name">
+                  <xsl:with-param name="name" select="."/>
+               </xsl:call-template>
+               <br/>
+            </xsl:for-each>
+         </xsl:when>
+         <xsl:when test="$assoEntity/n1:scopingOrganization">
+            <xsl:for-each select="$assoEntity/n1:scopingOrganization">
+               <xsl:if test="n1:name">
+                  <xsl:call-template name="show-name">
+                     <xsl:with-param name="name" select="n1:name"/>
+                  </xsl:call-template>
+                  <br/>
+               </xsl:if>
+               <xsl:if test="n1:standardIndustryClassCode">
+                  <xsl:value-of select="n1:standardIndustryClassCode/@displayName"/>
+                  <xsl:text> code:</xsl:text>
+                  <xsl:value-of select="n1:standardIndustryClassCode/@code"/>
+               </xsl:if>
+            </xsl:for-each>
+         </xsl:when>
+         <xsl:when test="$assoEntity/n1:code">
+            <xsl:call-template name="show-code">
+               <xsl:with-param name="code" select="$assoEntity/n1:code"/>
+            </xsl:call-template>
+         </xsl:when>
+         <xsl:when test="$assoEntity/n1:id">
+            <xsl:value-of select="$assoEntity/n1:id/@extension"/>
+            <xsl:text> </xsl:text>
+            <xsl:value-of select="$assoEntity/n1:id/@root"/>
+         </xsl:when>
+      </xsl:choose>
+   </xsl:template>
+   <!-- show code 
+    if originalText present, return it, otherwise, check and return attribute: display name
+    -->
+   <xsl:template name="show-code">
+      <xsl:param name="code"/>
+      <xsl:variable name="this-codeSystem">
+         <xsl:value-of select="$code/@codeSystem"/>
+      </xsl:variable>
+      <xsl:variable name="this-code">
+         <xsl:value-of select="$code/@code"/>
+      </xsl:variable>
+      <xsl:choose>
+         <xsl:when test="$code/n1:originalText">
+            <xsl:value-of select="$code/n1:originalText"/>
+         </xsl:when>
+         <xsl:when test="$code/@displayName">
+            <xsl:value-of select="$code/@displayName"/>
+         </xsl:when>
+         <!--
+      <xsl:when test="$the-valuesets/*/voc:system[@root=$this-codeSystem]/voc:code[@value=$this-code]/@displayName">
+        <xsl:value-of select="$the-valuesets/*/voc:system[@root=$this-codeSystem]/voc:code[@value=$this-code]/@displayName"/>
+      </xsl:when>
+      -->
+         <xsl:otherwise>
+            <xsl:value-of select="$this-code"/>
+         </xsl:otherwise>
+      </xsl:choose>
+   </xsl:template>
+   <!-- show classCode -->
+   <xsl:template name="show-actClassCode">
+      <xsl:param name="clsCode"/>
+      <xsl:choose>
+         <xsl:when test=" $clsCode = 'ACT' ">
+            <xsl:text>healthcare service</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'ACCM' ">
+            <xsl:text>accommodation</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'ACCT' ">
+            <xsl:text>account</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'ACSN' ">
+            <xsl:text>accession</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'ADJUD' ">
+            <xsl:text>financial adjudication</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'CONS' ">
+            <xsl:text>consent</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'CONTREG' ">
+            <xsl:text>container registration</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'CTTEVENT' ">
+            <xsl:text>clinical trial timepoint event</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'DISPACT' ">
+            <xsl:text>disciplinary action</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'ENC' ">
+            <xsl:text>encounter</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'INC' ">
+            <xsl:text>incident</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'INFRM' ">
+            <xsl:text>inform</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'INVE' ">
+            <xsl:text>invoice element</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'LIST' ">
+            <xsl:text>working list</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'MPROT' ">
+            <xsl:text>monitoring program</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'PCPR' ">
+            <xsl:text>care provision</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'PROC' ">
+            <xsl:text>procedure</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'REG' ">
+            <xsl:text>registration</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'REV' ">
+            <xsl:text>review</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'SBADM' ">
+            <xsl:text>substance administration</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'SPCTRT' ">
+            <xsl:text>speciment treatment</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'SUBST' ">
+            <xsl:text>substitution</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'TRNS' ">
+            <xsl:text>transportation</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'VERIF' ">
+            <xsl:text>verification</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $clsCode = 'XACT' ">
+            <xsl:text>financial transaction</xsl:text>
+         </xsl:when>
+      </xsl:choose>
+   </xsl:template>
+   <!-- show participationType -->
+   <xsl:template name="show-participationType">
+      <xsl:param name="ptype"/>
+      <xsl:choose>
+         <xsl:when test=" $ptype='PPRF' ">
+            <xsl:text>primary performer</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $ptype='PRF' ">
+            <xsl:text>performer</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $ptype='VRF' ">
+            <xsl:text>verifier</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $ptype='SPRF' ">
+            <xsl:text>secondary performer</xsl:text>
+         </xsl:when>
+      </xsl:choose>
+   </xsl:template>
+   <!-- show participationFunction -->
+   <xsl:template name="show-participationFunction">
+      <xsl:param name="pFunction"/>
+      <xsl:choose>
+         <!-- From the HL7 v3 ParticipationFunction code system -->
+         <xsl:when test=" $pFunction = 'ADMPHYS' ">
+            <xsl:text>(admitting physician)</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $pFunction = 'ANEST' ">
+            <xsl:text>(anesthesist)</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $pFunction = 'ANRS' ">
+            <xsl:text>(anesthesia nurse)</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $pFunction = 'ATTPHYS' ">
+            <xsl:text>(attending physician)</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $pFunction = 'DISPHYS' ">
+            <xsl:text>(discharging physician)</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $pFunction = 'FASST' ">
+            <xsl:text>(first assistant surgeon)</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $pFunction = 'MDWF' ">
+            <xsl:text>(midwife)</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $pFunction = 'NASST' ">
+            <xsl:text>(nurse assistant)</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $pFunction = 'PCP' ">
+            <xsl:text>(primary care physician)</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $pFunction = 'PRISURG' ">
+            <xsl:text>(primary surgeon)</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $pFunction = 'RNDPHYS' ">
+            <xsl:text>(rounding physician)</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $pFunction = 'SASST' ">
+            <xsl:text>(second assistant surgeon)</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $pFunction = 'SNRS' ">
+            <xsl:text>(scrub nurse)</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $pFunction = 'TASST' ">
+            <xsl:text>(third assistant)</xsl:text>
+         </xsl:when>
+         <!-- From the HL7 v2 Provider Role code system (2.16.840.1.113883.12.443) which is used by HITSP -->
+         <xsl:when test=" $pFunction = 'CP' ">
+            <xsl:text>(consulting provider)</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $pFunction = 'PP' ">
+            <xsl:text>(primary care provider)</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $pFunction = 'RP' ">
+            <xsl:text>(referring provider)</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $pFunction = 'MP' ">
+            <xsl:text>(medical home provider)</xsl:text>
+         </xsl:when>
+      </xsl:choose>
+   </xsl:template>
+   <xsl:template name="formatDateTime">
+      <xsl:param name="date"/>
+      <!-- month -->
+      <xsl:variable name="month" select="substring ($date, 5, 2)"/>
+      <xsl:choose>
+         <xsl:when test="$month='01'">
+            <xsl:text>January </xsl:text>
+         </xsl:when>
+         <xsl:when test="$month='02'">
+            <xsl:text>February </xsl:text>
+         </xsl:when>
+         <xsl:when test="$month='03'">
+            <xsl:text>March </xsl:text>
+         </xsl:when>
+         <xsl:when test="$month='04'">
+            <xsl:text>April </xsl:text>
+         </xsl:when>
+         <xsl:when test="$month='05'">
+            <xsl:text>May </xsl:text>
+         </xsl:when>
+         <xsl:when test="$month='06'">
+            <xsl:text>June </xsl:text>
+         </xsl:when>
+         <xsl:when test="$month='07'">
+            <xsl:text>July </xsl:text>
+         </xsl:when>
+         <xsl:when test="$month='08'">
+            <xsl:text>August </xsl:text>
+         </xsl:when>
+         <xsl:when test="$month='09'">
+            <xsl:text>September </xsl:text>
+         </xsl:when>
+         <xsl:when test="$month='10'">
+            <xsl:text>October </xsl:text>
+         </xsl:when>
+         <xsl:when test="$month='11'">
+            <xsl:text>November </xsl:text>
+         </xsl:when>
+         <xsl:when test="$month='12'">
+            <xsl:text>December </xsl:text>
+         </xsl:when>
+      </xsl:choose>
+      <!-- day -->
+      <xsl:choose>
+         <xsl:when test='substring ($date, 7, 1)="0"'>
+            <xsl:value-of select="substring ($date, 8, 1)"/>
+            <xsl:text>, </xsl:text>
+         </xsl:when>
+         <xsl:otherwise>
+            <xsl:value-of select="substring ($date, 7, 2)"/>
+            <xsl:text>, </xsl:text>
+         </xsl:otherwise>
+      </xsl:choose>
+      <!-- year -->
+      <xsl:value-of select="substring ($date, 1, 4)"/>
+      <!-- time and US timezone -->
+      <xsl:if test="string-length($date) > 8">
+         <xsl:text>, </xsl:text>
+         <!-- time -->
+         <xsl:variable name="time">
+            <xsl:value-of select="substring($date,9,6)"/>
+         </xsl:variable>
+         <xsl:variable name="hh">
+            <xsl:value-of select="substring($time,1,2)"/>
+         </xsl:variable>
+         <xsl:variable name="mm">
+            <xsl:value-of select="substring($time,3,2)"/>
+         </xsl:variable>
+         <xsl:variable name="ss">
+            <xsl:value-of select="substring($time,5,2)"/>
+         </xsl:variable>
+         <xsl:if test="string-length($hh)&gt;1">
+            <xsl:value-of select="$hh"/>
+            <xsl:if test="string-length($mm)&gt;1 and not(contains($mm,'-')) and not (contains($mm,'+'))">
+               <xsl:text>:</xsl:text>
+               <xsl:value-of select="$mm"/>
+               <xsl:if test="string-length($ss)&gt;1 and not(contains($ss,'-')) and not (contains($ss,'+'))">
+                  <xsl:text>:</xsl:text>
+                  <xsl:value-of select="$ss"/>
+               </xsl:if>
+            </xsl:if>
+         </xsl:if>
+         <!-- time zone -->
+         <xsl:variable name="tzon">
+            <xsl:choose>
+               <xsl:when test="contains($date,'+')">
+                  <xsl:text>+</xsl:text>
+                  <xsl:value-of select="substring-after($date, '+')"/>
+               </xsl:when>
+               <xsl:when test="contains($date,'-')">
+                  <xsl:text>-</xsl:text>
+                  <xsl:value-of select="substring-after($date, '-')"/>
+               </xsl:when>
+            </xsl:choose>
+         </xsl:variable>
+         <xsl:choose>
+            <!-- reference: http://www.timeanddate.com/library/abbreviations/timezones/na/ -->
+            <xsl:when test="$tzon = '-0500' ">
+               <xsl:text>, EST</xsl:text>
+            </xsl:when>
+            <xsl:when test="$tzon = '-0600' ">
+               <xsl:text>, CST</xsl:text>
+            </xsl:when>
+            <xsl:when test="$tzon = '-0700' ">
+               <xsl:text>, MST</xsl:text>
+            </xsl:when>
+            <xsl:when test="$tzon = '-0800' ">
+               <xsl:text>, PST</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+               <xsl:text> </xsl:text>
+               <xsl:value-of select="$tzon"/>
+            </xsl:otherwise>
+         </xsl:choose>
+      </xsl:if>
+   </xsl:template>
+   <!-- convert to lower case -->
+   <xsl:template name="caseDown">
+      <xsl:param name="data"/>
+      <xsl:if test="$data">
+         <xsl:value-of select="translate($data, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')"/>
+      </xsl:if>
+   </xsl:template>
+   <!-- convert to upper case -->
+   <xsl:template name="caseUp">
+      <xsl:param name="data"/>
+      <xsl:if test="$data">
+         <xsl:value-of select="translate($data,'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"/>
+      </xsl:if>
+   </xsl:template>
+   <!-- convert first character to upper case -->
+   <xsl:template name="firstCharCaseUp">
+      <xsl:param name="data"/>
+      <xsl:if test="$data">
+         <xsl:call-template name="caseUp">
+            <xsl:with-param name="data" select="substring($data,1,1)"/>
+         </xsl:call-template>
+         <xsl:value-of select="substring($data,2)"/>
+      </xsl:if>
+   </xsl:template>
+   <!-- show-noneFlavor -->
+   <xsl:template name="show-noneFlavor">
+      <xsl:param name="nf"/>
+      <xsl:choose>
+         <xsl:when test=" $nf = 'NI' ">
+            <xsl:text>no information</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $nf = 'INV' ">
+            <xsl:text>invalid</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $nf = 'MSK' ">
+            <xsl:text>masked</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $nf = 'NA' ">
+            <xsl:text>not applicable</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $nf = 'UNK' ">
+            <xsl:text>unknown</xsl:text>
+         </xsl:when>
+         <xsl:when test=" $nf = 'OTH' ">
+            <xsl:text>other</xsl:text>
+         </xsl:when>
+      </xsl:choose>
+   </xsl:template>
+   <xsl:template name="addCSS">
+      <style type="text/css">
+         <xsl:text>
+body {
+  color: #003366;
+  background-color: #FFFFFF;
+  font-family: Verdana, Tahoma, sans-serif;
+  font-size: 11px;
+}
+
+a {
+  color: #003366;
+  background-color: #FFFFFF;
+}
+
+h1 {
+  font-size: 12pt;
+  font-weight: bold;
+}
+
+h2 {
+  font-size: 11pt;
+  font-weight: bold;
+}
+
+h3 {
+  font-size: 10pt;
+  font-weight: bold;
+}
+
+h4 {
+  font-size: 8pt;
+  font-weight: bold;
+}
+
+div {
+  width: 80%;
+}
+
+table {
+  line-height: 10pt;
+  width: 80%;
+}
+
+tr {
+  background-color: #ccccff;
+}
+
+td {
+  padding: 0.1cm 0.2cm;
+  vertical-align: top;
+}
+
+.h1center {
+  font-size: 12pt;
+  font-weight: bold;
+  text-align: center;
+  width: 80%;
+}
+
+.header_table{
+  border: 1pt inset #00008b;
+}
+
+.narr_table {
+  width: 100%;
+}
+
+.narr_tr {
+  background-color: #ffffcc;
+}
+
+.narr_th {
+  background-color: #ffd700;
+}
+
+.td_label{
+  font-weight: bold;
+  color: white;
+}
+          </xsl:text>
+      </style>
+   </xsl:template>
+</xsl:stylesheet>

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/patientDiscovery.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/patientDiscovery.xhtml
@@ -120,7 +120,7 @@
                                                             </h:column>
                                                             <h:column>
                                                                 <f:facet name="header">Organization</f:facet>
-                                                                    #{patient.organization}
+                                                                    #{patientSearchBean.displayOrganizationName}
                                                             </h:column> 
                                                             <h:column>
                                                                 <f:facet name="header"></f:facet>
@@ -161,7 +161,7 @@
                                                         <p:outputLabel value="Patient ID:" />
                                                         <h:outputText  value="#{patientSearchBean.patientList[0].patientId}" />
                                                         <p:outputLabel value="Organization:" />
-                                                        <h:outputText value="#{patientSearchBean.patientList[0].organization}" />
+                                                        <h:outputText value="#{patientSearchBean.displayOrganizationName}" />
                                                         <p:outputLabel value="Gender:" />
                                                         <h:outputText  value="#{patientSearchBean.patientList[0].gender}"/>
                                                         <p:outputLabel value="Date Of Birth:" />
@@ -187,14 +187,14 @@
                                                 <div class="form-group">
                                                     <h:outputLabel for="inputDateRangeFrom" class="col-sm-3 control-label" id="labelDateRangeFrom" value="Date Range From:" />
                                                     <div class="col-sm-9">
-                                                        <p:calendar id="inputDateRangeFrom" showOn="button" pattern="MM/dd/yyyy" value="#{patientSearchBean.documentRangeFrom}" required="false" requiredMessage="Date Range From required."/>
+                                                        <p:calendar id="inputDateRangeFrom" showOn="button" value="#{patientSearchBean.documentRangeFrom}" pattern="MM/dd/yyyy" required="false" requiredMessage="Date Range From required."/>
                                                     </div>
                                                 </div>
                                                 <div class="form-group">
                                                     <h:outputLabel for="inputDateRangeTo" class="col-sm-3 control-label" id="labelDateRangeTo" value="To:" />
 
                                                     <div class="col-sm-9">
-                                                        <p:calendar id="inputDateRangeTo" showOn="button" pattern="MM/dd/yyyy" value="#{patientSearchBean.documentRangeTo}" required="false" requiredMessage="Date Range To required."/>
+                                                        <p:calendar id="inputDateRangeTo" showOn="button" value="#{patientSearchBean.documentRangeTo}" pattern="MM/dd/yyyy" required="false" requiredMessage="Date Range To required."/>
                                                     </div>
                                                 </div>
                                                 <div class="form-group">
@@ -218,8 +218,12 @@
                                                         </h:column>
 
                                                         <h:column>
-                                                            <f:facet name="header">Document Type</f:facet>
+                                                            <f:facet name="header">Content Type</f:facet>
                                                                 #{patientDocument.contentType}
+                                                        </h:column>
+                                                        <h:column>
+                                                            <f:facet name="header">Document Type</f:facet>
+                                                                #{patientDocument.documentType}
                                                         </h:column>
                                                         <h:column>
                                                             <f:facet name="header">Title</f:facet>
@@ -230,7 +234,7 @@
                                                                 #{patientDocument.authorPerson}
                                                         </h:column> 
                                                         <h:column>
-                                                            <f:facet name="header">Size</f:facet>
+                                                            <f:facet name="header">Size(KB)</f:facet>
                                                                 #{patientDocument.size}
                                                         </h:column> 
                                                         <h:column>
@@ -243,7 +247,7 @@
                                                             <f:facet name="header"></f:facet>
                                                             <p:commandButton id="viewDocument" value="Open" styleClass="add-button pull-right" icon="ui-icon-circle-plus" action="#{patientSearchBean.retrieveDocument()}" oncomplete="PF('documentContent').show();" update=":documentDialog">
                                                                 <f:setPropertyActionListener target="#{patientSearchBean.selectedDocument}" value="#{patientDocument.documentIndex}"/>
-                                                            </p:commandButton>    
+                                                            </p:commandButton>
                                                         </h:column>
                                                     </h:dataTable>                                                       
                                                 </div>
@@ -251,95 +255,83 @@
                                         </div>
                                     </div>
                                 </div>
-                            </h:form>
+                            </h:form>                            
                         </p:tab>                
                     </div>
                 </p:tabView>           
                 <div  class="modal-copyright-prime">
-                    <p:dialog header="Document Metadata" widgetVar="docMetadataWindow" id="documentMetadataDialog"  width="700px" showEffect="clip" hideEffect="clip" modal="true">
-                        <p:separator/>
-                        <h3>Document Metadata Information</h3>
+                    <p:dialog header="#{patientSearchBean.selectedCurrentDocument.documentType} for #{patientSearchBean.patientList[0].name} Created by #{patientSearchBean.selectedCurrentDocument.authorPerson} on #{patientSearchBean.selectedCurrentDocument.creationTimeUiDisplay}"  widgetVar="docMetadataWindow" id="documentMetadataDialog"  width="1100px" showEffect="clip" hideEffect="clip" modal="true">
+                        <p:separator/>                        
                         <p:panel id="DocumentMetadataPanel" widgetVar="DQMetadataPanel" style="width: 100%; margin: 0;border:0 none; padding-top: 0;margin-top: 0;margin-bottom: 0;padding-bottom: 0">
                             <p:panelGrid styleClass="ui-panelgrid-domain" style="margin: 0;border:0 none;" columns="6">
-                                <p:outputLabel value="Author Person:" />
-                                <h:outputText  value="#{patientSearchBean.selectedCurrentDocument.authorPerson}" />
-                                <p:outputLabel value="Author Role:" />
-                                <h:outputText  value="#{patientSearchBean.selectedCurrentDocument.authorRole}" />
-                                <p:outputLabel value="Author Speciality:" />
-                                <h:outputText value="#{patientSearchBean.selectedCurrentDocument.authorSpecialty}" />
-                                <p:outputLabel value="Author Institution" />
-                                <h:outputText value="#{patientSearchBean.selectedCurrentDocument.authorInstitution}" />
-                                <p:outputLabel value="Content Type:" />
-                                <h:outputText value="#{patientSearchBean.selectedCurrentDocument.contentType}"/>
-                                <p:outputLabel value="Size:" />
-                                <h:outputText value="#{patientSearchBean.selectedCurrentDocument.size}"/>
-                                <p:outputLabel value="URI:" />
-                                <h:outputText  value="#{patientSearchBean.selectedCurrentDocument.URI}"/>
-                                <p:outputLabel value="Creation Time:" />
+                                <p:outputLabel value="Document Title:" />
+                                <h:outputText  value="#{patientSearchBean.selectedCurrentDocument.name}" />
+                                <p:outputLabel value="Creation Date:" />
                                 <h:outputText value="#{patientSearchBean.selectedCurrentDocument.creationTime}">
-                                    <f:convertDateTime pattern="MM/dd/yyyy HHmmss" />
+                                    <f:convertDateTime pattern="MM/dd/yyyy HH:mm:ss" />
                                 </h:outputText>
                                 <p:outputLabel value="Service Start Time:" />
                                 <h:outputText value="#{patientSearchBean.selectedCurrentDocument.serviceStartTime}">
-                                    <f:convertDateTime pattern="MM/dd/yyyy HHmmss" />
+                                    <f:convertDateTime pattern="MM/dd/yyyy HH:mm:ss" />
                                 </h:outputText>
                                 <p:outputLabel value="Service Stop Time:" />
                                 <h:outputText value="#{patientSearchBean.selectedCurrentDocument.serviceStopTime}">
-                                    <f:convertDateTime pattern="MM/dd/yyyy HHmmss" />
+                                    <f:convertDateTime pattern="MM/dd/yyyy HH:MM:ss" />
                                 </h:outputText>
-                                <p:outputLabel value="Source Patient ID:" />
-                                <h:outputText value="#{patientSearchBean.selectedCurrentDocument.sourcePatientId}"/>
+                                <p:outputLabel value="Document Id:" />
+                                <h:outputText value="#{patientSearchBean.selectedCurrentDocument.documentId}"/>
+                                <p:outputLabel value="Content Type:" />
+                                <h:outputText value="#{patientSearchBean.selectedCurrentDocument.contentType}"/>
+                                <p:outputLabel value="Size(KB):" />
+                                <h:outputText value="#{patientSearchBean.selectedCurrentDocument.size}"/>
+                                <p:outputLabel value="Document Type Code:" />
+                                <h:outputText value="#{patientSearchBean.selectedCurrentDocument.documentTypeCode}"/>
+                                <p:outputLabel value="Document Class Code:" />
+                                <h:outputText value="#{patientSearchBean.selectedCurrentDocument.documentClassCode}"/>
+                                <p:outputLabel value="Document Format Code:" />
+                                <h:outputText value="#{patientSearchBean.selectedCurrentDocument.documentFormatCode}"/>
+                                <p:outputLabel value="Author Person:" />
+                                <h:outputText  value="#{patientSearchBean.selectedCurrentDocument.authorPerson}" />
+                                <p:outputLabel value="Author Institution" />
+                                <h:outputText value="#{patientSearchBean.selectedCurrentDocument.authorInstitution}" />
+                                <p:outputLabel value="Confidentiality Code:" />
+                                <h:outputText value="#{patientSearchBean.selectedCurrentDocument.confidentialityCode}"/>
+                                <p:outputLabel value="Entry UUID:" />
+                                <h:outputText value="#{patientSearchBean.selectedCurrentDocument.entryUUID}"/>
+                                <p:outputLabel value="Healthcare Facility Type Code:" />
+                                <h:outputText value="#{patientSearchBean.selectedCurrentDocument.healthcareFacilityTypeCode}"/>
                             </p:panelGrid>
                         </p:panel>
                         <p:separator/>
                     </p:dialog>   
-                </div>
+                </div> 
                 <div  class="modal-copyright-prime"  style="height:95%; width:90%; top: 2%; left: 2%">
-                    <p:dialog header="Document Content" widgetVar="documentContent" id="documentDialog"  style="height:95% !important; width:90% !important; top:1% !important; left: 1% !important;" modal="true" >
-                        <p:separator/>
-                        <h3>Document Information for Document ID #{patientSearchBean.selectedCurrentDocument.documentId}</h3>
-                        <p:panel id="documentContentPanel" style="width: 70%; margin: 0;border:0 none; padding-top: 0;margin-top: 0;margin-bottom: 0;padding-bottom: 0">
-                            <p:panelGrid styleClass="ui-panelgrid-domain" style="margin: 0;border:0 none;padding-top: 0;margin-top: 0;margin-bottom: 0;padding-bottom: 0" columns="6">
-                                <p:outputLabel value="Document ID:" />
-                                <h:outputText  value="#{patientSearchBean.selectedCurrentDocument.documentId}" />
-                                <p:outputLabel value="Source Patient Id:" />
-                                <h:outputText  value="#{patientSearchBean.selectedCurrentDocument.sourcePatientId}" />
-                                <p:outputLabel value="Document Name:" />
-                                <h:outputText  value="#{patientSearchBean.selectedCurrentDocument.name}" />
-                                <p:outputLabel value="Document Description:" />
-                                <h:outputText  value="#{patientSearchBean.selectedCurrentDocument.description}" />
-                                <p:outputLabel value="Content Type:" />
-                                <h:outputText  value="#{patientSearchBean.selectedCurrentDocument.contentType}" />
-                                <p:outputLabel value="Document Size:" />
-                                <h:outputText  value="#{patientSearchBean.selectedCurrentDocument.size}" />
-                                <p:outputLabel value="Document Creation Datetime:" />
-                                <h:outputText  value="#{patientSearchBean.selectedCurrentDocument.creationTime}">
-                                    <f:convertDateTime pattern="MM/dd/yyyy HHmmss" />
-                                </h:outputText>
-                            </p:panelGrid>
-                        </p:panel>
-                        <p:separator/>
+                    <p:dialog header="#{patientSearchBean.selectedCurrentDocument.documentType} for #{patientSearchBean.patientList[0].name} Created by #{patientSearchBean.selectedCurrentDocument.authorPerson} on #{patientSearchBean.selectedCurrentDocument.creationTimeUiDisplay}" widgetVar="documentContent" id="documentDialog"  style="height:95% !important; width:90% !important; top:1% !important; left: 1% !important;" modal="true" >                        
                         <p:commandButton id="downloadDocument" value="Download" styleClass="btn-default" immediate="true" rendered="false"/>
-                        <br/>
-                        <p:inputTextarea  autoResize="false" readonly="true" rows="35" value="#{patientSearchBean.documentList[patientSearchBean.selectedDocument].document}" style ="height:70% !important;width:100% !important;" rendered="#{patientSearchBean.renderDocumentText}"/>
-                        <!--All image files should be displayed displayed here-->
+                        <br/>                        
+                        <p:scrollPanel id="documentxml" rendered="#{patientSearchBean.renderDocumentText}"  style="height:90% !important;width:100% !important;" >
+                            <p:inputTextarea  autoResize="false" readonly="true" rows="60" value="#{patientSearchBean.documentList[patientSearchBean.selectedDocument].document}" style ="height:70% !important;width:100% !important;" rendered="#{patientSearchBean.renderDocumentText}"/>
+                        </p:scrollPanel>                        
+                        <!--All image files should be displayed here-->
                         <p:scrollPanel rendered="#{patientSearchBean.renderDocumentimage}" style ="height:90% !important;width:100% !important;">
-                            <p:graphicImage value="#{patientSearchBean.documentImage}" height="1000px" style ="height:90% !important;width:100% !important;"/>
+                            <p:graphicImage value="#{patientSearchBean.documentImage}" height="2000px" style ="height:90% !important;width:100% !important;"/>
                         </p:scrollPanel>
                         <p:media value="#{patientSearchBean.documentPdf}" rendered="#{patientSearchBean.renderDocumentPdf}" player="pdf" style="height: 800px; width: 100%;"/>
                         <p:outputLabel value="Document Can't be displayed." style="font-size: large" rendered="#{patientSearchBean.renderDcoumentNotSupported}"/>
-
                     </p:dialog>   
                 </div>
                 <p:hotkey bind="esc" handler="documentContent.hide();docMetadataWindow.hide();statusDialogBar.hide()" />
                 <p:ajaxStatus onstart="PF('statusDialogBar').show()" onsuccess="PF('statusDialogBar').hide()" />
                 <div  class="modal-copyright-prime">
                     <p:dialog widgetVar="statusDialogBar" modal="true" draggable="false" closable="false" resizable="false" showHeader="false">
-                        <h:outputText value="Loading...."/>
+                        <h:outputText value="SEARCHING PATIENT....." rendered="#{empty patientSearchBean.patientList}" style="text-align: center"/>
+                        <h:outputText value="SEARCHING PATIENT DOCUMENT....." rendered="#{not empty patientSearchBean.patientList}" />
+                        <h:outputText value="OPENING PATIENT DOCUMENT....." rendered="#{patientSearchBean.documentFound}" />
+                        <br/>
                         <p:graphicImage library="images" name="loading-bar-gif.gif" />
                     </p:dialog>
                 </div>
-            </ui:define>
+            </ui:define>            
         </ui:composition>
     </h:body>
 </html>

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
@@ -483,6 +483,9 @@ public class NhincConstants {
     // Standard Format for parsing String into Date
     public static final String DATE_PARSE_FORMAT = "yyyyMMddHHmmss";
 
+    //Document Type property for UClient
+    public static final String DOCUMET_TYPE_PROPERTY_FILE = "documentTypes";
+
     /* -- End Document Retrieve deferred Service Name -- */
     private NhincConstants() {
     }

--- a/Product/Production/Common/Properties/src/main/resources/documentTypes.properties
+++ b/Product/Production/Common/Properties/src/main/resources/documentTypes.properties
@@ -1,0 +1,15 @@
+56445-0=Medication Summary
+53576-5=Personal Health Monitoring Report
+11369-6=History of Immunization
+11485-0=Anesthesia Records
+11486-8=Chemotheropy Records
+18726-0=Radiology Studies
+27898-6=Pathology Studies
+28619-5=Opthomology Studies
+26436-6=Laboratory Studies
+26441-6=Cardiology Studies
+18842-5=Discharge Summarization Note
+18161-7=Transfer Summarization Note
+11488-4=Consultation Note
+29751-5=Critical Care Records
+34133-9=Summarization of Episode Note

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/builder/AdhocQueryRequestBuilder.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/builder/AdhocQueryRequestBuilder.java
@@ -29,6 +29,7 @@ import gov.hhs.fha.nhinc.messaging.builder.Builder;
 import gov.hhs.fha.nhinc.docquery.xdsb.helper.XDSbConstants.ReturnType;
 import gov.hhs.fha.nhinc.docquery.xdsb.helper.XDSbConstants.XDSbStoredQuery;
 import java.util.Date;
+import java.util.List;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
 
 /**
@@ -73,7 +74,7 @@ public interface AdhocQueryRequestBuilder extends Builder {
     /**
      * @param documentTypeCode
      */
-    public void setDocumentTypeCode(String documentTypeCode);
+    public void setDocumentTypeCode(List<String> documentTypeCode);
 
     /**
      * @param startTime

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/builder/impl/FindDocumentsAdhocQueryRequestBuilder.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/builder/impl/FindDocumentsAdhocQueryRequestBuilder.java
@@ -33,6 +33,7 @@ import gov.hhs.fha.nhinc.docquery.xdsb.helper.XDSbConstants.XDSQueryStatus;
 import gov.hhs.fha.nhinc.docquery.xdsb.helper.XDSbConstants.XDSbStoredQuery;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
 import org.apache.commons.lang.StringUtils;
 
@@ -41,6 +42,8 @@ import org.apache.commons.lang.StringUtils;
  * @author tjafri
  */
 public class FindDocumentsAdhocQueryRequestBuilder extends AbstractAdhocQueryRequestBuilder {
+
+    private final String loincSchemaCode;
 
     /**
      * The helper.
@@ -82,12 +85,13 @@ public class FindDocumentsAdhocQueryRequestBuilder extends AbstractAdhocQueryReq
     /**
      * The document type code.
      */
-    private String documentTypeCode = null;
+    private List<String> documentTypeCode = null;
 
     /**
-     * Instantiates a new find documents adhoc query request builder.
+     * Initialize with Schema Code unique value Instantiates a new find documents adhoc query request builder.
      */
     public FindDocumentsAdhocQueryRequestBuilder() {
+        this.loincSchemaCode = "2.16.840.1.113883.6.1";
         this.helper = new XDSbAdhocQueryRequestHelperImpl();
     }
 
@@ -97,6 +101,7 @@ public class FindDocumentsAdhocQueryRequestBuilder extends AbstractAdhocQueryReq
      * @param helper the helper
      */
     FindDocumentsAdhocQueryRequestBuilder(XDSbAdhocQueryRequestHelper helper) {
+        this.loincSchemaCode = "2.16.840.1.113883.6.1";
         this.helper = helper;
     }
 
@@ -133,9 +138,9 @@ public class FindDocumentsAdhocQueryRequestBuilder extends AbstractAdhocQueryReq
             helper.createOrReplaceSlotValue(RegistryStoredQueryParameter.$XDSDocumentEntryCreationTimeTo,
                 helper.formatXDSbDate(creationTimeTo), request);
         }
-        if (!StringUtils.isBlank(documentTypeCode)) {
-            helper.createOrReplaceSlotValue(RegistryStoredQueryParameter.$XDSDocumentEntryTypeCode,
-                helper.createCodeSchemeValue(documentTypeCode, "LOINC"), request);
+        if (!documentTypeCode.isEmpty()) {
+            helper.createOrReplaceSlotValue(RegistryStoredQueryParameter.$XDSDocumentEntryClassCode,
+                helper.createCodeSchemeValue(documentTypeCode, loincSchemaCode), request);
         }
     }
 
@@ -183,16 +188,6 @@ public class FindDocumentsAdhocQueryRequestBuilder extends AbstractAdhocQueryReq
         this.creationTimeTo = creationTimeTo;
     }
 
-    /**
-     * Sets the document type code.
-     *
-     * @param documentTypeCode the new document type code
-     */
-    @Override
-    public void setDocumentTypeCode(String documentTypeCode) {
-        this.documentTypeCode = documentTypeCode;
-    }
-
     @Override
     public XDSbStoredQuery getQueryId() {
         return queryId;
@@ -201,5 +196,10 @@ public class FindDocumentsAdhocQueryRequestBuilder extends AbstractAdhocQueryReq
     @Override
     public void setPatientIdRoot(String patientIdRoot) {
         this.patientIdRoot = patientIdRoot;
+    }
+
+    @Override
+    public void setDocumentTypeCode(List<String> documentTypeCode) {
+        this.documentTypeCode = documentTypeCode;
     }
 }

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/model/DocumentMetadata.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/model/DocumentMetadata.java
@@ -26,6 +26,7 @@
 package gov.hhs.fha.nhinc.docquery.model;
 
 import java.util.Date;
+import java.util.List;
 
 /**
  *
@@ -35,7 +36,7 @@ public class DocumentMetadata {
 
     private String patientId;
     private String patientIdRoot;
-    private String documentType;
+    private List<String> documentType;
     private Date startTime;
     private Date endTime;
     private String organization; //organization home community Id
@@ -62,35 +63,68 @@ public class DocumentMetadata {
         this.patientIdRoot = patientIdRoot;
     }
 
-    public String getDocumentType() {
-        return documentType;
-    }
-
-    public void setDocumentType(String documentType) {
-        this.documentType = documentType;
-    }
-
+    /**
+     *
+     * @return the startTime
+     */
     public Date getStartTime() {
         return startTime;
     }
 
+    /**
+     *
+     * @param startTime the startTime to set
+     */
     public void setStartTime(Date startTime) {
         this.startTime = startTime;
     }
 
+    /**
+     *
+     * @return the endTime
+     */
     public Date getEndTime() {
         return endTime;
     }
 
+    /**
+     *
+     * @param endTime the endTime to set
+     */
     public void setEndTime(Date endTime) {
         this.endTime = endTime;
     }
 
+    /**
+     *
+     * @return the organization
+     */
     public String getOrganization() {
         return organization;
     }
 
+    /**
+     *
+     * @param organization the organization to set
+     */
     public void setOrganization(String organization) {
         this.organization = organization;
     }
+
+    /**
+     *
+     * @return the documentType
+     */
+    public List<String> getDocumentType() {
+        return documentType;
+    }
+
+    /**
+     *
+     * @param documentType documentType to set
+     */
+    public void setDocumentType(List<String> documentType) {
+        this.documentType = documentType;
+    }
+
 }

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/xdsb/helper/XDSbAdhocQueryRequestHelper.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/xdsb/helper/XDSbAdhocQueryRequestHelper.java
@@ -48,6 +48,18 @@ public interface XDSbAdhocQueryRequestHelper {
         AdhocQueryRequest message);
 
     /**
+     * Creates a slot with the given name and a single value. If a slot already exists, its value will be replaced with
+     * the passed in value, even in cases where there are multiple existing values. For example, if a slot exists with 3
+     * values, and this method is invoked the resulting slot will have a single value.
+     *
+     * @param slotName the slot name
+     * @param value the value
+     * @param message the message
+     */
+    public void createOrReplaceSlotValue(XDSbConstants.RegistryStoredQueryParameter slotName, List<String> value,
+        AdhocQueryRequest message);
+
+    /**
      * Format date in UTC representation with no trailing zeros.
      *
      * @param date the date
@@ -72,10 +84,10 @@ public interface XDSbAdhocQueryRequestHelper {
     public String createSingleQuoteDelimitedListValue(List<String> values);
 
     /**
-     * @param documentTypeCode
+     * @param documentTypeCode the documentTypecode
      * @param string
-     * @return
+     * @return the list
      */
-    public String createCodeSchemeValue(String documentTypeCode, String string);
+    public List<String> createCodeSchemeValue(List<String> documentTypeCode, String string);
 
 }

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/xdsb/helper/XDSbAdhocQueryRequestHelperImpl.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/xdsb/helper/XDSbAdhocQueryRequestHelperImpl.java
@@ -28,6 +28,7 @@ package gov.hhs.fha.nhinc.docquery.xdsb.helper;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.docquery.xdsb.helper.XDSbConstants.RegistryStoredQueryParameter;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
@@ -89,7 +90,8 @@ public class XDSbAdhocQueryRequestHelperImpl implements XDSbAdhocQueryRequestHel
         slot.setName(slotName.toString());
         slot.setValueList(new ValueListType());
         slot.getValueList().getValue().addAll(values);
-        return null;
+        //return null;
+        return slot;
     }
 
     @Override
@@ -130,13 +132,33 @@ public class XDSbAdhocQueryRequestHelperImpl implements XDSbAdhocQueryRequestHel
     }
 
     @Override
-    public String createCodeSchemeValue(String documentTypeCode, String scheme) {
-        StringBuilder builder = new StringBuilder();
-        builder.append("('");
-        builder.append(documentTypeCode);
-        builder.append("^^");
-        builder.append(scheme);
-        builder.append("')");
-        return builder.toString();
+    public List<String> createCodeSchemeValue(List<String> documentTypeCode, String schema) {
+        List<String> docType = new ArrayList<String>();
+        for (String docTypeCode : documentTypeCode) {
+            StringBuilder builder = new StringBuilder();
+            builder.append("('");
+            builder.append(docTypeCode);
+            builder.append("^^");
+            builder.append(schema);
+            builder.append("')");
+            docType.add(builder.toString());
+        }
+        return docType;
+    }
+
+    @Override
+    public void createOrReplaceSlotValue(RegistryStoredQueryParameter slotName, List<String> value, AdhocQueryRequest message) {
+
+        if (message != null && message.getAdhocQuery() != null && message.getAdhocQuery().getSlot() != null) {
+            for (SlotType1 slot : message.getAdhocQuery().getSlot()) {
+                if (slot != null) {
+                    if (StringUtils.equalsIgnoreCase(slot.getName(), slotName.toString())) {
+                        message.getAdhocQuery().getSlot().remove(slot);
+                        break;
+                    }
+                }
+            }
+            message.getAdhocQuery().getSlot().add(createSlot(slotName, value));
+        }
     }
 }


### PR DESCRIPTION
Fixes for below items:
1.Document type drop down to show sample document types from the documenttype.properties
2.QD results to reflect correct document type, Size(in kb) and format timestamp
3.Document metadata model dialogue content update as per ticket (FHAC-246).
4.Removed  info section from Document Content page and header title update for metadata model and content display dialogue.
5. For XML CDA, conver XML CDA to HTML format and display HTML display.
6. Display selected organization name and relevant loading bar message update.
