### PR TITLE
FHAC-562:Fix Source ActiveParticipant UserId for all services other than RD and Destination ActiveParticipant UserId for RD

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/server/BaseService.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/server/BaseService.java
@@ -137,7 +137,7 @@ public abstract class BaseService {
         }
         Message message = ((WrappedMessageContext) messageContext).getWrappedMessage();
         AddressingProperties maps = (AddressingProperties) message.get(NhincConstants.INBOUND_REPLY_TO_HEADER);
-        return (maps.getReplyTo().getAddress().getValue());
+        return maps.getReplyTo().getAddress().getValue();
     }
 
     /**

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/server/BaseService.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/server/BaseService.java
@@ -36,7 +36,11 @@ import java.util.List;
 import java.util.Properties;
 import javax.servlet.http.HttpServletRequest;
 import javax.xml.ws.WebServiceContext;
+import javax.xml.ws.handler.MessageContext;
+import org.apache.cxf.jaxws.context.WrappedMessageContext;
+import org.apache.cxf.message.Message;
 import org.apache.cxf.transport.http.AbstractHTTPDestination;
+import org.apache.cxf.ws.addressing.AddressingProperties;
 
 /**
  * @author bhumphrey
@@ -125,6 +129,17 @@ public abstract class BaseService {
         return requestWebServiceUrl;
     }
 
+    private String getInboundReplyToHeader(WebServiceContext context) {
+
+        MessageContext messageContext = context.getMessageContext();
+        if (messageContext == null || !(messageContext instanceof WrappedMessageContext)) {
+            return null;
+        }
+        Message message = ((WrappedMessageContext) messageContext).getWrappedMessage();
+        AddressingProperties maps = (AddressingProperties) message.get(NhincConstants.INBOUND_REPLY_TO_HEADER);
+        return (maps.getReplyTo().getAddress().getValue());
+    }
+
     /**
      * Returns a Web Service Context properties object with the following properties: 1. Web Service Request URL 2.
      * Remote Host Address
@@ -133,15 +148,20 @@ public abstract class BaseService {
      * @return
      */
     public Properties getWebContextProperties(WebServiceContext context) {
+
         Properties webContextProperties = new Properties();
         if (context != null && context.getMessageContext() != null) {
             //add Web Service Request URL
             webContextProperties.put(NhincConstants.WEB_SERVICE_REQUEST_URL, getWebServiceRequestUrl(context));
+
             //add Remote Server address or Host
             webContextProperties.put(NhincConstants.REMOTE_HOST_ADDRESS, getRemoteAddress(context));
+
             //add Local Server address or Host
             webContextProperties.put(NhincConstants.LOCAL_HOST_ADDRESS, getLocalAddress(context));
 
+            //Get Inbound Message ReplyTo Header
+            webContextProperties.put(NhincConstants.INBOUND_REPLY_TO, getInboundReplyToHeader(context));
         }
         return webContextProperties;
     }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsAddressingServiceEndpointDecorator.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsAddressingServiceEndpointDecorator.java
@@ -29,20 +29,19 @@ package gov.hhs.fha.nhinc.messaging.service.decorator.cxf;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.messaging.service.ServiceEndpoint;
 import gov.hhs.fha.nhinc.messaging.service.decorator.ServiceEndpointDecorator;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import gov.hhs.fha.nhinc.wsa.WSAHeaderHelper;
-
 import javax.xml.ws.BindingProvider;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
 import org.apache.cxf.ws.addressing.AttributedURIType;
+import org.apache.cxf.ws.addressing.EndpointReferenceType;
 import org.apache.cxf.ws.addressing.JAXWSAConstants;
 import org.apache.cxf.ws.addressing.Names;
 import org.apache.cxf.ws.addressing.RelatesToType;
 import org.apache.cxf.ws.addressing.impl.AddressingPropertiesImpl;
 import org.apache.log4j.Logger;
