### PR TITLE
FHAC-546:Fix for Glassfish Application Server Audit Logging

### DIFF
--- a/Product/Production/Deploy/glassfish/pom.xml
+++ b/Product/Production/Deploy/glassfish/pom.xml
@@ -13,9 +13,45 @@
     <dependencies>
         <dependency>
             <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTCommonWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTGatewayWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTAdapterWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
             <artifactId>AuditRepositoryCore</artifactId>
             <version>${project.parent.version}</version>
             <type>ejb</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTCommonWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTGatewayWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTAdapterWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>pom</type>
         </dependency>
     </dependencies>
     <build>
@@ -31,6 +67,21 @@
                             <artifactId>AuditRepositoryCore</artifactId>
                             <bundleDir>lib</bundleDir>
                         </ejbModule>
+                        <webModule>
+                            <groupId>org.connectopensource</groupId>
+                            <artifactId>CONNECTCommonWeb</artifactId>
+                            <contextRoot>/CONNECTCommon</contextRoot>
+                        </webModule>
+                        <webModule>
+                            <groupId>org.connectopensource</groupId>
+                            <artifactId>CONNECTGatewayWeb</artifactId>
+                            <contextRoot>/CONNECTGateway</contextRoot>
+                        </webModule>
+                        <webModule>
+                            <groupId>org.connectopensource</groupId>
+                            <artifactId>CONNECTAdapterWeb</artifactId>
+                            <contextRoot>/CONNECTAdapter</contextRoot>
+                        </webModule>
                     </modules>
                     <version>6</version>
                     <defaultLibBundleDir>lib</defaultLibBundleDir>

--- a/Product/Production/Deploy/jboss7/pom.xml
+++ b/Product/Production/Deploy/jboss7/pom.xml
@@ -11,7 +11,90 @@
     <packaging>ear</packaging>
     <modelVersion>4.0.0</modelVersion>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTCommonWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTGatewayWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTAdapterWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>AuditRepositoryCore</artifactId>
+            <version>${project.parent.version}</version>
+            <type>ejb</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTCommonWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTGatewayWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTAdapterWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+
     <build>
         <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-ear-plugin</artifactId>
+                <configuration>
+                    <modules>
+                        <ejbModule>
+                            <groupId>org.connectopensource</groupId>
+                            <artifactId>AuditRepositoryCore</artifactId>
+                        </ejbModule>
+                        <webModule>
+                            <groupId>org.connectopensource</groupId>
+                            <artifactId>CONNECTCommonWeb</artifactId>
+                            <contextRoot>/CONNECTCommon</contextRoot>
+                        </webModule>
+                        <webModule>
+                            <groupId>org.connectopensource</groupId>
+                            <artifactId>CONNECTGatewayWeb</artifactId>
+                            <contextRoot>/CONNECTGateway</contextRoot>
+                        </webModule>
+                        <webModule>
+                            <groupId>org.connectopensource</groupId>
+                            <artifactId>CONNECTAdapterWeb</artifactId>
+                            <contextRoot>/CONNECTAdapter</contextRoot>
+                        </webModule>
+                    </modules>
+                    <version>6</version>
+                    <defaultLibBundleDir>lib</defaultLibBundleDir>
+                    <skinnyWars>true</skinnyWars>
+                    <packagingExcludes>
+                        lib/Properties-*.jar
+                    </packagingExcludes>
+
+                    <!-- Explode all archives on server (extremely time-consuming) -->
+                    <!--includeLibInApplicationXml>true</includeLibInApplicationXml-->
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/Product/Production/Deploy/pom.xml
+++ b/Product/Production/Deploy/pom.xml
@@ -28,48 +28,6 @@
     </reporting>
 
     <dependencies>
-        <dependency>
-            <groupId>org.connectopensource</groupId>
-            <artifactId>CONNECTCommonWeb</artifactId>
-            <version>${project.parent.version}</version>
-            <type>war</type>
-        </dependency>
-        <dependency>
-            <groupId>org.connectopensource</groupId>
-            <artifactId>CONNECTGatewayWeb</artifactId>
-            <version>${project.parent.version}</version>
-            <type>war</type>
-        </dependency>
-        <dependency>
-            <groupId>org.connectopensource</groupId>
-            <artifactId>CONNECTAdapterWeb</artifactId>
-            <version>${project.parent.version}</version>
-            <type>war</type>
-        </dependency>
-        <dependency>
-            <groupId>org.connectopensource</groupId>
-            <artifactId>AuditRepositoryCore</artifactId>
-            <version>${project.parent.version}</version>
-            <type>ejb</type>
-        </dependency>
-        <dependency>
-            <groupId>org.connectopensource</groupId>
-            <artifactId>CONNECTCommonWeb</artifactId>
-            <version>${project.parent.version}</version>
-            <type>pom</type>
-        </dependency>
-        <dependency>
-            <groupId>org.connectopensource</groupId>
-            <artifactId>CONNECTGatewayWeb</artifactId>
-            <version>${project.parent.version}</version>
-            <type>pom</type>
-        </dependency>
-        <dependency>
-            <groupId>org.connectopensource</groupId>
-            <artifactId>CONNECTAdapterWeb</artifactId>
-            <version>${project.parent.version}</version>
-            <type>pom</type>
-        </dependency>
 
         <!-- Security -->
         <dependency>
