### PR TITLE
FHAC-451:Fix Maven version for Validationtesting,embeddedtesting,RegressionTesting and DirectTesting profiles

### DIFF
--- a/Product/Production/Deploy/jboss7/pom.xml
+++ b/Product/Production/Deploy/jboss7/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Deploy</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>CONNECT-JB7</artifactId>

--- a/Product/Production/Deploy/was/pom.xml
+++ b/Product/Production/Deploy/was/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Deploy</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>CONNECT-WAS</artifactId>

--- a/Product/Production/Deploy/weblogic/pom.xml
+++ b/Product/Production/Deploy/weblogic/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Deploy</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>CONNECT-WL</artifactId>

--- a/Product/Production/Gateway/Direct/pom.xml
+++ b/Product/Production/Gateway/Direct/pom.xml
@@ -1,6 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>

--- a/Product/Production/Services/DirectCore/pom.xml
+++ b/Product/Production/Services/DirectCore/pom.xml
@@ -1,6 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>

--- a/Product/Production/Services/DirectCoreTest/pom.xml
+++ b/Product/Production/Services/DirectCoreTest/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Services</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>DirectCoreTest</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Bimodal/AdapterPatientDiscoveryAsyncReq/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Bimodal/AdapterPatientDiscoveryAsyncReq/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Bimodal</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>AdapterPatientDiscoveryAsyncReq</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Bimodal/AdapterPatientDiscoveryAsyncReqError/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Bimodal/AdapterPatientDiscoveryAsyncReqError/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Bimodal</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>AdapterPatientDiscoveryAsyncReqError</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Bimodal/AdapterPatientDiscoveryAsyncResp/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Bimodal/AdapterPatientDiscoveryAsyncResp/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Bimodal</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>AdapterPatientDiscoveryAsyncResp</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Bimodal/AdapterPolicyEngineSAMLConformanceTests/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Bimodal/AdapterPolicyEngineSAMLConformanceTests/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Bimodal</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>AdapterPolicyEngineConformance</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Bimodal/AdapterRegistryErrorListMissingTest/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Bimodal/AdapterRegistryErrorListMissingTest/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Bimodal</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>AdapterRegistryErrorListMissingTest</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Bimodal/ConnectionManagerTest/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Bimodal/ConnectionManagerTest/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Bimodal</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>ConnectionManagerTest</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Bimodal/DocRegistryAndRepository/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Bimodal/DocRegistryAndRepository/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Bimodal</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>DocRegistryAndRepository</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Bimodal/DocumentRetrieveXDSErrorValidation/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Bimodal/DocumentRetrieveXDSErrorValidation/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Bimodal</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>DocumentRetrieveXDSErrorValidation</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Bimodal/QueryByState/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Bimodal/QueryByState/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Bimodal</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>QueryByState</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Bimodal/ValidateDQAdapterMultipleEventCodesTest/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Bimodal/ValidateDQAdapterMultipleEventCodesTest/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Bimodal</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>ValidateDQAdapterMultipleEventCodesTest</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Bimodal/ValidateDQDRMultispecSupportTest/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Bimodal/ValidateDQDRMultispecSupportTest/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Bimodal</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>ValidateDQDRMultispecSupportTest</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Bimodal/ValidatePDCommunicationErrorHandlingTest/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Bimodal/ValidatePDCommunicationErrorHandlingTest/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Bimodal</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>ValidatePDCommunicationErrorHandlingTest</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Bimodal/ValidatePDCountryCodeTest/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Bimodal/ValidatePDCountryCodeTest/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Bimodal</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>ValidatePDCountryCodeTest</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Bimodal/ValidateQDMessageSpecVersionTest/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Bimodal/ValidateQDMessageSpecVersionTest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Bimodal</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>ValidateQDMessageSpecVersionTest</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Bimodal/ValidateRDMessageSpecVersionTest/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Bimodal/ValidateRDMessageSpecVersionTest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Bimodal</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>ValidateRDMessageSpecVersionTest</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Bimodal/ValidateSAMLResourceURIAttributeTest/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Bimodal/ValidateSAMLResourceURIAttributeTest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Bimodal</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>ValidateSAMLResourceURIAttributeTest</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Bimodal/XDRAdapterTests/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Bimodal/XDRAdapterTests/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Bimodal</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>XDRAdapterTests</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Bimodal/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Bimodal/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>RegressionSuite</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>Bimodal</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Direct/AutomatedDirectOutboundTesting/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Direct/AutomatedDirectOutboundTesting/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Direct</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>AutomatedDirectOutboundTesting</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Direct/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Direct/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>RegressionSuite</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>Direct</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Manual/LargePayloadTest/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Manual/LargePayloadTest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>SoapUI_Test</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>LargePayloadTest</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/NewFeature/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/NewFeature/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>RegressionSuite</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>NewFeature</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/Admin-Distribution-Passthrough/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/Admin-Distribution-Passthrough/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Passthru</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>Admin-Distribution-Passthrough</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Passthru</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>AuditLogging-Passthrough</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/DocQueryAdditionalStoredQueries/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/DocQueryAdditionalStoredQueries/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Passthru</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>DocQueryAdditionalStoredQueries</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/DocQueryErrorCodesPassthru/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/DocQueryErrorCodesPassthru/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Passthru</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>DocQueryErrorCodesPassthru</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/DocQueryRetrieveSelfTest/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/DocQueryRetrieveSelfTest/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Passthru</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>DocQueryRetrieveSelfTest</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/DocQueryXDSErrors/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/DocQueryXDSErrors/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Passthru</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>DocQueryXDSErrors</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/EventLogging-Passthrough/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/EventLogging-Passthrough/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Passthru</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>EventLogging-Passthrough</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/NHINCReceivingXDRAsyncRequestTests/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/NHINCReceivingXDRAsyncRequestTests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Passthru</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>NHINCReceivingXDRAsyncRequestTests</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/NHINCReceivingXDRAsyncResponseTests/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/NHINCReceivingXDRAsyncResponseTests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Passthru</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>NHINCReceivingXDRAsyncResponseTests</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/X12ErrorHandlingTest/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/X12ErrorHandlingTest/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Passthru</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>X12ErrorHandlingTest</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>RegressionSuite</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>Passthru</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/Admin-Distribution-Standard/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/Admin-Distribution-Standard/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>Admin-Distribution-Standard</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>AuditLogging-Standard</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/DQDROnDemandAndStableDocumentRetrievalTest/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/DQDROnDemandAndStableDocumentRetrievalTest/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>DQDROnDemandAndStableDocumentRetrievalTest</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/DocQueryErrorCodesStandard/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/DocQueryErrorCodesStandard/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>DocQueryErrorCodesStandard</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/DocQueryFanoutTestTarget/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/DocQueryFanoutTestTarget/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>DocQueryFanoutTestTarget</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/DocQueryOnDemand/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/DocQueryOnDemand/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>DocQueryOnDemand</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/DocQuerytestsforUDDI/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/DocQuerytestsforUDDI/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>DocQuerytestsforUDDI</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/EntityDocQuery/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/EntityDocQuery/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>EntityDocQuery</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/EntityDocQuerySecuredInterfaceTest/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/EntityDocQuerySecuredInterfaceTest/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>EntityDocQuerySecuredInterfaceTest</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/EntityDocRetrieve/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/EntityDocRetrieve/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>EntityDocRetrieve</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/EntityDocRetrieveSecuredInterfaceTest/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/EntityDocRetrieveSecuredInterfaceTest/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>EntityDocRetrieveSecuredInterfaceTest</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/EntityPolicyEngineTest/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/EntityPolicyEngineTest/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>EntityPolicyEngineTest</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/EntitySendingXDRAsyncReqTests/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/EntitySendingXDRAsyncReqTests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>EntitySendingXDRAsyncReqTests</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/EntitySendingXDRAsyncResponseTests/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/EntitySendingXDRAsyncResponseTests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>EntitySendingXDRAsyncResponseTests</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/EntityXDRTests/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/EntityXDRTests/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>EntityXDRTests</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/EventLogging-Standard/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/EventLogging-Standard/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>EventLogging-Standard</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/Fanout-Test/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/Fanout-Test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>Fanout-Test</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/NHINCPatientDiscoveryMAA/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/NHINCPatientDiscoveryMAA/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>NHINCPatientDiscoveryMAA</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/PDSAMLIssuerWithX509SubjectNameTest/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/PDSAMLIssuerWithX509SubjectNameTest/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>PDSAMLIssuerWithX509SubjectNameTest</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/PatientCorrelation/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/PatientCorrelation/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>PatientCorrelation</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/PatientDiscoveryDB/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/PatientDiscoveryDB/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>PatientDiscoveryDB</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/PatientDiscoveryInternalErrorMessageIdTest/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/PatientDiscoveryInternalErrorMessageIdTest/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>PatientDiscoveryInternalErrorMessageIdTest</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/TransactionIDTest/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/TransactionIDTest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>TransactionIDTest</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/ValidateConnectionManagerForAllServices/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/ValidateConnectionManagerForAllServices/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>ValidateConnectionManagerForAllServices</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/XDRAsyncRequestInbound-Tests/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/XDRAsyncRequestInbound-Tests/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>XDRAsyncRequestInbound-Tests</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/XDRAsyncRequestOutbound-Tests/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/XDRAsyncRequestOutbound-Tests/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Standard</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>XDRAsyncRequestOutbound-Tests</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/pom.xml
@@ -1,11 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>RegressionSuite</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>Standard</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/Utility/JMXConfigTest/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Utility/JMXConfigTest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>Bimodal</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>JMXConfigTest</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/startEmbedded/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/startEmbedded/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>RegressionSuite</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>startEmbedded</artifactId>

--- a/Product/SoapUI_Test/RegressionSuite/stopEmbedded/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/stopEmbedded/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>RegressionSuite</artifactId>
-        <version>4.5.0-SNAPSHOT</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>stopEmbedded</artifactId>

--- a/Product/pom.xml
+++ b/Product/pom.xml
@@ -1111,7 +1111,7 @@
                         <dependency>
                             <groupId>org.connectopensource</groupId>
                             <artifactId>build-tools</artifactId>
-                            <version>4.5.0-SNAPSHOT</version>
+                            <version>4.5.1-SNAPSHOT</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
Fix Maven Development version to "4.5.1-SNAPSHOT"  in 4.5 branch for various active profiles validationtesting, Directtesting, Regressiontesting and embeddedtesting.