-import org.apache.cxf.ws.addressing.EndpointReferenceType;
 
 /**
  * @author akong and young weezy
@@ -57,7 +56,7 @@ public class WsAddressingServiceEndpointDecorator<T> extends ServiceEndpointDeco
     private AssertionType assertion;
 
     public WsAddressingServiceEndpointDecorator(ServiceEndpoint<T> decoratoredEndpoint, String wsAddressingTo,
-            String wsAddressingAction, AssertionType assertion) {
+        String wsAddressingAction, AssertionType assertion) {
         super(decoratoredEndpoint);
 
         this.bindingProviderPort = (BindingProvider) decoratedEndpoint.getPort();
@@ -78,7 +77,7 @@ public class WsAddressingServiceEndpointDecorator<T> extends ServiceEndpointDeco
 
         EndpointReferenceType replyTo = new EndpointReferenceType();
         AttributedURIType replyToAddress = new AttributedURIType();
-        replyToAddress.setValue("http://www.w3.org/2005/08/addressing/anonymous");
+        replyToAddress.setValue(NhincConstants.WSA_REPLY_TO);
         replyTo.setAddress(replyToAddress);
         maps.getMustUnderstand().add(Names.WSA_REPLYTO_QNAME);
         maps.setReplyTo(replyTo);

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
@@ -467,6 +467,13 @@ public class NhincConstants {
     public static final String AUDIT_LOGGER_EJB_BEAN_NAME = "AuditEJBLoggerImpl";
     /* -- End Document Retrieve deferred Service Name -- */
 
