### PR TITLE
FHAC-558: Removed ParticpantObjectName from PD,QD and RD

### DIFF
--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/audit/transform/DocQueryAuditTransforms.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/audit/transform/DocQueryAuditTransforms.java
@@ -53,7 +53,7 @@ public class DocQueryAuditTransforms extends AuditTransforms<AdhocQueryRequest, 
 
     @Override
     protected AuditMessageType getParticipantObjectIdentificationForRequest(AdhocQueryRequest request,
-            AssertionType assertion, AuditMessageType auditMsg) {
+        AssertionType assertion, AuditMessageType auditMsg) {
         // ParticipantObjectIdentification for Patient is an optional element and can range from 0..1 . If PatientId is
         // not present in the request, the Audit Object will not hold ParticipantObjectIdentification for Patient.
         auditMsg = getPatientParticipantObjectIdentificationForRequest(request, auditMsg);
@@ -61,21 +61,21 @@ public class DocQueryAuditTransforms extends AuditTransforms<AdhocQueryRequest, 
             auditMsg = getQueryParamsParticipantObjectIdentificationForRequest(request, auditMsg);
         } catch (JAXBException ex) {
             LOG.error("Error while creating ParticipantObjectIdentificationQueryByParameters segment : "
-                    + ex.getLocalizedMessage(), ex);
+                + ex.getLocalizedMessage(), ex);
         }
         return auditMsg;
     }
 
     @Override
     protected AuditMessageType getParticipantObjectIdentificationForResponse(AdhocQueryRequest request,
-            AdhocQueryResponse response,
-            AssertionType assertion, AuditMessageType auditMsg) {
+        AdhocQueryResponse response,
+        AssertionType assertion, AuditMessageType auditMsg) {
         auditMsg = getPatientParticipantObjectIdentificationForResponse(request, response, auditMsg);
         try {
             auditMsg = getQueryParticipantObjectIdentificationForResponse(request, response, auditMsg);
         } catch (JAXBException ex) {
             LOG.error("Error while creating ParticipantObjectIdentificationQueryByParameters segment : "
-                    + ex.getLocalizedMessage(), ex);
+                + ex.getLocalizedMessage(), ex);
         }
         return auditMsg;
 
