### PR TITLE
FHAC-323: Fixed the code to populate the remote community identifier through the Audit Log interface

### DIFF
--- a/Product/Production/Gateway/CONNECTGatewayWeb/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryUnsecuredImpl.java
+++ b/Product/Production/Gateway/CONNECTGatewayWeb/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryUnsecuredImpl.java
@@ -42,6 +42,7 @@ import org.apache.log4j.Logger;
  * @author mflynn02
  */
 public class AuditRepositoryUnsecuredImpl {
+
     private static final Logger LOG = Logger.getLogger(AuditRepositoryUnsecuredImpl.class);
 
     protected AuditRepositoryOrchImpl getAuditRepositoryOrchImpl() {
@@ -69,6 +70,7 @@ public class AuditRepositoryUnsecuredImpl {
                     secureRequest.setAuditMessage(logEventRequest.getAuditMessage());
                     secureRequest.setDirection(logEventRequest.getDirection());
                     secureRequest.setInterface(logEventRequest.getInterface());
+                    secureRequest.setCommunityId(logEventRequest.getCommunityId());
 
                     response = processor.logAudit(secureRequest, assertion);
                 } catch (Exception ex) {
@@ -86,7 +88,7 @@ public class AuditRepositoryUnsecuredImpl {
     }
 
     public FindCommunitiesAndAuditEventsResponseType queryAuditEvents(
-            FindCommunitiesAndAuditEventsRequestType queryAuditEventsRequest, WebServiceContext context) {
+        FindCommunitiesAndAuditEventsRequestType queryAuditEventsRequest, WebServiceContext context) {
         LOG.info("Entering AuditRepositoryUnsecuredImpl.queryAuditEvents");
         FindCommunitiesAndAuditEventsResponseType response = null;
 
@@ -102,7 +104,7 @@ public class AuditRepositoryUnsecuredImpl {
                     response = processor.findAudit(queryAuditEventsRequest.getFindAuditEvents(), assertion);
                 } catch (Exception ex) {
                     String message = "Error occurred calling AuditRepositoryUnsecuredImpl.queryAuditEvents. Error: "
-                            + ex.getMessage();
+                        + ex.getMessage();
                     LOG.error(message, ex);
                     throw new RuntimeException(message, ex);
                 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyJavaImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyJavaImpl.java
@@ -54,6 +54,7 @@ public class AuditRepositoryProxyJavaImpl implements AuditRepositoryProxy {
         securedRequest.setAuditMessage(request.getAuditMessage());
         securedRequest.setDirection(request.getDirection());
         securedRequest.setInterface(request.getInterface());
+        securedRequest.setCommunityId(request.getCommunityId());
 
         return getAuditRepositoryOrchImpl().logAudit(securedRequest, assertion);
 

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyWebServiceSecuredImpl.java
@@ -63,6 +63,7 @@ public class AuditRepositoryProxyWebServiceSecuredImpl implements AuditRepositor
         secureRequest.setAuditMessage(request.getAuditMessage());
         secureRequest.setDirection(request.getDirection());
         secureRequest.setInterface(request.getInterface());
+        secureRequest.setCommunityId(request.getCommunityId());
 
         try {
             if (request != null) {

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/audit/transform/CORE_X12AuditDataTransform.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/audit/transform/CORE_X12AuditDataTransform.java
@@ -139,15 +139,14 @@ public class CORE_X12AuditDataTransform {
         AuditSourceIdentificationType auditSource = getAuditSourceIdentificationType();
 
         //******************************Constuct Audit Source Identification**********************
-        //This  will be used by persistence layer, needs to be changed in the future
-        AuditSourceIdentificationType auditSourceLocal = AuditDataTransformHelper.createAuditSourceIdentification(communityId, "INTERNAL");
-        auditMsg.getAuditSourceIdentification().add(auditSourceLocal);
         auditMsg.getAuditSourceIdentification().add(auditSource);
 
         //Set the all the required data
         result.setAuditMessage(auditMsg);
         result.setDirection(direction);
         result.setInterface(_interface);
+        //set the target community identifier
+        result.setCommunityId(communityId);
 
         LOG.trace("End CORE_X12AuditDataTransform -> transformX12MsgToAuditMsg() -- NHIN");
         return result;
@@ -467,10 +466,12 @@ public class CORE_X12AuditDataTransform {
     }
 
     protected String getMessageCommunityId(AssertionType assertion, NhinTargetSystemType target, boolean isRequesting) {
+        String communityId = null;
         if (isRequesting) {
-            return HomeCommunityMap.getCommunityIdFromTargetSystem(target);
+            communityId = HomeCommunityMap.getCommunityIdFromTargetSystem(target);
         } else {
-            return HomeCommunityMap.getHomeCommunityIdFromAssertion(assertion);
+            communityId = HomeCommunityMap.getHomeCommunityIdFromAssertion(assertion);
         }
+        return HomeCommunityMap.formatHomeCommunityId(communityId);
     }
 }


### PR DESCRIPTION
Fixed the code to populate the remote community identifier through the Audit Log interface.
