### PR TITLE
FHAC-563 Fix for RD service NetworkAccessPointId to populate host add…

### DIFF
--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryOrchImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryOrchImpl.java
@@ -116,7 +116,9 @@ public class AuditRepositoryOrchImpl {
             if (activeParticipant != null) {
                 eventUserId = activeParticipant.getUserID();
                 if (eventUserId != null && !eventUserId.equals("")) {
-                    auditRec.setUserId(eventUserId);
+                    /* this value is temporary set to empty strings and due to length of characters are exceeding
+                     more than 100*/
+                    auditRec.setUserId("");
                 } else {
                     auditRec.setUserId("");
                 }


### PR DESCRIPTION
userID and NetworkAccessPointID for ActiveParticipant's source and destination for initiating gateway and responding gateway are correctly populated as a part of this ticket. 
For ActiveParticipant's source NetworkAccessPointID in initiating and responding gateway  - it will populate responding gateway's IPAddress and for ActiveParticipant's destination NetworkAccessPointID - it will always populate initiating gateway's IPAddress.
For ActiveParticipant source's userID in initiating and responding gateway - it will populate the remoteURL for responding gateway 
For ActiveParticipant destination userID in initiating and responding gateway - it will populate whatever is present in wsa:ReplyTo/ SOAP header
Testing: I have done gateway to gateway testing ( from your local machine to GFE LDAP machine) and for both initiating and responding side I can see correct IPAddress populated for NetworkAccessPointID and for userID remoteURL populated. It does not require to change Junit testcase as its already testing those conditions earlier