@@ -132,9 +132,9 @@ public class DocQueryAuditTransforms extends AuditTransforms<AdhocQueryRequest, 
     }
 
     private AuditMessageType getQueryParamsParticipantObjectIdentificationForRequest(AdhocQueryRequest request,
-            AuditMessageType auditMsg) throws JAXBException {
-        ParticipantObjectIdentificationType participantObject =
-                createQueryParticipantObjectIdentification(getQueryIdFromRequest(request));
+        AuditMessageType auditMsg) throws JAXBException {
+        ParticipantObjectIdentificationType participantObject
+            = createQueryParticipantObjectIdentification(getQueryIdFromRequest(request));
         participantObject.setParticipantObjectQuery(getParticipantObjectQueryForRequest(request));
         auditMsg.getParticipantObjectIdentification().add(participantObject);
         return auditMsg;
@@ -143,22 +143,22 @@ public class DocQueryAuditTransforms extends AuditTransforms<AdhocQueryRequest, 
     // ParticipantObjectIdentification for Patient is an optional element and can range from 0..1 . If PatientId is
     // not present in the request, the Audit Object will not hold ParticipantObjectIdentification for Patient.
     private AuditMessageType getPatientParticipantObjectIdentificationForRequest(AdhocQueryRequest request,
-            AuditMessageType auditMsg) {
+        AuditMessageType auditMsg) {
         String patientId = getPatientIdFromRequest(request);
         if (patientId != null) {
-            ParticipantObjectIdentificationType participantObject =
-                    createPatientParticipantObjectIdentification(patientId);
+            ParticipantObjectIdentificationType participantObject
+                = createPatientParticipantObjectIdentification(patientId);
             auditMsg.getParticipantObjectIdentification().add(participantObject);
         }
         return auditMsg;
     }
 
     private AuditMessageType getPatientParticipantObjectIdentificationForResponse(AdhocQueryRequest request,
-            AdhocQueryResponse response, AuditMessageType auditMsg) {
+        AdhocQueryResponse response, AuditMessageType auditMsg) {
         String patientId = getPatientIdFromRequest(request);
         if (patientId != null) {
-            ParticipantObjectIdentificationType participantObject =
-                    createPatientParticipantObjectIdentification(patientId);
+            ParticipantObjectIdentificationType participantObject
+                = createPatientParticipantObjectIdentification(patientId);
             auditMsg.getParticipantObjectIdentification().add(participantObject);
         }
         return auditMsg;
@@ -166,9 +166,9 @@ public class DocQueryAuditTransforms extends AuditTransforms<AdhocQueryRequest, 
     }
 
     private AuditMessageType getQueryParticipantObjectIdentificationForResponse(AdhocQueryRequest request,
-            AdhocQueryResponse response, AuditMessageType auditMsg) throws JAXBException {
-        ParticipantObjectIdentificationType participantObject =
-                createQueryParticipantObjectIdentification(getQueryIdFromRequest(request));
+        AdhocQueryResponse response, AuditMessageType auditMsg) throws JAXBException {
+        ParticipantObjectIdentificationType participantObject
+            = createQueryParticipantObjectIdentification(getQueryIdFromRequest(request));
         participantObject.setParticipantObjectQuery(getParticipantObjectQueryForRequest(request));
         auditMsg.getParticipantObjectIdentification().add(participantObject);
         return auditMsg;
@@ -176,17 +176,15 @@ public class DocQueryAuditTransforms extends AuditTransforms<AdhocQueryRequest, 
 
     private ParticipantObjectIdentificationType createQueryParticipantObjectIdentification(String queryId) {
         ParticipantObjectIdentificationType participantObject = createParticipantObject(
-                DocQueryAuditTransformsConstants.PARTICIPANT_QUERY_OBJ_TYPE_CODE_SYSTEM,
-                DocQueryAuditTransformsConstants.PARTICIPANT_QUERY_OBJ_TYPE_CODE_ROLE,
-                DocQueryAuditTransformsConstants.PARTICIPANT_QUERY_OBJ_ID_TYPE_CODE,
-                DocQueryAuditTransformsConstants.PARTICIPANT_QUERY_OBJ_ID_TYPE_CODE_SYSTEM,
-                DocQueryAuditTransformsConstants.PARTICIPANT_QUERY_OBJ_ID_TYPE_DISPLAY_NAME);
+            DocQueryAuditTransformsConstants.PARTICIPANT_QUERY_OBJ_TYPE_CODE_SYSTEM,
+            DocQueryAuditTransformsConstants.PARTICIPANT_QUERY_OBJ_TYPE_CODE_ROLE,
+            DocQueryAuditTransformsConstants.PARTICIPANT_QUERY_OBJ_ID_TYPE_CODE,
+            DocQueryAuditTransformsConstants.PARTICIPANT_QUERY_OBJ_ID_TYPE_CODE_SYSTEM,
+            DocQueryAuditTransformsConstants.PARTICIPANT_QUERY_OBJ_ID_TYPE_DISPLAY_NAME);
 
         if (queryId != null && !queryId.isEmpty()) {
             participantObject.setParticipantObjectID(queryId);
         }
-        participantObject.setParticipantObjectName(HomeCommunityMap.formatHomeCommunityId(
-                HomeCommunityMap.getLocalHomeCommunityId()));
         TypeValuePairType encoding = new TypeValuePairType();
         encoding.setType(DocQueryAuditTransformsConstants.QUERY_ENCODING_TYPE);
         encoding.setValue(DocQueryAuditTransformsConstants.UTF_8.getBytes());
@@ -195,7 +193,7 @@ public class DocQueryAuditTransforms extends AuditTransforms<AdhocQueryRequest, 
         TypeValuePairType homeCommunityTypeValue = new TypeValuePairType();
         homeCommunityTypeValue.setType(DocQueryAuditTransformsConstants.HOME_COMMUNITY_ID);
         homeCommunityTypeValue.setValue(HomeCommunityMap.formatHomeCommunityId(
-                HomeCommunityMap.getLocalHomeCommunityId()).getBytes());
+            HomeCommunityMap.getLocalHomeCommunityId()).getBytes());
         participantObject.getParticipantObjectDetail().add(homeCommunityTypeValue);
 
         return participantObject;
