### PR TITLE
FHAC-591:Remove xml-apis dependency from Direct module

### DIFF
--- a/Product/Production/Services/DirectCore/pom.xml
+++ b/Product/Production/Services/DirectCore/pom.xml
@@ -91,12 +91,6 @@
             <artifactId>spring-beans</artifactId>
         </dependency>
 
-        <!-- XML -->
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-        </dependency>
-
         <!-- Guava -->
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Remove xml-apis jar from Direct module. 
CONNECT ear is built without xml-apis and xercesImpl jar
