### PR TITLE
FHAC-547:xml-api and xercesImpl jars are modified to provided scope to use jdk provided jars during runtime

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdapterPDPOpenSSO/pom.xml
+++ b/Product/Production/Adapters/General/CONNECTAdapterPDPOpenSSO/pom.xml
@@ -29,10 +29,10 @@
         </dependency>
 
         <!-- XML -->
-        <dependency>
+       <!-- <dependency>
             <groupId>xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
-        </dependency>
+        </dependency>-->
 
         <!-- Spring Framework -->
         <dependency>

--- a/Product/Production/Adapters/General/CONNECTAdapterPDPOpenSSO/pom.xml
+++ b/Product/Production/Adapters/General/CONNECTAdapterPDPOpenSSO/pom.xml
@@ -28,12 +28,6 @@
             </exclusions>
         </dependency>
 
-        <!-- XML -->
-       <!-- <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-        </dependency>-->
-
         <!-- Spring Framework -->
         <dependency>
             <groupId>org.springframework</groupId>

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/pom.xml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/pom.xml
@@ -195,10 +195,6 @@
 
         <!-- XML -->
         <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.opensaml</groupId>
             <artifactId>xmltooling</artifactId>
             <scope>runtime</scope>

--- a/Product/Production/Adapters/PatientDiscovery_a0/pom.xml
+++ b/Product/Production/Adapters/PatientDiscovery_a0/pom.xml
@@ -31,12 +31,6 @@
             <artifactId>PatientDiscoveryWebservices</artifactId>
         </dependency>
 
-        <!-- XML -->
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-        </dependency>
-
         <!-- Logging -->
         <dependency>
             <groupId>log4j</groupId>

--- a/Product/Production/Common/CONNECTCoreLib/pom.xml
+++ b/Product/Production/Common/CONNECTCoreLib/pom.xml
@@ -196,9 +196,13 @@
                     <artifactId>xalan</artifactId>
                 </exclusion>
                 <exclusion>
-                <groupId>xerces</groupId> 
-                <artifactId>xercesImpl</artifactId> 
-            </exclusion>
+                    <groupId>xerces</groupId> 
+                    <artifactId>xercesImpl</artifactId> 
+                </exclusion>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -209,10 +213,14 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>log4j-over-slf4j</artifactId>
                 </exclusion>
-            <exclusion>
-                <groupId>xerces</groupId> 
-                <artifactId>xercesImpl</artifactId> 
-            </exclusion>
+                <exclusion>
+                    <groupId>xerces</groupId> 
+                    <artifactId>xercesImpl</artifactId> 
+                </exclusion>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/Product/Production/Common/CONNECTCoreLib/pom.xml
+++ b/Product/Production/Common/CONNECTCoreLib/pom.xml
@@ -135,18 +135,9 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>xerces</groupId>
-            <artifactId>xercesImpl</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
             <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlbeans</groupId>
@@ -204,6 +195,10 @@
                     <groupId>xalan</groupId>
                     <artifactId>xalan</artifactId>
                 </exclusion>
+                <exclusion>
+                <groupId>xerces</groupId> 
+                <artifactId>xercesImpl</artifactId> 
+            </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -214,6 +209,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>log4j-over-slf4j</artifactId>
                 </exclusion>
+            <exclusion>
+                <groupId>xerces</groupId> 
+                <artifactId>xercesImpl</artifactId> 
+            </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/Product/Production/Deploy/weblogic/src/main/application/META-INF/weblogic-application.xml
+++ b/Product/Production/Deploy/weblogic/src/main/application/META-INF/weblogic-application.xml
@@ -9,7 +9,6 @@
         <package-name>org.apache.geronimo.webservices.*</package-name>
         <package-name>org.apache.jcp.*</package-name>
         <package-name>org.apache.ws.*</package-name>
-        <package-name>org.apache.xerces.*</package-name>
         <package-name>org.apache.xml.*</package-name>
         <package-name>org.apache.xalan.*</package-name>
         <package-name>org.apache.log4j.*</package-name>

--- a/Product/Production/Services/AdminDistributionCore/pom.xml
+++ b/Product/Production/Services/AdminDistributionCore/pom.xml
@@ -43,13 +43,7 @@
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-api</artifactId>
         </dependency>
-
-        <!-- XML -->
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-        </dependency>
-
+        
         <!-- Guava -->
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/Product/Production/Services/AuditRepositoryCore/pom.xml
+++ b/Product/Production/Services/AuditRepositoryCore/pom.xml
@@ -39,12 +39,6 @@
             <artifactId>hibernate</artifactId>
         </dependency>
 