@@ -205,11 +203,11 @@ public class DocQueryAuditTransforms extends AuditTransforms<AdhocQueryRequest, 
     private ParticipantObjectIdentificationType createPatientParticipantObjectIdentification(String pid) {
 
         ParticipantObjectIdentificationType participantObject = createParticipantObject(
-                DocQueryAuditTransformsConstants.PARTICIPANT_PATIENT_OBJ_TYPE_CODE_SYSTEM,
-                DocQueryAuditTransformsConstants.PARTICIPANT_PATIENT_OBJ_TYPE_CODE_ROLE,
-                DocQueryAuditTransformsConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE,
-                DocQueryAuditTransformsConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE_SYSTEM,
-                DocQueryAuditTransformsConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_DISPLAY_NAME);
+            DocQueryAuditTransformsConstants.PARTICIPANT_PATIENT_OBJ_TYPE_CODE_SYSTEM,
+            DocQueryAuditTransformsConstants.PARTICIPANT_PATIENT_OBJ_TYPE_CODE_ROLE,
+            DocQueryAuditTransformsConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE,
+            DocQueryAuditTransformsConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE_SYSTEM,
+            DocQueryAuditTransformsConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_DISPLAY_NAME);
 
         if (pid != null && !pid.isEmpty()) {
             participantObject.setParticipantObjectID(pid);
@@ -219,10 +217,10 @@ public class DocQueryAuditTransforms extends AuditTransforms<AdhocQueryRequest, 
     }
 
     private ParticipantObjectIdentificationType createParticipantObject(short objTypeCodeSys, short objTypeCodeRole,
-            String objIdTypeCode, String objIdTypeCodeSys, String objIdTypeDisplayName) {
+        String objIdTypeCode, String objIdTypeCodeSys, String objIdTypeDisplayName) {
 
         return createParticipantObjectIdentification(objTypeCodeSys, objTypeCodeRole,
-                objIdTypeCode, objIdTypeCodeSys, objIdTypeDisplayName);
+            objIdTypeCode, objIdTypeCodeSys, objIdTypeDisplayName);
     }
 
     private byte[] getParticipantObjectQueryForRequest(AdhocQueryRequest request) throws JAXBException {
@@ -240,8 +238,8 @@ public class DocQueryAuditTransforms extends AuditTransforms<AdhocQueryRequest, 
 
     private String getQueryIdFromRequest(AdhocQueryRequest request) {
         if (request != null
-                && request.getAdhocQuery() != null
-                && request.getAdhocQuery().getId() != null) {
+            && request.getAdhocQuery() != null
+            && request.getAdhocQuery().getId() != null) {
             return request.getAdhocQuery().getId();
         }
         return null;
@@ -249,9 +247,9 @@ public class DocQueryAuditTransforms extends AuditTransforms<AdhocQueryRequest, 
 
     private String getPatientIdFromRequest(AdhocQueryRequest request) {
         if (request != null
-                && request.getAdhocQuery() != null
-                && request.getAdhocQuery().getSlot() != null
-                && !request.getAdhocQuery().getSlot().isEmpty()) {
+            && request.getAdhocQuery() != null
+            && request.getAdhocQuery().getSlot() != null
+            && !request.getAdhocQuery().getSlot().isEmpty()) {
             for (SlotType1 slot : request.getAdhocQuery().getSlot()) {
                 if (slot.getName().equals(DocQueryAuditTransformsConstants.XDS_DOCUMENT_ENTRY_PATIENT_ID)) {
                     String value = slot.getValueList().getValue().toString();

--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/audit/transform/DocQueryAuditTransformsTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/audit/transform/DocQueryAuditTransformsTest.java
@@ -51,6 +51,7 @@ import org.junit.AfterClass;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -211,6 +212,12 @@ public class DocQueryAuditTransformsTest extends AuditTransformsTest<AdhocQueryR
         assertEquals("ParticipantPatient.ParticipantObjectIDTypeCode.DisplayName mismatch",
             DocQueryAuditTransformsConstants.PARTICIPANT_QUERY_OBJ_ID_TYPE_DISPLAY_NAME,
             participantQuery.getParticipantObjectIDTypeCode().getDisplayName());
+        assertNull("ParticipantPatient.ParticipantObjectName is not null",
+            participantPatient.getParticipantObjectName());
+        assertNull("ParticipantQuery.ParticipantObjectName is not null",
+            participantQuery.getParticipantObjectName());
+        assertNotNull("ParticipantQuery.ParticipantObjectQuery is null",
+            participantQuery.getParticipantObjectQuery());
     }
 
     private AdhocQueryResponse createAdhocQueryResponse() {

--- a/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/audit/transform/DocRetrieveAuditTransforms.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/audit/transform/DocRetrieveAuditTransforms.java
@@ -34,7 +34,6 @@ import com.services.nhinc.schema.auditmessage.TypeValuePairType;
 import gov.hhs.fha.nhinc.audit.transform.AuditTransforms;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docretrieve.audit.DocRetrieveAuditTransformsConstants;
-import gov.hhs.fha.nhinc.util.HomeCommunityMap;
 import ihe.iti.xds_b._2007.RetrieveDocumentSetRequestType;
 import ihe.iti.xds_b._2007.RetrieveDocumentSetResponseType;
 import java.net.URL;
@@ -258,8 +257,6 @@ public class DocRetrieveAuditTransforms
             DocRetrieveAuditTransformsConstants.PARTICIPANT_DOCUMENT_OBJ_ID_TYPE_CODE,
             DocRetrieveAuditTransformsConstants.PARTICIPANT_DOCUMENT_OBJ_ID_TYPE_CODE_SYSTEM,
             DocRetrieveAuditTransformsConstants.PARTICIPANT_DOCUMENT_OBJ_ID_TYPE_DISPLAY_NAME);
-        participantObject.setParticipantObjectName(HomeCommunityMap.formatHomeCommunityId(
-            HomeCommunityMap.getLocalHomeCommunityId()));
 
         return participantObject;
     }

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/audit/transform/DocRetrieveAuditTransformsTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/audit/transform/DocRetrieveAuditTransformsTest.java
@@ -48,6 +48,7 @@ import org.junit.AfterClass;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -203,6 +204,9 @@ public class DocRetrieveAuditTransformsTest
             participantObject.getParticipantObjectIDTypeCode().getCodeSystemName());
         assertEquals(DocRetrieveAuditTransformsConstants.PARTICIPANT_DOCUMENT_OBJ_ID_TYPE_DISPLAY_NAME,
             participantObject.getParticipantObjectIDTypeCode().getDisplayName());
+        assertNull("ParticipantDocument.ParticpantObjectName is not null",
+            participantObject.getParticipantObjectName());
+
     }
 
     private void assertParticipantPatientObjectIdentification(ParticipantObjectIdentificationType participantObject) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransforms.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransforms.java
@@ -32,7 +32,6 @@ import gov.hhs.fha.nhinc.audit.transform.AuditTransforms;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryAuditTransformsConstants;
 import gov.hhs.fha.nhinc.transform.marshallers.JAXBContextHandler;
-import gov.hhs.fha.nhinc.util.HomeCommunityMap;
 import java.io.ByteArrayOutputStream;
 import java.util.List;
 import javax.xml.bind.JAXBException;
@@ -284,9 +283,6 @@ public class PatientDiscoveryAuditTransforms extends AuditTransforms<PRPAIN20130
             PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE_SYSTEM,
             PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_DISPLAY_NAME);
         participantObject.setParticipantObjectID(participantObjectId);
-        participantObject.setParticipantObjectName(HomeCommunityMap.formatHomeCommunityId(
-            HomeCommunityMap.getLocalHomeCommunityId()));
-
         return participantObject;
     }
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransformsTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransformsTest.java
@@ -77,6 +77,7 @@ import org.junit.AfterClass;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -252,6 +253,12 @@ public class PatientDiscoveryAuditTransformsTest extends AuditTransformsTest<PRP
         assertEquals("ParticipantPatient.ParticipantObjectIDTypeCode.DisplayName mismatch",
             PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_DISPLAY_NAME,
             participantQuery.getParticipantObjectIDTypeCode().getDisplayName());
+        assertNull("ParticipantPatient.ParticipantObjectName is not null",
+            participantPatient.getParticipantObjectName());
+        assertNull("ParticipantQuery.ParticipantObjectName is not null",
+            participantQuery.getParticipantObjectName());
+        assertNotNull("ParticipantQuery.ParticipantObjectQuery is null",
+            participantQuery.getParticipantObjectQuery());
     }
 
     private PRPAIN201305UV02 createPRPAIN201305UV02Request() {


### PR DESCRIPTION
1. Removed the ParticpantObjectName from PD, RD and QD.
2. Update Unit test for PD, QD and RD.
