### PR TITLE
FHAC-293: Fixed the code to make AuthzDecisionStatement>Evidence>Assertion>Conditions SAML element not requried

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
@@ -40,7 +40,6 @@ public class NhincConstants {
 
         LEVEL_g0, LEVEL_g1
     }
-
     public static final String HCID_PREFIX = "urn:oid:";
 
     public static enum ADAPTER_API_LEVEL {
@@ -77,17 +76,16 @@ public class NhincConstants {
     public static enum NHIN_SERVICE_NAMES {
 
         PATIENT_DISCOVERY(PATIENT_DISCOVERY_SERVICE_NAME), PATIENT_DISCOVERY_DEFERRED_REQUEST(
-            PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME), PATIENT_DISCOVERY_DEFERRED_RESPONSE(
-                PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
+        PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME), PATIENT_DISCOVERY_DEFERRED_RESPONSE(
+        PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
         DOCUMENT_QUERY(DOC_QUERY_SERVICE_NAME),
         DOCUMENT_RETRIEVE(DOC_RETRIEVE_SERVICE_NAME),
         DOCUMENT_SUBMISSION(NHINC_XDR_SERVICE_NAME), DOCUMENT_SUBMISSION_DEFERRED_REQUEST(
-            NHINC_XDR_REQUEST_SERVICE_NAME), DOCUMENT_SUBMISSION_DEFERRED_RESPONSE(NHINC_XDR_RESPONSE_SERVICE_NAME),
+        NHINC_XDR_REQUEST_SERVICE_NAME), DOCUMENT_SUBMISSION_DEFERRED_RESPONSE(NHINC_XDR_RESPONSE_SERVICE_NAME),
         ADMINISTRATIVE_DISTRIBUTION(NHIN_ADMIN_DIST_SERVICE_NAME),
         CORE_X12DS_REALTIME(CORE_X12DS_REALTIME_SERVICE_NAME),
         CORE_X12DS_GENERICBATCH_REQUEST(CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME),
         CORE_X12DS_GENERICBATCH_RESPONSE(CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME);
-
         private String UDDIServiceName = null;
 
         NHIN_SERVICE_NAMES(String value) {
@@ -109,24 +107,19 @@ public class NhincConstants {
             throw new IllegalArgumentException("No enum constant " + valueString);
         }
     };
-
     // Authorization Framework
     public static final String AUTH_FRWK_NAME_ID_FORMAT_EMAIL_ADDRESS = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
     public static final String AUTH_FRWK_NAME_ID_FORMAT_X509 = "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName";
     public static final String AUTH_FRWK_NAME_ID_FORMAT_WINDOWS_NAME = "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName";
-
     // SAML constants
     public static final String SAML_DEFAULT_ISSUER_NAME = "CN=SAML User,OU=SU,O=SAML User,L=Los Angeles,ST=CA,C=US";
-
     // Initiating multispec errors
     public static final String INIT_MULTISPEC_ERROR_UNSUPPORTED_GUIDANCE = "Unsupported guidance for API level.";
     public static final String INIT_MULTISPEC_ERROR_NO_MATCHING_ENDPOINT = "No matching target endpoint for guidance: ";
     public static final String INIT_MULTISPEC_LOC_ENTITY_DR = "Entity Document Retrieve ";
     public static final String INIT_MULTISPEC_LOC_ENTITY_DQ = "Entity Document Query ";
     public static final String INIT_MULTISPEC_ERROR_NO_ENDPOINT_AVAILABLE = "No endpoint available for HCID: ";
-
     public static final String SERVICE_NAME = "serviceName";
-
     // Property File Constants
     public static final String GATEWAY_PROPERTY_FILE = "gateway";
     public static final String HOME_COMMUNITY_ID_PROPERTY = "localHomeCommunityId";
@@ -142,7 +135,6 @@ public class NhincConstants {
     public static final String LARGEJOB_POOL_SIZE = "LargeJobPoolSize";
     public static final String LARGEJOB_SIZE_PERCENT = "LargeJobSizePercent";
     public static final String HL7_PREFIX_FOR_ATTR_PROPERTY = "hl7PrefixForAttributes";
-
     // Streaming Large Files Constants
     public static final String PARSE_PAYLOAD_AS_FILE_URI_OUTBOUND = "ParsePayloadAsFileURIOutbound";
     public static final String SAVE_PAYLOAD_TO_FILE_INBOUND = "SavePayloadToFileInbound";
@@ -154,14 +146,13 @@ public class NhincConstants {
     public static final String X12_GENERIC_BATCH_TIMESTAMP_TIME_TO_LIVE = "CoreX12GenericBatchTimeStampTimeToLive";
     public static final String X12_GENERIC_BATCH_TIMESTAMP_STRICT = "CoreX12GenericBatchTimeStampStrict";
     public static final String X12_GENERIC_BATCH_TIMESTAMP_FUTURE_TIME_TO_LIVE = "CoreX12GenericBatchFutureTimeToLive";
-
     // Response Message Interceptor Constants
     public static final String RESPONSE_MESSAGE_ID_KEY = "RESPONSE_MESSAGE_ID";
     public static final String RESPONSE_MESSAGE_ID_LIST_KEY = "RESPONSE_MESSAGE_ID_LIST";
-
+	
     // Flag to enable SAML AuthzDecisionStatement->Evidence->Assertion->Conditions element default value
     public static final String ENABLE_AUTH_DEC_EVIDENCE_CONDITIONS_DEFAULT_VALUE = "enableAuthDecEvidenceConditionsDefaultValue";
-
+	
     // these 6 not used anymore
     public static final String PATIENT_DISCOVERY_CONNECT_TIMEOUT = "PDConnectTimeout";
     public static final String PATIENT_DISCOVERY_REQUEST_TIMEOUT = "PDRequestTimeout";
@@ -169,7 +160,6 @@ public class NhincConstants {
     public static final String DOC_QUERY_REQUEST_TIMEOUT = "DQRequestTimeout";
     public static final String CONNECT_TIMEOUT_NAME = "com.sun.xml.ws.connect.timeout";
     public static final String REQUEST_TIMEOUT_NAME = "com.sun.xml.ws.request.timeout";
-
     // SAML Constants
     public static final String TARGET_API_LEVEL = "targetAPILevel";
     public static final String ACTION_PROP = "action";
@@ -214,7 +204,6 @@ public class NhincConstants {
     public static final String PAT_CORR_ACTION = "patientcorrelation";
     public static final String XDR_REQUEST_ACTION = "xdrrequest";
     public static final String XDR_RESPONSE_ACTION = "xdrresponse";
-
     public static final String USERNAME_ATTR = "urn:oasis:names:tc:xspa:1.0:subject:subject-id";
     public static final String USER_ORG_ATTR = "urn:oasis:names:tc:xspa:1.0:subject:organization";
     public static final String USER_ORG_ID_ATTR = "urn:oasis:names:tc:xspa:1.0:subject:organization-id";
@@ -224,7 +213,6 @@ public class NhincConstants {
     public static final String PATIENT_ID_ATTR = "urn:oasis:names:tc:xacml:2.0:resource:resource-id";
     public static final String ACCESS_CONSENT_ATTR = "AccessConsentPolicy";
     public static final String INST_ACCESS_CONSENT_ATTR = "InstanceAccessConsentPolicy";
-
     // Attribute NameID Constants
     public static final String ATTRIBUTE_NAME_SUBJECT_ID = "urn:oasis:names:tc:xacml:1.0:subject:subject-id";
     public static final String ATTRIBUTE_NAME_SUBJECT_ID_XSPA = "urn:oasis:names:tc:xspa:1.0:subject:subject-id";
@@ -235,7 +223,6 @@ public class NhincConstants {
     public static final String ATTRIBUTE_NAME_PURPOSE_OF_USE = "urn:oasis:names:tc:xspa:1.0:subject:purposeofuse";
     public static final String ATTRIBUTE_NAME_RESOURCE_ID = "urn:oasis:names:tc:xacml:2.0:resource:resource-id";
     public static final String ATTRIBUTE_NAME_NPI = "urn:oasis:names:tc:xspa:2.0:subject:npi";
-
     public static final String CE_CODE_ID = "code";
     public static final String CE_CODESYS_ID = "codeSystem";
     public static final String CE_CODESYSNAME_ID = "codeSystemName";
@@ -255,7 +242,6 @@ public class NhincConstants {
     public static final String NS_ADDRESSING_2005 = "http://www.w3.org/2005/08/addressing";
     public static final String HEADER_MESSAGEID = "MessageID";
     public static final String HEADER_RELATESTO = "RelatesTo";
-
     // HL7 references
     public static final String HL7_NAME = "hl7";
     public static final String HL7_NS = "urn:hl7-org:v3";
@@ -293,6 +279,8 @@ public class NhincConstants {
     public static final String AUDIT_LOG_REQUEST_PROCESS = "Request";
     public static final String AUDIT_LOG_RESPONSE_PROCESS = "Response";
     public static final String AUDIT_DISABLED_ACK_MSG = "Audit Service is not enabled";
+    public static final String WEB_SERVICE_REQUEST_URL = "webservicerequesturl";
+    public static final String REMOTE_HOST_ADDRESS = "remotehostaddress";
     // Policy Engine Constants
     public static final String POLICYENGINE_DTE_SERVICE_NAME = "policyenginedte";
     public static final String POLICYENGINE_SERVICE_NAME = "policyengineservice";
@@ -417,50 +405,36 @@ public class NhincConstants {
     public static final String ENTITY_ADMIN_DIST_SECURED_SERVICE_NAME = "entityadmindistsecured";
     public static final String ADAPTER_ADMIN_DIST_SERVICE_NAME = "adapteradmindist";
     public static final String ADAPTER_ADMIN_DIST_SECURED_SERVICE_NAME = "adapteradmindistsecured";
-
     // CORE X12 Document Submission RealTime Constants
     public static final String CORE_X12DS_REALTIME_SERVICE_NAME = "CORE_X12DSRealTime";
-
     public static final String NHIN_CORE_X12DS_REALTIME_SERVICE_NAME = "nhincore_x12dsrealtime";
     public static final String NHIN_CORE_X12DS_REALTIME_SECURED_SERVICE_NAME = "CORE_X12DSRealTime";
-
     public static final String ADAPTER_CORE_X12DS_REALTIME_SERVICE_NAME = "adaptercore_x12dsrealtime";
     public static final String ADAPTER_CORE_X12DS_REALTIME_SECURED_SERVICE_NAME = "adaptercore_x12dsrealtimesecured";
-
     public static final String CORE_X12DS_REALTIME_PROXY_CONFIG_FILE_NAME = "CORE_X12DSRealTimeProxyConfig.xml";
-
     // CORE X12 Document Submission Generic Batch Constants
     public static final String CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME = "CORE_X12DSGenericBatchRequest";
     public static final String CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME = "CORE_X12DSGenericBatchResponse";
     public static final String NHIN_CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME = "nhincore_x12dsgenericbatchrequest";
     public static final String NHIN_CORE_X12DS_GENERICBATCH_REQUEST_SECURED_SERVICE_NAME = "nhincore_x12dsgenericbatchrequestwssecured";
-
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME = "entitycore_x12dsgenericbatchrequest";
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_REQUEST_SECURED_SERVICE_NAME = "entitycore_x12dsgenericbatchrequestsecured";
-
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME = "adaptercore_x12dsgenericbatchrequest";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_SECURED_SERVICE_NAME = "adaptercore_x12dsgenericbatchrequestsecured";
-
     public static final String NHIN_CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME = "nhincore_x12dsgenericbatchresponse";
     public static final String NHIN_CORE_X12DS_GENERICBATCH_RESPONSE_SECURED_SERVICE_NAME = "nhincore_x12dsgenericbatchresponsewssecured";
-
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME = "entitycore_x12dsgenericbatchresponse";
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_RESPONSE_SECURED_SERVICE_NAME = "entitycore_x12dsgenericbatchresponsesecured";
-
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME = "adaptercore_x12dsgenericbatchresponse";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_SECURED_SERVICE_NAME = "adaptercore_x12dsgenericbatchresponsesecured";
-
     public static final String CORE_X12DS_GENERICBATCH_PROXY_CONFIG_FILE_NAME = "CORE_X12DSGenericBatchProxyConfig.xml";
     public static final String ADMIN_GUI_PROXY_CONFIG_FILE_NAME = "AdminGUIProxyConfig.xml";
     public static final String CORE_X12DS_ACK_ERROR_MSG = null;
     public static final String CORE_X12DS_ACK_ERROR_CODE = null;
-
     //Adapter properties for retrieving X12 RealTime payload
     public static final String CORE_X12DS_RT_DYNAMIC_DOC_FILE = "x12.realtime.doc.file";
-
     //DocumentQueryTransform Constants
     public static final String EBXML_DOCENTRY_PATIENT_ID = "$XDSDocumentEntryPatientId";
-
     // Hibernate Config Files
     public static final String HIBERNATE_AUDIT_REPOSITORY = "auditrepo.hibernate.cfg.xml";
     public static final String HIBERNATE_ASSIGNING_AUTHORITY = "assignauthority.hibernate.cfg.xml";
@@ -472,22 +446,17 @@ public class NhincConstants {
     public static final String HIBERNATE_EVENT_REPOSITORY = "event.hibernate.cfg.xml";
     public static final String HIBERNATE_DIRECTCONFIG_REPOSITORY = "configdb.hibernate.cfg.xml";
     public static final String HIBERNATE_MESSAGE_MONITORING_REPOSITORY = "messagemonitoringdb.hibernate.cfg.xml";
-
     public static final String XDS_REGISTRY_ERROR_SEVERITY_WARNING = "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Warning";
     public static final String XDS_REGISTRY_ERROR_SEVERITY_ERROR = "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error";
-
     public static final String DIRECT_SOAP_EDGE_SERVICE_NAME = "directsoapedge";
-
     // JMX configurations
     public static final String JMX_ENABLED_SYSTEM_PROPERTY = "org.connectopensource.enablejmx";
     public static final String JMX_CONFIGURATION_BEAN_NAME = "org.connectopensource.mbeans:type=Configuration";
     public static final String JMX_DOCUMENT_QUERY_30_BEAN_NAME = "org.connectopensource.mbeans:type=DocumentQuery30WebServices";
     public static final String JMX_DOCUMENT_QUERY_20_BEAN_NAME = "org.connectopensource.mbeans:type=DocumentQuery20WebServices";
     public static final String JMX_PATIENT_DISCOVERY_10_BEAN_NAME = "org.connectopensource.mbeans:type=PatientDiscovery10WebServices";
-
     // Standard Format for parsing String into Date
     public static final String DATE_PARSE_FORMAT = "yyyyMMddHHmmss";
-
     //Document Type property for UClient
     public static final String DOCUMENT_TYPE_PROPERTY_FILE = "documentTypes";
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
@@ -40,6 +40,7 @@ public class NhincConstants {
 
         LEVEL_g0, LEVEL_g1
     }
+
     public static final String HCID_PREFIX = "urn:oid:";
 
     public static enum ADAPTER_API_LEVEL {
@@ -76,16 +77,17 @@ public class NhincConstants {
     public static enum NHIN_SERVICE_NAMES {
 
         PATIENT_DISCOVERY(PATIENT_DISCOVERY_SERVICE_NAME), PATIENT_DISCOVERY_DEFERRED_REQUEST(
-        PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME), PATIENT_DISCOVERY_DEFERRED_RESPONSE(
-        PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
+            PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME), PATIENT_DISCOVERY_DEFERRED_RESPONSE(
+                PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
         DOCUMENT_QUERY(DOC_QUERY_SERVICE_NAME),
         DOCUMENT_RETRIEVE(DOC_RETRIEVE_SERVICE_NAME),
         DOCUMENT_SUBMISSION(NHINC_XDR_SERVICE_NAME), DOCUMENT_SUBMISSION_DEFERRED_REQUEST(
-        NHINC_XDR_REQUEST_SERVICE_NAME), DOCUMENT_SUBMISSION_DEFERRED_RESPONSE(NHINC_XDR_RESPONSE_SERVICE_NAME),
+            NHINC_XDR_REQUEST_SERVICE_NAME), DOCUMENT_SUBMISSION_DEFERRED_RESPONSE(NHINC_XDR_RESPONSE_SERVICE_NAME),
         ADMINISTRATIVE_DISTRIBUTION(NHIN_ADMIN_DIST_SERVICE_NAME),
         CORE_X12DS_REALTIME(CORE_X12DS_REALTIME_SERVICE_NAME),
         CORE_X12DS_GENERICBATCH_REQUEST(CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME),
         CORE_X12DS_GENERICBATCH_RESPONSE(CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME);
+
         private String UDDIServiceName = null;
 
         NHIN_SERVICE_NAMES(String value) {
@@ -107,19 +109,24 @@ public class NhincConstants {
             throw new IllegalArgumentException("No enum constant " + valueString);
         }
     };
+
     // Authorization Framework
     public static final String AUTH_FRWK_NAME_ID_FORMAT_EMAIL_ADDRESS = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
     public static final String AUTH_FRWK_NAME_ID_FORMAT_X509 = "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName";
     public static final String AUTH_FRWK_NAME_ID_FORMAT_WINDOWS_NAME = "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName";
+
     // SAML constants
     public static final String SAML_DEFAULT_ISSUER_NAME = "CN=SAML User,OU=SU,O=SAML User,L=Los Angeles,ST=CA,C=US";
+
     // Initiating multispec errors
     public static final String INIT_MULTISPEC_ERROR_UNSUPPORTED_GUIDANCE = "Unsupported guidance for API level.";
     public static final String INIT_MULTISPEC_ERROR_NO_MATCHING_ENDPOINT = "No matching target endpoint for guidance: ";
     public static final String INIT_MULTISPEC_LOC_ENTITY_DR = "Entity Document Retrieve ";
     public static final String INIT_MULTISPEC_LOC_ENTITY_DQ = "Entity Document Query ";
     public static final String INIT_MULTISPEC_ERROR_NO_ENDPOINT_AVAILABLE = "No endpoint available for HCID: ";
+
     public static final String SERVICE_NAME = "serviceName";
+
     // Property File Constants
     public static final String GATEWAY_PROPERTY_FILE = "gateway";
     public static final String HOME_COMMUNITY_ID_PROPERTY = "localHomeCommunityId";
@@ -135,6 +142,7 @@ public class NhincConstants {
     public static final String LARGEJOB_POOL_SIZE = "LargeJobPoolSize";
     public static final String LARGEJOB_SIZE_PERCENT = "LargeJobSizePercent";
     public static final String HL7_PREFIX_FOR_ATTR_PROPERTY = "hl7PrefixForAttributes";
+
     // Streaming Large Files Constants
     public static final String PARSE_PAYLOAD_AS_FILE_URI_OUTBOUND = "ParsePayloadAsFileURIOutbound";
     public static final String SAVE_PAYLOAD_TO_FILE_INBOUND = "SavePayloadToFileInbound";
@@ -146,9 +154,14 @@ public class NhincConstants {
     public static final String X12_GENERIC_BATCH_TIMESTAMP_TIME_TO_LIVE = "CoreX12GenericBatchTimeStampTimeToLive";
     public static final String X12_GENERIC_BATCH_TIMESTAMP_STRICT = "CoreX12GenericBatchTimeStampStrict";
     public static final String X12_GENERIC_BATCH_TIMESTAMP_FUTURE_TIME_TO_LIVE = "CoreX12GenericBatchFutureTimeToLive";
+
     // Response Message Interceptor Constants
     public static final String RESPONSE_MESSAGE_ID_KEY = "RESPONSE_MESSAGE_ID";
     public static final String RESPONSE_MESSAGE_ID_LIST_KEY = "RESPONSE_MESSAGE_ID_LIST";
+
+    // Flag to enable SAML AuthzDecisionStatement->Evidence->Assertion->Conditions element default value
+    public static final String ENABLE_AUTH_DEC_EVIDENCE_CONDITIONS_DEFAULT_VALUE = "enableAuthDecEvidenceConditionsDefaultValue";
+
     // these 6 not used anymore
     public static final String PATIENT_DISCOVERY_CONNECT_TIMEOUT = "PDConnectTimeout";
     public static final String PATIENT_DISCOVERY_REQUEST_TIMEOUT = "PDRequestTimeout";
@@ -156,6 +169,7 @@ public class NhincConstants {
     public static final String DOC_QUERY_REQUEST_TIMEOUT = "DQRequestTimeout";
     public static final String CONNECT_TIMEOUT_NAME = "com.sun.xml.ws.connect.timeout";
     public static final String REQUEST_TIMEOUT_NAME = "com.sun.xml.ws.request.timeout";
+
     // SAML Constants
     public static final String TARGET_API_LEVEL = "targetAPILevel";
     public static final String ACTION_PROP = "action";
@@ -200,6 +214,7 @@ public class NhincConstants {
     public static final String PAT_CORR_ACTION = "patientcorrelation";
     public static final String XDR_REQUEST_ACTION = "xdrrequest";
     public static final String XDR_RESPONSE_ACTION = "xdrresponse";
+
     public static final String USERNAME_ATTR = "urn:oasis:names:tc:xspa:1.0:subject:subject-id";
     public static final String USER_ORG_ATTR = "urn:oasis:names:tc:xspa:1.0:subject:organization";
     public static final String USER_ORG_ID_ATTR = "urn:oasis:names:tc:xspa:1.0:subject:organization-id";
@@ -209,6 +224,7 @@ public class NhincConstants {
     public static final String PATIENT_ID_ATTR = "urn:oasis:names:tc:xacml:2.0:resource:resource-id";
     public static final String ACCESS_CONSENT_ATTR = "AccessConsentPolicy";
     public static final String INST_ACCESS_CONSENT_ATTR = "InstanceAccessConsentPolicy";
+
     // Attribute NameID Constants
     public static final String ATTRIBUTE_NAME_SUBJECT_ID = "urn:oasis:names:tc:xacml:1.0:subject:subject-id";
     public static final String ATTRIBUTE_NAME_SUBJECT_ID_XSPA = "urn:oasis:names:tc:xspa:1.0:subject:subject-id";
@@ -219,6 +235,7 @@ public class NhincConstants {
     public static final String ATTRIBUTE_NAME_PURPOSE_OF_USE = "urn:oasis:names:tc:xspa:1.0:subject:purposeofuse";
     public static final String ATTRIBUTE_NAME_RESOURCE_ID = "urn:oasis:names:tc:xacml:2.0:resource:resource-id";
     public static final String ATTRIBUTE_NAME_NPI = "urn:oasis:names:tc:xspa:2.0:subject:npi";
+
     public static final String CE_CODE_ID = "code";
     public static final String CE_CODESYS_ID = "codeSystem";
     public static final String CE_CODESYSNAME_ID = "codeSystemName";
@@ -238,6 +255,7 @@ public class NhincConstants {
     public static final String NS_ADDRESSING_2005 = "http://www.w3.org/2005/08/addressing";
     public static final String HEADER_MESSAGEID = "MessageID";
     public static final String HEADER_RELATESTO = "RelatesTo";
+
     // HL7 references
     public static final String HL7_NAME = "hl7";
     public static final String HL7_NS = "urn:hl7-org:v3";
@@ -275,8 +293,6 @@ public class NhincConstants {
     public static final String AUDIT_LOG_REQUEST_PROCESS = "Request";
     public static final String AUDIT_LOG_RESPONSE_PROCESS = "Response";
     public static final String AUDIT_DISABLED_ACK_MSG = "Audit Service is not enabled";
-    public static final String WEB_SERVICE_REQUEST_URL = "webservicerequesturl";
-    public static final String REMOTE_HOST_ADDRESS = "remotehostaddress";
     // Policy Engine Constants
     public static final String POLICYENGINE_DTE_SERVICE_NAME = "policyenginedte";
     public static final String POLICYENGINE_SERVICE_NAME = "policyengineservice";
@@ -401,36 +417,50 @@ public class NhincConstants {
     public static final String ENTITY_ADMIN_DIST_SECURED_SERVICE_NAME = "entityadmindistsecured";
     public static final String ADAPTER_ADMIN_DIST_SERVICE_NAME = "adapteradmindist";
     public static final String ADAPTER_ADMIN_DIST_SECURED_SERVICE_NAME = "adapteradmindistsecured";
+
     // CORE X12 Document Submission RealTime Constants
     public static final String CORE_X12DS_REALTIME_SERVICE_NAME = "CORE_X12DSRealTime";
+
     public static final String NHIN_CORE_X12DS_REALTIME_SERVICE_NAME = "nhincore_x12dsrealtime";
     public static final String NHIN_CORE_X12DS_REALTIME_SECURED_SERVICE_NAME = "CORE_X12DSRealTime";
+
     public static final String ADAPTER_CORE_X12DS_REALTIME_SERVICE_NAME = "adaptercore_x12dsrealtime";
     public static final String ADAPTER_CORE_X12DS_REALTIME_SECURED_SERVICE_NAME = "adaptercore_x12dsrealtimesecured";
+
     public static final String CORE_X12DS_REALTIME_PROXY_CONFIG_FILE_NAME = "CORE_X12DSRealTimeProxyConfig.xml";
+
     // CORE X12 Document Submission Generic Batch Constants
     public static final String CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME = "CORE_X12DSGenericBatchRequest";
     public static final String CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME = "CORE_X12DSGenericBatchResponse";
     public static final String NHIN_CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME = "nhincore_x12dsgenericbatchrequest";
     public static final String NHIN_CORE_X12DS_GENERICBATCH_REQUEST_SECURED_SERVICE_NAME = "nhincore_x12dsgenericbatchrequestwssecured";
+
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME = "entitycore_x12dsgenericbatchrequest";
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_REQUEST_SECURED_SERVICE_NAME = "entitycore_x12dsgenericbatchrequestsecured";
+
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME = "adaptercore_x12dsgenericbatchrequest";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_SECURED_SERVICE_NAME = "adaptercore_x12dsgenericbatchrequestsecured";
+
     public static final String NHIN_CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME = "nhincore_x12dsgenericbatchresponse";
     public static final String NHIN_CORE_X12DS_GENERICBATCH_RESPONSE_SECURED_SERVICE_NAME = "nhincore_x12dsgenericbatchresponsewssecured";
+
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME = "entitycore_x12dsgenericbatchresponse";
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_RESPONSE_SECURED_SERVICE_NAME = "entitycore_x12dsgenericbatchresponsesecured";
+
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME = "adaptercore_x12dsgenericbatchresponse";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_SECURED_SERVICE_NAME = "adaptercore_x12dsgenericbatchresponsesecured";
+
     public static final String CORE_X12DS_GENERICBATCH_PROXY_CONFIG_FILE_NAME = "CORE_X12DSGenericBatchProxyConfig.xml";
     public static final String ADMIN_GUI_PROXY_CONFIG_FILE_NAME = "AdminGUIProxyConfig.xml";
     public static final String CORE_X12DS_ACK_ERROR_MSG = null;
     public static final String CORE_X12DS_ACK_ERROR_CODE = null;
+
     //Adapter properties for retrieving X12 RealTime payload
     public static final String CORE_X12DS_RT_DYNAMIC_DOC_FILE = "x12.realtime.doc.file";
+
     //DocumentQueryTransform Constants
     public static final String EBXML_DOCENTRY_PATIENT_ID = "$XDSDocumentEntryPatientId";
+
     // Hibernate Config Files
     public static final String HIBERNATE_AUDIT_REPOSITORY = "auditrepo.hibernate.cfg.xml";
     public static final String HIBERNATE_ASSIGNING_AUTHORITY = "assignauthority.hibernate.cfg.xml";
@@ -442,17 +472,22 @@ public class NhincConstants {
     public static final String HIBERNATE_EVENT_REPOSITORY = "event.hibernate.cfg.xml";
     public static final String HIBERNATE_DIRECTCONFIG_REPOSITORY = "configdb.hibernate.cfg.xml";
     public static final String HIBERNATE_MESSAGE_MONITORING_REPOSITORY = "messagemonitoringdb.hibernate.cfg.xml";
+
     public static final String XDS_REGISTRY_ERROR_SEVERITY_WARNING = "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Warning";
     public static final String XDS_REGISTRY_ERROR_SEVERITY_ERROR = "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error";
+
     public static final String DIRECT_SOAP_EDGE_SERVICE_NAME = "directsoapedge";
+
     // JMX configurations
     public static final String JMX_ENABLED_SYSTEM_PROPERTY = "org.connectopensource.enablejmx";
     public static final String JMX_CONFIGURATION_BEAN_NAME = "org.connectopensource.mbeans:type=Configuration";
     public static final String JMX_DOCUMENT_QUERY_30_BEAN_NAME = "org.connectopensource.mbeans:type=DocumentQuery30WebServices";
     public static final String JMX_DOCUMENT_QUERY_20_BEAN_NAME = "org.connectopensource.mbeans:type=DocumentQuery20WebServices";
     public static final String JMX_PATIENT_DISCOVERY_10_BEAN_NAME = "org.connectopensource.mbeans:type=PatientDiscovery10WebServices";
+
     // Standard Format for parsing String into Date
     public static final String DATE_PARSE_FORMAT = "yyyyMMddHHmmss";
+
     //Document Type property for UClient
     public static final String DOCUMENT_TYPE_PROPERTY_FILE = "documentTypes";
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/openSAML/extraction/OpenSAMLAssertionExtractorImpl.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/openSAML/extraction/OpenSAMLAssertionExtractorImpl.java
@@ -1,28 +1,28 @@
 /*
- * Copyright (c) 2009-2013, United States Government, as represented by the Secretary of Health and Human Services. 
- * All rights reserved. 
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions are met: 
- *     * Redistributions of source code must retain the above 
- *       copyright notice, this list of conditions and the following disclaimer. 
- *     * Redistributions in binary form must reproduce the above copyright 
- *       notice, this list of conditions and the following disclaimer in the documentation 
- *       and/or other materials provided with the distribution. 
- *     * Neither the name of the United States Government nor the 
- *       names of its contributors may be used to endorse or promote products 
- *       derived from this software without specific prior written permission. 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
- * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY 
- * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package gov.hhs.fha.nhinc.openSAML.extraction;
 
@@ -72,7 +72,7 @@ import org.w3c.dom.NodeList;
 
 /**
  * @author mweaver
- * 
+ *
  */
 public class OpenSAMLAssertionExtractorImpl implements SAMLExtractorDOM {
 
@@ -84,7 +84,7 @@ public class OpenSAMLAssertionExtractorImpl implements SAMLExtractorDOM {
 
     /**
      * This method is used to extract the SAML assertion information.
-     * 
+     *
      * @param Element element
      * @return AssertionType
      */
@@ -115,7 +115,7 @@ public class OpenSAMLAssertionExtractorImpl implements SAMLExtractorDOM {
 
     /**
      * This method will return the first Assertion encountered in the passed in element.
-     * 
+     *
      * @param element the xml element to extract the assertion from
      * @return The first encountered Assertion object in the element
      */
@@ -164,7 +164,7 @@ public class OpenSAMLAssertionExtractorImpl implements SAMLExtractorDOM {
 
     /**
      * This method is used to populate the Attribute Statement.
-     * 
+     *
      * @param saml2Assertion saml2 assertion
      * @param target target assertion
      */
@@ -255,7 +255,7 @@ public class OpenSAMLAssertionExtractorImpl implements SAMLExtractorDOM {
 
     /**
      * This method is used to populate the Authentication Statement Information.
-     * 
+     *
      * @param saml2Assertion saml2 assertion
      * @param target target assertion
      */
@@ -283,7 +283,7 @@ public class OpenSAMLAssertionExtractorImpl implements SAMLExtractorDOM {
 
     /**
      * This method is used to populate the Subject Information into the target assertion.
-     * 
+     *
      * @param saml2Assertion saml2 assertion
      * @param target target assertion
      */
@@ -309,7 +309,7 @@ public class OpenSAMLAssertionExtractorImpl implements SAMLExtractorDOM {
 
     /**
      * This method is used to populate the Authorization Decision Statement Information.
-     * 
+     *
      * @param saml2Assertion saml2 assertion
      * @param target target assertion
      */
@@ -383,15 +383,20 @@ public class OpenSAMLAssertionExtractorImpl implements SAMLExtractorDOM {
                 }
             }
         }
-
-        // Translate Evidence Conditions
-        Conditions saml2EvidenceCondition = saml2EvidenceAssertion.getConditions();
-
-        SamlAuthzDecisionStatementEvidenceConditionsType targetConditions = new SamlAuthzDecisionStatementEvidenceConditionsType();
-        targetEvidenceAssertion.setConditions(targetConditions);
-
-        targetConditions.setNotBefore(saml2EvidenceCondition.getNotBefore().toString());
-        targetConditions.setNotOnOrAfter(saml2EvidenceCondition.getNotOnOrAfter().toString());
+        //Only create the Conditions if NotBefore and/or NotOnOrAfter is present
+        if (saml2EvidenceAssertion.getConditions() != null &&
+            (saml2EvidenceAssertion.getConditions().getNotBefore() != null || saml2EvidenceAssertion.getConditions().getNotOnOrAfter() != null)) {
+            // Translate Evidence Conditions
+            Conditions saml2EvidenceCondition = saml2EvidenceAssertion.getConditions();
+            SamlAuthzDecisionStatementEvidenceConditionsType targetConditions = new SamlAuthzDecisionStatementEvidenceConditionsType();
+            targetEvidenceAssertion.setConditions(targetConditions);
+            if (saml2EvidenceCondition.getNotBefore() != null) {
+                targetConditions.setNotBefore(saml2EvidenceCondition.getNotBefore().toString());
+            }
+            if (saml2EvidenceCondition.getNotOnOrAfter() != null) {
+                targetConditions.setNotOnOrAfter(saml2EvidenceCondition.getNotOnOrAfter().toString());
+            }
+        }
 
         // Translate Evidence Issuer
         Issuer saml2EvidenceIssuer = saml2EvidenceAssertion.getIssuer();
@@ -402,7 +407,7 @@ public class OpenSAMLAssertionExtractorImpl implements SAMLExtractorDOM {
 
     /**
      * This method is used to construct HL7 PurposeOfUse Attribute, and adds it to the Assertion.
-     * 
+     *
      * @param attribute attribute
      * @param target target assertion
      */
@@ -424,7 +429,7 @@ public class OpenSAMLAssertionExtractorImpl implements SAMLExtractorDOM {
     /**
      * Initializes the assertion object to contain empty strings for all values. These are overwritten in the extraction
      * process with real values if they are available
-     * 
+     *
      * @param assertOut The Assertion element being written to
      */
     private AssertionType initializeAssertion() {
@@ -519,7 +524,7 @@ public class OpenSAMLAssertionExtractorImpl implements SAMLExtractorDOM {
 
     /**
      * This method is used to construct HL7 Subject Role Attribute, and adds it to the Assertion.
-     * 
+     *
      * @param attribute attribute
      * @param target target assertion
      */

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/openSAML/HOKSAMLAssertionBuilderTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/openSAML/HOKSAMLAssertionBuilderTest.java
@@ -1,9 +1,34 @@
-/**
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
  *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package gov.hhs.fha.nhinc.callback.openSAML;
 
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants.GATEWAY_API_LEVEL;
+import gov.hhs.fha.nhinc.properties.PropertyAccessException;
+import gov.hhs.fha.nhinc.properties.PropertyAccessor;
 import gov.hhs.fha.nhinc.util.AbstractSuppressRootLoggerTest;
 import java.math.BigInteger;
 import java.security.InvalidKeyException;
@@ -27,12 +52,18 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertTrue;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import org.opensaml.saml2.core.Action;
@@ -47,11 +78,10 @@ import org.opensaml.saml2.core.Evidence;
 import org.opensaml.saml2.core.Issuer;
 import org.opensaml.saml2.core.Subject;
 import org.w3c.dom.Element;
-import org.joda.time.DateTime;
 
 /**
  * @author bhumphrey
- * 
+ *
  */
 public class HOKSAMLAssertionBuilderTest extends AbstractSuppressRootLoggerTest {
 
@@ -76,7 +106,7 @@ public class HOKSAMLAssertionBuilderTest extends AbstractSuppressRootLoggerTest 
      * certificate = (X509Certificate) keyStore.getCertificate("alias");
      */
     /**
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -133,12 +163,12 @@ public class HOKSAMLAssertionBuilderTest extends AbstractSuppressRootLoggerTest 
 
                     @Override
                     public void verify(PublicKey key, String sigProvider) throws CertificateException,
-                            NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException, SignatureException {
+                        NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException, SignatureException {
                     }
 
                     @Override
                     public void verify(PublicKey key) throws CertificateException, NoSuchAlgorithmException,
-                            InvalidKeyException, NoSuchProviderException, SignatureException {
+                        InvalidKeyException, NoSuchProviderException, SignatureException {
                     }
 
                     @Override
@@ -251,7 +281,7 @@ public class HOKSAMLAssertionBuilderTest extends AbstractSuppressRootLoggerTest 
 
                     @Override
                     public void checkValidity(Date date) throws CertificateExpiredException,
-                            CertificateNotYetValidException {
+                        CertificateNotYetValidException {
                     }
 
                     @Override
@@ -267,7 +297,7 @@ public class HOKSAMLAssertionBuilderTest extends AbstractSuppressRootLoggerTest 
 
     @Test
     public void testCreateAuthenicationStatement() {
-        List<AuthnStatement> authnStatement = HOKSAMLAssertionBuilder.createAuthenicationStatements(getProperties());
+        List<AuthnStatement> authnStatement = (new HOKSAMLAssertionBuilder()).createAuthenicationStatements(getProperties());
         assertNotNull(authnStatement);
 
         assertFalse(authnStatement.isEmpty());
@@ -287,20 +317,19 @@ public class HOKSAMLAssertionBuilderTest extends AbstractSuppressRootLoggerTest 
         List<AttributeStatement> statements = new ArrayList<AttributeStatement>();
         statements.add(0, e);
         Evidence evidence1 = builder.buildEvidence(evAssertionID, issueInstant, format, beginValidTime, endValidTime,
-                issuer, statements, subject);
+            issuer, statements, subject);
         assertTrue(evidence1.getAssertions().get(0).getID().startsWith("_"));
     }
 
     @Test
-    public void testCreateAuthenticationDecisionStatements() {
+    public void testCreateAuthenticationDecisionStatements() throws PropertyAccessException {
         CallbackProperties callbackProps = mock(CallbackProperties.class);
         Subject subject = mock(Subject.class);
         DateTime beforeCreation = new DateTime();
-
         when(callbackProps.getAuthenicationStatementExists()).thenReturn(true);
 
-        List<AuthzDecisionStatement> statementList = HOKSAMLAssertionBuilder.createAuthenicationDecsionStatements(
-                callbackProps, subject);
+        List<AuthzDecisionStatement> statementList = (new HOKSAMLAssertionBuilder()).createAuthenicationDecsionStatements(
+            callbackProps, subject);
 
         assertFalse(statementList.isEmpty());
         AuthzDecisionStatement statement = statementList.get(0);
@@ -314,16 +343,16 @@ public class HOKSAMLAssertionBuilderTest extends AbstractSuppressRootLoggerTest 
         assertTrue(assertion.getID().startsWith("_"));
 
         assertTrue(beforeCreation.isBefore(assertion.getIssueInstant())
-                || beforeCreation.isEqual(assertion.getIssueInstant()));
+            || beforeCreation.isEqual(assertion.getIssueInstant()));
 
         Issuer issuer = assertion.getIssuer();
         assertEquals(issuer.getFormat(), SAMLAssertionBuilder.X509_NAME_ID);
 
         Conditions conditions = assertion.getConditions();
         assertTrue(beforeCreation.isBefore(conditions.getNotBefore())
-                || beforeCreation.isEqual(conditions.getNotBefore()));
+            || beforeCreation.isEqual(conditions.getNotBefore()));
         assertTrue(beforeCreation.isBefore(conditions.getNotOnOrAfter())
-                || beforeCreation.isEqual(conditions.getNotOnOrAfter()));
+            || beforeCreation.isEqual(conditions.getNotOnOrAfter()));
 
         List<AttributeStatement> attributeStatement = assertion.getAttributeStatements();
         assertEquals(attributeStatement.get(0).getAttributes().size(), 2);
@@ -332,6 +361,93 @@ public class HOKSAMLAssertionBuilderTest extends AbstractSuppressRootLoggerTest 
         Attribute secondAttribute = attributeStatement.get(0).getAttributes().get(1);
         assertEquals(firstAttribute.getName(), "AccessConsentPolicy");
         assertEquals(secondAttribute.getName(), "InstanceAccessConsentPolicy");
+    }
+
+    @Test
+    public void testEvidanceConditionsNotBeforeAndNotAfterPresent() throws PropertyAccessException {
+        CallbackProperties callbackProps = mock(CallbackProperties.class);
+        Subject subject = mock(Subject.class);
+        DateTime conditionNotBefore = new DateTime();
+        DateTime conditionNotAfter = new DateTime();
+        PropertyAccessor propertyAccessor = mock(PropertyAccessor.class);
+        when(propertyAccessor.getProperty(Mockito.anyString(), Mockito.anyString())).thenReturn(Boolean.TRUE.toString());
+
+        when(callbackProps.getAuthenicationStatementExists()).thenReturn(true);
+        when(callbackProps.getEvidenceConditionNotBefore()).thenReturn(conditionNotBefore);
+        when(callbackProps.getEvidenceConditionNotAfter()).thenReturn(conditionNotAfter);
+
+        List<AuthzDecisionStatement> statementList = getHOKSAMLAssertionBuilder().createAuthenicationDecsionStatements(
+            callbackProps, subject);
+
+        assertFalse(statementList.isEmpty());
+        AuthzDecisionStatement statement = statementList.get(0);
+
+        Evidence evidence = statement.getEvidence();
+        Assertion assertion = evidence.getAssertions().get(0);
+
+        Conditions conditions = assertion.getConditions();
+        assertEquals(conditions.getNotBefore(), conditionNotBefore.withZone(DateTimeZone.UTC));
+        assertEquals(conditions.getNotOnOrAfter(), conditionNotAfter.withZone(DateTimeZone.UTC));
+    }
+
+    @Test
+    public void testEvidanceConditionsNotBeforeIsNull() throws PropertyAccessException {
+        CallbackProperties callbackProps = mock(CallbackProperties.class);
+        Subject subject = mock(Subject.class);
+        DateTime conditionNotAfter = new DateTime();
+        PropertyAccessor propertyAccessor = mock(PropertyAccessor.class);
+        when(propertyAccessor.getProperty(Mockito.anyString(), Mockito.anyString())).thenReturn(Boolean.FALSE.toString());
+
+        when(callbackProps.getAuthenicationStatementExists()).thenReturn(true);
+        when(callbackProps.getEvidenceConditionNotAfter()).thenReturn(conditionNotAfter);
+
+        List<AuthzDecisionStatement> statementList = getHOKSAMLAssertionBuilder().createAuthenicationDecsionStatements(
+            callbackProps, subject);
+
+        assertFalse(statementList.isEmpty());
+        AuthzDecisionStatement statement = statementList.get(0);
+
+        Evidence evidence = statement.getEvidence();
+        Assertion assertion = evidence.getAssertions().get(0);
+
+        Conditions conditions = assertion.getConditions();
+        assertEquals(conditions.getNotBefore(), null);
+        assertEquals(conditions.getNotOnOrAfter(), conditionNotAfter.withZone(DateTimeZone.UTC));
+    }
+
+    @Test
+    public void testEvidanceConditionsNotAfterIsNull() throws PropertyAccessException {
+        CallbackProperties callbackProps = mock(CallbackProperties.class);
+        Subject subject = mock(Subject.class);
+        DateTime conditionNotBefore = new DateTime();
+        PropertyAccessor propertyAccessor = mock(PropertyAccessor.class);
+        when(propertyAccessor.getProperty(Mockito.anyString(), Mockito.anyString())).thenReturn(Boolean.FALSE.toString());
+
+        when(callbackProps.getAuthenicationStatementExists()).thenReturn(true);
+        when(callbackProps.getEvidenceConditionNotBefore()).thenReturn(conditionNotBefore);
+
+        List<AuthzDecisionStatement> statementList = getHOKSAMLAssertionBuilder().createAuthenicationDecsionStatements(
+            callbackProps, subject);
+
+        assertFalse(statementList.isEmpty());
+        AuthzDecisionStatement statement = statementList.get(0);
+
+        Evidence evidence = statement.getEvidence();
+        Assertion assertion = evidence.getAssertions().get(0);
+
+        Conditions conditions = assertion.getConditions();
+        assertEquals(conditions.getNotBefore(), conditionNotBefore.withZone(DateTimeZone.UTC));
+        assertEquals(conditions.getNotOnOrAfter(), null);
+    }
+
+    HOKSAMLAssertionBuilder getHOKSAMLAssertionBuilder() {
+        //return authDEvidenceConditionsDefaultValueEnabled flag to false
+        return new HOKSAMLAssertionBuilder() {
+            @Override
+            protected boolean isAuthDEvidenceConditionsDefaultValueEnabled() {
+                return false;
+            }
+        };
     }
 
     CallbackProperties getProperties() {

--- a/Product/Production/Common/Properties/src/main/resources/gateway.properties
+++ b/Product/Production/Common/Properties/src/main/resources/gateway.properties
@@ -109,6 +109,9 @@ CoreX12GenericBatchTimeStampTimeToLive=300
 # This is only valid for  Core X12 Batch request and response services.
 CoreX12GenericBatchFutureTimeToLive=60
 
+# Boolean for adding the default values for SAML AuthDecision->Evidence Before and After Conditions. Default property value is true.
+enableAuthDecEvidenceConditionsDefaultValue=true
+
 !           Direct Message Monitoring properties
 !   ****These properties should be moved to DIRECT Config Service setting****
 


### PR DESCRIPTION
Fixed the code to make AuthzDecisionStatement>Evidence>Assertion>Conditions SAML element not required
Fixed the code to enable or disable the SAML AuthzDecisionStatement->Evidence->Assertion->Conditions element value through configuration

All the previous reviews comments can be found from the closed PR:
https://github.com/CONNECT-Solution/CONNECT/pull/1075