-        <!-- XML -->
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-        </dependency>
-
         <!-- Logging -->
         <dependency>
             <groupId>log4j</groupId>

--- a/Product/Production/Services/DocumentQueryCore/pom.xml
+++ b/Product/Production/Services/DocumentQueryCore/pom.xml
@@ -60,12 +60,6 @@
             <artifactId>spring-core</artifactId>
         </dependency>
 
-        <!-- XML -->
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-        </dependency>
-
         <!-- Guava -->
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/Product/Production/Services/DocumentSubmissionCore/pom.xml
+++ b/Product/Production/Services/DocumentSubmissionCore/pom.xml
@@ -48,12 +48,6 @@
             <artifactId>spring-context</artifactId>
         </dependency>
 
-        <!-- XML -->
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-        </dependency>
-
         <!-- Guava -->
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/Product/Production/Services/PatientDiscoveryCore/pom.xml
+++ b/Product/Production/Services/PatientDiscoveryCore/pom.xml
@@ -53,12 +53,6 @@
             <artifactId>spring-context</artifactId>
         </dependency>
 
-        <!-- XML -->
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-        </dependency>
-
         <!-- Guava -->
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/Product/Production/Services/PolicyEngineCore/pom.xml
+++ b/Product/Production/Services/PolicyEngineCore/pom.xml
@@ -33,12 +33,6 @@
             <artifactId>clientsdk</artifactId>
         </dependency>
 
-        <!-- XML -->
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-        </dependency>
-
         <!-- Logging -->
         <dependency>
             <groupId>log4j</groupId>

--- a/Product/pom.xml
+++ b/Product/pom.xml
@@ -577,6 +577,10 @@
                         <groupId>xerces</groupId> 
                         <artifactId>xercesImpl</artifactId> 
                     </exclusion>
+                    <exclusion>
+                        <groupId>xml-apis</groupId>
+                        <artifactId>xml-apis</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -591,6 +595,10 @@
                     <exclusion>
                         <groupId>xerces</groupId> 
                         <artifactId>xercesImpl</artifactId> 
+                    </exclusion>
+                    <exclusion>
+                        <groupId>xml-apis</groupId>
+                        <artifactId>xml-apis</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -610,6 +618,10 @@
                     <exclusion>
                         <groupId>xerces</groupId> 
                         <artifactId>xercesImpl</artifactId> 
+                    </exclusion>
+                    <exclusion>
+                        <groupId>xml-apis</groupId>
+                        <artifactId>xml-apis</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/Product/pom.xml
+++ b/Product/pom.xml
@@ -289,12 +289,6 @@
                 <version>1.5.5</version>
             </dependency>
             <dependency>
-                <groupId>xerces</groupId>
-                <artifactId>xercesImpl</artifactId>
-                <version>2.10.0</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
                 <groupId>com.thoughtworks.xstream</groupId>
                 <artifactId>xstream</artifactId>
                 <version>1.4.3</version>
@@ -354,12 +348,6 @@
                 <groupId>org.apache.servicemix.bundles</groupId>
                 <artifactId>org.apache.servicemix.bundles.saaj-impl</artifactId>
                 <version>1.3.18_1</version>
-            </dependency>
-            <dependency>
-                <groupId>xml-apis</groupId>
-                <artifactId>xml-apis</artifactId>
-                <version>1.4.01</version>
-                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.xmlbeans</groupId>
@@ -585,6 +573,10 @@
                         <groupId>velocity</groupId>
                         <artifactId>velocity</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>xerces</groupId> 
+                        <artifactId>xercesImpl</artifactId> 
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -595,6 +587,10 @@
                     <exclusion>
                         <groupId>commons-httpclient</groupId>
                         <artifactId>commons-httpclient</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>xerces</groupId> 
+                        <artifactId>xercesImpl</artifactId> 
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -610,6 +606,10 @@
                     <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>jcl-over-slf4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>xerces</groupId> 
+                        <artifactId>xercesImpl</artifactId> 
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/Product/pom.xml
+++ b/Product/pom.xml
@@ -292,6 +292,7 @@
                 <groupId>xerces</groupId>
                 <artifactId>xercesImpl</artifactId>
                 <version>2.10.0</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>com.thoughtworks.xstream</groupId>
@@ -358,6 +359,7 @@
                 <groupId>xml-apis</groupId>
                 <artifactId>xml-apis</artifactId>
                 <version>1.4.01</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.xmlbeans</groupId>


### PR DESCRIPTION
1. xml-api and xercesImpl jars modified from compile, runtime to scope provided.
2. Tested on weblogic 12.1.3,websphere 8.5.5.3, wildfly 8.2.1-Final on Windows 
