### PR TITLE
FHAC-539: PD audit fixes for ATNA compliance

### DIFF
--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
@@ -105,6 +105,7 @@ public abstract class AuditTransforms<T, K> {
     /**
      * Build and AuditLog Request Message from response
      *
+     * @param request Request Object
      * @param response Response Object
      * @param assertion Assertion Object
      * @param target Target Community
@@ -142,6 +143,7 @@ public abstract class AuditTransforms<T, K> {
     /**
      * Adds Participant Object Identification information to auditMsg
      *
+     * @param request
      * @param response
      * @param assertion
      * @param auditMsg

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransforms.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransforms.java
@@ -149,6 +149,8 @@ public class PatientDiscoveryAuditTransforms extends AuditTransforms<PRPAIN20130
 
     private II getLivingSubjectIdFromAuthorOrPerformerValue(PRPAIN201305UV02 request, List<PRPAMT201306UV02LivingSubjectId> ids) {
 
+        II livingSubjectId = null;
+        
         // Get assignedDevice root
         if (request.getControlActProcess().getAuthorOrPerformer() != null
             && !request.getControlActProcess().getAuthorOrPerformer().isEmpty()
@@ -171,11 +173,15 @@ public class PatientDiscoveryAuditTransforms extends AuditTransforms<PRPAIN20130
                 II oII = getLivingSubjectId(id);
 
                 if (oII != null && oII.getRoot() != null && oII.getRoot().equals(root)) {
-                    return oII;
+                    livingSubjectId = oII;
+                    break;
                 }
-            }
-        } //TODO Is it correct to return a NULL here if no root value or should we return the first value found?
-        return null;
+            } 
+        } else {
+            livingSubjectId = getLivingSubjectId(ids.get(0));
+        }
+        
+        return livingSubjectId;
     }
 
     private II getLivingSubjectId(PRPAMT201306UV02LivingSubjectId id) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransforms.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransforms.java
@@ -42,6 +42,7 @@ import org.hl7.v3.II;
 import org.hl7.v3.PRPAIN201305UV02;
 import org.hl7.v3.PRPAIN201306UV02;
 import org.hl7.v3.PRPAIN201306UV02MFMIMT700711UV01Subject1;
+import org.hl7.v3.PRPAMT201306UV02LivingSubjectId;
 
 /**
  * Patient Discovery audit transforms to support PD audit logging.
@@ -71,8 +72,8 @@ public class PatientDiscoveryAuditTransforms extends AuditTransforms<PRPAIN20130
     }
 
     @Override
-    protected AuditMessageType getParticipantObjectIdentificationForResponse(PRPAIN201305UV02 request, PRPAIN201306UV02 response,
-        AssertionType assertion, AuditMessageType auditMsg) {
+    protected AuditMessageType getParticipantObjectIdentificationForResponse(PRPAIN201305UV02 request,
+        PRPAIN201306UV02 response, AssertionType assertion, AuditMessageType auditMsg) {
 
         auditMsg = getPatientParticipantObjectIdentificationForResponse(response, auditMsg);
 
@@ -121,7 +122,7 @@ public class PatientDiscoveryAuditTransforms extends AuditTransforms<PRPAIN20130
     }
 
     private II getPatientIdFromRequest(PRPAIN201305UV02 request) {
-        II oII = null;
+        II livingSubjectId = null;
 
         // TODO: We should use a helper library to get elements nested this deeply
         if (request != null && request.getControlActProcess() != null
@@ -129,19 +130,42 @@ public class PatientDiscoveryAuditTransforms extends AuditTransforms<PRPAIN20130
             && request.getControlActProcess().getQueryByParameter().getValue() != null
             && request.getControlActProcess().getQueryByParameter().getValue().getParameterList() != null
             && request.getControlActProcess().getQueryByParameter().getValue().getParameterList()
-            .getLivingSubjectId() != null
-            && request.getControlActProcess().getQueryByParameter().getValue().getParameterList()
-            .getLivingSubjectId().get(0) != null
-            && request.getControlActProcess().getQueryByParameter().getValue().getParameterList()
-            .getLivingSubjectId().get(0).getValue() != null
-            && request.getControlActProcess().getQueryByParameter().getValue().getParameterList()
-            .getLivingSubjectId().get(0).getValue().get(0) != null) {
+            .getLivingSubjectId() != null) {
 
-            oII = request.getControlActProcess().getQueryByParameter().getValue().getParameterList().
-                getLivingSubjectId().get(0).getValue().get(0);
+            List<PRPAMT201306UV02LivingSubjectId> ids = request.getControlActProcess().getQueryByParameter().getValue()
+                .getParameterList().getLivingSubjectId();
+
+            if (ids.size() == 1) {
+                livingSubjectId = getLivingSubjectId(ids.get(0));
+            } else if (ids.size() > 1) {
+                // Get assignedDevice root
+                String root = request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice()
+                    .getValue().getId().get(0).getRoot();
+
+                // Compare assignedDevice root to each livingSubjectId root
+                for (PRPAMT201306UV02LivingSubjectId id : ids) {
+                    II oII = getLivingSubjectId(id);
+
+                    if (oII != null && oII.getRoot() != null && oII.getRoot().equals(root)) {
+                        livingSubjectId = oII;
+                        break;
+                    }
+                }
+            }
         } else {
             LOG.error("PatientId doesn't exist in the received PRPAIN201305UV02 message");
         }
+
+        return livingSubjectId;
+    }
+
+    private II getLivingSubjectId(PRPAMT201306UV02LivingSubjectId id) {
+        II oII = null;
+
+        if (id != null && id.getValue() != null) {
+            oII = id.getValue().get(0);
+        }
+
         return oII;
     }
 
@@ -150,8 +174,7 @@ public class PatientDiscoveryAuditTransforms extends AuditTransforms<PRPAIN20130
         if (response != null && response.getControlActProcess() != null
             && response.getControlActProcess().getSubject() != null) {
 
-            List<PRPAIN201306UV02MFMIMT700711UV01Subject1> oSubject1 = response.getControlActProcess().getSubject();
-            for (PRPAIN201306UV02MFMIMT700711UV01Subject1 subject : oSubject1) {
+            for (PRPAIN201306UV02MFMIMT700711UV01Subject1 subject : response.getControlActProcess().getSubject()) {
                 if (subject.getRegistrationEvent() != null && subject.getRegistrationEvent().getSubject1() != null
                     && subject.getRegistrationEvent().getSubject1().getPatient() != null
                     && subject.getRegistrationEvent().getSubject1().getPatient().getId() != null) {
@@ -177,10 +200,9 @@ public class PatientDiscoveryAuditTransforms extends AuditTransforms<PRPAIN20130
 
         if (aa != null && patientId != null && !aa.isEmpty() && !patientId.isEmpty()) {
             participantObject.setParticipantObjectID(createPatientId(aa, patientId));
-            auditMsg.getParticipantObjectIdentification().add(participantObject);
-        } else {
-            auditMsg.getParticipantObjectIdentification().add(participantObject);
         }
+
+        auditMsg.getParticipantObjectIdentification().add(participantObject);
 
         return auditMsg;
     }
@@ -192,7 +214,8 @@ public class PatientDiscoveryAuditTransforms extends AuditTransforms<PRPAIN20130
     private AuditMessageType getQueryParamsParticipantObjectIdentificationForRequest(PRPAIN201305UV02 request,
         AuditMessageType auditMsg) throws JAXBException {
 
-        ParticipantObjectIdentificationType participantObject = buildBaseParticipantObjectIdentificationType();
+        ParticipantObjectIdentificationType participantObject = buildBaseParticipantObjectIdentificationType(
+            getParticipantObjectId(request));
         participantObject.setParticipantObjectQuery(getParticipantObjectQueryForRequest(request));
         auditMsg.getParticipantObjectIdentification().add(participantObject);
         return auditMsg;
@@ -201,7 +224,8 @@ public class PatientDiscoveryAuditTransforms extends AuditTransforms<PRPAIN20130
     private AuditMessageType getQueryParamsParticipantObjectIdentificationForResponse(PRPAIN201306UV02 response,
         AuditMessageType auditMsg) throws JAXBException {
 
-        ParticipantObjectIdentificationType participantObject = buildBaseParticipantObjectIdentificationType();
+        ParticipantObjectIdentificationType participantObject = buildBaseParticipantObjectIdentificationType(
+            getParticipantObjectId(response));
         participantObject.setParticipantObjectQuery(getParticipantObjectQueryForResponse(response));
         auditMsg.getParticipantObjectIdentification().add(participantObject);
         return auditMsg;
@@ -223,18 +247,50 @@ public class PatientDiscoveryAuditTransforms extends AuditTransforms<PRPAIN20130
         return baos.toByteArray();
     }
 
-    private ParticipantObjectIdentificationType buildBaseParticipantObjectIdentificationType() {
+    private ParticipantObjectIdentificationType buildBaseParticipantObjectIdentificationType(
+        String participantObjectId) {
+
         ParticipantObjectIdentificationType participantObject = createParticipantObjectIdentification(
             PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_SYSTEM,
             PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_ROLE,
             PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE,
             PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE_SYSTEM,
             PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_DISPLAY_NAME);
-        participantObject.setParticipantObjectID(createUUID());
+        participantObject.setParticipantObjectID(participantObjectId);
         participantObject.setParticipantObjectName(HomeCommunityMap.formatHomeCommunityId(
             HomeCommunityMap.getLocalHomeCommunityId()));
 
         return participantObject;
+    }
+
+    private String getParticipantObjectId(PRPAIN201305UV02 request) {
+        String oid = null;
+
+        if (request != null
+            && request.getControlActProcess() != null
+            && request.getControlActProcess().getQueryByParameter() != null
+            && request.getControlActProcess().getQueryByParameter().getValue() != null
+            && request.getControlActProcess().getQueryByParameter().getValue().getQueryId() != null) {
+
+            oid = request.getControlActProcess().getQueryByParameter().getValue().getQueryId().getExtension();
+        }
+
+        return oid;
+    }
+
+    private String getParticipantObjectId(PRPAIN201306UV02 response) {
+        String oid = null;
+
+        if (response != null
+            && response.getControlActProcess() != null
+            && response.getControlActProcess().getQueryByParameter() != null
+            && response.getControlActProcess().getQueryByParameter().getValue() != null
+            && response.getControlActProcess().getQueryByParameter().getValue().getQueryId() != null) {
+
+            oid = response.getControlActProcess().getQueryByParameter().getValue().getQueryId().getExtension();
+        }
+
+        return oid;
     }
 
     private Marshaller getMarshaller() throws JAXBException {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransforms.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransforms.java
@@ -138,25 +138,44 @@ public class PatientDiscoveryAuditTransforms extends AuditTransforms<PRPAIN20130
             if (ids.size() == 1) {
                 livingSubjectId = getLivingSubjectId(ids.get(0));
             } else if (ids.size() > 1) {
-                // Get assignedDevice root
-                String root = request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice()
-                    .getValue().getId().get(0).getRoot();
-
-                // Compare assignedDevice root to each livingSubjectId root
-                for (PRPAMT201306UV02LivingSubjectId id : ids) {
-                    II oII = getLivingSubjectId(id);
-
-                    if (oII != null && oII.getRoot() != null && oII.getRoot().equals(root)) {
-                        livingSubjectId = oII;
-                        break;
-                    }
-                }
+                livingSubjectId = getLivingSubjectIdFromAuthorOrPerformerValue(request, ids);
             }
         } else {
             LOG.error("PatientId doesn't exist in the received PRPAIN201305UV02 message");
         }
 
         return livingSubjectId;
+    }
+
+    private II getLivingSubjectIdFromAuthorOrPerformerValue(PRPAIN201305UV02 request, List<PRPAMT201306UV02LivingSubjectId> ids) {
+
+        // Get assignedDevice root
+        if (request.getControlActProcess().getAuthorOrPerformer() != null
+            && !request.getControlActProcess().getAuthorOrPerformer().isEmpty()
+            && request.getControlActProcess().getAuthorOrPerformer().get(0) != null
+            && request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice() != null
+            && request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice().getValue() != null
+            && request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice().getValue().getId() != null
+            && !request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice().getValue().getId()
+            .isEmpty()
+            && request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice().getValue().getId()
+            .get(0) != null
+            && request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice().getValue().getId()
+            .get(0).getRoot() != null) {
+
+            String root = request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice()
+                .getValue().getId().get(0).getRoot();
+
+            // Compare assignedDevice root to each livingSubjectId root
+            for (PRPAMT201306UV02LivingSubjectId id : ids) {
+                II oII = getLivingSubjectId(id);
+
+                if (oII != null && oII.getRoot() != null && oII.getRoot().equals(root)) {
+                    return oII;
+                }
+            }
+        } //TODO Is it correct to return a NULL here if no root value or should we return the first value found?
+        return null;
     }
 
     private II getLivingSubjectId(PRPAMT201306UV02LivingSubjectId id) {


### PR DESCRIPTION
- Updated logic for pulling correct livingSubjectId
- Set participantObjectId to the correct value, instead of a random UUID