+    //ReplyTo Header value for Nwhin Outbound messages
+    public static final String WSA_REPLY_TO = "http://www.w3.org/2005/08/addressing/anonymous";
+    //ReplyTo key value to be retrieved from cxf message Inbound Headers
+    public static final String INBOUND_REPLY_TO = "ReplyTo";
+    //ReplyTo Header to be retrieved from cxf Inbound messages
+    public static final String INBOUND_REPLY_TO_HEADER = "javax.xml.ws.addressing.context.inbound";
+
     private NhincConstants() {
     }
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
@@ -270,7 +270,7 @@ public abstract class AuditTransforms<T, K> {
         String hostAddress = isRequesting ? getLocalHostAddress() : getRemoteHostAddress(webContextProperties);
 
         AuditMessageType.ActiveParticipant participant = new AuditMessageType.ActiveParticipant();
-        participant.setUserID(AuditTransformsConstants.ACTIVE_PARTICIPANT_USER_ID_SOURCE);
+        participant.setUserID(isRequesting ? NhincConstants.WSA_REPLY_TO : getInboundReplyToFromHeader(webContextProperties));
         participant.setAlternativeUserID(ManagementFactory.getRuntimeMXBean().getName());
         participant.setNetworkAccessPointID(hostAddress);
         participant.setNetworkAccessPointTypeCode(getNetworkAccessPointTypeCode(hostAddress));
@@ -383,6 +383,17 @@ public abstract class AuditTransforms<T, K> {
             return webContextProperties.getProperty(NhincConstants.LOCAL_HOST_ADDRESS);
         }
         return AuditTransformsConstants.ACTIVE_PARTICIPANT_UNKNOWN_IP_ADDRESS;
+    }
+
+    protected String getInboundReplyToFromHeader(Properties webContextProperties) {
+
+        String inboundReplyTo = null;
+        if (webContextProperties != null && !webContextProperties.isEmpty() && webContextProperties.getProperty(
+            NhincConstants.INBOUND_REPLY_TO) != null) {
+
+            inboundReplyTo = webContextProperties.getProperty(NhincConstants.INBOUND_REPLY_TO);
+        }
+        return inboundReplyTo;
     }
 
     protected String getLocalHostAddress() {
@@ -560,4 +571,5 @@ public abstract class AuditTransforms<T, K> {
     protected abstract String getServiceEventActionCodeRequestor();
 
     protected abstract String getServiceEventActionCodeResponder();
+
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
@@ -270,7 +270,8 @@ public abstract class AuditTransforms<T, K> {
         String hostAddress = isRequesting ? getLocalHostAddress() : getRemoteHostAddress(webContextProperties);
 
         AuditMessageType.ActiveParticipant participant = new AuditMessageType.ActiveParticipant();
-        participant.setUserID(isRequesting ? NhincConstants.WSA_REPLY_TO : getInboundReplyToFromHeader(webContextProperties));
+        participant.setUserID(isRequesting ? NhincConstants.WSA_REPLY_TO
+            : getInboundReplyToFromHeader(webContextProperties));
         participant.setAlternativeUserID(ManagementFactory.getRuntimeMXBean().getName());
         participant.setNetworkAccessPointID(hostAddress);
         participant.setNetworkAccessPointTypeCode(getNetworkAccessPointTypeCode(hostAddress));

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformsTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformsTest.java
@@ -166,14 +166,12 @@ public abstract class AuditTransformsTest<T, K> {
         }
         if (isRequesting) {
             assertEquals(NhincConstants.WSA_REPLY_TO, sourceActiveParticipant.getUserID());
-        }
-        if (isRequesting) {
             assertEquals(ManagementFactory.getRuntimeMXBean().getName(), sourceActiveParticipant.getAlternativeUserID());
-        }
-        assertEquals(isRequesting, sourceActiveParticipant.isUserIsRequestor());
-        if (isRequesting) {
             assertEquals(localIP, sourceActiveParticipant.getNetworkAccessPointID());
-        } else {
+        }
+
+        assertEquals(isRequesting, sourceActiveParticipant.isUserIsRequestor());
+        if (!isRequesting) {
             assertEquals(webContextProperties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS),
                 sourceActiveParticipant.getNetworkAccessPointID());
         }

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformsTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformsTest.java
@@ -164,7 +164,9 @@ public abstract class AuditTransformsTest<T, K> {
                 sourceActiveParticipant = item;
             }
         }
-        assertEquals(AuditTransformsConstants.ACTIVE_PARTICIPANT_USER_ID_SOURCE, sourceActiveParticipant.getUserID());
+        if (isRequesting) {
+            assertEquals(NhincConstants.WSA_REPLY_TO, sourceActiveParticipant.getUserID());
+        }
         if (isRequesting) {
             assertEquals(ManagementFactory.getRuntimeMXBean().getName(), sourceActiveParticipant.getAlternativeUserID());
         }

--- a/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/audit/transform/DocRetrieveAuditTransforms.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/audit/transform/DocRetrieveAuditTransforms.java
@@ -45,6 +45,7 @@ import gov.hhs.fha.nhinc.transform.audit.AuditDataTransformHelper;
 import com.services.nhinc.schema.auditmessage.AuditMessageType.ActiveParticipant;
 import java.net.MalformedURLException;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 
 /**
  * This class is designed for supporting Audit Logging for Retrieve Document.
@@ -386,25 +387,22 @@ public class DocRetrieveAuditTransforms
 
         if (isRequesting) {
             hostAddress = getLocalHostAddress();
-            participant.setUserID(AuditTransformsConstants.ACTIVE_PARTICIPANT_USER_ID_SOURCE);
+            participant.setUserID(NhincConstants.WSA_REPLY_TO);
             participant.setAlternativeUserID(ManagementFactory.getRuntimeMXBean().getName());
             participant.setNetworkAccessPointID(hostAddress);
             participant.setNetworkAccessPointTypeCode(getNetworkAccessPointTypeCode(hostAddress));
 
         } else {
             hostAddress = getLocalAddressFromProperties(webContextProperties);
-
+            participant.setUserID(getInboundReplyToFromHeader(webContextProperties));
             if (hostAddress != null) {
                 try {
                     URL url = new URL(hostAddress);
-                    participant.setUserID(hostAddress);
                     hostAddress = url.getHost();
                     participant.setNetworkAccessPointID(hostAddress);
                     participant.setNetworkAccessPointTypeCode(getNetworkAccessPointTypeCode(hostAddress));
                 } catch (MalformedURLException ex) {
                     LOG.error("Error while returning remote address: " + ex.getLocalizedMessage(), ex);
-                    // The url is null or not a valid url; for now, set the user id to anonymous
-                    participant.setUserID(AuditTransformsConstants.ACTIVE_PARTICIPANT_USER_ID_SOURCE);
                     // TODO: For now, hardcode the value to localhost; need to find out if this needs to be set
                     participant.setNetworkAccessPointTypeCode(
                         AuditTransformsConstants.NETWORK_ACCESSOR_PT_TYPE_CODE_NAME);

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/audit/transform/DocRetrieveAuditTransformsTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/audit/transform/DocRetrieveAuditTransformsTest.java
@@ -357,7 +357,7 @@ public class DocRetrieveAuditTransformsTest extends AuditTransformsTest<Retrieve
             }
         }
         if (!isRequesting) {
-            assertEquals(AuditTransformsConstants.ACTIVE_PARTICIPANT_USER_ID_SOURCE,
+            assertEquals(NhincConstants.WSA_REPLY_TO,
                 destinationActiveParticipant.getUserID());
         } else {
             assertEquals(webContextProperties.getProperty(NhincConstants.WEB_SERVICE_REQUEST_URL),


### PR DESCRIPTION
1. Source ActiveParticipant UserId should be content of WSA:ReplyTo for all services other than RD
2. The initiating Gateway read this value as a constant since ReplyTo is set from Gateway as a constant value for all Nwhin Outbound messages.
3. The Responding Gateway retrieves this WSA:ReplyTo content from inbound messages.
4. The same approach is adopted for Destination ActiveParticipant UserId for RD.
