### PR TITLE
Fhac 487 - ATNA complaint PatientDiscovery Audit Logger

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxy.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxy.java
@@ -29,8 +29,6 @@ package gov.hhs.fha.nhinc.auditrepository.nhinc.proxy;
 import gov.hhs.fha.nhinc.common.auditlog.LogEventRequestType;
 import gov.hhs.fha.nhinc.common.nhinccommon.AcknowledgementType;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
-import gov.hhs.fha.nhinc.common.nhinccommonadapter.FindCommunitiesAndAuditEventsRequestType;
-import gov.hhs.fha.nhinc.common.nhinccommonadapter.FindCommunitiesAndAuditEventsResponseType;
 
 /**
  *
@@ -42,6 +40,7 @@ public interface AuditRepositoryProxy {
      * Logs an audit record to the audit repository.
      *
      * @param request Audit record
+     * @param assertion
      * @return Repsonse that is a simple ack.
      */
     public AcknowledgementType auditLog(LogEventRequestType request, AssertionType assertion);

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/server/BaseService.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/server/BaseService.java
@@ -83,7 +83,7 @@ public abstract class BaseService {
      * @param context
      * @return
      */
-    private String getRemoteAddress(WebServiceContext context) {
+    protected String getRemoteAddress(WebServiceContext context) {
         String remoteAddress = null;
         if (context != null && context.getMessageContext() != null && context.getMessageContext().get(AbstractHTTPDestination.HTTP_REQUEST) != null) {
             HttpServletRequest httpServletRequest = (HttpServletRequest) context.getMessageContext().get(AbstractHTTPDestination.HTTP_REQUEST);
@@ -98,7 +98,7 @@ public abstract class BaseService {
      * @param context
      * @return
      */
-    private String getWebServiceRequestUrl(WebServiceContext context) {
+    protected String getWebServiceRequestUrl(WebServiceContext context) {
         String requestWebServiceUrl = null;
         if (context != null && context.getMessageContext() != null) {
             requestWebServiceUrl = (String) context.getMessageContext().get(org.apache.cxf.message.Message.REQUEST_URL);
@@ -107,18 +107,20 @@ public abstract class BaseService {
     }
 
     /**
-     * Returns a Web Service Context properties object with the following
-     * properties: 1. Web Service Request URL 2. Remote Host Address
+     * Returns a Web Service Context properties object with the following properties: 1. Web Service Request URL 2.
+     * Remote Host Address
      *
      * @param context
      * @return
      */
     public Properties getWebContextProperties(WebServiceContext context) {
         Properties webContextProperties = new Properties();
-        //add Web Service Request URL
-        webContextProperties.put(NhincConstants.WEB_SERVICE_REQUEST_URL, getWebServiceRequestUrl(context));
-        //add Remote Server address or Host
-        webContextProperties.put(NhincConstants.REMOTE_HOST_ADDRESS, getRemoteAddress(context));
+        if (context != null && context.getMessageContext() != null) {
+            //add Web Service Request URL
+            webContextProperties.put(NhincConstants.WEB_SERVICE_REQUEST_URL, getWebServiceRequestUrl(context));
+            //add Remote Server address or Host
+            webContextProperties.put(NhincConstants.REMOTE_HOST_ADDRESS, getRemoteAddress(context));
+        }
         return webContextProperties;
     }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/MessageGeneratorUtils.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/MessageGeneratorUtils.java
@@ -28,14 +28,12 @@ package gov.hhs.fha.nhinc.util;
 
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunityType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.transform.marshallers.Marshaller;
 import gov.hhs.fha.nhinc.wsa.WSAHeaderHelper;
-
 import javax.xml.namespace.QName;
-
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
-
 import org.hl7.v3.PRPAIN201305UV02;
 import org.w3c.dom.Element;
 
@@ -80,6 +78,22 @@ public class MessageGeneratorUtils {
         if (targets != null && targets.getNhinTargetCommunity() != null && targets.getNhinTargetCommunity().size() > 0) {
             nhinTargetSystem.setHomeCommunity(targets.getNhinTargetCommunity().get(0).getHomeCommunity());
             nhinTargetSystem.setUseSpecVersion(targets.getUseSpecVersion());
+        }
+
+        return nhinTargetSystem;
+    }
+
+    /**
+     * Converts the first target into a NhinTargetSystemType format.
+     *
+     * @param target
+     * @return NhinTargetSystemType
+     */
+    public NhinTargetSystemType convertToNhinTargetSystemType(NhinTargetCommunityType target) {
+        NhinTargetSystemType nhinTargetSystem = new NhinTargetSystemType();
+
+        if (target != null && target.getHomeCommunity() != null) {
+            nhinTargetSystem.setHomeCommunity(target.getHomeCommunity());
         }
 
         return nhinTargetSystem;

--- a/Product/Production/Gateway/PatientDiscovery_10/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/_10/gateway/ws/NhinPatientDiscovery.java
+++ b/Product/Production/Gateway/PatientDiscovery_10/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/_10/gateway/ws/NhinPatientDiscovery.java
@@ -68,13 +68,12 @@ public class NhinPatientDiscovery extends BaseService implements RespondingGatew
      * @throws PRPAIN201305UV02Fault a fault if there's an exception
      */
     @InboundMessageEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
-            afterReturningBuilder = PRPAIN201306UV02EventDescriptionBuilder.class,
-            serviceType = "Patient Discovery", version = "1.0")
+        afterReturningBuilder = PRPAIN201306UV02EventDescriptionBuilder.class,
+        serviceType = "Patient Discovery", version = "1.0")
     public PRPAIN201306UV02 respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 body) throws PRPAIN201305UV02Fault {
         try {
             AssertionType assertion = getAssertion(context, null);
-
-            return inboundPatientDiscovery.respondingGatewayPRPAIN201305UV02(body, assertion);
+            return inboundPatientDiscovery.respondingGatewayPRPAIN201305UV02(body, assertion, getWebContextProperties(context));
         } catch (PatientDiscoveryException e) {
             PatientDiscoveryFaultType type = new PatientDiscoveryFaultType();
             type.setErrorCode("920");

--- a/Product/Production/Gateway/PatientDiscovery_10/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/_10/gateway/ws/PatientDiscoverySpringContextTest.java
+++ b/Product/Production/Gateway/PatientDiscovery_10/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/_10/gateway/ws/PatientDiscoverySpringContextTest.java
@@ -26,14 +26,8 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery._10.gateway.ws;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryException;
 import gov.hhs.fha.nhinc.patientdiscovery.inbound.InboundPatientDiscovery;
 import gov.hhs.fha.nhinc.patientdiscovery.inbound.PassthroughInboundPatientDiscovery;
@@ -41,25 +35,48 @@ import gov.hhs.fha.nhinc.patientdiscovery.inbound.StandardInboundPatientDiscover
 import gov.hhs.fha.nhinc.patientdiscovery.outbound.PassthroughOutboundPatientDiscovery;
 import gov.hhs.fha.nhinc.patientdiscovery.outbound.StandardOutboundPatientDiscovery;
 import ihe.iti.xcpd._2009.PRPAIN201305UV02Fault;
-
+import java.security.Principal;
+import java.util.Properties;
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+import javax.xml.ws.EndpointReference;
+import javax.xml.ws.WebServiceContext;
+import javax.xml.ws.handler.MessageContext;
+import org.apache.cxf.jaxws.context.WebServiceContextImpl;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.transport.http.AbstractHTTPDestination;
 import org.hl7.v3.PRPAIN201305UV02;
 import org.hl7.v3.PRPAIN201306UV02;
 import org.hl7.v3.RespondingGatewayPRPAIN201305UV02RequestType;
 import org.hl7.v3.RespondingGatewayPRPAIN201306UV02ResponseType;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import org.mockito.Mockito;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.w3c.dom.Element;
 
 /**
  * @author akong
  *
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = { "/patientdiscovery/_10/applicationContext.xml" })
+@ContextConfiguration(locations = {"/patientdiscovery/_10/applicationContext.xml"})
 public class PatientDiscoverySpringContextTest {
 
     @Rule
@@ -89,44 +106,43 @@ public class PatientDiscoverySpringContextTest {
     @Test
     public void inbound() throws PRPAIN201305UV02Fault {
         assertNotNull(inboundPatientDiscoveryEndpoint);
-
         PRPAIN201305UV02 request = new PRPAIN201305UV02();
+        WebServiceContext context = new WebServiceContextImpl();
+        inboundPatientDiscoveryEndpoint.setContext(context);
         PRPAIN201306UV02 response = inboundPatientDiscoveryEndpoint.respondingGatewayPRPAIN201305UV02(request);
-
         assertNotNull(response);
     }
 
-   /* @Test
-    public void inboundFault() throws PatientDiscoveryException {
-        PRPAIN201305UV02 request = new PRPAIN201305UV02();
+    /* @Test
+     public void inboundFault() throws PatientDiscoveryException {
+     PRPAIN201305UV02 request = new PRPAIN201305UV02();
 
-        NhinPatientDiscovery inboundPDEndpoint = new NhinPatientDiscovery();
+     NhinPatientDiscovery inboundPDEndpoint = new NhinPatientDiscovery();
 
-        InboundPatientDiscovery inboundPatientDiscovery = mock(InboundPatientDiscovery.class);
+     InboundPatientDiscovery inboundPatientDiscovery = mock(InboundPatientDiscovery.class);
 
-        when(inboundPatientDiscovery.respondingGatewayPRPAIN201305UV02(eq(request), any(AssertionType.class)))
-                .thenThrow(new PatientDiscoveryException(""));
+     when(inboundPatientDiscovery.respondingGatewayPRPAIN201305UV02(eq(request), any(AssertionType.class)))
+     .thenThrow(new PatientDiscoveryException(""));
 
-        inboundPDEndpoint.setInboundPatientDiscovery(inboundPatientDiscovery);
+     inboundPDEndpoint.setInboundPatientDiscovery(inboundPatientDiscovery);
 
-        boolean faultThrown = false;
-        try {
-            inboundPDEndpoint.respondingGatewayPRPAIN201305UV02(request);
-        } catch (PRPAIN201305UV02Fault fault) {
-            faultThrown = true;
-            assertEquals("920", fault.getFaultInfo().getErrorCode());
-        }
+     boolean faultThrown = false;
+     try {
+     inboundPDEndpoint.respondingGatewayPRPAIN201305UV02(request);
+     } catch (PRPAIN201305UV02Fault fault) {
+     faultThrown = true;
+     assertEquals("920", fault.getFaultInfo().getErrorCode());
+     }
 
-        assertTrue(faultThrown);
-    }*/
-
+     assertTrue(faultThrown);
+     }*/
     @Test
     public void outboundUnsecured() {
         assertNotNull(outboundPatientDiscoveryUnsecuredEndpoint);
 
         RespondingGatewayPRPAIN201305UV02RequestType request = new RespondingGatewayPRPAIN201305UV02RequestType();
         RespondingGatewayPRPAIN201306UV02ResponseType response = outboundPatientDiscoveryUnsecuredEndpoint
-                .respondingGatewayPRPAIN201305UV02(request);
+            .respondingGatewayPRPAIN201305UV02(request);
 
         assertNotNull(response);
     }
@@ -137,7 +153,7 @@ public class PatientDiscoverySpringContextTest {
 
         RespondingGatewayPRPAIN201305UV02RequestType request = new RespondingGatewayPRPAIN201305UV02RequestType();
         RespondingGatewayPRPAIN201306UV02ResponseType response = outboundPatientDiscoverySecuredEndpoint
-                .respondingGatewayPRPAIN201305UV02(request);
+            .respondingGatewayPRPAIN201305UV02(request);
 
         assertNotNull(response);
     }

--- a/Product/Production/Gateway/PatientDiscovery_10/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/_10/gateway/ws/PatientDiscoverySpringContextTest.java
+++ b/Product/Production/Gateway/PatientDiscovery_10/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/_10/gateway/ws/PatientDiscoverySpringContextTest.java
@@ -27,7 +27,6 @@
 package gov.hhs.fha.nhinc.patientdiscovery._10.gateway.ws;
 
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
-import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryException;
 import gov.hhs.fha.nhinc.patientdiscovery.inbound.InboundPatientDiscovery;
 import gov.hhs.fha.nhinc.patientdiscovery.inbound.PassthroughInboundPatientDiscovery;
@@ -35,41 +34,28 @@ import gov.hhs.fha.nhinc.patientdiscovery.inbound.StandardInboundPatientDiscover
 import gov.hhs.fha.nhinc.patientdiscovery.outbound.PassthroughOutboundPatientDiscovery;
 import gov.hhs.fha.nhinc.patientdiscovery.outbound.StandardOutboundPatientDiscovery;
 import ihe.iti.xcpd._2009.PRPAIN201305UV02Fault;
-import java.security.Principal;
 import java.util.Properties;
-import javax.annotation.PostConstruct;
-import javax.servlet.http.HttpServletRequest;
-import javax.xml.ws.EndpointReference;
 import javax.xml.ws.WebServiceContext;
-import javax.xml.ws.handler.MessageContext;
 import org.apache.cxf.jaxws.context.WebServiceContextImpl;
-import org.apache.cxf.message.Message;
-import org.apache.cxf.transport.http.AbstractHTTPDestination;
 import org.hl7.v3.PRPAIN201305UV02;
 import org.hl7.v3.PRPAIN201306UV02;
 import org.hl7.v3.RespondingGatewayPRPAIN201305UV02RequestType;
 import org.hl7.v3.RespondingGatewayPRPAIN201306UV02ResponseType;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import org.mockito.Mockito;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.w3c.dom.Element;
 
 /**
  * @author akong
@@ -113,7 +99,8 @@ public class PatientDiscoverySpringContextTest {
         assertNotNull(response);
     }
 
-    /* @Test
+    @Ignore 
+    @Test
      public void inboundFault() throws PatientDiscoveryException {
      PRPAIN201305UV02 request = new PRPAIN201305UV02();
 
@@ -121,7 +108,8 @@ public class PatientDiscoverySpringContextTest {
 
      InboundPatientDiscovery inboundPatientDiscovery = mock(InboundPatientDiscovery.class);
 
-     when(inboundPatientDiscovery.respondingGatewayPRPAIN201305UV02(eq(request), any(AssertionType.class)))
+     when(inboundPatientDiscovery.respondingGatewayPRPAIN201305UV02(eq(request), any(AssertionType.class), 
+         any(Properties.class)))
      .thenThrow(new PatientDiscoveryException(""));
 
      inboundPDEndpoint.setInboundPatientDiscovery(inboundPatientDiscovery);
@@ -135,7 +123,7 @@ public class PatientDiscoverySpringContextTest {
      }
 
      assertTrue(faultThrown);
-     }*/
+     }
     @Test
     public void outboundUnsecured() {
         assertNotNull(outboundPatientDiscoveryUnsecuredEndpoint);

--- a/Product/Production/Gateway/PatientDiscovery_10/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/_10/gateway/ws/PatientDiscoverySpringContextTest.java
+++ b/Product/Production/Gateway/PatientDiscovery_10/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/_10/gateway/ws/PatientDiscoverySpringContextTest.java
@@ -99,31 +99,32 @@ public class PatientDiscoverySpringContextTest {
         assertNotNull(response);
     }
 
-    @Ignore 
+    @Ignore
     @Test
-     public void inboundFault() throws PatientDiscoveryException {
-     PRPAIN201305UV02 request = new PRPAIN201305UV02();
+    public void inboundFault() throws PatientDiscoveryException {
+        PRPAIN201305UV02 request = new PRPAIN201305UV02();
 
-     NhinPatientDiscovery inboundPDEndpoint = new NhinPatientDiscovery();
+        NhinPatientDiscovery inboundPDEndpoint = new NhinPatientDiscovery();
 
-     InboundPatientDiscovery inboundPatientDiscovery = mock(InboundPatientDiscovery.class);
+        InboundPatientDiscovery inboundPatientDiscovery = mock(InboundPatientDiscovery.class);
 
-     when(inboundPatientDiscovery.respondingGatewayPRPAIN201305UV02(eq(request), any(AssertionType.class), 
-         any(Properties.class)))
-     .thenThrow(new PatientDiscoveryException(""));
+        when(inboundPatientDiscovery.respondingGatewayPRPAIN201305UV02(eq(request), any(AssertionType.class),
+            any(Properties.class)))
+            .thenThrow(new PatientDiscoveryException(""));
 
-     inboundPDEndpoint.setInboundPatientDiscovery(inboundPatientDiscovery);
+        inboundPDEndpoint.setInboundPatientDiscovery(inboundPatientDiscovery);
 
-     boolean faultThrown = false;
-     try {
-     inboundPDEndpoint.respondingGatewayPRPAIN201305UV02(request);
-     } catch (PRPAIN201305UV02Fault fault) {
-     faultThrown = true;
-     assertEquals("920", fault.getFaultInfo().getErrorCode());
-     }
+        boolean faultThrown = false;
+        try {
+            inboundPDEndpoint.respondingGatewayPRPAIN201305UV02(request);
+        } catch (PRPAIN201305UV02Fault fault) {
+            faultThrown = true;
+            assertEquals("920", fault.getFaultInfo().getErrorCode());
+        }
 
-     assertTrue(faultThrown);
-     }
+        assertTrue(faultThrown);
+    }
+
     @Test
     public void outboundUnsecured() {
         assertNotNull(outboundPatientDiscoveryUnsecuredEndpoint);

--- a/Product/Production/Services/AuditRepositoryCore/pom.xml
+++ b/Product/Production/Services/AuditRepositoryCore/pom.xml
@@ -51,4 +51,20 @@
             <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/AuditTransformConstants.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/AuditTransformConstants.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package gov.hhs.fha.nhinc.audit;
+
+/**
+ *
+ * @author achidamb
+ */
+public class AuditTransformConstants {
+    public static final Integer EVENT_OUTCOME_INDICATOR_SUCCESS = 0;
+    public static final String ACTIVE_PARTICPANT_USER_ID_SOURCE = "anonymous";
+    public static final String ACTIVE_PARTICPANT_ROLE_CODE_SOURCE_DISPLAY_NAME = "Source";
+    public static final String ACTIVE_PARTICPANT_ROLE_CODE_DESTINATION_DISPLAY_NAME = "Destination";
+    public static final String ACTIVE_PARTICPANT_UNKNOWN_IP_ADDRESS = "unknown";
+    public static final Short NETWORK_ACCESSOR_PT_TYPE_CODE_NAME = 2;
+    public static final String ACTIVE_PARTICIPANT_ROLE_CODE_DEST = "110152";
+    public static final String ACTIVE_PARTICIPANT_ROLE_CODE_Source = "110153";
+    public static final String ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME = "DCM";
+    public static final Short NETWORK_ACCESSOR_PT_TYPE_CODE_IP = 2;
+}

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/AuditTransformConstants.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/AuditTransformConstants.java
@@ -33,10 +33,10 @@ package gov.hhs.fha.nhinc.audit;
  */
 public class AuditTransformConstants {
     public static final Integer EVENT_OUTCOME_INDICATOR_SUCCESS = 0;
-    public static final String ACTIVE_PARTICPANT_USER_ID_SOURCE = "anonymous";
-    public static final String ACTIVE_PARTICPANT_ROLE_CODE_SOURCE_DISPLAY_NAME = "Source";
-    public static final String ACTIVE_PARTICPANT_ROLE_CODE_DESTINATION_DISPLAY_NAME = "Destination";
-    public static final String ACTIVE_PARTICPANT_UNKNOWN_IP_ADDRESS = "unknown";
+    public static final String ACTIVE_PARTICIPANT_USER_ID_SOURCE = "anonymous";
+    public static final String ACTIVE_PARTICIPANT_ROLE_CODE_SOURCE_DISPLAY_NAME = "Source";
+    public static final String ACTIVE_PARTICIPANT_ROLE_CODE_DESTINATION_DISPLAY_NAME = "Destination";
+    public static final String ACTIVE_PARTICIPANT_UNKNOWN_IP_ADDRESS = "unknown";
     public static final Short NETWORK_ACCESSOR_PT_TYPE_CODE_NAME = 2;
     public static final String ACTIVE_PARTICIPANT_ROLE_CODE_DEST = "110152";
     public static final String ACTIVE_PARTICIPANT_ROLE_CODE_SOURCE = "110153";

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/AuditTransformConstants.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/AuditTransformConstants.java
@@ -39,7 +39,7 @@ public class AuditTransformConstants {
     public static final String ACTIVE_PARTICPANT_UNKNOWN_IP_ADDRESS = "unknown";
     public static final Short NETWORK_ACCESSOR_PT_TYPE_CODE_NAME = 2;
     public static final String ACTIVE_PARTICIPANT_ROLE_CODE_DEST = "110152";
-    public static final String ACTIVE_PARTICIPANT_ROLE_CODE_Source = "110153";
+    public static final String ACTIVE_PARTICIPANT_ROLE_CODE_SOURCE = "110153";
     public static final String ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME = "DCM";
     public static final Short NETWORK_ACCESSOR_PT_TYPE_CODE_IP = 2;
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/AuditTransformDataBuilder.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/AuditTransformDataBuilder.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.audit;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/*
+ *
+ * @author achidamb
+ */
+public class AuditTransformDataBuilder {
+
+    public Map<String, String> eventIdCodeMap;
+    public Map<String, String> eventCodeSystemMap;
+    public Map<String, String> eventDisplayNameRequestorMap;
+    public Map<String, String> eventDisplayNameResponderMap;
+    public Map<String, String> eventTypeCodeMap;
+    public Map<String, String> eventTypeCodeSystemMap;
+    public Map<String, String> eventTypeCodeDisplayNameMap;
+    public Map<String, String> eventActionCodeRequestorMap;
+    public Map<String, String> eventActionCodeResponderMap;
+
+    private AuditTransformDataBuilder() {
+        eventIdCodeMap = createEventIdCodeMap();
+        eventCodeSystemMap = createEventCodeSystemMap();
+        eventDisplayNameRequestorMap = createEventDisplayNameRequestorMap();
+        eventDisplayNameResponderMap = createEventDisplayNameResponderMap();
+        eventTypeCodeMap = createEventTypeCodeMap();
+        eventTypeCodeSystemMap = createEventTypeCodeSystemMap();
+        eventTypeCodeDisplayNameMap = createEventTypeCodeDisplayNameMap();
+        eventActionCodeRequestorMap = createEventActionCodeRequestorMap();
+        eventActionCodeResponderMap = createEventActionCodeResponderMap();
+    }
+
+    private Map<String, String> createEventIdCodeMap() {
+        eventIdCodeMap = new HashMap();
+        eventIdCodeMap.put("PatientDiscovery", "110112");
+        return eventIdCodeMap;
+    }
+
+    /**
+     *
+     * @param serviceName
+     * @return
+     */
+    public String getEventIdCode(String serviceName) {
+        if (eventIdCodeMap.containsKey(serviceName)) {
+            return eventIdCodeMap.get(serviceName);
+        }
+        return null;
+    }
+
+    private Map<String, String> createEventCodeSystemMap() {
+        eventCodeSystemMap = new HashMap();
+        eventCodeSystemMap.put("PatientDiscovery", "DCM");
+        return eventCodeSystemMap;
+    }
+
+    public String getEventCodeSystem(String serviceName) {
+        if (eventCodeSystemMap.containsKey(serviceName)) {
+            return eventCodeSystemMap.get(serviceName);
+        }
+        return null;
+    }
+
+    private Map<String, String> createEventDisplayNameRequestorMap() {
+        eventDisplayNameRequestorMap = new HashMap();
+        eventDisplayNameRequestorMap.put("PatientDiscovery", "Query");
+        return eventDisplayNameRequestorMap;
+    }
+
+    public String getEventDisplayNameRequestor(String serviceName) {
+        if (eventDisplayNameRequestorMap.containsKey(serviceName)) {
+            return eventDisplayNameRequestorMap.get(serviceName);
+        }
+        return null;
+    }
+
+    private Map<String, String> createEventDisplayNameResponderMap() {
+        eventDisplayNameResponderMap = new HashMap();
+        eventDisplayNameResponderMap.put("PatientDiscovery", "Query");
+        return eventDisplayNameResponderMap;
+    }
+
+    public String getEventDisplayNameResponder(String serviceName) {
+        if (eventDisplayNameResponderMap.containsKey(serviceName)) {
+            return eventDisplayNameResponderMap.get(serviceName);
+        }
+        return null;
+    }
+
+    private Map<String, String> createEventTypeCodeMap() {
+        eventTypeCodeMap = new HashMap();
+        eventTypeCodeMap.put("PatientDiscovery", "ITI-55");
+        return eventTypeCodeMap;
+    }
+
+    public String getEventTypeCode(String serviceName) {
+        if (eventTypeCodeMap.containsKey(serviceName)) {
+            return eventTypeCodeMap.get(serviceName);
+        }
+        return null;
+    }
+
+    private Map<String, String> createEventTypeCodeSystemMap() {
+        eventTypeCodeSystemMap = new HashMap();
+        eventTypeCodeSystemMap.put("PatientDiscovery", "IHE Transactions");
+        return eventTypeCodeSystemMap;
+    }
+
+    public String getEventTypeCodeSystem(String serviceName) {
+        if (eventTypeCodeSystemMap.containsKey(serviceName)) {
+            return eventTypeCodeSystemMap.get(serviceName);
+        }
+        return null;
+    }
+
+    private Map<String, String> createEventTypeCodeDisplayNameMap() {
+        eventTypeCodeDisplayNameMap = new HashMap();
+        eventTypeCodeDisplayNameMap.put("PatientDiscovery", "Cross Gateway Patient Discovery");
+        return eventTypeCodeDisplayNameMap;
+    }
+
+    public String getEventTypeCodeDisplayName(String serviceName) {
+        if (eventTypeCodeDisplayNameMap.containsKey(serviceName)) {
+            return eventTypeCodeDisplayNameMap.get(serviceName);
+        }
+        return null;
+    }
+
+    private Map<String, String> createEventActionCodeRequestorMap() {
+        eventActionCodeRequestorMap = new HashMap();
+        eventActionCodeRequestorMap.put("PatientDiscovery", "E");
+        return eventActionCodeRequestorMap;
+    }
+
+    public String getEventActionCodeRequestor(String serviceName) {
+        if (eventActionCodeRequestorMap.containsKey(serviceName)) {
+            return eventActionCodeRequestorMap.get(serviceName);
+        }
+        return null;
+    }
+
+    private Map<String, String> createEventActionCodeResponderMap() {
+        eventActionCodeResponderMap = new HashMap();
+        eventActionCodeResponderMap.put("PatientDiscovery", "E");
+        return eventActionCodeResponderMap;
+    }
+
+    public String getEventActionCodeResponder(String serviceName) {
+        if (eventActionCodeResponderMap.containsKey(serviceName)) {
+            return eventActionCodeResponderMap.get(serviceName);
+        }
+        return null;
+    }
+
+    private static class AuditTransformDataBuilderHolder {
+
+        private static final AuditTransformDataBuilder INSTANCE = new AuditTransformDataBuilder();
+    }
+
+    /**
+     *
+     * @return
+     */
+    public static AuditTransformDataBuilder getInstance() {
+        return AuditTransformDataBuilderHolder.INSTANCE;
+    }
+}

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/AuditTransformDataBuilder.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/AuditTransformDataBuilder.java
@@ -33,21 +33,21 @@ package gov.hhs.fha.nhinc.audit;
 public abstract class AuditTransformDataBuilder {
 
     public abstract String getServiceEvenIdCode();
-    
+
     public abstract String getServiceEventCodeSystem();
-    
+
     public abstract String getServiceEventDisplayRequestor();
-    
+
     public abstract String getServiceEventDisplayResponder();
-    
+
     public abstract String getServiceEventTypeCode();
-    
+
     public abstract String getServiceEventTypeCodeSystem();
-    
+
     public abstract String getServiceEventTypeCodeDisplayName();
-    
+
     public abstract String getServiceEventActionCodeRequestor();
-    
+
     public abstract String getServiceEventActionCodeResponder();
-    
+
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransform.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransform.java
@@ -1,0 +1,579 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.audit.transform;
+
+import com.services.nhinc.schema.auditmessage.AuditMessageType;
+import com.services.nhinc.schema.auditmessage.AuditSourceIdentificationType;
+import com.services.nhinc.schema.auditmessage.CodedValueType;
+import com.services.nhinc.schema.auditmessage.EventIdentificationType;
+import com.services.nhinc.schema.auditmessage.ParticipantObjectIdentificationType;
+import gov.hhs.fha.nhinc.audit.AuditTransformConstants;
+import gov.hhs.fha.nhinc.audit.AuditTransformDataBuilder;
+import gov.hhs.fha.nhinc.common.auditlog.LogEventRequestType;
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.common.nhinccommon.UserType;
+import gov.hhs.fha.nhinc.connectmgr.ConnectionManagerCache;
+import gov.hhs.fha.nhinc.connectmgr.ConnectionManagerException;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.nhinclib.NullChecker;
+import gov.hhs.fha.nhinc.transform.audit.AuditDataTransformHelper;
+import gov.hhs.fha.nhinc.util.HomeCommunityMap;
+import java.lang.management.ManagementFactory;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.Properties;
+import java.util.TimeZone;
+import java.util.UUID;
+import javax.xml.datatype.DatatypeConfigurationException;
+import org.apache.commons.validator.routines.InetAddressValidator;
+import org.apache.log4j.Logger;
+
+/**
+ *
+ * @author achidamb
+ * @param <T> request Object Type
+ * @param <K> response Object Type
+ */
+public abstract class AuditTransform<T, K> {
+
+    private static final Logger LOG = Logger.getLogger(AuditTransform.class);
+
+    /**
+     *
+     * @param request
+     * @param assertion
+     * @param target
+     * @param direction
+     * @param _interface
+     * @param isRequesting
+     * @param webContextProperties
+     * @param serviceName
+     * @param response
+     * @return
+     */
+    public final LogEventRequestType transformMsgToAuditMsg(T request, AssertionType assertion,
+        NhinTargetSystemType target, String direction, String _interface, boolean isRequesting, Properties webContextProperties, String serviceName, K response) {
+        LOG.trace("Begin AuditDataTransform -> transformMsgToAuditMsg() ----");
+        if (request == null && response == null) {
+            LOG.error("message Object was null");
+            return null;
+        }
+        if (assertion == null) {
+            LOG.error("Assertion was null");
+            return null;
+        }
+
+        LogEventRequestType result = new LogEventRequestType();
+
+        AuditMessageType auditMsg = new AuditMessageType();
+        //****************************Construct Event Identification**************************
+
+        auditMsg.setEventIdentification(createEventIdentification(serviceName, isRequesting));
+
+        //*********************************Construct Active Participant************************
+        //Active Participant for human requester only required for requesting gateway
+        if (isRequesting) {
+            AuditMessageType.ActiveParticipant participantHumanFactor = getActiveParticipant(assertion.getUserInfo());
+            auditMsg.getActiveParticipant().add(participantHumanFactor);
+        }
+        AuditMessageType.ActiveParticipant participantSource = getActiveParticipantSource(isRequesting, webContextProperties, serviceName);
+        AuditMessageType.ActiveParticipant participantDestination = getActiveParticipantDestination(target, isRequesting, webContextProperties, serviceName);
+        auditMsg.getActiveParticipant().add(participantSource);
+        auditMsg.getActiveParticipant().add(participantDestination);
+
+        //******************************Constuct Participation Object Identification*************
+        // Assign ParticipationObjectIdentification
+        auditMsg = getParticipantObjectIdentification(request, response, assertion, auditMsg);
+
+        //Create the AuditSourceIdentifierType object
+        String communityId = getMessageCommunityId(assertion, target, isRequesting);
+        AuditSourceIdentificationType auditSource = getAuditSourceIdentificationType();
+
+        //******************************Constuct Audit Source Identification**********************
+        auditMsg.getAuditSourceIdentification().add(auditSource);
+
+        //Set the all the required data
+        result.setAuditMessage(auditMsg);
+        result.setDirection(direction);
+        result.setInterface(_interface);
+        //set the target community identifier
+        result.setCommunityId(communityId);
+
+        LOG.trace("End AuditDataTransform transformMsgToAuditMsg() ----");
+        return result;
+    }
+
+    /**
+     *
+     * @param request
+     * @param response
+     * @param assertion
+     * @param auditMsg
+     * @return
+     */
+    protected abstract AuditMessageType getParticipantObjectIdentification(T request, K response, AssertionType assertion, AuditMessageType auditMsg);
+
+    /**
+     *
+     * @return
+     */
+    protected AuditSourceIdentificationType getAuditSourceIdentificationType() {
+        String hcid = HomeCommunityMap.getLocalHomeCommunityId();
+        String homeCommunityName = HomeCommunityMap.getHomeCommunityName(hcid);
+        return createAuditSourceIdentification(hcid, homeCommunityName);
+    }
+
+    /**
+     *
+     * @param oUserInfo
+     * @return
+     */
+    protected AuditMessageType.ActiveParticipant getActiveParticipant(UserType oUserInfo) {
+        // Create Active Participant Section
+        // create a method to call the AuditDataTransformHelper - one expectation
+        AuditMessageType.ActiveParticipant participant = createActiveParticipantFromUser(
+            oUserInfo, Boolean.TRUE);
+        if (oUserInfo.getRoleCoded() != null) {
+            participant.getRoleIDCode().add(AuditDataTransformHelper.createCodeValueType(oUserInfo.getRoleCoded().getCode(), "",
+                oUserInfo.getRoleCoded().getCodeSystemName(), oUserInfo.getRoleCoded().getDisplayName()));
+        }
+        return participant;
+    }
+
+    /**
+     *
+     * @param serviceName
+     * @param isRequesting
+     * @return
+     */
+    protected EventIdentificationType createEventIdentification(String serviceName, boolean isRequesting) {
+        CodedValueType eventID = createCodeValueType(getEventIdCode(serviceName), null,
+            getEventCodeSystemName(serviceName), isRequesting ? getEventDisplayNameRequestor(serviceName) : getEventDisplayNameResponder(serviceName));
+
+        EventIdentificationType oEventIdentificationType = getEventIdentificationType(eventID, isRequesting, serviceName);
+        oEventIdentificationType.getEventTypeCode().add(AuditDataTransformHelper.createCodeValueType(getEventTypeCode(serviceName), null,
+            getEventTypeCodeSystem(serviceName), getEventTypeCodeDisplayName(serviceName)));
+        return oEventIdentificationType;
+    }
+
+    /**
+     * Create the ActiveParticipant for an audit log record.
+     *
+     * @param userInfo
+     * @param userIsReq
+     * @return
+     */
+    protected AuditMessageType.ActiveParticipant createActiveParticipantFromUser(UserType userInfo,
+        Boolean userIsReq) {
+        AuditMessageType.ActiveParticipant participant = new AuditMessageType.ActiveParticipant();
+
+        // Set the User Id
+        String userId = null;
+        if (userInfo != null && userInfo.getUserName() != null && userInfo.getUserName().length() > 0) {
+            userId = userInfo.getUserName();
+            participant.setUserID(userId);
+        }
+
+        // If specified, set the User Name
+        String userName = null;
+        if (userInfo != null && userInfo.getPersonName() != null) {
+            if (userInfo.getPersonName().getGivenName() != null && userInfo.getPersonName().getGivenName().length() > 0) {
+                userName = userInfo.getPersonName().getGivenName();
+            }
+
+            if (userInfo.getPersonName().getFamilyName() != null
+                && userInfo.getPersonName().getFamilyName().length() > 0) {
+                if (userName != null) {
+                    userName += (" " + userInfo.getPersonName().getFamilyName());
+                } else {
+                    userName = userInfo.getPersonName().getFamilyName();
+                }
+            }
+            if (userName != null) {
+                participant.setUserName(userName);
+            }
+        }
+
+        participant.setUserIsRequestor(userIsReq);
+        return participant;
+    }
+
+    /**
+     *
+     * @param eventID
+     * @param isRequesting
+     * @param serviceName
+     * @return
+     */
+    protected EventIdentificationType getEventIdentificationType(CodedValueType eventID, boolean isRequesting, String serviceName) {
+        EventIdentificationType oEventIdentificationType = createEventIdentification(
+            isRequesting ? getEventActionCodeRequestor(serviceName) : getEventActionCodeResponder(serviceName),
+            AuditTransformConstants.EVENT_OUTCOME_INDICATOR_SUCCESS, eventID);
+        return oEventIdentificationType;
+    }
+
+    /**
+     *
+     * @param isRequesting
+     * @param webContextProperties
+     * @param serviceName
+     * @return
+     */
+    protected AuditMessageType.ActiveParticipant getActiveParticipantSource(boolean isRequesting, Properties webContextProperties, String serviceName) {
+        AuditMessageType.ActiveParticipant participant = new AuditMessageType.ActiveParticipant();
+        participant.setUserID(AuditTransformConstants.ACTIVE_PARTICPANT_USER_ID_SOURCE);
+        participant.setAlternativeUserID(ManagementFactory.getRuntimeMXBean().getName());
+        String hostAddress = null;
+        hostAddress = isRequesting ? getLocalHostAddress() : getRemoteHostAddress(webContextProperties);
+        participant.setNetworkAccessPointID(hostAddress);
+        participant.setNetworkAccessPointTypeCode(getNetworkAccessPointTypeCode(hostAddress));
+
+        participant.getRoleIDCode().add(AuditDataTransformHelper.createCodeValueType(AuditTransformConstants.ACTIVE_PARTICIPANT_ROLE_CODE_Source, null,
+            AuditTransformConstants.ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME, AuditTransformConstants.ACTIVE_PARTICPANT_ROLE_CODE_SOURCE_DISPLAY_NAME));
+        participant.setUserIsRequestor(isRequesting);
+        return participant;
+    }
+
+    /**
+     *
+     * @param target
+     * @param isRequesting
+     * @param webContextProprties
+     * @param serviceName
+     * @return
+     */
+    protected AuditMessageType.ActiveParticipant getActiveParticipantDestination(NhinTargetSystemType target, boolean isRequesting, Properties webContextProprties, String serviceName) {
+        String strUrl = null;
+        String strHost = null;
+        boolean setDefaultValue = true;
+
+        AuditMessageType.ActiveParticipant participant = new AuditMessageType.ActiveParticipant();
+
+        strUrl = isRequesting ? getWebServiceUrlFromRemoteObject(target, serviceName) : getWebServiceRequestURL(webContextProprties);
+        if (strUrl != null) {
+            try {
+                URL url = new URL(strUrl);
+                participant.setUserID(strUrl);
+                strHost = url.getHost();
+                participant.setNetworkAccessPointID(strHost);
+                participant.setNetworkAccessPointTypeCode(getNetworkAccessPointTypeCode(strHost));
+                setDefaultValue = false;
+            } catch (MalformedURLException ex) {
+                LOG.error(ex);
+                setDefaultValue = true;
+            }
+        }
+        //if the url is null or not a valid url
+        if (setDefaultValue) {
+            //for now set the user id to anonymouns
+            participant.setUserID(AuditTransformConstants.ACTIVE_PARTICPANT_USER_ID_SOURCE);
+            //for now hardcode the value to localhost, need to find out if this needs to be set
+            participant.setNetworkAccessPointTypeCode(AuditTransformConstants.NETWORK_ACCESSOR_PT_TYPE_CODE_NAME);
+            participant.setNetworkAccessPointID(AuditTransformConstants.ACTIVE_PARTICPANT_UNKNOWN_IP_ADDRESS);
+        }
+        participant.setUserIsRequestor(Boolean.FALSE);
+        participant.getRoleIDCode().add(AuditDataTransformHelper.createCodeValueType(AuditTransformConstants.ACTIVE_PARTICIPANT_ROLE_CODE_DEST, null,
+            AuditTransformConstants.ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME, AuditTransformConstants.ACTIVE_PARTICPANT_ROLE_CODE_DESTINATION_DISPLAY_NAME));
+        return participant;
+    }
+
+    /**
+     *
+     * @param webContextProeprties
+     * @return
+     */
+    protected String getRemoteHostAddress(Properties webContextProeprties) {
+        if (webContextProeprties != null && !webContextProeprties.isEmpty() && webContextProeprties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS) != null) {
+            return webContextProeprties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS);
+        }
+        return AuditTransformConstants.ACTIVE_PARTICPANT_UNKNOWN_IP_ADDRESS;
+    }
+
+    /**
+     *
+     * @param hostAddress
+     * @return
+     */
+    protected Short getNetworkAccessPointTypeCode(String hostAddress) {
+        if (InetAddressValidator.getInstance().isValid(hostAddress)) {
+            return AuditTransformConstants.NETWORK_ACCESSOR_PT_TYPE_CODE_IP;
+        } else {
+            return AuditTransformConstants.NETWORK_ACCESSOR_PT_TYPE_CODE_NAME;
+        }
+    }
+
+    /**
+     *
+     * @param webContextProeprties
+     * @return
+     */
+    protected String getWebServiceRequestURL(Properties webContextProeprties) {
+        if (webContextProeprties != null && !webContextProeprties.isEmpty() && webContextProeprties.getProperty(NhincConstants.WEB_SERVICE_REQUEST_URL) != null) {
+            return webContextProeprties.getProperty(NhincConstants.WEB_SERVICE_REQUEST_URL);
+        }
+        return AuditTransformConstants.ACTIVE_PARTICPANT_USER_ID_SOURCE;
+    }
+
+    /**
+     *
+     * @param target
+     * @param serviceName
+     * @return
+     */
+    protected String getWebServiceUrlFromRemoteObject(NhinTargetSystemType target, String serviceName) {
+        if (target != null && serviceName != null) {
+            try {
+                return getConnectionManagerCache().getEndpointURLFromNhinTarget(target, serviceName);
+            } catch (ConnectionManagerException ex) {
+                LOG.error(ex);
+            }
+        }
+        return AuditTransformConstants.ACTIVE_PARTICPANT_USER_ID_SOURCE;
+    }
+
+    /**
+     *
+     * @return
+     */
+    protected ConnectionManagerCache getConnectionManagerCache() {
+        return ConnectionManagerCache.getInstance();
+    }
+
+    /**
+     *
+     * @return
+     */
+    protected String getLocalHostAddress() {
+        try {
+            return InetAddress.getLocalHost().getHostAddress();
+        } catch (UnknownHostException ex) {
+            return AuditTransformConstants.ACTIVE_PARTICPANT_UNKNOWN_IP_ADDRESS;
+        }
+    }
+
+    /**
+     *
+     * @return
+     */
+    protected String createUUID() {
+        return (UUID.randomUUID().toString());
+
+    }
+
+    /**
+     *
+     * @param assertion
+     * @param target
+     * @param isRequesting
+     * @return
+     */
+    protected String getMessageCommunityId(AssertionType assertion, NhinTargetSystemType target, boolean isRequesting) {
+        String communityId = null;
+        if (isRequesting) {
+            communityId = HomeCommunityMap.getCommunityIdFromTargetSystem(target);
+        } else {
+            communityId = HomeCommunityMap.getHomeCommunityIdFromAssertion(assertion);
+        }
+        return HomeCommunityMap.formatHomeCommunityId(communityId);
+    }
+
+    /**
+     *
+     * @param participantObjectCode
+     * @param participantObjectCodeRole
+     * @param participantObjectIdCode
+     * @param particpantObjectIdCodeSystem
+     * @param participantObjectIdDisplayName
+     * @return
+     */
+    protected ParticipantObjectIdentificationType createParticipantObjectIdentification(short participantObjectCode, short participantObjectCodeRole,
+        String participantObjectIdCode, String particpantObjectIdCodeSystem, String participantObjectIdDisplayName) {
+        ParticipantObjectIdentificationType participantObject = new ParticipantObjectIdentificationType();
+
+        // Set the Participation Object Typecode
+        participantObject.setParticipantObjectTypeCode(participantObjectCode);
+
+        // Set the Participation Object Typecode Role
+        participantObject.setParticipantObjectTypeCodeRole(participantObjectCodeRole);
+
+        // Set the Participation Object Id Type code
+        CodedValueType partObjIdTypeCode = new CodedValueType();
+        partObjIdTypeCode.setCode(participantObjectIdCode);
+        partObjIdTypeCode.setCodeSystemName(particpantObjectIdCodeSystem);
+        partObjIdTypeCode.setDisplayName(participantObjectIdDisplayName);
+        participantObject.setParticipantObjectIDTypeCode(partObjIdTypeCode);
+        return participantObject;
+    }
+
+    /**
+     * Create the <code>EventIdentificationType</code> for an audit log record.
+     *
+     * @param actionCode
+     * @param eventOutcome
+     * @param eventId
+     * @return <code>EventIdentificationType</code>
+     */
+    private static EventIdentificationType createEventIdentification(String actionCode, Integer eventOutcome,
+        CodedValueType eventId) {
+        EventIdentificationType eventIdentification = new EventIdentificationType();
+
+        // Set the Event Action Code
+        eventIdentification.setEventActionCode(actionCode);
+
+        // Set the Event Action Time
+        try {
+            java.util.GregorianCalendar today = new java.util.GregorianCalendar(TimeZone.getTimeZone("GMT"));
+            javax.xml.datatype.DatatypeFactory factory = javax.xml.datatype.DatatypeFactory.newInstance();
+            javax.xml.datatype.XMLGregorianCalendar calendar = factory.newXMLGregorianCalendar(
+                today.get(java.util.GregorianCalendar.YEAR), today.get(java.util.GregorianCalendar.MONTH) + 1,
+                today.get(java.util.GregorianCalendar.DAY_OF_MONTH),
+                today.get(java.util.GregorianCalendar.HOUR_OF_DAY), today.get(java.util.GregorianCalendar.MINUTE),
+                today.get(java.util.GregorianCalendar.SECOND), today.get(java.util.GregorianCalendar.MILLISECOND),
+                0);
+            eventIdentification.setEventDateTime(calendar);
+        } catch (DatatypeConfigurationException e) {
+            LOG.error("DatatypeConfigurationException when creating XMLGregorian Date");
+            LOG.error(" message: " + e.getMessage());
+        } catch (ArrayIndexOutOfBoundsException e) {
+            LOG.error("ArrayIndexOutOfBoundsException when creating XMLGregorian Date");
+            LOG.error(" message: " + e.getMessage());
+        }
+        // Set the Event Outcome Indicator
+        BigInteger eventOutcomeBig = BigInteger.ZERO;
+        if (eventOutcome != null) {
+            eventOutcomeBig = new BigInteger(eventOutcome.toString());
+        }
+        eventIdentification.setEventOutcomeIndicator(eventOutcomeBig);
+
+        // Set the Event Id
+        eventIdentification.setEventID(eventId);
+
+        return eventIdentification;
+    }
+
+    /**
+     * Create the <code>CodedValueType</code> for an audit log record.
+     *
+     * @param code
+     * @param codeSys
+     * @param codeSysName
+     * @param dispName
+     * @return <code>CodedValueType</code>
+     */
+    public static CodedValueType createCodeValueType(String code, String codeSys, String codeSysName, String dispName) {
+        CodedValueType codeValueType = new CodedValueType();
+
+        // Set the Code
+        if (NullChecker.isNotNullish(code)) {
+            codeValueType.setCode(code);
+        }
+
+        // Set the Codesystem
+        if (NullChecker.isNotNullish(codeSys)) {
+            codeValueType.setCodeSystem(codeSys);
+        }
+
+        // Set the Codesystem Name
+        if (NullChecker.isNotNullish(codeSysName)) {
+            codeValueType.setCodeSystemName(codeSysName);
+        }
+
+        // Set the Display Name
+        if (NullChecker.isNotNullish(dispName)) {
+            codeValueType.setDisplayName(dispName);
+        }
+
+        return codeValueType;
+    }
+
+    /**
+     * Create an <code>AuditSourceIdentificationType</code> based on the community id and name for an audit log record.
+     *
+     * @param communityId
+     * @param communityName
+     * @return <code>AuditSourceIdentificationType</code>
+     */
+    private static AuditSourceIdentificationType createAuditSourceIdentification(String communityId, String communityName) {
+        AuditSourceIdentificationType auditSrcId = new AuditSourceIdentificationType();
+
+        // Set the Audit Source Id (community id)
+        if (communityId != null) {
+            if (communityId.startsWith("urn:oid:")) {
+                auditSrcId.setAuditSourceID(communityId.substring(8));
+            } else {
+                auditSrcId.setAuditSourceID(communityId);
+            }
+        }
+
+        // If specified, set the Audit Enterprise Site Id (community name)
+        if (communityName != null) {
+            auditSrcId.setAuditEnterpriseSiteID(communityName);
+        }
+
+        return auditSrcId;
+    }
+
+    private String getEventIdCode(String serviceName) {
+        return AuditTransformDataBuilder.getInstance().getEventIdCode(serviceName);
+    }
+
+    private String getEventCodeSystemName(String serviceName) {
+        return AuditTransformDataBuilder.getInstance().getEventCodeSystem(serviceName);
+    }
+
+    private String getEventDisplayNameRequestor(String serviceName) {
+        return AuditTransformDataBuilder.getInstance().getEventDisplayNameRequestor(serviceName);
+    }
+
+    private String getEventDisplayNameResponder(String serviceName) {
+        return AuditTransformDataBuilder.getInstance().getEventDisplayNameResponder(serviceName);
+    }
+
+    private String getEventTypeCode(String serviceName) {
+        return AuditTransformDataBuilder.getInstance().getEventTypeCode(serviceName);
+    }
+
+    private String getEventTypeCodeSystem(String serviceName) {
+        return AuditTransformDataBuilder.getInstance().getEventTypeCodeSystem(serviceName);
+    }
+
+    private String getEventTypeCodeDisplayName(String serviceName) {
+        return AuditTransformDataBuilder.getInstance().getEventTypeCodeDisplayName(serviceName);
+    }
+
+    private String getEventActionCodeRequestor(String serviceName) {
+        return AuditTransformDataBuilder.getInstance().getEventActionCodeRequestor(serviceName);
+    }
+
+    private String getEventActionCodeResponder(String serviceName) {
+        return AuditTransformDataBuilder.getInstance().getEventActionCodeResponder(serviceName);
+    }
+}

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransform.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransform.java
@@ -173,14 +173,12 @@ public abstract class AuditTransform<T, K> {
     /**
      *
      * @param oUserInfo
-     * @param isRequesting
      * @return
      */
-    protected AuditMessageType.ActiveParticipant getActiveParticipant(UserType oUserInfo, Boolean isRequesting) {
+    protected AuditMessageType.ActiveParticipant getActiveParticipant(UserType oUserInfo) {
         // Create Active Participant Section
         // create a method to call the AuditDataTransformHelper - one expectation
-        AuditMessageType.ActiveParticipant participant = createActiveParticipantFromUser(
-            oUserInfo, isRequesting);
+        AuditMessageType.ActiveParticipant participant = createActiveParticipantFromUser(oUserInfo);
         if (oUserInfo.getRoleCoded() != null) {
             participant.getRoleIDCode().add(AuditDataTransformHelper.createCodeValueType(oUserInfo.getRoleCoded().
                 getCode(), "",
@@ -214,11 +212,9 @@ public abstract class AuditTransform<T, K> {
      * Create the ActiveParticipant for an audit log record.
      *
      * @param userInfo
-     * @param userIsReq
      * @return
      */
-    protected AuditMessageType.ActiveParticipant createActiveParticipantFromUser(UserType userInfo,
-        Boolean userIsReq) {
+    protected AuditMessageType.ActiveParticipant createActiveParticipantFromUser(UserType userInfo) {
         AuditMessageType.ActiveParticipant participant = new AuditMessageType.ActiveParticipant();
 
         // Set the User Id
@@ -249,7 +245,7 @@ public abstract class AuditTransform<T, K> {
             }
         }
 
-        participant.setUserIsRequestor(userIsReq);
+        participant.setUserIsRequestor(Boolean.TRUE);
         return participant;
     }
 
@@ -287,7 +283,7 @@ public abstract class AuditTransform<T, K> {
 
         participant.getRoleIDCode().add(AuditDataTransformHelper.createCodeValueType(AuditTransformConstants.ACTIVE_PARTICIPANT_ROLE_CODE_SOURCE, null,
             AuditTransformConstants.ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME, AuditTransformConstants.ACTIVE_PARTICIPANT_ROLE_CODE_SOURCE_DISPLAY_NAME));
-        participant.setUserIsRequestor(isRequesting);
+        participant.setUserIsRequestor(Boolean.TRUE);
         return participant;
     }
 
@@ -585,7 +581,7 @@ public abstract class AuditTransform<T, K> {
         //*********************************Construct Active Participant************************
         //Active Participant for human requester only required for requesting gateway
         if (isRequesting) {
-            AuditMessageType.ActiveParticipant participantHumanFactor = getActiveParticipant(assertion.getUserInfo(), isRequesting);
+            AuditMessageType.ActiveParticipant participantHumanFactor = getActiveParticipant(assertion.getUserInfo());
             auditMsg.getActiveParticipant().add(participantHumanFactor);
         }
         AuditMessageType.ActiveParticipant participantSource = getActiveParticipantSource(isRequesting,

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.audit.transform;
+
+import com.services.nhinc.schema.auditmessage.AuditMessageType.ActiveParticipant;
+import com.services.nhinc.schema.auditmessage.EventIdentificationType;
+import gov.hhs.fha.nhinc.audit.AuditTransformConstants;
+import gov.hhs.fha.nhinc.audit.AuditTransformDataBuilder;
+import gov.hhs.fha.nhinc.common.auditlog.LogEventRequestType;
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import java.lang.management.ManagementFactory;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.Properties;
+import org.junit.After;
+import org.junit.AfterClass;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+
+/**
+ *
+ * @author achidamb
+ */
+public abstract class AuditTransformTest<T,K> {
+
+    public AuditTransformTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() {
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+    }
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    /**
+     * Test of transformMsgToAuditMsg method, of class AuditTransform.
+     */
+    /*@Test
+     public void testTransformMsgToAuditMsg() {
+     System.out.println("transformMsgToAuditMsg");
+     Object request = null;
+     AssertionType assertion = null;
+     NhinTargetSystemType target = null;
+     String direction = "";
+     String _interface = "";
+     boolean isRequesting = false;
+     Properties webContextProperties = null;
+     String serviceName = "";
+     AuditTransform instance = new AuditTransformImpl();
+     LogEventRequestType expResult = null;
+     LogEventRequestType result = instance.transformMsgToAuditMsg(request, assertion, target, direction, _interface, isRequesting, webContextProperties, serviceName);
+     assertEquals(expResult, result);
+     // TODO review the generated test code and remove the default call to fail.
+     fail("The test case is a prototype.");
+     }*/
+    /**
+     * Test of getParticipantObjectIdentification method, of class AuditTransform.
+     */
+    /*@Test
+     public void testGetParticipantObjectIdentification() {
+     System.out.println("getParticipantObjectIdentification");
+     Object request = null;
+     AssertionType assertion = null;
+     Boolean isRequesting = null;
+     AuditMessageType auditMsg = null;
+     AuditTransform instance = new AuditTransformImpl();
+     AuditMessageType expResult = null;
+     AuditMessageType result = instance.getParticipantObjectIdentification(request, assertion, isRequesting, auditMsg);
+     assertEquals(expResult, result);
+     // TODO review the generated test code and remove the default call to fail.
+     fail("The test case is a prototype.");
+     }*/
+
+    /**
+     * Test of createEventIdentification method, of class AuditTransform.
+     *
+     * @param request
+     * @param serviceName
+     * @param isRequesting
+     */
+    public void testGetEventIdentificationType(LogEventRequestType request, String serviceName, Boolean isRequesting) {
+        EventIdentificationType eventIdentificationType = request.getAuditMessage().getEventIdentification();
+        if (isRequesting) {
+            assertEquals(AuditTransformDataBuilder.getInstance().eventActionCodeRequestorMap.get(serviceName), eventIdentificationType.getEventActionCode());
+        } else {
+            assertEquals(AuditTransformDataBuilder.getInstance().eventActionCodeResponderMap.get(serviceName), eventIdentificationType.getEventActionCode());
+        }
+        assertEquals(AuditTransformConstants.EVENT_OUTCOME_INDICATOR_SUCCESS.toString(), eventIdentificationType.getEventOutcomeIndicator().toString());
+        assertEquals(AuditTransformDataBuilder.getInstance().eventIdCodeMap.get(serviceName), eventIdentificationType.getEventID().getCode());
+        assertEquals(AuditTransformDataBuilder.getInstance().eventCodeSystemMap.get(serviceName), eventIdentificationType.getEventID().getCodeSystemName());
+        if (isRequesting) {
+            assertEquals(AuditTransformDataBuilder.getInstance().eventDisplayNameRequestorMap.get(serviceName), eventIdentificationType.getEventID().getDisplayName());
+        } else {
+            assertEquals(AuditTransformDataBuilder.getInstance().eventDisplayNameResponderMap.get(serviceName), eventIdentificationType.getEventID().getDisplayName());
+        }
+
+        assertEquals(AuditTransformDataBuilder.getInstance().eventTypeCodeMap.get(serviceName), eventIdentificationType.getEventTypeCode().get(0).getCode());
+        assertEquals(AuditTransformDataBuilder.getInstance().eventTypeCodeSystemMap.get(serviceName), eventIdentificationType.getEventTypeCode().get(0).getCodeSystemName());
+        assertEquals(AuditTransformDataBuilder.getInstance().eventTypeCodeDisplayNameMap.get(serviceName), eventIdentificationType.getEventTypeCode().get(0).getDisplayName());
+    }
+
+    /**
+     * Test of createActiveParticipantFromUser method, of class AuditTransform.
+     *
+     * @param request
+     * @param isRequesting
+     * @param assertion
+     */
+    public void testCreateActiveParticipantFromUser(LogEventRequestType request, Boolean isRequesting, AssertionType assertion) {
+        if (isRequesting) {
+            ActiveParticipant userActiveParticipant = null;
+            List<ActiveParticipant> activeParticipant = request.getAuditMessage().getActiveParticipant();
+            for (ActiveParticipant item : activeParticipant) {
+                if (item.getRoleIDCode().get(0).getCode() != null && item.getRoleIDCode().get(0).getCode().equals("Code")) {
+                    userActiveParticipant = item;
+                }
+            }
+            assertEquals(assertion.getUserInfo().getUserName(), userActiveParticipant.getUserID());
+            assertEquals(assertion.getUserInfo().getPersonName().getGivenName() + " " + assertion.getUserInfo().getPersonName().getFamilyName(), userActiveParticipant.getUserName());
+            assertEquals(assertion.getUserInfo().getRoleCoded().getCode(), userActiveParticipant.getRoleIDCode().get(0).getCode());
+            assertEquals(assertion.getUserInfo().getRoleCoded().getCodeSystemName(), userActiveParticipant.getRoleIDCode().get(0).getCodeSystemName());
+            assertEquals(assertion.getUserInfo().getRoleCoded().getDisplayName(), userActiveParticipant.getRoleIDCode().get(0).getDisplayName());
+        }
+    }
+
+    /**
+     * Test of getActiveParticipantSource method, of class AuditTransform.
+     *
+     * @param request
+     * @param isRequesting
+     * @param localIP
+     * @throws java.net.UnknownHostException
+     */
+    public void testGetActiveParticipantSource(LogEventRequestType request, Boolean isRequesting, String localIP, Properties webContextProperties) throws UnknownHostException {
+        ActiveParticipant sourceActiveParticipant = null;
+        List<ActiveParticipant> activeParticipant = request.getAuditMessage().getActiveParticipant();
+        for (ActiveParticipant item : activeParticipant) {
+            if (item.getRoleIDCode().get(0).getDisplayName() != null && item.getRoleIDCode().get(0).getDisplayName().equals(AuditTransformConstants.ACTIVE_PARTICPANT_ROLE_CODE_SOURCE_DISPLAY_NAME)) {
+                sourceActiveParticipant = item;
+            }
+        }
+        assertEquals(AuditTransformConstants.ACTIVE_PARTICPANT_USER_ID_SOURCE, sourceActiveParticipant.getUserID());
+        if (isRequesting) {
+            assertEquals(ManagementFactory.getRuntimeMXBean().getName(), sourceActiveParticipant.getAlternativeUserID());
+        }
+        assertEquals(isRequesting, sourceActiveParticipant.isUserIsRequestor());
+        if (isRequesting) {
+            assertEquals(localIP, sourceActiveParticipant.getNetworkAccessPointID());
+        } else {
+            assertEquals(webContextProperties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS), sourceActiveParticipant.getNetworkAccessPointID());
+        }
+        assertEquals(AuditTransformConstants.NETWORK_ACCESSOR_PT_TYPE_CODE_NAME, sourceActiveParticipant.getNetworkAccessPointTypeCode());
+        assertEquals(AuditTransformConstants.ACTIVE_PARTICIPANT_ROLE_CODE_Source, sourceActiveParticipant.getRoleIDCode().get(0).getCode());
+        assertEquals(AuditTransformConstants.ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME, sourceActiveParticipant.getRoleIDCode().get(0).getCodeSystemName());
+        assertEquals(AuditTransformConstants.ACTIVE_PARTICPANT_ROLE_CODE_SOURCE_DISPLAY_NAME, sourceActiveParticipant.getRoleIDCode().get(0).getDisplayName());
+    }
+
+    /**
+     * Test of getActiveParticipantDestination method, of class AuditTransform.
+     *
+     * @param request
+     * @param isRequesting
+     * @param webContextProperties
+     * @param remoteObjectIP
+     */
+    public void testGetActiveParticipantDestination(LogEventRequestType request, Boolean isRequesting, Properties webContextProperties, String remoteObjectIP) {
+        ActiveParticipant destinationActiveParticipant = null;
+        for (ActiveParticipant item : request.getAuditMessage().getActiveParticipant()) {
+            if (item.getRoleIDCode().get(0).getDisplayName() != null && item.getRoleIDCode().get(0).getDisplayName().equals(AuditTransformConstants.ACTIVE_PARTICPANT_ROLE_CODE_DESTINATION_DISPLAY_NAME)) {
+                destinationActiveParticipant = item;
+            }
+        }
+        if (isRequesting) {
+            assertEquals(remoteObjectIP, destinationActiveParticipant.getUserID());
+        } else {
+            assertEquals(webContextProperties.getProperty(NhincConstants.WEB_SERVICE_REQUEST_URL), destinationActiveParticipant.getUserID());
+        }
+
+        assertEquals(!(isRequesting), destinationActiveParticipant.isUserIsRequestor());
+        assertEquals(webContextProperties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS), destinationActiveParticipant.getNetworkAccessPointID());
+        assertEquals(AuditTransformConstants.NETWORK_ACCESSOR_PT_TYPE_CODE_NAME, destinationActiveParticipant.getNetworkAccessPointTypeCode());
+        assertEquals(AuditTransformConstants.ACTIVE_PARTICIPANT_ROLE_CODE_DEST, destinationActiveParticipant.getRoleIDCode().get(0).getCode());
+        assertEquals(AuditTransformConstants.ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME, destinationActiveParticipant.getRoleIDCode().get(0).getCodeSystemName());
+        assertEquals(AuditTransformConstants.ACTIVE_PARTICPANT_ROLE_CODE_DESTINATION_DISPLAY_NAME, destinationActiveParticipant.getRoleIDCode().get(0).getDisplayName());
+    }
+
+}

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformTest.java
@@ -148,11 +148,11 @@ public abstract class AuditTransformTest<T,K> {
         List<ActiveParticipant> activeParticipant = request.getAuditMessage().getActiveParticipant();
         for (ActiveParticipant item : activeParticipant) {
             if (item.getRoleIDCode().get(0).getDisplayName() != null && item.getRoleIDCode().get(0).getDisplayName().
-                equals(AuditTransformConstants.ACTIVE_PARTICPANT_ROLE_CODE_SOURCE_DISPLAY_NAME)) {
+                equals(AuditTransformConstants.ACTIVE_PARTICIPANT_ROLE_CODE_SOURCE_DISPLAY_NAME)) {
                 sourceActiveParticipant = item;
             }
         }
-        assertEquals(AuditTransformConstants.ACTIVE_PARTICPANT_USER_ID_SOURCE, sourceActiveParticipant.getUserID());
+        assertEquals(AuditTransformConstants.ACTIVE_PARTICIPANT_USER_ID_SOURCE, sourceActiveParticipant.getUserID());
         if (isRequesting) {
             assertEquals(ManagementFactory.getRuntimeMXBean().getName(), sourceActiveParticipant.getAlternativeUserID());
         }
@@ -169,7 +169,7 @@ public abstract class AuditTransformTest<T,K> {
             sourceActiveParticipant.getRoleIDCode().get(0).getCode());
         assertEquals(AuditTransformConstants.ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME, 
             sourceActiveParticipant.getRoleIDCode().get(0).getCodeSystemName());
-        assertEquals(AuditTransformConstants.ACTIVE_PARTICPANT_ROLE_CODE_SOURCE_DISPLAY_NAME, 
+        assertEquals(AuditTransformConstants.ACTIVE_PARTICIPANT_ROLE_CODE_SOURCE_DISPLAY_NAME, 
             sourceActiveParticipant.getRoleIDCode().get(0).getDisplayName());
     }
 
@@ -186,7 +186,7 @@ public abstract class AuditTransformTest<T,K> {
         ActiveParticipant destinationActiveParticipant = null;
         for (ActiveParticipant item : request.getAuditMessage().getActiveParticipant()) {
             if (item.getRoleIDCode().get(0).getDisplayName() != null && item.getRoleIDCode().get(0).
-                getDisplayName().equals(AuditTransformConstants.ACTIVE_PARTICPANT_ROLE_CODE_DESTINATION_DISPLAY_NAME)) {
+                getDisplayName().equals(AuditTransformConstants.ACTIVE_PARTICIPANT_ROLE_CODE_DESTINATION_DISPLAY_NAME)) {
                 destinationActiveParticipant = item;
             }
         }
@@ -206,7 +206,7 @@ public abstract class AuditTransformTest<T,K> {
             getRoleIDCode().get(0).getCode());
         assertEquals(AuditTransformConstants.ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME, destinationActiveParticipant.
             getRoleIDCode().get(0).getCodeSystemName());
-        assertEquals(AuditTransformConstants.ACTIVE_PARTICPANT_ROLE_CODE_DESTINATION_DISPLAY_NAME, 
+        assertEquals(AuditTransformConstants.ACTIVE_PARTICIPANT_ROLE_CODE_DESTINATION_DISPLAY_NAME, 
             destinationActiveParticipant.getRoleIDCode().get(0).getDisplayName());
     }
 

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformTest.java
@@ -48,7 +48,7 @@ import org.junit.BeforeClass;
  *
  * @author achidamb
  */
-public abstract class AuditTransformTest<T,K> {
+public abstract class AuditTransformTest {
 
     public AuditTransformTest() {
     }

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformTest.java
@@ -70,70 +70,38 @@ public abstract class AuditTransformTest<T,K> {
     }
 
     /**
-     * Test of transformMsgToAuditMsg method, of class AuditTransform.
-     */
-    /*@Test
-     public void testTransformMsgToAuditMsg() {
-     System.out.println("transformMsgToAuditMsg");
-     Object request = null;
-     AssertionType assertion = null;
-     NhinTargetSystemType target = null;
-     String direction = "";
-     String _interface = "";
-     boolean isRequesting = false;
-     Properties webContextProperties = null;
-     String serviceName = "";
-     AuditTransform instance = new AuditTransformImpl();
-     LogEventRequestType expResult = null;
-     LogEventRequestType result = instance.transformMsgToAuditMsg(request, assertion, target, direction, _interface, isRequesting, webContextProperties, serviceName);
-     assertEquals(expResult, result);
-     // TODO review the generated test code and remove the default call to fail.
-     fail("The test case is a prototype.");
-     }*/
-    /**
-     * Test of getParticipantObjectIdentification method, of class AuditTransform.
-     */
-    /*@Test
-     public void testGetParticipantObjectIdentification() {
-     System.out.println("getParticipantObjectIdentification");
-     Object request = null;
-     AssertionType assertion = null;
-     Boolean isRequesting = null;
-     AuditMessageType auditMsg = null;
-     AuditTransform instance = new AuditTransformImpl();
-     AuditMessageType expResult = null;
-     AuditMessageType result = instance.getParticipantObjectIdentification(request, assertion, isRequesting, auditMsg);
-     assertEquals(expResult, result);
-     // TODO review the generated test code and remove the default call to fail.
-     fail("The test case is a prototype.");
-     }*/
-
-    /**
      * Test of createEventIdentification method, of class AuditTransform.
      *
      * @param request
      * @param serviceName
      * @param isRequesting
+     * @param builder
      */
-    public void testGetEventIdentificationType(LogEventRequestType request, String serviceName, Boolean isRequesting) {
+    protected void testGetEventIdentificationType(LogEventRequestType request, String serviceName, Boolean isRequesting, 
+        AuditTransformDataBuilder builder) {
         EventIdentificationType eventIdentificationType = request.getAuditMessage().getEventIdentification();
         if (isRequesting) {
-            assertEquals(AuditTransformDataBuilder.getInstance().eventActionCodeRequestorMap.get(serviceName), eventIdentificationType.getEventActionCode());
+            assertEquals(builder.getServiceEventActionCodeRequestor(), eventIdentificationType.getEventActionCode());
         } else {
-            assertEquals(AuditTransformDataBuilder.getInstance().eventActionCodeResponderMap.get(serviceName), eventIdentificationType.getEventActionCode());
+            assertEquals(builder.getServiceEventActionCodeResponder(), eventIdentificationType.getEventActionCode());
         }
-        assertEquals(AuditTransformConstants.EVENT_OUTCOME_INDICATOR_SUCCESS.toString(), eventIdentificationType.getEventOutcomeIndicator().toString());
-        assertEquals(AuditTransformDataBuilder.getInstance().eventIdCodeMap.get(serviceName), eventIdentificationType.getEventID().getCode());
-        assertEquals(AuditTransformDataBuilder.getInstance().eventCodeSystemMap.get(serviceName), eventIdentificationType.getEventID().getCodeSystemName());
+        assertEquals(AuditTransformConstants.EVENT_OUTCOME_INDICATOR_SUCCESS.toString(), eventIdentificationType.
+            getEventOutcomeIndicator().toString());
+        assertEquals(builder.getServiceEvenIdCode(), eventIdentificationType.getEventID().getCode());
+        assertEquals(builder.getServiceEventCodeSystem(), eventIdentificationType.getEventID().getCodeSystemName());
         if (isRequesting) {
-            assertEquals(AuditTransformDataBuilder.getInstance().eventDisplayNameRequestorMap.get(serviceName), eventIdentificationType.getEventID().getDisplayName());
+            assertEquals(builder.getServiceEventDisplayRequestor(), eventIdentificationType.getEventID().
+                getDisplayName());
         } else {
-            assertEquals(AuditTransformDataBuilder.getInstance().eventDisplayNameResponderMap.get(serviceName), eventIdentificationType.getEventID().getDisplayName());
+            assertEquals(builder.getServiceEventDisplayResponder(), eventIdentificationType.getEventID().
+                getDisplayName());
         }
 
-        assertEquals(AuditTransformDataBuilder.getInstance().eventTypeCodeMap.get(serviceName), eventIdentificationType.getEventTypeCode().get(0).getCode());
-        assertEquals(AuditTransformDataBuilder.getInstance().eventTypeCodeSystemMap.get(serviceName), eventIdentificationType.getEventTypeCode().get(0).getCodeSystemName());
-        assertEquals(AuditTransformDataBuilder.getInstance().eventTypeCodeDisplayNameMap.get(serviceName), eventIdentificationType.getEventTypeCode().get(0).getDisplayName());
+        assertEquals(builder.getServiceEventTypeCode(), eventIdentificationType.getEventTypeCode().get(0).getCode());
+        assertEquals(builder.getServiceEventTypeCodeSystem(),eventIdentificationType.getEventTypeCode().get(0).
+            getCodeSystemName());
+        assertEquals(builder.getServiceEventTypeCodeDisplayName(), eventIdentificationType.getEventTypeCode().get(0).
+            getDisplayName());
     }
 
     /**
@@ -143,20 +111,25 @@ public abstract class AuditTransformTest<T,K> {
      * @param isRequesting
      * @param assertion
      */
-    public void testCreateActiveParticipantFromUser(LogEventRequestType request, Boolean isRequesting, AssertionType assertion) {
+    protected void testCreateActiveParticipantFromUser(LogEventRequestType request, Boolean isRequesting, AssertionType assertion) {
         if (isRequesting) {
             ActiveParticipant userActiveParticipant = null;
             List<ActiveParticipant> activeParticipant = request.getAuditMessage().getActiveParticipant();
             for (ActiveParticipant item : activeParticipant) {
-                if (item.getRoleIDCode().get(0).getCode() != null && item.getRoleIDCode().get(0).getCode().equals("Code")) {
+                if (item.getRoleIDCode().get(0).getCode() != null && item.getRoleIDCode().get(0).getCode().
+                    equals("Code")) {
                     userActiveParticipant = item;
                 }
             }
             assertEquals(assertion.getUserInfo().getUserName(), userActiveParticipant.getUserID());
-            assertEquals(assertion.getUserInfo().getPersonName().getGivenName() + " " + assertion.getUserInfo().getPersonName().getFamilyName(), userActiveParticipant.getUserName());
-            assertEquals(assertion.getUserInfo().getRoleCoded().getCode(), userActiveParticipant.getRoleIDCode().get(0).getCode());
-            assertEquals(assertion.getUserInfo().getRoleCoded().getCodeSystemName(), userActiveParticipant.getRoleIDCode().get(0).getCodeSystemName());
-            assertEquals(assertion.getUserInfo().getRoleCoded().getDisplayName(), userActiveParticipant.getRoleIDCode().get(0).getDisplayName());
+            assertEquals(assertion.getUserInfo().getPersonName().getGivenName() + " " + 
+                assertion.getUserInfo().getPersonName().getFamilyName(), userActiveParticipant.getUserName());
+            assertEquals(assertion.getUserInfo().getRoleCoded().getCode(), userActiveParticipant.
+                getRoleIDCode().get(0).getCode());
+            assertEquals(assertion.getUserInfo().getRoleCoded().getCodeSystemName(), userActiveParticipant.
+                getRoleIDCode().get(0).getCodeSystemName());
+            assertEquals(assertion.getUserInfo().getRoleCoded().getDisplayName(), userActiveParticipant.
+                getRoleIDCode().get(0).getDisplayName());
         }
     }
 
@@ -164,15 +137,18 @@ public abstract class AuditTransformTest<T,K> {
      * Test of getActiveParticipantSource method, of class AuditTransform.
      *
      * @param request
+     * @param webContextProperties
      * @param isRequesting
      * @param localIP
      * @throws java.net.UnknownHostException
      */
-    public void testGetActiveParticipantSource(LogEventRequestType request, Boolean isRequesting, String localIP, Properties webContextProperties) throws UnknownHostException {
+    protected void testGetActiveParticipantSource(LogEventRequestType request, Boolean isRequesting, String localIP, 
+        Properties webContextProperties) throws UnknownHostException {
         ActiveParticipant sourceActiveParticipant = null;
         List<ActiveParticipant> activeParticipant = request.getAuditMessage().getActiveParticipant();
         for (ActiveParticipant item : activeParticipant) {
-            if (item.getRoleIDCode().get(0).getDisplayName() != null && item.getRoleIDCode().get(0).getDisplayName().equals(AuditTransformConstants.ACTIVE_PARTICPANT_ROLE_CODE_SOURCE_DISPLAY_NAME)) {
+            if (item.getRoleIDCode().get(0).getDisplayName() != null && item.getRoleIDCode().get(0).getDisplayName().
+                equals(AuditTransformConstants.ACTIVE_PARTICPANT_ROLE_CODE_SOURCE_DISPLAY_NAME)) {
                 sourceActiveParticipant = item;
             }
         }
@@ -184,12 +160,17 @@ public abstract class AuditTransformTest<T,K> {
         if (isRequesting) {
             assertEquals(localIP, sourceActiveParticipant.getNetworkAccessPointID());
         } else {
-            assertEquals(webContextProperties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS), sourceActiveParticipant.getNetworkAccessPointID());
+            assertEquals(webContextProperties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS), 
+                sourceActiveParticipant.getNetworkAccessPointID());
         }
-        assertEquals(AuditTransformConstants.NETWORK_ACCESSOR_PT_TYPE_CODE_NAME, sourceActiveParticipant.getNetworkAccessPointTypeCode());
-        assertEquals(AuditTransformConstants.ACTIVE_PARTICIPANT_ROLE_CODE_Source, sourceActiveParticipant.getRoleIDCode().get(0).getCode());
-        assertEquals(AuditTransformConstants.ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME, sourceActiveParticipant.getRoleIDCode().get(0).getCodeSystemName());
-        assertEquals(AuditTransformConstants.ACTIVE_PARTICPANT_ROLE_CODE_SOURCE_DISPLAY_NAME, sourceActiveParticipant.getRoleIDCode().get(0).getDisplayName());
+        assertEquals(AuditTransformConstants.NETWORK_ACCESSOR_PT_TYPE_CODE_NAME, 
+            sourceActiveParticipant.getNetworkAccessPointTypeCode());
+        assertEquals(AuditTransformConstants.ACTIVE_PARTICIPANT_ROLE_CODE_SOURCE, 
+            sourceActiveParticipant.getRoleIDCode().get(0).getCode());
+        assertEquals(AuditTransformConstants.ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME, 
+            sourceActiveParticipant.getRoleIDCode().get(0).getCodeSystemName());
+        assertEquals(AuditTransformConstants.ACTIVE_PARTICPANT_ROLE_CODE_SOURCE_DISPLAY_NAME, 
+            sourceActiveParticipant.getRoleIDCode().get(0).getDisplayName());
     }
 
     /**
@@ -200,25 +181,33 @@ public abstract class AuditTransformTest<T,K> {
      * @param webContextProperties
      * @param remoteObjectIP
      */
-    public void testGetActiveParticipantDestination(LogEventRequestType request, Boolean isRequesting, Properties webContextProperties, String remoteObjectIP) {
+    protected void testGetActiveParticipantDestination(LogEventRequestType request, Boolean isRequesting, 
+        Properties webContextProperties, String remoteObjectIP) {
         ActiveParticipant destinationActiveParticipant = null;
         for (ActiveParticipant item : request.getAuditMessage().getActiveParticipant()) {
-            if (item.getRoleIDCode().get(0).getDisplayName() != null && item.getRoleIDCode().get(0).getDisplayName().equals(AuditTransformConstants.ACTIVE_PARTICPANT_ROLE_CODE_DESTINATION_DISPLAY_NAME)) {
+            if (item.getRoleIDCode().get(0).getDisplayName() != null && item.getRoleIDCode().get(0).
+                getDisplayName().equals(AuditTransformConstants.ACTIVE_PARTICPANT_ROLE_CODE_DESTINATION_DISPLAY_NAME)) {
                 destinationActiveParticipant = item;
             }
         }
         if (isRequesting) {
             assertEquals(remoteObjectIP, destinationActiveParticipant.getUserID());
         } else {
-            assertEquals(webContextProperties.getProperty(NhincConstants.WEB_SERVICE_REQUEST_URL), destinationActiveParticipant.getUserID());
+            assertEquals(webContextProperties.getProperty(NhincConstants.WEB_SERVICE_REQUEST_URL), 
+                destinationActiveParticipant.getUserID());
         }
 
         assertEquals(!(isRequesting), destinationActiveParticipant.isUserIsRequestor());
-        assertEquals(webContextProperties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS), destinationActiveParticipant.getNetworkAccessPointID());
-        assertEquals(AuditTransformConstants.NETWORK_ACCESSOR_PT_TYPE_CODE_NAME, destinationActiveParticipant.getNetworkAccessPointTypeCode());
-        assertEquals(AuditTransformConstants.ACTIVE_PARTICIPANT_ROLE_CODE_DEST, destinationActiveParticipant.getRoleIDCode().get(0).getCode());
-        assertEquals(AuditTransformConstants.ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME, destinationActiveParticipant.getRoleIDCode().get(0).getCodeSystemName());
-        assertEquals(AuditTransformConstants.ACTIVE_PARTICPANT_ROLE_CODE_DESTINATION_DISPLAY_NAME, destinationActiveParticipant.getRoleIDCode().get(0).getDisplayName());
+        assertEquals(webContextProperties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS), 
+            destinationActiveParticipant.getNetworkAccessPointID());
+        assertEquals(AuditTransformConstants.NETWORK_ACCESSOR_PT_TYPE_CODE_NAME, destinationActiveParticipant.
+            getNetworkAccessPointTypeCode());
+        assertEquals(AuditTransformConstants.ACTIVE_PARTICIPANT_ROLE_CODE_DEST, destinationActiveParticipant.
+            getRoleIDCode().get(0).getCode());
+        assertEquals(AuditTransformConstants.ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME, destinationActiveParticipant.
+            getRoleIDCode().get(0).getCodeSystemName());
+        assertEquals(AuditTransformConstants.ACTIVE_PARTICPANT_ROLE_CODE_DESTINATION_DISPLAY_NAME, 
+            destinationActiveParticipant.getRoleIDCode().get(0).getDisplayName());
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/pom.xml
+++ b/Product/Production/Services/PatientDiscoveryCore/pom.xml
@@ -129,6 +129,13 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>AuditRepositoryCore</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryAuditDataBuilder.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryAuditDataBuilder.java
@@ -24,30 +24,60 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package gov.hhs.fha.nhinc.audit;
+package gov.hhs.fha.nhinc.patientdiscovery.audit;
 
-/*
+import gov.hhs.fha.nhinc.audit.AuditTransformDataBuilder;
+
+
+/**
  *
  * @author achidamb
  */
-public abstract class AuditTransformDataBuilder {
+public class PatientDiscoveryAuditDataBuilder extends AuditTransformDataBuilder {
+     
+    @Override
+    public String getServiceEvenIdCode() {
+        return PatientDiscoveryTransformConstants.EVENT_ID_CODE;
+    }
+    
+    @Override
+    public String getServiceEventCodeSystem() {
+        return PatientDiscoveryTransformConstants.EVENT_CODE_SYSTEM;
+    }
 
-    public abstract String getServiceEvenIdCode();
-    
-    public abstract String getServiceEventCodeSystem();
-    
-    public abstract String getServiceEventDisplayRequestor();
-    
-    public abstract String getServiceEventDisplayResponder();
-    
-    public abstract String getServiceEventTypeCode();
-    
-    public abstract String getServiceEventTypeCodeSystem();
-    
-    public abstract String getServiceEventTypeCodeDisplayName();
-    
-    public abstract String getServiceEventActionCodeRequestor();
-    
-    public abstract String getServiceEventActionCodeResponder();
-    
+    @Override
+    public String getServiceEventDisplayRequestor() {
+        return PatientDiscoveryTransformConstants.EVENT_CODE_DISPLAY_REQUESTOR;
+    }
+
+    @Override
+    public String getServiceEventDisplayResponder() {
+        return PatientDiscoveryTransformConstants.EVENT_CODE_DISPLAY_RESPONDER;
+    }
+
+    @Override
+    public String getServiceEventTypeCode() {
+        return PatientDiscoveryTransformConstants.EVENT_TYPE_CODE;
+    }
+
+    @Override
+    public String getServiceEventTypeCodeSystem() {
+        return PatientDiscoveryTransformConstants.EVENT_TYPE_CODE_SYSTEM;
+    }
+
+    @Override
+    public String getServiceEventTypeCodeDisplayName() {
+        return PatientDiscoveryTransformConstants.EVENT_TYPE_CODE_DISPLAY_NAME;
+    }
+
+    @Override
+    public String getServiceEventActionCodeRequestor() {
+        return PatientDiscoveryTransformConstants.EVENT_ACTION_CODE_REQUESTOR;
+    }
+
+    @Override
+    public String getServiceEventActionCodeResponder() {
+        return PatientDiscoveryTransformConstants.EVENT_ACTION_CODE_RESPONDER;
+    }
+
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryAuditLogger.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryAuditLogger.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.patientdiscovery.audit;
+
+import gov.hhs.fha.nhinc.auditrepository.nhinc.proxy.AuditRepositoryProxy;
+import gov.hhs.fha.nhinc.auditrepository.nhinc.proxy.AuditRepositoryProxyObjectFactory;
+import gov.hhs.fha.nhinc.common.auditlog.LogEventRequestType;
+import gov.hhs.fha.nhinc.common.nhinccommon.AcknowledgementType;
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.patientdiscovery.audit.transform.PatientDiscoveryTransforms;
+import java.util.Properties;
+import org.apache.log4j.Logger;
+import org.hl7.v3.PRPAIN201305UV02;
+import org.hl7.v3.PRPAIN201306UV02;
+
+/**
+ *
+ * @author achidamb
+ */
+public class PatientDiscoveryAuditLogger {
+
+    private static final Logger LOG = Logger.getLogger(PatientDiscoveryAuditLogger.class);
+    PatientDiscoveryTransforms patientDiscoveryTransforms = new PatientDiscoveryTransforms();
+
+    public void auditPatientDiscoveryMessage(PRPAIN201305UV02 message, AssertionType assertion, NhinTargetSystemType target, String direction, String _interface, Boolean isRequesting, Properties webContextProperties, String serviceName, PRPAIN201306UV02 response) {
+        LOG.trace("---Begin PatientDiscoveryAuditLogger.auditPatientDiscoveryMessage()---");
+        LogEventRequestType auditLogMsg = patientDiscoveryTransforms.transformMsgToAuditMsg(message, assertion, target, direction, _interface, isRequesting, webContextProperties, serviceName, response);
+        if (auditLogMsg != null && auditLogMsg.getAuditMessage() != null) {
+            audit(auditLogMsg, assertion);
+        } else {
+            LOG.error("Core X12 Nhin Batch Request auditLogMsg is null");
+        }
+        LOG.trace("---End PatientDiscoveryAuditLogger.auditPatientDiscoveryMessage()---");
+    }
+
+    /**
+     * Submits a generic Audit Log message to the Audit Log Repository.
+     *
+     * @param auditLogMsg The generic audit log to be audited
+     * @param assertion The assertion to be audited
+     * @return
+     */
+    private AcknowledgementType audit(LogEventRequestType auditLogMsg, AssertionType assertion) {
+        AuditRepositoryProxyObjectFactory auditRepoFactory = new AuditRepositoryProxyObjectFactory();
+        AuditRepositoryProxy proxy = auditRepoFactory.getAuditRepositoryProxy();
+        return proxy.auditLog(auditLogMsg, assertion);
+    }
+
+}

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryAuditLogger.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryAuditLogger.java
@@ -48,16 +48,38 @@ public class PatientDiscoveryAuditLogger {
     PatientDiscoveryTransforms patientDiscoveryTransforms = new PatientDiscoveryTransforms();
     PatientDiscoveryAuditDataBuilder databuilder = new PatientDiscoveryAuditDataBuilder();
 
-    public void auditPatientDiscoveryRequestMessage(PRPAIN201305UV02 message, AssertionType assertion, 
+    /**
+     *
+     * @param request Request to be audited
+     * @param assertion assertion to be audited
+     * @param target target community
+     * @param direction defines the Outbound/Inbound message
+     * @param _interface defines the Entity,Adapter and Nwhin interfaces
+     * @param isRequesting true/false identifies initiator/responder
+     * @param webContextProperties Properties loaded from message context
+     * @param serviceName Name of the Service being audited.
+     */
+    public void auditPatientDiscoveryRequestMessage(PRPAIN201305UV02 request, AssertionType assertion, 
         NhinTargetSystemType target, String direction, String _interface, Boolean isRequesting, 
         Properties webContextProperties, String serviceName) {
         LOG.trace("---Begin PatientDiscoveryRequestAuditLogger.auditPatientDiscoveryRequestMessage()---");
-        LogEventRequestType auditLogMsg = patientDiscoveryTransforms.transformRequestToAuditMsg(message, assertion, 
+        LogEventRequestType auditLogMsg = patientDiscoveryTransforms.transformRequestToAuditMsg(request, assertion, 
             target, direction, _interface, isRequesting, webContextProperties, serviceName, databuilder);
         auditLogMessages(auditLogMsg, assertion);
         LOG.trace("---End PatientDiscoveryRequestAuditLogger.auditPatientDiscoveryRequestMessage()---");
     }
 
+    /**
+     *
+     * @param response Response to be audited
+     * @param assertion assertion to be audited
+     * @param target target community
+     * @param direction defines the Outbound/Inbound message
+     * @param _interface defines the Entity,Adapter and Nwhin interfaces
+     * @param isRequesting true/false identifies initiator/responder
+     * @param webContextProperties Properties loaded from message context
+     * @param serviceName Name of the Service being audited.
+     */
     public void auditPatientDiscoveryResponseMessage(PRPAIN201306UV02 response, AssertionType assertion, 
         NhinTargetSystemType target, String direction, String _interface, Boolean isRequesting, 
         Properties webContextProperties, String serviceName) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryAuditLogger.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryAuditLogger.java
@@ -72,7 +72,7 @@ public class PatientDiscoveryAuditLogger {
         if (auditLogMsg != null && auditLogMsg.getAuditMessage() != null) {
             audit(auditLogMsg, assertion);
         } else {
-            LOG.error("PatientDiscoveryResponseAuditLogger auditLogMsg is null");
+            LOG.error("PatientDiscoveryAuditLogger auditLogMsg is null");
         }
     }
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryAuditLogger.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryAuditLogger.java
@@ -46,16 +46,34 @@ public class PatientDiscoveryAuditLogger {
 
     private static final Logger LOG = Logger.getLogger(PatientDiscoveryAuditLogger.class);
     PatientDiscoveryTransforms patientDiscoveryTransforms = new PatientDiscoveryTransforms();
+    PatientDiscoveryAuditDataBuilder databuilder = new PatientDiscoveryAuditDataBuilder();
 
-    public void auditPatientDiscoveryMessage(PRPAIN201305UV02 message, AssertionType assertion, NhinTargetSystemType target, String direction, String _interface, Boolean isRequesting, Properties webContextProperties, String serviceName, PRPAIN201306UV02 response) {
-        LOG.trace("---Begin PatientDiscoveryAuditLogger.auditPatientDiscoveryMessage()---");
-        LogEventRequestType auditLogMsg = patientDiscoveryTransforms.transformMsgToAuditMsg(message, assertion, target, direction, _interface, isRequesting, webContextProperties, serviceName, response);
+    public void auditPatientDiscoveryRequestMessage(PRPAIN201305UV02 message, AssertionType assertion, 
+        NhinTargetSystemType target, String direction, String _interface, Boolean isRequesting, 
+        Properties webContextProperties, String serviceName) {
+        LOG.trace("---Begin PatientDiscoveryRequestAuditLogger.auditPatientDiscoveryRequestMessage()---");
+        LogEventRequestType auditLogMsg = patientDiscoveryTransforms.transformRequestToAuditMsg(message, assertion, 
+            target, direction, _interface, isRequesting, webContextProperties, serviceName, databuilder);
+        auditLogMessages(auditLogMsg, assertion);
+        LOG.trace("---End PatientDiscoveryRequestAuditLogger.auditPatientDiscoveryRequestMessage()---");
+    }
+
+    public void auditPatientDiscoveryResponseMessage(PRPAIN201306UV02 response, AssertionType assertion, 
+        NhinTargetSystemType target, String direction, String _interface, Boolean isRequesting, 
+        Properties webContextProperties, String serviceName) {
+        LOG.trace("---Begin PatientDiscoveryResponseAuditLogger.auditPatientDiscoveryResponseMessage()---");
+        LogEventRequestType auditLogMsg = patientDiscoveryTransforms.transformResponseToAuditMsg(response, assertion, 
+            target, direction, _interface, isRequesting, webContextProperties, serviceName, databuilder);
+        auditLogMessages(auditLogMsg, assertion);
+        LOG.trace("---End PatientDiscoveryResponseAuditLogger.auditPatientDiscoveryResponseMessage()---");
+    }
+
+    private void auditLogMessages(LogEventRequestType auditLogMsg, AssertionType assertion) {
         if (auditLogMsg != null && auditLogMsg.getAuditMessage() != null) {
             audit(auditLogMsg, assertion);
         } else {
             LOG.error("Core X12 Nhin Batch Request auditLogMsg is null");
         }
-        LOG.trace("---End PatientDiscoveryAuditLogger.auditPatientDiscoveryMessage()---");
     }
 
     /**

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryAuditLogger.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryAuditLogger.java
@@ -72,7 +72,7 @@ public class PatientDiscoveryAuditLogger {
         if (auditLogMsg != null && auditLogMsg.getAuditMessage() != null) {
             audit(auditLogMsg, assertion);
         } else {
-            LOG.error("Core X12 Nhin Batch Request auditLogMsg is null");
+            LOG.error("PatientDiscoveryResponseAuditLogger auditLogMsg is null");
         }
     }
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryTransformConstants.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryTransformConstants.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.patientdiscovery.audit;
+
+/**
+ *
+ * @author achidamb
+ */
+public class PatientDiscoveryTransformConstants {
+
+    public static final short PARTICIPANT_PATIENT_OBJ_TYPE_CODE_SYSTEM = 1;
+    public static final short PARTICIPANT_PATIENT_OBJ_TYPE_CODE_ROLE = 1;
+    public static final String PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE = "2";
+    public static final String PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE_SYSTEM = "RFC-3881";
+    public static final String PARTICIPANT_PATIENT_OBJ_ID_TYPE_DISPLAY_NAME = "Patient Number";
+    public static final short PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_SYSTEM = 2;
+    public static final short PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_ROLE = 24;
+    public static final String PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE = "ITI-55";
+    public static final String PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE_SYSTEM = "IHE Transactions";
+    public static final String PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_DISPLAY_NAME = "Cross Gateway Patient Discovery";
+}

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryTransformConstants.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryTransformConstants.java
@@ -43,12 +43,12 @@ public class PatientDiscoveryTransformConstants {
     public static final String PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE_SYSTEM = "IHE Transactions";
     public static final String PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_DISPLAY_NAME = "Cross Gateway Patient Discovery";
     public static final String EVENT_ID_CODE = "110112";
-    public static final String EVENT_CODE_SYSTEM = "Query";
-    public static final String EVENT_CODE_DISPLAY_REQUESTOR = "DCM";
-    public static final String EVENT_CODE_DISPLAY_RESPONDER = "DCM";
+    public static final String EVENT_CODE_SYSTEM = "DCM";
+    public static final String EVENT_CODE_DISPLAY_REQUESTOR = "Query";
+    public static final String EVENT_CODE_DISPLAY_RESPONDER = "Query";
     public static final String EVENT_TYPE_CODE = "ITI-55";
-    public static final String EVENT_TYPE_CODE_SYSTEM = "Cross Gateway Patient Discovery";
-    public static final String EVENT_TYPE_CODE_DISPLAY_NAME = "IHE Transactions";
+    public static final String EVENT_TYPE_CODE_SYSTEM = "IHE Transactions";
+    public static final String EVENT_TYPE_CODE_DISPLAY_NAME = "Cross Gateway Patient Discovery";
     public static final String EVENT_ACTION_CODE_REQUESTOR = "E";
     public static final String EVENT_ACTION_CODE_RESPONDER = "E";
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryTransformConstants.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryTransformConstants.java
@@ -42,4 +42,13 @@ public class PatientDiscoveryTransformConstants {
     public static final String PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE = "ITI-55";
     public static final String PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE_SYSTEM = "IHE Transactions";
     public static final String PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_DISPLAY_NAME = "Cross Gateway Patient Discovery";
+    public static final String EVENT_ID_CODE = "110112";
+    public static final String EVENT_CODE_SYSTEM = "Query";
+    public static final String EVENT_CODE_DISPLAY_REQUESTOR = "DCM";
+    public static final String EVENT_CODE_DISPLAY_RESPONDER = "DCM";
+    public static final String EVENT_TYPE_CODE = "ITI-55";
+    public static final String EVENT_TYPE_CODE_SYSTEM = "Cross Gateway Patient Discovery";
+    public static final String EVENT_TYPE_CODE_DISPLAY_NAME = "IHE Transactions";
+    public static final String EVENT_ACTION_CODE_REQUESTOR = "E";
+    public static final String EVENT_ACTION_CODE_RESPONDER = "E";
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryTransforms.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryTransforms.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.patientdiscovery.audit.transform;
+
+import com.services.nhinc.schema.auditmessage.AuditMessageType;
+import com.services.nhinc.schema.auditmessage.ParticipantObjectIdentificationType;
+import gov.hhs.fha.nhinc.audit.transform.AuditTransform;
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryTransformConstants;
+import gov.hhs.fha.nhinc.transform.marshallers.JAXBContextHandler;
+import gov.hhs.fha.nhinc.util.HomeCommunityMap;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import org.apache.log4j.Logger;
+import org.hl7.v3.II;
+import org.hl7.v3.PRPAIN201305UV02;
+import org.hl7.v3.PRPAIN201306UV02;
+import org.hl7.v3.PRPAIN201306UV02MFMIMT700711UV01Subject1;
+
+/**
+ *
+ * @author achidamb
+ * @param <T>
+ * @param <K>
+ */
+public class PatientDiscoveryTransforms<T extends PRPAIN201305UV02, K extends PRPAIN201306UV02> extends AuditTransform<T, K> {
+
+    private static final Logger LOG = Logger.getLogger(PatientDiscoveryTransforms.class);
+
+    /**
+     *
+     * @param msg
+     * @param assertion
+     * @param auditMsg
+     * @param response
+     * @return
+     */
+    @Override
+    protected AuditMessageType getParticipantObjectIdentification(PRPAIN201305UV02 request, PRPAIN201306UV02 response, AssertionType assertion, AuditMessageType auditMsg) {
+        auditMsg = getPatientParticipantObjectIdentification(request, response, auditMsg);
+        try {
+            auditMsg = getQueryParamsParticipantObjectIdentification(request, response, auditMsg);
+        } catch (JAXBException ex) {
+            LOG.debug("Error while creating ParticipantObjectIdentificationQueryByParameters segemnt : " + ex);
+        }
+        return auditMsg;
+    }
+
+    private AuditMessageType getPatientParticipantObjectIdentification(PRPAIN201305UV02 request, PRPAIN201306UV02 response, AuditMessageType auditMsg) {
+
+        // Set the Partipation Object Id (patient id)
+        if (request != null) {
+            II oII = getPatientIdFromRequest(request);
+            if (oII != null && oII.getRoot() != null && oII.getExtension() != null && !oII.getRoot().isEmpty() && !oII.getExtension().isEmpty()) {
+                createPatientParticipantObjectIdentification(auditMsg, oII.getRoot(), oII.getExtension());
+            }
+
+        } else if (response != null) {
+            List<II> oII = getPatientIdFromResponse(response);
+            if (oII != null && oII.size() > 0) {
+                for (II entry : oII) {
+                    if (entry != null && entry.getRoot() != null && entry.getExtension() != null && !entry.getRoot().isEmpty() && !entry.getExtension().isEmpty()) {
+                        createPatientParticipantObjectIdentification(auditMsg, entry.getRoot(), entry.getExtension());
+                    }
+                }
+            } else {
+                createPatientParticipantObjectIdentification(auditMsg, null, null);
+            }
+        }
+        return auditMsg;
+    }
+
+    private AuditMessageType getQueryParamsParticipantObjectIdentification(PRPAIN201305UV02 request, PRPAIN201306UV02 response, AuditMessageType auditMsg) throws JAXBException {
+
+        ParticipantObjectIdentificationType participantObject = new ParticipantObjectIdentificationType();
+        participantObject = createParticipantObjectIdentification(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_SYSTEM, PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_ROLE, PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE, PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE_SYSTEM, PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_DISPLAY_NAME);
+        participantObject.setParticipantObjectID(createUUID());
+        participantObject.setParticipantObjectName(HomeCommunityMap.formatHomeCommunityId(HomeCommunityMap.getLocalHomeCommunityId()));
+        byte[] byteArray = getParticipantObjectQuery(request, response);
+        if (byteArray != null) {
+            participantObject.setParticipantObjectQuery(byteArray);
+        }
+        auditMsg.getParticipantObjectIdentification().add(participantObject);
+        return auditMsg;
+
+    }
+
+    private byte[] getParticipantObjectQuery(PRPAIN201305UV02 request, PRPAIN201306UV02 response) throws JAXBException {
+        JAXBContextHandler oHandler = new JAXBContextHandler();
+        String JAXB_HL7_CONTEXT_NAME = "org.hl7.v3";
+        JAXBContext jc = oHandler.getJAXBContext(JAXB_HL7_CONTEXT_NAME);
+        Marshaller marshaller = jc.createMarshaller();
+        ByteArrayOutputStream baOutStrm = new ByteArrayOutputStream();
+        baOutStrm.reset();
+        if (request != null && request.getControlActProcess() != null && request.getControlActProcess().getQueryByParameter() != null) {
+            marshaller.marshal(request.getControlActProcess().getQueryByParameter(), baOutStrm);
+        } else if (response != null && response.getControlActProcess() != null && response.getControlActProcess().getQueryByParameter() != null) {
+            marshaller.marshal(response.getControlActProcess().getQueryByParameter(), baOutStrm);
+        }
+
+        return baOutStrm.toByteArray();
+    }
+
+    private II getPatientIdFromRequest(PRPAIN201305UV02 msg) {
+        PRPAIN201305UV02 oPatientDiscoveryRequestMessage = msg;
+        II oII = null;
+
+        if (oPatientDiscoveryRequestMessage != null && oPatientDiscoveryRequestMessage.getControlActProcess() != null
+            && oPatientDiscoveryRequestMessage.getControlActProcess().getQueryByParameter() != null
+            && oPatientDiscoveryRequestMessage.getControlActProcess().getQueryByParameter().getValue() != null
+            && oPatientDiscoveryRequestMessage.getControlActProcess().getQueryByParameter().getValue().getParameterList() != null
+            && oPatientDiscoveryRequestMessage.getControlActProcess().getQueryByParameter().getValue().getParameterList().getLivingSubjectId() != null
+            && oPatientDiscoveryRequestMessage.getControlActProcess().getQueryByParameter().getValue().getParameterList().getLivingSubjectId().get(0) != null && oPatientDiscoveryRequestMessage.getControlActProcess().getQueryByParameter().getValue().getParameterList().getLivingSubjectId().get(0).getValue() != null && oPatientDiscoveryRequestMessage.getControlActProcess().getQueryByParameter().getValue().getParameterList().getLivingSubjectId().get(0).getValue().get(0) != null) {
+            oII = oPatientDiscoveryRequestMessage.getControlActProcess().getQueryByParameter().getValue().getParameterList().getLivingSubjectId().get(0).getValue().get(0);
+
+        } else {
+            LOG.error("PatientId doesn't exists in the received PRPAIN201305UV02 message");
+            return oII;
+        }
+        return oII;
+    }
+
+    private List<II> getPatientIdFromResponse(PRPAIN201306UV02 msg) {
+        List<II> oIIs = null;
+        PRPAIN201306UV02 oPatientDiscoveryResponseMessage = msg;
+        if (oPatientDiscoveryResponseMessage != null && oPatientDiscoveryResponseMessage.getControlActProcess() != null
+            && oPatientDiscoveryResponseMessage.getControlActProcess().getSubject() != null) {
+            List<PRPAIN201306UV02MFMIMT700711UV01Subject1> oSubject1 = oPatientDiscoveryResponseMessage.getControlActProcess().getSubject();
+            for (PRPAIN201306UV02MFMIMT700711UV01Subject1 subject : oSubject1) {
+                if (subject.getRegistrationEvent() != null && subject.getRegistrationEvent().getSubject1() != null
+                    && subject.getRegistrationEvent().getSubject1().getPatient() != null
+                    && subject.getRegistrationEvent().getSubject1().getPatient().getId() != null) {
+                    oIIs = subject.getRegistrationEvent().getSubject1().getPatient().getId();
+                } else {
+                    LOG.error("PatientId doesn't exists in the received PRPAIN201306UV02 message");
+                    return oIIs;
+                }
+            }
+        }
+        return oIIs;
+    }
+
+    private AuditMessageType createPatientParticipantObjectIdentification(AuditMessageType auditMsg, String aa, String patientId) {
+        ParticipantObjectIdentificationType participantObject = createParticipantObjectIdentification(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_TYPE_CODE_SYSTEM, PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_TYPE_CODE_ROLE, PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE, PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE_SYSTEM, PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_DISPLAY_NAME);
+        if (aa != null && patientId != null && !aa.isEmpty() && !patientId.isEmpty()) {
+            participantObject.setParticipantObjectID(createPatientId(aa, patientId));
+            auditMsg.getParticipantObjectIdentification().add(participantObject);
+        } else {
+            auditMsg.getParticipantObjectIdentification().add(participantObject);
+        }
+        return auditMsg;
+    }
+
+    private static String createPatientId(String assigningAuthId, String patientId) {
+        String sValue = null;
+        sValue = patientId + "^^^&" + assigningAuthId + "&ISO";
+        return sValue;
+    }
+
+}

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryTransforms.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryTransforms.java
@@ -47,10 +47,8 @@ import org.hl7.v3.PRPAIN201306UV02MFMIMT700711UV01Subject1;
 /**
  *
  * @author achidamb
- * @param <T>
- * @param <K>
  */
-public class PatientDiscoveryTransforms<T extends PRPAIN201305UV02, K extends PRPAIN201306UV02> extends AuditTransform<T, K> {
+public class PatientDiscoveryTransforms  extends AuditTransform<PRPAIN201305UV02, PRPAIN201306UV02> {
 
     private static final Logger LOG = Logger.getLogger(PatientDiscoveryTransforms.class);
 
@@ -92,6 +90,8 @@ public class PatientDiscoveryTransforms<T extends PRPAIN201305UV02, K extends PR
         if (oII != null && oII.getRoot() != null && oII.getExtension() != null && !oII.getRoot().isEmpty()
             && !oII.getExtension().isEmpty()) {
             createPatientParticipantObjectIdentification(auditMsg, oII.getRoot(), oII.getExtension());
+        }else {
+            createPatientParticipantObjectIdentification(auditMsg, null, null);
         }
         return auditMsg;
     }
@@ -129,10 +129,8 @@ public class PatientDiscoveryTransforms<T extends PRPAIN201305UV02, K extends PR
             getLivingSubjectId().get(0).getValue().get(0) != null) {
             oII = request.getControlActProcess().getQueryByParameter().getValue().getParameterList().
                 getLivingSubjectId().get(0).getValue().get(0);
-
         } else {
             LOG.error("PatientId doesn't exists in the received PRPAIN201305UV02 message");
-            return oII;
         }
         return oII;
     }
@@ -173,7 +171,6 @@ public class PatientDiscoveryTransforms<T extends PRPAIN201305UV02, K extends PR
     }
 
     private static String createPatientId(String assigningAuthId, String patientId) {
-
         return patientId + "^^^&" + assigningAuthId + "&ISO";
 
     }
@@ -187,7 +184,6 @@ public class PatientDiscoveryTransforms<T extends PRPAIN201305UV02, K extends PR
         }
         auditMsg.getParticipantObjectIdentification().add(participantObject);
         return auditMsg;
-
     }
 
     private AuditMessageType getQueryParamsParticipantObjectIdentificationForResponse(PRPAIN201306UV02 response, AuditMessageType auditMsg)
@@ -199,7 +195,6 @@ public class PatientDiscoveryTransforms<T extends PRPAIN201305UV02, K extends PR
         }
         auditMsg.getParticipantObjectIdentification().add(participantObject);
         return auditMsg;
-
     }
 
     private byte[] getParticipantObjectQueryForRequest(PRPAIN201305UV02 request) throws JAXBException {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/entity/OutboundPatientDiscoveryStrategyImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/entity/OutboundPatientDiscoveryStrategyImpl.java
@@ -28,6 +28,7 @@ package gov.hhs.fha.nhinc.patientdiscovery.entity;
 
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants.GATEWAY_API_LEVEL;
+import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryAuditLogger;
 import gov.hhs.fha.nhinc.patientdiscovery.nhin.proxy.NhinPatientDiscoveryProxy;
 import gov.hhs.fha.nhinc.patientdiscovery.nhin.proxy.NhinPatientDiscoveryProxyObjectFactory;
 import gov.hhs.fha.nhinc.transform.subdisc.HL7PRPA201306Transforms;
@@ -43,7 +44,8 @@ import org.hl7.v3.PRPAIN201306UV02;
  */
 public class OutboundPatientDiscoveryStrategyImpl extends OutboundPatientDiscoveryStrategy {
 
-	private static final Logger LOG = Logger.getLogger(OutboundPatientDiscoveryStrategyImpl.class);
+    private static final Logger LOG = Logger.getLogger(OutboundPatientDiscoveryStrategyImpl.class);
+    private final PatientDiscoveryAuditLogger patientDiscoveryAuditor = new PatientDiscoveryAuditLogger();
 
     /**
      * @param message contains request message to execute
@@ -60,30 +62,29 @@ public class OutboundPatientDiscoveryStrategyImpl extends OutboundPatientDiscove
 
     public void executeStrategy(OutboundPatientDiscoveryOrchestratable message) {
         LOG.debug("begin executeStrategy");
-        auditRequestMessage(message.getRequest(), message.getAssertion(), message.getTarget().getHomeCommunity()
-                .getHomeCommunityId());
+        patientDiscoveryAuditor.auditPatientDiscoveryMessage(message.getRequest(), message.getAssertion(), message.getTarget(), NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE, null, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, null);
+
         try {
             NhinPatientDiscoveryProxy proxy = new NhinPatientDiscoveryProxyObjectFactory()
-                    .getNhinPatientDiscoveryProxy();
+                .getNhinPatientDiscoveryProxy();
             String url = (new WebServiceProxyHelper()).getUrlFromTargetSystemByGatewayAPILevel(
-                    message.getTarget(), NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME,
-                    GATEWAY_API_LEVEL.LEVEL_g0);
+                message.getTarget(), NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME,
+                GATEWAY_API_LEVEL.LEVEL_g0);
             message.getTarget().setUrl(url);
             LOG.debug(
-                    "executeStrategy sending nhin patient discovery request to "
-                            + " target hcid=" + message.getTarget().getHomeCommunity().getHomeCommunityId()
-                            + " at url=" + url);
+                "executeStrategy sending nhin patient discovery request to "
+                + " target hcid=" + message.getTarget().getHomeCommunity().getHomeCommunityId()
+                + " at url=" + url);
             message.setResponse(proxy.respondingGatewayPRPAIN201305UV02(message.getRequest(), message.getAssertion(),
-                    message.getTarget()));
+                message.getTarget()));
             LOG.debug("executeStrategy returning response");
         } catch (Exception ex) {
             PRPAIN201306UV02 response = new HL7PRPA201306Transforms().createPRPA201306ForErrors(message.getRequest(),
-                 NhincConstants.PATIENT_DISCOVERY_ANSWER_NOT_AVAIL_ERR_CODE, ex.getMessage());
+                NhincConstants.PATIENT_DISCOVERY_ANSWER_NOT_AVAIL_ERR_CODE, ex.getMessage());
             message.setResponse(response);
             LOG.debug("executeStrategy returning error response");
         }
-        auditResponseMessage(message.getResponse(), message.getAssertion(), message.getTarget().getHomeCommunity()
-                .getHomeCommunityId());
+        patientDiscoveryAuditor.auditPatientDiscoveryMessage(null, message.getAssertion(), message.getTarget(), NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE, null, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, message.getResponse());
 
     }
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/entity/OutboundPatientDiscoveryStrategyImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/entity/OutboundPatientDiscoveryStrategyImpl.java
@@ -62,7 +62,9 @@ public class OutboundPatientDiscoveryStrategyImpl extends OutboundPatientDiscove
 
     public void executeStrategy(OutboundPatientDiscoveryOrchestratable message) {
         LOG.debug("begin executeStrategy");
-        patientDiscoveryAuditor.auditPatientDiscoveryMessage(message.getRequest(), message.getAssertion(), message.getTarget(), NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE, null, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, null);
+        patientDiscoveryAuditor.auditPatientDiscoveryRequestMessage(message.getRequest(), message.getAssertion(), 
+            message.getTarget(), NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, 
+            Boolean.TRUE, null, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
 
         try {
             NhinPatientDiscoveryProxy proxy = new NhinPatientDiscoveryProxyObjectFactory()
@@ -84,7 +86,9 @@ public class OutboundPatientDiscoveryStrategyImpl extends OutboundPatientDiscove
             message.setResponse(response);
             LOG.debug("executeStrategy returning error response");
         }
-        patientDiscoveryAuditor.auditPatientDiscoveryMessage(null, message.getAssertion(), message.getTarget(), NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE, null, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, message.getResponse());
+        patientDiscoveryAuditor.auditPatientDiscoveryResponseMessage(message.getResponse(), message.getAssertion(), 
+            message.getTarget(), NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, 
+            Boolean.TRUE, null, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
 
     }
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/AbstractInboundPatientDiscovery.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/AbstractInboundPatientDiscovery.java
@@ -26,13 +26,10 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.inbound;
 
-import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryException;
 import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryAuditLogger;
-import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201305UV02EventDescriptionBuilder;
-import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201306UV02EventDescriptionBuilder;
 import java.util.Properties;
 import org.hl7.v3.PRPAIN201305UV02;
 import org.hl7.v3.PRPAIN201306UV02;
@@ -65,18 +62,18 @@ public abstract class AbstractInboundPatientDiscovery implements InboundPatientD
     }
 
     protected void auditRequestFromNhin(PRPAIN201305UV02 body, AssertionType assertion, Properties webContextProperties) {
-        getAuditLogger().auditPatientDiscoveryMessage(body, assertion, null, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE, webContextProperties, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, null);
+        getAuditLogger().auditPatientDiscoveryRequestMessage(body, assertion, null, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE, webContextProperties, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
     }
 
     protected void auditResponseToNhin(PRPAIN201306UV02 response, AssertionType assertion, Properties webContextProperties) {
-        getAuditLogger().auditPatientDiscoveryMessage(null, assertion, null, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE, webContextProperties, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, response);
+        getAuditLogger().auditPatientDiscoveryResponseMessage(response, assertion, null, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE, webContextProperties, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
     }
 
     protected void auditRequestToAdapter(PRPAIN201305UV02 body, AssertionType assertion, Properties webContextProperties) {
-        getAuditLogger().auditPatientDiscoveryMessage(body, assertion, null, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE, Boolean.FALSE, webContextProperties, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, null);
+        getAuditLogger().auditPatientDiscoveryRequestMessage(body, assertion, null, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE, Boolean.FALSE, webContextProperties, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
     }
 
     protected void auditResponseFromAdapter(PRPAIN201306UV02 response, AssertionType assertion, Properties webContextProperties) {
-        getAuditLogger().auditPatientDiscoveryMessage(null, assertion, null, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE, Boolean.FALSE, webContextProperties, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, response);
+        getAuditLogger().auditPatientDiscoveryResponseMessage(response, assertion, null, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE, Boolean.FALSE, webContextProperties, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/AbstractInboundPatientDiscovery.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/AbstractInboundPatientDiscovery.java
@@ -26,52 +26,57 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.inbound;
 
+import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
-import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryAuditor;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryException;
-
+import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryAuditLogger;
+import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201305UV02EventDescriptionBuilder;
+import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201306UV02EventDescriptionBuilder;
+import java.util.Properties;
 import org.hl7.v3.PRPAIN201305UV02;
 import org.hl7.v3.PRPAIN201306UV02;
 
 public abstract class AbstractInboundPatientDiscovery implements InboundPatientDiscovery {
 
-    abstract PRPAIN201306UV02 process(PRPAIN201305UV02 body, AssertionType assertion) throws PatientDiscoveryException;
+    abstract PRPAIN201306UV02 process(PRPAIN201305UV02 body, AssertionType assertion, Properties webContextProperties) throws PatientDiscoveryException;
 
-    abstract PatientDiscoveryAuditor getAuditLogger();
+    abstract PatientDiscoveryAuditLogger getAuditLogger();
 
     /**
      * Method that processes the Patient Discovery request
      *
      * @param body the body of the PD request
      * @param assertion the assertion of the PD request
+     * @param webContextProperties
      * @return PRPAIN201306UV02 response message
+     * @throws gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryException
      */
     @Override
-    public PRPAIN201306UV02 respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 body, AssertionType assertion)
-            throws PatientDiscoveryException {
-          auditRequestFromNhin(body, assertion);
+    public PRPAIN201306UV02 respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 body, AssertionType assertion, Properties webContextProperties)
+        throws PatientDiscoveryException {
+        auditRequestFromNhin(body, assertion, webContextProperties);
 
-          PRPAIN201306UV02 response = process(body, assertion);
+        PRPAIN201306UV02 response = process(body, assertion, webContextProperties);
 
-          auditResponseToNhin(response, assertion);
+        auditResponseToNhin(response, assertion, webContextProperties);
 
-          return response;
+        return response;
     }
 
-    protected void auditRequestFromNhin(PRPAIN201305UV02 body, AssertionType assertion) {
-        getAuditLogger().auditNhin201305(body, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
+    protected void auditRequestFromNhin(PRPAIN201305UV02 body, AssertionType assertion, Properties webContextProperties) {
+        getAuditLogger().auditPatientDiscoveryMessage(body, assertion, null, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE, webContextProperties, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, null);
     }
 
-    protected void auditResponseToNhin(PRPAIN201306UV02 response, AssertionType assertion) {
-        getAuditLogger().auditNhin201306(response, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
+    protected void auditResponseToNhin(PRPAIN201306UV02 response, AssertionType assertion, Properties webContextProperties) {
+        getAuditLogger().auditPatientDiscoveryMessage(null, assertion, null, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE, webContextProperties, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, response);
     }
 
-    protected void auditRequestToAdapter(PRPAIN201305UV02 body, AssertionType assertion) {
-        getAuditLogger().auditAdapter201305(body, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
+    protected void auditRequestToAdapter(PRPAIN201305UV02 body, AssertionType assertion, Properties webContextProperties) {
+        getAuditLogger().auditPatientDiscoveryMessage(body, assertion, null, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE, Boolean.FALSE, webContextProperties, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, null);
     }
 
-    protected void auditResponseFromAdapter(PRPAIN201306UV02 response, AssertionType assertion) {
-        getAuditLogger().auditAdapter201306(response, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
+    protected void auditResponseFromAdapter(PRPAIN201306UV02 response, AssertionType assertion, Properties webContextProperties) {
+        getAuditLogger().auditPatientDiscoveryMessage(null, assertion, null, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE, Boolean.FALSE, webContextProperties, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, response);
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/InboundPatientDiscovery.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/InboundPatientDiscovery.java
@@ -28,13 +28,21 @@ package gov.hhs.fha.nhinc.patientdiscovery.inbound;
 
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryException;
-
+import java.util.Properties;
 import org.hl7.v3.PRPAIN201305UV02;
 import org.hl7.v3.PRPAIN201306UV02;
 
 public interface InboundPatientDiscovery {
 
-    public abstract PRPAIN201306UV02 respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 body, AssertionType assertion)
-            throws PatientDiscoveryException;
+    /**
+     *
+     * @param body
+     * @param assertion
+     * @param webContextProperties
+     * @return
+     * @throws PatientDiscoveryException
+     */
+    public abstract PRPAIN201306UV02 respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 body, AssertionType assertion, Properties webContextProperties)
+        throws PatientDiscoveryException;
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/InboundPatientDiscovery.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/InboundPatientDiscovery.java
@@ -42,7 +42,7 @@ public interface InboundPatientDiscovery {
      * @return
      * @throws PatientDiscoveryException
      */
-    public abstract PRPAIN201306UV02 respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 body, AssertionType assertion, Properties webContextProperties)
-        throws PatientDiscoveryException;
+    public abstract PRPAIN201306UV02 respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 body, AssertionType assertion, 
+        Properties webContextProperties) throws PatientDiscoveryException;
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/PassthroughInboundPatientDiscovery.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/PassthroughInboundPatientDiscovery.java
@@ -27,12 +27,11 @@
 package gov.hhs.fha.nhinc.patientdiscovery.inbound;
 
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
-import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryAuditLogger;
-import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryAuditor;
+import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryAuditLogger;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryException;
 import gov.hhs.fha.nhinc.patientdiscovery.adapter.proxy.AdapterPatientDiscoveryProxy;
 import gov.hhs.fha.nhinc.patientdiscovery.adapter.proxy.AdapterPatientDiscoveryProxyObjectFactory;
-
+import java.util.Properties;
 import org.hl7.v3.PRPAIN201305UV02;
 import org.hl7.v3.PRPAIN201306UV02;
 
@@ -43,7 +42,7 @@ import org.hl7.v3.PRPAIN201306UV02;
 public class PassthroughInboundPatientDiscovery extends AbstractInboundPatientDiscovery {
 
     private final AdapterPatientDiscoveryProxyObjectFactory adapterFactory;
-    private final PatientDiscoveryAuditor auditLogger;
+    private final PatientDiscoveryAuditLogger auditLogger;
 
     /**
      * Constructor.
@@ -60,13 +59,13 @@ public class PassthroughInboundPatientDiscovery extends AbstractInboundPatientDi
      * @param auditLogger
      */
     public PassthroughInboundPatientDiscovery(AdapterPatientDiscoveryProxyObjectFactory adapterFactory,
-            PatientDiscoveryAuditor auditLogger) {
+        PatientDiscoveryAuditLogger auditLogger) {
         this.adapterFactory = adapterFactory;
         this.auditLogger = auditLogger;
     }
 
     @Override
-    PRPAIN201306UV02 process(PRPAIN201305UV02 body, AssertionType assertion) throws PatientDiscoveryException {
+    PRPAIN201306UV02 process(PRPAIN201305UV02 body, AssertionType assertion, Properties webContextProperties) throws PatientDiscoveryException {
         PRPAIN201306UV02 response = sendToAdapter(body, assertion);
 
         return response;
@@ -78,12 +77,12 @@ public class PassthroughInboundPatientDiscovery extends AbstractInboundPatientDi
      * @see gov.hhs.fha.nhinc.patientdiscovery.inbound.AbstractInboundPatientDiscovery#getAuditLogger()
      */
     @Override
-    PatientDiscoveryAuditor getAuditLogger() {
+    PatientDiscoveryAuditLogger getAuditLogger() {
         return auditLogger;
     }
 
     private PRPAIN201306UV02 sendToAdapter(PRPAIN201305UV02 request, AssertionType assertion)
-            throws PatientDiscoveryException {
+        throws PatientDiscoveryException {
         AdapterPatientDiscoveryProxy proxy = adapterFactory.create();
         return proxy.respondingGatewayPRPAIN201305UV02(request, assertion);
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/PassthroughInboundPatientDiscovery.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/PassthroughInboundPatientDiscovery.java
@@ -29,7 +29,6 @@ package gov.hhs.fha.nhinc.patientdiscovery.inbound;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryAuditLogger;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryException;
-import gov.hhs.fha.nhinc.patientdiscovery.adapter.proxy.AdapterPatientDiscoveryProxy;
 import gov.hhs.fha.nhinc.patientdiscovery.adapter.proxy.AdapterPatientDiscoveryProxyObjectFactory;
 import java.util.Properties;
 import org.hl7.v3.PRPAIN201305UV02;
@@ -83,8 +82,8 @@ public class PassthroughInboundPatientDiscovery extends AbstractInboundPatientDi
 
     private PRPAIN201306UV02 sendToAdapter(PRPAIN201305UV02 request, AssertionType assertion)
         throws PatientDiscoveryException {
-        AdapterPatientDiscoveryProxy proxy = adapterFactory.create();
-        return proxy.respondingGatewayPRPAIN201305UV02(request, assertion);
+        
+        return adapterFactory.create().respondingGatewayPRPAIN201305UV02(request, assertion);
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/StandardInboundPatientDiscovery.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/StandardInboundPatientDiscovery.java
@@ -29,12 +29,11 @@ package gov.hhs.fha.nhinc.patientdiscovery.inbound;
 import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscovery201305Processor;
-import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryAuditLogger;
-import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryAuditor;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryException;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201305UV02EventDescriptionBuilder;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201306UV02EventDescriptionBuilder;
-
+import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryAuditLogger;
+import java.util.Properties;
 import org.hl7.v3.PRPAIN201305UV02;
 import org.hl7.v3.PRPAIN201306UV02;
 
@@ -45,7 +44,7 @@ import org.hl7.v3.PRPAIN201306UV02;
 public class StandardInboundPatientDiscovery extends AbstractInboundPatientDiscovery {
 
     private final PatientDiscovery201305Processor patientDiscoveryProcessor;
-    private final PatientDiscoveryAuditor auditLogger;
+    private final PatientDiscoveryAuditLogger auditLogger;
 
     /**
      * Constructor.
@@ -62,32 +61,31 @@ public class StandardInboundPatientDiscovery extends AbstractInboundPatientDisco
      * @param auditLogger
      */
     public StandardInboundPatientDiscovery(PatientDiscovery201305Processor patientDiscoveryProcessor,
-            PatientDiscoveryAuditor auditLogger) {
+        PatientDiscoveryAuditLogger auditLogger) {
         this.patientDiscoveryProcessor = patientDiscoveryProcessor;
         this.auditLogger = auditLogger;
     }
 
     @Override
     @InboundProcessingEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class, afterReturningBuilder = PRPAIN201306UV02EventDescriptionBuilder.class, serviceType = "Patient Discovery", version = "1.0")
-    public PRPAIN201306UV02 respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 body, AssertionType assertion)
-            throws PatientDiscoveryException {
-        auditRequestFromNhin(body, assertion);
+    public PRPAIN201306UV02 respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 body, AssertionType assertion, Properties webContextProperties)
+        throws PatientDiscoveryException {
+        auditRequestFromNhin(body, assertion, webContextProperties);
 
-        PRPAIN201306UV02 response = process(body, assertion);
+        PRPAIN201306UV02 response = process(body, assertion, webContextProperties);
 
-        auditResponseToNhin(response, assertion);
+        auditResponseToNhin(response, assertion, webContextProperties);
 
         return response;
     }
 
     @Override
-    //@InboundProcessingEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class, afterReturningBuilder = PRPAIN201306UV02EventDescriptionBuilder.class, serviceType = "Patient Discovery", version = "1.0")
-    PRPAIN201306UV02 process(PRPAIN201305UV02 body, AssertionType assertion) throws PatientDiscoveryException {
-        auditRequestToAdapter(body, assertion);
+    PRPAIN201306UV02 process(PRPAIN201305UV02 body, AssertionType assertion, Properties webContextProperties) throws PatientDiscoveryException {
+        auditRequestToAdapter(body, assertion, webContextProperties);
 
         PRPAIN201306UV02 response = patientDiscoveryProcessor.process201305(body, assertion);
 
-        auditResponseFromAdapter(response, assertion);
+        auditResponseFromAdapter(response, assertion, webContextProperties);
 
         return response;
     }
@@ -98,7 +96,7 @@ public class StandardInboundPatientDiscovery extends AbstractInboundPatientDisco
      * @see gov.hhs.fha.nhinc.patientdiscovery.inbound.AbstractInboundPatientDiscovery#getAuditLogger()
      */
     @Override
-    PatientDiscoveryAuditor getAuditLogger() {
+    PatientDiscoveryAuditLogger getAuditLogger() {
         return auditLogger;
     }
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/PassthroughOutboundPatientDiscovery.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/PassthroughOutboundPatientDiscovery.java
@@ -68,17 +68,17 @@ public class PassthroughOutboundPatientDiscovery implements OutboundPatientDisco
      * @param auditLogger
      */
     public PassthroughOutboundPatientDiscovery(OutboundPatientDiscoveryDelegate delegate,
-            PatientDiscoveryAuditLogger auditLogger) {
+        PatientDiscoveryAuditLogger auditLogger) {
         this.delegate = delegate;
         this.auditLogger = auditLogger;
     }
 
     @Override
     public RespondingGatewayPRPAIN201306UV02ResponseType respondingGatewayPRPAIN201305UV02(
-            RespondingGatewayPRPAIN201305UV02RequestType request, AssertionType assertion) {
+        RespondingGatewayPRPAIN201305UV02RequestType request, AssertionType assertion) {
 
         RespondingGatewayPRPAIN201306UV02ResponseType response = sendToNhin(request.getPRPAIN201305UV02(), assertion,
-                msgUtils.convertFirstToNhinTargetSystemType(request.getNhinTargetCommunities()));
+            msgUtils.convertFirstToNhinTargetSystemType(request.getNhinTargetCommunities()));
 
         return response;
     }
@@ -89,18 +89,18 @@ public class PassthroughOutboundPatientDiscovery implements OutboundPatientDisco
     }
 
     private RespondingGatewayPRPAIN201306UV02ResponseType sendToNhin(PRPAIN201305UV02 request, AssertionType assertion,
-            NhinTargetSystemType target) {
+        NhinTargetSystemType target) {
         PRPAIN201306UV02 response;
 
         try {
             OutboundPatientDiscoveryOrchestratable inMessage = new OutboundPatientDiscoveryOrchestratable(delegate,
-                    Optional.<OutboundResponseProcessor> absent(), null, null, assertion,
-                    NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, target, request);
+                Optional.<OutboundResponseProcessor>absent(), null, null, assertion,
+                NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, target, request);
             OutboundPatientDiscoveryOrchestratable outMessage = delegate.process(inMessage);
             response = outMessage.getResponse();
         } catch (Exception ex) {
             String err = ExecutorServiceHelper.getFormattedExceptionInfo(ex, target,
-                    NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
+                NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
             response = generateErrorResponse(target, request, err);
         }
 
@@ -110,7 +110,7 @@ public class PassthroughOutboundPatientDiscovery implements OutboundPatientDisco
     private RespondingGatewayPRPAIN201306UV02ResponseType convert(PRPAIN201306UV02 response, NhinTargetSystemType target) {
         String hcid = getHCID(target);
         CommunityPRPAIN201306UV02ResponseType communityResponse = msgUtils
-                .createCommunityPRPAIN201306UV02ResponseType(hcid);
+            .createCommunityPRPAIN201306UV02ResponseType(hcid);
         communityResponse.setPRPAIN201306UV02(response);
 
         RespondingGatewayPRPAIN201306UV02ResponseType gatewayResponse = new RespondingGatewayPRPAIN201306UV02ResponseType();

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscovery.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscovery.java
@@ -404,12 +404,12 @@ public class StandardOutboundPatientDiscovery implements OutboundPatientDiscover
 
     private void auditRequestFromAdapter(RespondingGatewayPRPAIN201305UV02RequestType request, AssertionType assertion) {
         NhinTargetSystemType targetSystem = MessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(request.getNhinTargetCommunities());
-        patientDiscoveryAuditor.auditPatientDiscoveryMessage(request.getPRPAIN201305UV02(), assertion, targetSystem, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, Boolean.TRUE, null, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, null);
+        patientDiscoveryAuditor.auditPatientDiscoveryRequestMessage(request.getPRPAIN201305UV02(), assertion, targetSystem, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, Boolean.TRUE, null, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
     }
 
     private void auditResponseToAdapter(RespondingGatewayPRPAIN201306UV02ResponseType response, AssertionType assertion) {
         for (CommunityPRPAIN201306UV02ResponseType responseEntry : response.getCommunityResponse()) {
-            patientDiscoveryAuditor.auditPatientDiscoveryMessage(null, assertion, MessageGeneratorUtils.getInstance().convertToNhinTargetSystemType(responseEntry.getNhinTargetCommunity()), NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, Boolean.TRUE, null, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, responseEntry.getPRPAIN201306UV02());
+            patientDiscoveryAuditor.auditPatientDiscoveryResponseMessage(responseEntry.getPRPAIN201306UV02(), assertion, MessageGeneratorUtils.getInstance().convertToNhinTargetSystemType(responseEntry.getNhinTargetCommunity()), NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, Boolean.TRUE, null, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
         }
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryTransformsTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryTransformsTest.java
@@ -1,0 +1,425 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.patientdiscovery.audit.transform;
+
+import gov.hhs.fha.nhinc.audit.AuditTransformConstants;
+import gov.hhs.fha.nhinc.audit.transform.AuditTransformTest;
+import gov.hhs.fha.nhinc.common.auditlog.LogEventRequestType;
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.CeType;
+import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.common.nhinccommon.PersonNameType;
+import gov.hhs.fha.nhinc.common.nhinccommon.UserType;
+import gov.hhs.fha.nhinc.connectmgr.ConnectionManagerException;
+import gov.hhs.fha.nhinc.mpilib.Identifier;
+import gov.hhs.fha.nhinc.mpilib.Identifiers;
+import gov.hhs.fha.nhinc.mpilib.Patient;
+import gov.hhs.fha.nhinc.mpilib.PersonName;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryTransformConstants;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.Properties;
+import javax.xml.bind.JAXBElement;
+import org.hl7.v3.ActClassControlAct;
+import org.hl7.v3.CD;
+import org.hl7.v3.CE;
+import org.hl7.v3.CS;
+import org.hl7.v3.CommunicationFunctionType;
+import org.hl7.v3.ENExplicit;
+import org.hl7.v3.EnExplicitFamily;
+import org.hl7.v3.EnExplicitGiven;
+import org.hl7.v3.II;
+import org.hl7.v3.IVLTSExplicit;
+import org.hl7.v3.MCCIMT000100UV01Device;
+import org.hl7.v3.MCCIMT000100UV01Receiver;
+import org.hl7.v3.MCCIMT000100UV01Sender;
+import org.hl7.v3.PRPAIN201305UV02;
+import org.hl7.v3.PRPAIN201305UV02QUQIMT021001UV01ControlActProcess;
+import org.hl7.v3.PRPAIN201306UV02;
+import org.hl7.v3.PRPAMT201306UV02LivingSubjectAdministrativeGender;
+import org.hl7.v3.PRPAMT201306UV02LivingSubjectBirthTime;
+import org.hl7.v3.PRPAMT201306UV02LivingSubjectId;
+import org.hl7.v3.PRPAMT201306UV02LivingSubjectName;
+import org.hl7.v3.PRPAMT201306UV02ParameterList;
+import org.hl7.v3.PRPAMT201306UV02QueryByParameter;
+import org.hl7.v3.TELExplicit;
+import org.hl7.v3.XActMoodIntentEvent;
+import org.junit.After;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertSame;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ *
+ * @author achidamb
+ * @param <T>
+ * @param <K>
+ */
+public class PatientDiscoveryTransformsTest<T extends PRPAIN201305UV02,K extends PRPAIN201306UV02> extends AuditTransformTest<T,K> {
+
+    public PatientDiscoveryTransformsTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() {
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+    }
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void testTransformToAuditMsg() throws ConnectionManagerException, UnknownHostException {
+        final String localIP = "10.10.10.10";
+        Properties webContextProperties = new Properties();
+        webContextProperties.setProperty(NhincConstants.WEB_SERVICE_REQUEST_URL, "http://16.14.13.12:9090/AuditService");
+        webContextProperties.setProperty(NhincConstants.REMOTE_HOST_ADDRESS, "16.14.13.12");
+        final String remoteObjectIP = "http://16.14.13.12:9090/source/AuditService";
+        PRPAIN201306UV02 response = null;
+        PatientDiscoveryTransforms transforms = new PatientDiscoveryTransforms() {
+            @Override
+            protected String getLocalHostAddress() {
+                return localIP;
+            }
+
+            @Override
+            protected String getRemoteHostAddress(Properties webContextProeprties) {
+                if (webContextProeprties != null && !webContextProeprties.isEmpty() && webContextProeprties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS) != null) {
+                    return webContextProeprties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS);
+                }
+                return AuditTransformConstants.ACTIVE_PARTICPANT_UNKNOWN_IP_ADDRESS;
+            }
+
+            @Override
+            protected String getWebServiceUrlFromRemoteObject(NhinTargetSystemType target, String serviceName) {
+                return remoteObjectIP;
+            }
+
+        };
+
+        PRPAIN201305UV02 request = createPRPAIN201305UV02Request();
+        AssertionType assertion = createAssertion();
+
+        LogEventRequestType auditRequest = transforms.transformMsgToAuditMsg(request, assertion, createNhinTarget(), NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, Boolean.TRUE, webContextProperties, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, response);
+        testGetEventIdentificationType(auditRequest, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, Boolean.TRUE);
+        testGetActiveParticipantSource(auditRequest, Boolean.TRUE, localIP, webContextProperties);
+        testGetActiveParticipantDestination(auditRequest, Boolean.TRUE, webContextProperties, remoteObjectIP);
+        testCreateActiveParticipantFromUser(auditRequest, Boolean.TRUE, assertion);
+        assertParticiopantObjectIdentification(auditRequest);
+    }
+
+    private void assertParticiopantObjectIdentification(LogEventRequestType auditRequest) {
+        assertEquals("D123401^^^&1.1&ISO", auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).getParticipantObjectID());
+        assertSame(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_TYPE_CODE_SYSTEM, auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).getParticipantObjectTypeCode());
+        assertSame(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_TYPE_CODE_ROLE, auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).getParticipantObjectTypeCodeRole());
+        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE, auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).getParticipantObjectIDTypeCode().getCode());
+        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE_SYSTEM, auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).getParticipantObjectIDTypeCode().getCodeSystemName());
+        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_DISPLAY_NAME, auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).getParticipantObjectIDTypeCode().getDisplayName());
+        assertSame(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_SYSTEM, auditRequest.getAuditMessage().getParticipantObjectIdentification().get(1).getParticipantObjectTypeCode());
+        assertSame(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_ROLE, auditRequest.getAuditMessage().getParticipantObjectIdentification().get(1).getParticipantObjectTypeCodeRole());
+        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE, auditRequest.getAuditMessage().getParticipantObjectIdentification().get(1).getParticipantObjectIDTypeCode().getCode());
+        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE_SYSTEM, auditRequest.getAuditMessage().getParticipantObjectIdentification().get(1).getParticipantObjectIDTypeCode().getCodeSystemName());
+        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_DISPLAY_NAME, auditRequest.getAuditMessage().getParticipantObjectIdentification().get(1).getParticipantObjectIDTypeCode().getDisplayName());
+    }
+
+    private AssertionType createAssertion() {
+        AssertionType assertion = new AssertionType();
+        UserType userType = new UserType();
+        userType.setOrg(createHomeCommunityType());
+        userType.setPersonName(createPersonNameType());
+        userType.setRoleCoded(createCeType());
+        userType.setUserName("Wanderson");
+        assertion.setUserInfo(userType);
+        return assertion;
+    }
+
+    private HomeCommunityType createHomeCommunityType() {
+        HomeCommunityType homeCommunityType = new HomeCommunityType();
+        homeCommunityType.setHomeCommunityId("1.1");
+        homeCommunityType.setName("DOD");
+        homeCommunityType.setDescription("This is DOD Gateway");
+        return homeCommunityType;
+    }
+
+    private PersonNameType createPersonNameType() {
+        PersonNameType personNameType = new PersonNameType();
+        personNameType.setFamilyName("Tamney");
+        personNameType.setFullName("Erica");
+        personNameType.setGivenName("Jasmine");
+        personNameType.setPrefix("Ms");
+        return personNameType;
+    }
+
+    private CeType createCeType() {
+        CeType ceType = new CeType();
+        ceType.setCode("Code");
+        ceType.setCodeSystem("CodeSystem");
+        ceType.setCodeSystemVersion("1.1");
+        ceType.setDisplayName("DisplayName");
+        return ceType;
+    }
+
+    private NhinTargetSystemType createNhinTarget() {
+        NhinTargetSystemType targetSystem = new NhinTargetSystemType();
+        targetSystem.setHomeCommunity(createTragetHomeCommunityType());
+        return targetSystem;
+    }
+
+    private HomeCommunityType createTragetHomeCommunityType() {
+        HomeCommunityType homeCommunityType = new HomeCommunityType();
+        homeCommunityType.setHomeCommunityId("2.2");
+        homeCommunityType.setName("SSA");
+        homeCommunityType.setDescription("This is DOD Gateway");
+        return homeCommunityType;
+    }
+
+    private PRPAIN201305UV02 createPRPAIN201305UV02Request() {
+        PRPAIN201305UV02 request = new PRPAIN201305UV02();
+        request.setControlActProcess(createControlActProcess());
+        return request;
+    }
+
+    private PRPAIN201305UV02QUQIMT021001UV01ControlActProcess createControlActProcess() {
+
+        PRPAIN201305UV02QUQIMT021001UV01ControlActProcess controlActProcess = new PRPAIN201305UV02QUQIMT021001UV01ControlActProcess();
+        controlActProcess.setClassCode(ActClassControlAct.CACT);
+        controlActProcess.setMoodCode(XActMoodIntentEvent.EVN);
+        CD code = new CD();
+        code.setCode("PRPA_TE201306UV02");
+        code.setCodeSystem("2.16.840.1.113883.1.6");
+        controlActProcess.setCode(code);
+        II subjectId = new II();
+        subjectId.setRoot("1.1");
+        subjectId.setExtension("D123401");
+        controlActProcess.setQueryByParameter(createQueryParams("Allen", "Wanderson", "M", "09-8-1971", subjectId));
+        return controlActProcess;
+    }
+
+    private static JAXBElement<PRPAMT201306UV02QueryByParameter> createQueryParams(String firstName, String lastName,
+        String gender, String birthTime, II subjectId) {
+        PRPAMT201306UV02QueryByParameter params = new PRPAMT201306UV02QueryByParameter();
+
+        II id = new II();
+        id.setRoot("12345");
+        params.setQueryId(id);
+
+        CS statusCode = new CS();
+        statusCode.setCode("new");
+        params.setStatusCode(statusCode);
+
+        params.setParameterList(createParamList(firstName, lastName, gender, birthTime, subjectId));
+
+        javax.xml.namespace.QName xmlqname = new javax.xml.namespace.QName("urn:hl7-org:v3", "queryByParameter");
+        JAXBElement<PRPAMT201306UV02QueryByParameter> queryParams
+            = new JAXBElement<PRPAMT201306UV02QueryByParameter>(xmlqname, PRPAMT201306UV02QueryByParameter.class,
+                params);
+
+        return queryParams;
+    }
+
+    private static PRPAMT201306UV02ParameterList createParamList(String firstName, String lastName, String gender,
+        String birthTime, II subjectId) {
+        PRPAMT201306UV02ParameterList paramList = new PRPAMT201306UV02ParameterList();
+
+        // Set the Subject Gender Code
+        paramList.getLivingSubjectAdministrativeGender().add(createGender(gender));
+
+        // Set the Subject Birth Time
+        paramList.getLivingSubjectBirthTime().add(createBirthTime(birthTime));
+
+        // Set the Subject Name
+        paramList.getLivingSubjectName().add(createName(firstName, lastName));
+
+        // Set the subject Id
+        paramList.getLivingSubjectId().add(createSubjectId(subjectId));
+
+        return paramList;
+    }
+
+    private static PRPAMT201306UV02LivingSubjectId createSubjectId(II subjectId) {
+        PRPAMT201306UV02LivingSubjectId id = new PRPAMT201306UV02LivingSubjectId();
+        if (subjectId != null) {
+            id.getValue().add(subjectId);
+        }
+
+        return id;
+    }
+
+    private static PRPAMT201306UV02LivingSubjectName createName(String firstName, String lastName) {
+        PRPAMT201306UV02LivingSubjectName subjectName = new PRPAMT201306UV02LivingSubjectName();
+        org.hl7.v3.ObjectFactory factory = new org.hl7.v3.ObjectFactory();
+        ENExplicit name = (factory.createENExplicit());
+        List namelist = name.getContent();
+
+        if (lastName != null && lastName.length() > 0) {
+            EnExplicitFamily familyName = new EnExplicitFamily();
+            familyName.setPartType("FAM");
+            familyName.setContent(lastName);
+
+            namelist.add(factory.createENExplicitFamily(familyName));
+        }
+
+        if (firstName != null && firstName.length() > 0) {
+            EnExplicitGiven givenName = new EnExplicitGiven();
+            givenName.setPartType("GIV");
+            givenName.setContent(firstName);
+
+            namelist.add(factory.createENExplicitGiven(givenName));
+        }
+
+        subjectName.getValue().add(name);
+
+        return subjectName;
+    }
+
+    private static PRPAMT201306UV02LivingSubjectBirthTime createBirthTime(String birthTime) {
+        PRPAMT201306UV02LivingSubjectBirthTime subjectBirthTime = new PRPAMT201306UV02LivingSubjectBirthTime();
+        IVLTSExplicit bday = new IVLTSExplicit();
+
+        if (birthTime != null && birthTime.length() > 0) {
+            bday.setValue(birthTime);
+            subjectBirthTime.getValue().add(bday);
+        }
+
+        return subjectBirthTime;
+    }
+
+    private static PRPAMT201306UV02LivingSubjectAdministrativeGender createGender(String gender) {
+        PRPAMT201306UV02LivingSubjectAdministrativeGender adminGender
+            = new PRPAMT201306UV02LivingSubjectAdministrativeGender();
+        CE genderCode = new CE();
+
+        if (gender != null && gender.length() > 0) {
+            genderCode.setCode(gender);
+            adminGender.getValue().add(genderCode);
+        }
+
+        return adminGender;
+    }
+
+    private static MCCIMT000100UV01Receiver createReceiver() {
+        MCCIMT000100UV01Receiver receiver = new MCCIMT000100UV01Receiver();
+
+        receiver.setTypeCode(CommunicationFunctionType.RCV);
+
+        MCCIMT000100UV01Device device = new MCCIMT000100UV01Device();
+        device.setDeterminerCode("INSTANCE");
+
+        II id = new II();
+        id.setRoot("2.16.840.1.113883.3.200");
+        device.getId().add(id);
+
+        TELExplicit url = new TELExplicit();
+        url.setValue("http://localhost:9080/NhinConnect/AdapterComponentMpiService");
+        device.getTelecom().add(url);
+
+        receiver.setDevice(device);
+
+        return receiver;
+    }
+
+    private static MCCIMT000100UV01Sender createSender() {
+        MCCIMT000100UV01Sender sender = new MCCIMT000100UV01Sender();
+
+        sender.setTypeCode(CommunicationFunctionType.SND);
+
+        MCCIMT000100UV01Device device = new MCCIMT000100UV01Device();
+        device.setDeterminerCode("INSTANCE");
+
+        II id = new II();
+        id.setRoot("2.16.840.1.113883.3.200");
+        device.getId().add(id);
+
+        sender.setDevice(device);
+
+        return sender;
+    }
+
+    public static Patient createMpiPatient(String firstName, String lastName, String gender, String birthTime,
+        Identifier subjectId) {
+        Patient result = new Patient();
+
+        // Set the patient name
+        PersonName name = new PersonName();
+        name.setFirstName(firstName);
+        name.setLastName(lastName);
+        result.getNames().add(name);
+
+        // Set the patient gender
+        result.setGender(gender);
+
+        // Set the patient birth time
+        result.setDateOfBirth(birthTime);
+
+        // Set the patient Id
+        Identifiers ids = new Identifiers();
+        ids.add(subjectId);
+        result.setIdentifiers(ids);
+
+        return result;
+    }
+
+    public static Patient createMpiPatient(String firstName, String lastName, String middleName, String gender,
+        String birthTime, Identifier subjectId) {
+        Patient result = new Patient();
+
+        // Set the patient name
+        PersonName name = new PersonName();
+        name.setFirstName(firstName);
+        name.setLastName(lastName);
+        name.setMiddleName(middleName);
+        result.getNames().add(name);
+
+        // Set the patient gender
+        result.setGender(gender);
+
+        // Set the patient birth time
+        result.setDateOfBirth(birthTime);
+
+        // Set the patient Id
+        Identifiers ids = new Identifiers();
+        ids.add(subjectId);
+        result.setIdentifiers(ids);
+
+        return result;
+    }
+}

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryTransformsTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryTransformsTest.java
@@ -41,6 +41,7 @@ import gov.hhs.fha.nhinc.mpilib.Identifiers;
 import gov.hhs.fha.nhinc.mpilib.Patient;
 import gov.hhs.fha.nhinc.mpilib.PersonName;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryAuditDataBuilder;
 import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryTransformConstants;
 import java.net.UnknownHostException;
 import java.util.List;
@@ -73,8 +74,6 @@ import org.hl7.v3.XActMoodIntentEvent;
 import org.junit.After;
 import org.junit.AfterClass;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertSame;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -86,7 +85,8 @@ import org.junit.Test;
  * @param <T>
  * @param <K>
  */
-public class PatientDiscoveryTransformsTest<T extends PRPAIN201305UV02,K extends PRPAIN201306UV02> extends AuditTransformTest<T,K> {
+public class PatientDiscoveryTransformsTest<T extends PRPAIN201305UV02,K extends PRPAIN201306UV02> extends 
+    AuditTransformTest<T,K> {
 
     public PatientDiscoveryTransformsTest() {
     }
@@ -123,7 +123,8 @@ public class PatientDiscoveryTransformsTest<T extends PRPAIN201305UV02,K extends
 
             @Override
             protected String getRemoteHostAddress(Properties webContextProeprties) {
-                if (webContextProeprties != null && !webContextProeprties.isEmpty() && webContextProeprties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS) != null) {
+                if (webContextProeprties != null && !webContextProeprties.isEmpty() && webContextProeprties.
+                    getProperty(NhincConstants.REMOTE_HOST_ADDRESS) != null) {
                     return webContextProeprties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS);
                 }
                 return AuditTransformConstants.ACTIVE_PARTICPANT_UNKNOWN_IP_ADDRESS;
@@ -138,9 +139,12 @@ public class PatientDiscoveryTransformsTest<T extends PRPAIN201305UV02,K extends
 
         PRPAIN201305UV02 request = createPRPAIN201305UV02Request();
         AssertionType assertion = createAssertion();
-
-        LogEventRequestType auditRequest = transforms.transformMsgToAuditMsg(request, assertion, createNhinTarget(), NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, Boolean.TRUE, webContextProperties, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, response);
-        testGetEventIdentificationType(auditRequest, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, Boolean.TRUE);
+        PatientDiscoveryAuditDataBuilder builder = new PatientDiscoveryAuditDataBuilder();
+        LogEventRequestType auditRequest = transforms.transformRequestToAuditMsg(request, assertion, createNhinTarget(), 
+            NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, Boolean.TRUE, 
+            webContextProperties, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, builder);
+        testGetEventIdentificationType(auditRequest, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, Boolean.TRUE, 
+            builder);
         testGetActiveParticipantSource(auditRequest, Boolean.TRUE, localIP, webContextProperties);
         testGetActiveParticipantDestination(auditRequest, Boolean.TRUE, webContextProperties, remoteObjectIP);
         testCreateActiveParticipantFromUser(auditRequest, Boolean.TRUE, assertion);
@@ -148,17 +152,35 @@ public class PatientDiscoveryTransformsTest<T extends PRPAIN201305UV02,K extends
     }
 
     private void assertParticiopantObjectIdentification(LogEventRequestType auditRequest) {
-        assertEquals("D123401^^^&1.1&ISO", auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).getParticipantObjectID());
-        assertSame(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_TYPE_CODE_SYSTEM, auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).getParticipantObjectTypeCode());
-        assertSame(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_TYPE_CODE_ROLE, auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).getParticipantObjectTypeCodeRole());
-        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE, auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).getParticipantObjectIDTypeCode().getCode());
-        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE_SYSTEM, auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).getParticipantObjectIDTypeCode().getCodeSystemName());
-        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_DISPLAY_NAME, auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).getParticipantObjectIDTypeCode().getDisplayName());
-        assertSame(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_SYSTEM, auditRequest.getAuditMessage().getParticipantObjectIdentification().get(1).getParticipantObjectTypeCode());
-        assertSame(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_ROLE, auditRequest.getAuditMessage().getParticipantObjectIdentification().get(1).getParticipantObjectTypeCodeRole());
-        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE, auditRequest.getAuditMessage().getParticipantObjectIdentification().get(1).getParticipantObjectIDTypeCode().getCode());
-        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE_SYSTEM, auditRequest.getAuditMessage().getParticipantObjectIdentification().get(1).getParticipantObjectIDTypeCode().getCodeSystemName());
-        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_DISPLAY_NAME, auditRequest.getAuditMessage().getParticipantObjectIdentification().get(1).getParticipantObjectIDTypeCode().getDisplayName());
+        assertEquals("D123401^^^&1.1&ISO", 
+            auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).getParticipantObjectID());
+        assertSame(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_TYPE_CODE_SYSTEM, 
+            auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).getParticipantObjectTypeCode());
+        assertSame(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_TYPE_CODE_ROLE, 
+            auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).
+            getParticipantObjectTypeCodeRole());
+        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE, 
+            auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).
+            getParticipantObjectIDTypeCode().getCode());
+        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE_SYSTEM, 
+            auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).getParticipantObjectIDTypeCode().
+            getCodeSystemName());
+        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_DISPLAY_NAME, 
+            auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).getParticipantObjectIDTypeCode().
+            getDisplayName());
+        assertSame(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_SYSTEM, 
+            auditRequest.getAuditMessage().getParticipantObjectIdentification().get(1).getParticipantObjectTypeCode());
+        assertSame(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_ROLE, 
+            auditRequest.getAuditMessage().getParticipantObjectIdentification().get(1).getParticipantObjectTypeCodeRole());
+        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE, 
+            auditRequest.getAuditMessage().getParticipantObjectIdentification().get(1).getParticipantObjectIDTypeCode().
+            getCode());
+        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE_SYSTEM, 
+            auditRequest.getAuditMessage().getParticipantObjectIdentification().get(1).getParticipantObjectIDTypeCode().
+            getCodeSystemName());
+        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_DISPLAY_NAME, 
+            auditRequest.getAuditMessage().getParticipantObjectIdentification().get(1).getParticipantObjectIDTypeCode().
+            getDisplayName());
     }
 
     private AssertionType createAssertion() {

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryTransformsTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryTransformsTest.java
@@ -59,7 +59,6 @@ import org.hl7.v3.II;
 import org.hl7.v3.IVLTSExplicit;
 import org.hl7.v3.MCCIMT000100UV01Device;
 import org.hl7.v3.MCCIMT000100UV01Receiver;
-import org.hl7.v3.MCCIMT000100UV01Sender;
 import org.hl7.v3.PRPAIN201305UV02;
 import org.hl7.v3.PRPAIN201305UV02QUQIMT021001UV01ControlActProcess;
 import org.hl7.v3.PRPAIN201306UV02;
@@ -85,8 +84,8 @@ import org.junit.Test;
  * @param <T>
  * @param <K>
  */
-public class PatientDiscoveryTransformsTest<T extends PRPAIN201305UV02,K extends PRPAIN201306UV02> extends 
-    AuditTransformTest<T,K> {
+public class PatientDiscoveryTransformsTest<T extends PRPAIN201305UV02, K extends PRPAIN201306UV02> extends
+    AuditTransformTest<T, K> {
 
     public PatientDiscoveryTransformsTest() {
     }
@@ -108,13 +107,12 @@ public class PatientDiscoveryTransformsTest<T extends PRPAIN201305UV02,K extends
     }
 
     @Test
-    public void testTransformToAuditMsg() throws ConnectionManagerException, UnknownHostException {
+    public void transformRequestToAuditMsg() throws ConnectionManagerException, UnknownHostException {
         final String localIP = "10.10.10.10";
         Properties webContextProperties = new Properties();
         webContextProperties.setProperty(NhincConstants.WEB_SERVICE_REQUEST_URL, "http://16.14.13.12:9090/AuditService");
         webContextProperties.setProperty(NhincConstants.REMOTE_HOST_ADDRESS, "16.14.13.12");
         final String remoteObjectIP = "http://16.14.13.12:9090/source/AuditService";
-        PRPAIN201306UV02 response = null;
         PatientDiscoveryTransforms transforms = new PatientDiscoveryTransforms() {
             @Override
             protected String getLocalHostAddress() {
@@ -127,7 +125,7 @@ public class PatientDiscoveryTransformsTest<T extends PRPAIN201305UV02,K extends
                     getProperty(NhincConstants.REMOTE_HOST_ADDRESS) != null) {
                     return webContextProeprties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS);
                 }
-                return AuditTransformConstants.ACTIVE_PARTICPANT_UNKNOWN_IP_ADDRESS;
+                return AuditTransformConstants.ACTIVE_PARTICIPANT_UNKNOWN_IP_ADDRESS;
             }
 
             @Override
@@ -140,10 +138,10 @@ public class PatientDiscoveryTransformsTest<T extends PRPAIN201305UV02,K extends
         PRPAIN201305UV02 request = createPRPAIN201305UV02Request();
         AssertionType assertion = createAssertion();
         PatientDiscoveryAuditDataBuilder builder = new PatientDiscoveryAuditDataBuilder();
-        LogEventRequestType auditRequest = transforms.transformRequestToAuditMsg(request, assertion, createNhinTarget(), 
-            NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, Boolean.TRUE, 
+        LogEventRequestType auditRequest = transforms.transformRequestToAuditMsg(request, assertion, createNhinTarget(),
+            NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, Boolean.TRUE,
             webContextProperties, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, builder);
-        testGetEventIdentificationType(auditRequest, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, Boolean.TRUE, 
+        testGetEventIdentificationType(auditRequest, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, Boolean.TRUE,
             builder);
         testGetActiveParticipantSource(auditRequest, Boolean.TRUE, localIP, webContextProperties);
         testGetActiveParticipantDestination(auditRequest, Boolean.TRUE, webContextProperties, remoteObjectIP);
@@ -152,33 +150,33 @@ public class PatientDiscoveryTransformsTest<T extends PRPAIN201305UV02,K extends
     }
 
     private void assertParticiopantObjectIdentification(LogEventRequestType auditRequest) {
-        assertEquals("D123401^^^&1.1&ISO", 
+        assertEquals("D123401^^^&1.1&ISO",
             auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).getParticipantObjectID());
-        assertSame(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_TYPE_CODE_SYSTEM, 
+        assertSame(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_TYPE_CODE_SYSTEM,
             auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).getParticipantObjectTypeCode());
-        assertSame(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_TYPE_CODE_ROLE, 
+        assertSame(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_TYPE_CODE_ROLE,
             auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).
             getParticipantObjectTypeCodeRole());
-        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE, 
+        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE,
             auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).
             getParticipantObjectIDTypeCode().getCode());
-        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE_SYSTEM, 
+        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE_SYSTEM,
             auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).getParticipantObjectIDTypeCode().
             getCodeSystemName());
-        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_DISPLAY_NAME, 
+        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_DISPLAY_NAME,
             auditRequest.getAuditMessage().getParticipantObjectIdentification().get(0).getParticipantObjectIDTypeCode().
             getDisplayName());
-        assertSame(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_SYSTEM, 
+        assertSame(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_SYSTEM,
             auditRequest.getAuditMessage().getParticipantObjectIdentification().get(1).getParticipantObjectTypeCode());
-        assertSame(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_ROLE, 
+        assertSame(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_ROLE,
             auditRequest.getAuditMessage().getParticipantObjectIdentification().get(1).getParticipantObjectTypeCodeRole());
-        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE, 
+        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE,
             auditRequest.getAuditMessage().getParticipantObjectIdentification().get(1).getParticipantObjectIDTypeCode().
             getCode());
-        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE_SYSTEM, 
+        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE_SYSTEM,
             auditRequest.getAuditMessage().getParticipantObjectIdentification().get(1).getParticipantObjectIDTypeCode().
             getCodeSystemName());
-        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_DISPLAY_NAME, 
+        assertEquals(PatientDiscoveryTransformConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_DISPLAY_NAME,
             auditRequest.getAuditMessage().getParticipantObjectIdentification().get(1).getParticipantObjectIDTypeCode().
             getDisplayName());
     }
@@ -379,23 +377,6 @@ public class PatientDiscoveryTransformsTest<T extends PRPAIN201305UV02,K extends
         return receiver;
     }
 
-    private static MCCIMT000100UV01Sender createSender() {
-        MCCIMT000100UV01Sender sender = new MCCIMT000100UV01Sender();
-
-        sender.setTypeCode(CommunicationFunctionType.SND);
-
-        MCCIMT000100UV01Device device = new MCCIMT000100UV01Device();
-        device.setDeterminerCode("INSTANCE");
-
-        II id = new II();
-        id.setRoot("2.16.840.1.113883.3.200");
-        device.getId().add(id);
-
-        sender.setDevice(device);
-
-        return sender;
-    }
-
     public static Patient createMpiPatient(String firstName, String lastName, String gender, String birthTime,
         Identifier subjectId) {
         Patient result = new Patient();
@@ -444,4 +425,5 @@ public class PatientDiscoveryTransformsTest<T extends PRPAIN201305UV02,K extends
 
         return result;
     }
+
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryTransformsTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryTransformsTest.java
@@ -85,11 +85,8 @@ import org.junit.Test;
 /**
  *
  * @author achidamb
- * @param <T>
- * @param <K>
  */
-public class PatientDiscoveryTransformsTest<T extends PRPAIN201305UV02, K extends PRPAIN201306UV02> extends
-    AuditTransformTest<T, K> {
+public class PatientDiscoveryTransformsTest extends AuditTransformTest {
 
     public PatientDiscoveryTransformsTest() {
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/PassthroughInboundPatientDiscoveryTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/PassthroughInboundPatientDiscoveryTest.java
@@ -37,11 +37,9 @@ import java.util.Properties;
 import org.hl7.v3.PRPAIN201305UV02;
 import org.hl7.v3.PRPAIN201306UV02;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertSame;
 import org.junit.Test;
 import org.mockito.InOrder;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -78,21 +76,24 @@ public class PassthroughInboundPatientDiscoveryTest {
             assertion, webContextProperties);
 
         assertSame(expectedResponse, actualResponse);
-        PRPAIN201305UV02 nullRequest = null;
-        PRPAIN201306UV02 nullResponse = null;
-
+       
         InOrder inOrder = inOrder(auditLogger);
 
-        inOrder.verify(auditLogger).auditPatientDiscoveryMessage(eq(request), eq(assertion), eq(target),
-            eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME), eq(nullResponse));
+        inOrder.verify(auditLogger).auditPatientDiscoveryRequestMessage(eq(request), eq(assertion), eq(target),
+            eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), 
+            eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME));
 
-        inOrder.verify(auditLogger).auditPatientDiscoveryMessage(eq(nullRequest), eq(assertion), eq(target),
-            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME), eq(actualResponse));
+        inOrder.verify(auditLogger).auditPatientDiscoveryResponseMessage(eq(actualResponse),eq(assertion), eq(target),
+            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), 
+            eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME));
 
-        verify(auditLogger, never()).auditPatientDiscoveryMessage(eq(request), any(AssertionType.class), eq(target),
-            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME), eq(nullResponse));
+        verify(auditLogger, never()).auditPatientDiscoveryRequestMessage(eq(request), any(AssertionType.class), eq(target),
+            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE), 
+            eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME));
 
-        verify(auditLogger, never()).auditPatientDiscoveryMessage(eq(nullRequest), any(AssertionType.class), eq(target), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME), eq(actualResponse));
+        verify(auditLogger, never()).auditPatientDiscoveryResponseMessage(eq(actualResponse), any(AssertionType.class), 
+            eq(target), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE), 
+            eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME));
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/PassthroughInboundPatientDiscoveryTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/PassthroughInboundPatientDiscoveryTest.java
@@ -26,25 +26,28 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.inbound;
 
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryException;
+import gov.hhs.fha.nhinc.patientdiscovery.adapter.proxy.AdapterPatientDiscoveryProxy;
+import gov.hhs.fha.nhinc.patientdiscovery.adapter.proxy.AdapterPatientDiscoveryProxyObjectFactory;
+import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryAuditLogger;
+import java.util.Properties;
+import org.hl7.v3.PRPAIN201305UV02;
+import org.hl7.v3.PRPAIN201306UV02;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertSame;
+import org.junit.Test;
+import org.mockito.InOrder;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
-import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
-import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryAuditLogger;
-import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryException;
-import gov.hhs.fha.nhinc.patientdiscovery.adapter.proxy.AdapterPatientDiscoveryProxy;
-import gov.hhs.fha.nhinc.patientdiscovery.adapter.proxy.AdapterPatientDiscoveryProxyObjectFactory;
-
-import org.hl7.v3.PRPAIN201305UV02;
-import org.hl7.v3.PRPAIN201306UV02;
-import org.junit.Test;
-import org.mockito.InOrder;
 
 /**
  * @author akong
@@ -57,6 +60,8 @@ public class PassthroughInboundPatientDiscoveryTest {
         PRPAIN201305UV02 request = new PRPAIN201305UV02();
         AssertionType assertion = new AssertionType();
         PRPAIN201306UV02 expectedResponse = new PRPAIN201306UV02();
+        Properties webContextProperties = new Properties();
+        NhinTargetSystemType target = null;
 
         AdapterPatientDiscoveryProxyObjectFactory adapterFactory = mock(AdapterPatientDiscoveryProxyObjectFactory.class);
         AdapterPatientDiscoveryProxy adapterProxy = mock(AdapterPatientDiscoveryProxy.class);
@@ -67,26 +72,27 @@ public class PassthroughInboundPatientDiscoveryTest {
         when(adapterProxy.respondingGatewayPRPAIN201305UV02(request, assertion)).thenReturn(expectedResponse);
 
         PassthroughInboundPatientDiscovery passthroughPatientDiscovery = new PassthroughInboundPatientDiscovery(
-                adapterFactory, auditLogger);
+            adapterFactory, auditLogger);
 
         PRPAIN201306UV02 actualResponse = passthroughPatientDiscovery.respondingGatewayPRPAIN201305UV02(request,
-                assertion);
+            assertion, webContextProperties);
 
         assertSame(expectedResponse, actualResponse);
+        PRPAIN201305UV02 nullRequest = null;
+        PRPAIN201306UV02 nullResponse = null;
 
         InOrder inOrder = inOrder(auditLogger);
 
-        inOrder.verify(auditLogger).auditNhin201305(eq(request), eq(assertion),
-                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION));
+        inOrder.verify(auditLogger).auditPatientDiscoveryMessage(eq(request), eq(assertion), eq(target),
+            eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME), eq(nullResponse));
 
-        inOrder.verify(auditLogger).auditNhin201306(eq(actualResponse), eq(assertion),
-                eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION));
+        inOrder.verify(auditLogger).auditPatientDiscoveryMessage(eq(nullRequest), eq(assertion), eq(target),
+            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME), eq(actualResponse));
 
-        verify(auditLogger, never()).auditAdapter201305(any(PRPAIN201305UV02.class), any(AssertionType.class),
-                any(String.class));
+        verify(auditLogger, never()).auditPatientDiscoveryMessage(eq(request), any(AssertionType.class), eq(target),
+            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME), eq(nullResponse));
 
-        verify(auditLogger, never()).auditAdapter201306(any(PRPAIN201306UV02.class), any(AssertionType.class),
-                any(String.class));
+        verify(auditLogger, never()).auditPatientDiscoveryMessage(eq(nullRequest), any(AssertionType.class), eq(target), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME), eq(actualResponse));
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/StandardInboundPatientDiscoveryTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/StandardInboundPatientDiscoveryTest.java
@@ -41,13 +41,8 @@ import org.hl7.v3.PRPAIN201305UV02;
 import org.hl7.v3.PRPAIN201306UV02;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertSame;
 import org.junit.Test;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -92,19 +87,22 @@ public class StandardInboundPatientDiscoveryTest {
             .respondingGatewayPRPAIN201305UV02(request, assertion, webContextProperties);
 
         assertSame(expectedResponse, actualResponse);
-        PRPAIN201306UV02 nullResponse = null;
-        PRPAIN201305UV02 nullRequest = null;
 
-        verify(auditLogger).auditPatientDiscoveryMessage(eq(request), eq(assertion), eq(target), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME), eq(nullResponse));
+        verify(auditLogger).auditPatientDiscoveryRequestMessage(eq(request), eq(assertion), eq(target),
+            eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
+            eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME));
 
-        verify(auditLogger).auditPatientDiscoveryMessage(eq(nullRequest), eq(assertion), eq(target),
-            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME), eq(actualResponse));
+        verify(auditLogger).auditPatientDiscoveryResponseMessage(eq(actualResponse), eq(assertion), eq(target),
+            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
+            eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME));
 
-        verify(auditLogger).auditPatientDiscoveryMessage(eq(request), eq(assertion), eq(target),
-            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME), eq(nullResponse));
+        verify(auditLogger).auditPatientDiscoveryRequestMessage(eq(request), eq(assertion), eq(target),
+            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE),
+            eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME));
 
-        verify(auditLogger).auditPatientDiscoveryMessage(eq(nullRequest), eq(assertion), eq(target),
-            eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME), eq(actualResponse));
+        verify(auditLogger).auditPatientDiscoveryResponseMessage(eq(actualResponse), eq(assertion), eq(target),
+            eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE),
+            eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME));
 
     }
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/TestInboundPatientDiscovery.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/TestInboundPatientDiscovery.java
@@ -28,7 +28,7 @@ package gov.hhs.fha.nhinc.patientdiscovery.inbound;
 
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryException;
-
+import java.util.Properties;
 import org.hl7.v3.PRPAIN201305UV02;
 import org.hl7.v3.PRPAIN201306UV02;
 
@@ -38,10 +38,9 @@ import org.hl7.v3.PRPAIN201306UV02;
  */
 public class TestInboundPatientDiscovery implements InboundPatientDiscovery {
 
-
     @Override
-    public PRPAIN201306UV02 respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 body, AssertionType assertion)
-            throws PatientDiscoveryException {
+    public PRPAIN201306UV02 respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 body, AssertionType assertion, Properties webContextProperties)
+        throws PatientDiscoveryException {
         return new PRPAIN201306UV02();
     }
 


### PR DESCRIPTION
AuditTransformer is created in AuditRepositoryCore which can be utilized across services for Audit Logging.  PatientDiscovery Transformer is also created to transform objects specific to PatientDiscovery request and responses. Patient Discovery Audit Logger is created and calls were modified in Outbound and inbound. The number of audit log entries remain the same both in Standard and Passthrough mode.