@@ -113,7 +71,6 @@
 
     <build>
         <finalName>${project.artifactId}</finalName>
-
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -121,27 +78,6 @@
                 <configuration>
                     <applicationName>CONNECT</applicationName>
                     <initialize-in-order>true</initialize-in-order>
-                    <modules>
-                        <ejbModule>
-                            <groupId>org.connectopensource</groupId>
-                            <artifactId>AuditRepositoryCore</artifactId>
-                        </ejbModule>
-                        <webModule>
-                            <groupId>org.connectopensource</groupId>
-                            <artifactId>CONNECTCommonWeb</artifactId>
-                            <contextRoot>/CONNECTCommon</contextRoot>
-                        </webModule>
-                        <webModule>
-                            <groupId>org.connectopensource</groupId>
-                            <artifactId>CONNECTGatewayWeb</artifactId>
-                            <contextRoot>/CONNECTGateway</contextRoot>
-                        </webModule>
-                        <webModule>
-                            <groupId>org.connectopensource</groupId>
-                            <artifactId>CONNECTAdapterWeb</artifactId>
-                            <contextRoot>/CONNECTAdapter</contextRoot>
-                        </webModule>
-                    </modules>
                     <version>6</version>
                     <defaultLibBundleDir>lib</defaultLibBundleDir>
                     <skinnyWars>true</skinnyWars>

--- a/Product/Production/Deploy/was/pom.xml
+++ b/Product/Production/Deploy/was/pom.xml
@@ -17,6 +17,48 @@
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.saaj-impl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTCommonWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTGatewayWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTAdapterWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>AuditRepositoryCore</artifactId>
+            <version>${project.parent.version}</version>
+            <type>ejb</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTCommonWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTGatewayWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTAdapterWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>pom</type>
+        </dependency>
     </dependencies>
 
     <build>
@@ -26,6 +68,27 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
                 <configuration>
+                    <modules>
+                        <ejbModule>
+                            <groupId>org.connectopensource</groupId>
+                            <artifactId>AuditRepositoryCore</artifactId>
+                        </ejbModule>
+                        <webModule>
+                            <groupId>org.connectopensource</groupId>
+                            <artifactId>CONNECTCommonWeb</artifactId>
+                            <contextRoot>/CONNECTCommon</contextRoot>
+                        </webModule>
+                        <webModule>
+                            <groupId>org.connectopensource</groupId>
+                            <artifactId>CONNECTGatewayWeb</artifactId>
+                            <contextRoot>/CONNECTGateway</contextRoot>
+                        </webModule>
+                        <webModule>
+                            <groupId>org.connectopensource</groupId>
+                            <artifactId>CONNECTAdapterWeb</artifactId>
+                            <contextRoot>/CONNECTAdapter</contextRoot>
+                        </webModule>
+                    </modules>
                     <packagingExcludes>
                         lib/jetty*,
                         lib/log4j-over-slf4j*.jar,

--- a/Product/Production/Deploy/weblogic/pom.xml
+++ b/Product/Production/Deploy/weblogic/pom.xml
@@ -28,6 +28,48 @@
             <artifactId>slf4j-api</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTCommonWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTGatewayWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTAdapterWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>AuditRepositoryCore</artifactId>
+            <version>${project.parent.version}</version>
+            <type>ejb</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTCommonWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTGatewayWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.connectopensource</groupId>
+            <artifactId>CONNECTAdapterWeb</artifactId>
+            <version>${project.parent.version}</version>
+            <type>pom</type>
+        </dependency>
     </dependencies>
 
     <build>
@@ -37,6 +79,27 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
                 <configuration>
+                    <modules>
+                        <ejbModule>
+                            <groupId>org.connectopensource</groupId>
+                            <artifactId>AuditRepositoryCore</artifactId>
+                        </ejbModule>
+                        <webModule>
+                            <groupId>org.connectopensource</groupId>
+                            <artifactId>CONNECTCommonWeb</artifactId>
+                            <contextRoot>/CONNECTCommon</contextRoot>
+                        </webModule>
+                        <webModule>
+                            <groupId>org.connectopensource</groupId>
+                            <artifactId>CONNECTGatewayWeb</artifactId>
+                            <contextRoot>/CONNECTGateway</contextRoot>
+                        </webModule>
+                        <webModule>
+                            <groupId>org.connectopensource</groupId>
+                            <artifactId>CONNECTAdapterWeb</artifactId>
+                            <contextRoot>/CONNECTAdapter</contextRoot>
+                        </webModule>
+                    </modules>
                     <version>6</version>
                     <packagingExcludes>
                         lib/geronimo-stax-api-*.jar,


### PR DESCRIPTION
1. Ear packaging changed into Application server specific pom since Glassfish requires EJB jar to be bundled in lib directory.
