### PR TITLE
FHAC-547:Fix WebLogic Auditing issue requires restart of Application server after deployment

### DIFF
--- a/Product/Production/Gateway/CONNECTGatewayWeb/pom.xml
+++ b/Product/Production/Gateway/CONNECTGatewayWeb/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.connectopensource</groupId>
             <artifactId>AuditRepositoryCore</artifactId>
-            <version>${project.parent.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.connectopensource</groupId>


### PR DESCRIPTION
1. Fix CONNECTGatewayWeb to use the AuditRepositoryCore EJB jar from ear.
2. Tested fix on WIildFly 8.2.1, WebLogic 12.1.3 and WebSphere 8.5.5.3 development servers on Windows environment.
