### PR TITLE
FHAC-368:Fix Mimemessage sender for Direct Outbound XDR Messages

### DIFF
--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/MimeMessageBuilder.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/MimeMessageBuilder.java
@@ -141,7 +141,7 @@ public class MimeMessageBuilder {
 
         final MimeMessage message = new MimeMessage(session);
 
-        try {
+        try {    
             message.setFrom(fromAddress);
         } catch (Exception e) {
             throw new DirectException("Exception setting from address: " + fromAddress, e);

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/MimeMessageBuilder.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/MimeMessageBuilder.java
@@ -141,7 +141,7 @@ public class MimeMessageBuilder {
 
         final MimeMessage message = new MimeMessage(session);
 
-        try {    
+        try {
             message.setFrom(fromAddress);
         } catch (Exception e) {
             throw new DirectException("Exception setting from address: " + fromAddress, e);
@@ -177,7 +177,7 @@ public class MimeMessageBuilder {
                 attachmentPart = createAttachmentFromSOAPRequest(attachment, attachmentName);
             } else {
                 throw new Exception(
-                        "Could not create attachment. Need documents and messageId or attachment and attachmentName.");
+                    "Could not create attachment. Need documents and messageId or attachment and attachmentName.");
             }
         } catch (Exception e) {
             throw new DirectException("Exception creating attachment: " + attachmentName, e);
@@ -209,7 +209,7 @@ public class MimeMessageBuilder {
     }
 
     private MimeBodyPart createAttachmentFromSOAPRequest(Document data, String name) throws MessagingException,
-            IOException {
+        IOException {
 
         InputStream is = null;
         DataSource source = null;

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/messagemonitoring/impl/MessageMonitoringAPI.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/messagemonitoring/impl/MessageMonitoringAPI.java
@@ -117,12 +117,8 @@ public class MessageMonitoringAPI {
                 return;
             }
             //get the mail sender
-            InternetAddress sender = (InternetAddress) message.getSender();
-            if (sender == null) {
-                InternetAddress[] fromAddresses = (InternetAddress[]) message.getFrom();
-                sender = fromAddresses[0];
-            }
-            String senderMailId = sender.getAddress();
+
+            String senderMailId = getSenderEmailId(message);
 
             MonitoredMessageNotification tmn = getTrackmessagenotification(tm, senderMailId);
             //check if its a MDN or DSN
@@ -180,10 +176,7 @@ public class MessageMonitoringAPI {
         try {
             //get the all recipients
             InternetAddress recipients[] = (InternetAddress[]) message.getAllRecipients();
-
-            //get the mail sender
-            InternetAddress sender = (InternetAddress) message.getSender();
-            String senderMailId = sender.getAddress();
+            String senderMailId = getSenderEmailId(message);
             //Mail Subject
             String mailSubject = message.getSubject();
             //get the message id
@@ -692,6 +685,15 @@ public class MessageMonitoringAPI {
             NhincConstants.MESSAGEMONITORING_DELAYINMINUTES, trackMessage.getUpdatetime())) {
             deleteFromMessageMonitoringDB(trackMessage);
         }
+    }
+
+    private String getSenderEmailId(MimeMessage message) throws MessagingException {
+        InternetAddress sender = (InternetAddress) message.getSender();
+        if (sender == null) {
+            InternetAddress[] fromAddresses = (InternetAddress[]) message.getFrom();
+            sender = fromAddresses[0];
+        }
+        return (sender.getAddress());
     }
 
 }

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/messagemonitoring/impl/MessageMonitoringAPI.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/messagemonitoring/impl/MessageMonitoringAPI.java
@@ -688,12 +688,15 @@ public class MessageMonitoringAPI {
     }
 
     private String getSenderEmailId(MimeMessage message) throws MessagingException {
-        InternetAddress sender = (InternetAddress) message.getSender();
+        InternetAddress sender = null;
+        sender = (InternetAddress) message.getSender();
         if (sender == null) {
             InternetAddress[] fromAddresses = (InternetAddress[]) message.getFrom();
-            sender = fromAddresses[0];
+            if (fromAddresses.length > 0) {
+                sender = fromAddresses[0];
+            }
         }
-        return (sender.getAddress());
+        return ((sender == null) ? null : sender.getAddress());
     }
 
 }


### PR DESCRIPTION
Retrieve the sender from Mime Message "From" header when the MessageMonitoring is enabled for the Outbound XDR.
