### PR TITLE
FHAC-520: Incorporated AsyncEJB to DS Audit logging

### DIFF
--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/AbstractInboundDocSubmission.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/AbstractInboundDocSubmission.java
@@ -53,11 +53,9 @@ public abstract class AbstractInboundDocSubmission implements InboundDocSubmissi
     public RegistryResponseType documentRepositoryProvideAndRegisterDocumentSetB(
         ProvideAndRegisterDocumentSetRequestType body, AssertionType assertion, Properties webContextProperties) {
 
-        auditRequestFromNhin(body, assertion, webContextProperties);
-
         RegistryResponseType response = processDocSubmission(body, assertion, webContextProperties);
 
-        auditResponseToNhin(body, response, assertion, webContextProperties);
+        auditResponse(body, response, assertion, webContextProperties);
 
         return response;
     }
@@ -68,31 +66,10 @@ public abstract class AbstractInboundDocSubmission implements InboundDocSubmissi
         return proxy.provideAndRegisterDocumentSetB(request, assertion);
     }
 
-    protected void auditRequestFromNhin(ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion,
-        Properties webContextProperties) {
-        auditLogger.auditRequestMessage(request, assertion, null, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
-            NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE, webContextProperties,
-            NhincConstants.NHINC_XDR_SERVICE_NAME);
-    }
-
-    protected void auditResponseToNhin(ProvideAndRegisterDocumentSetRequestType request, RegistryResponseType response,
+    protected void auditResponse(ProvideAndRegisterDocumentSetRequestType request, RegistryResponseType response,
         AssertionType assertion, Properties webContextProperties) {
         auditLogger.auditResponseMessage(request, response, assertion, null,
             NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE,
             Boolean.FALSE, webContextProperties, NhincConstants.NHINC_XDR_SERVICE_NAME);
-    }
-
-    protected void auditRequestToAdapter(ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion,
-        Properties webContextProperties) {
-        auditLogger.auditRequestMessage(request, assertion, null, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
-            NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE, Boolean.FALSE, webContextProperties,
-            NhincConstants.NHINC_XDR_SERVICE_NAME);
-    }
-
-    protected void auditResponseFromAdapter(ProvideAndRegisterDocumentSetRequestType request,
-        RegistryResponseType response, AssertionType assertion, Properties webContextProperties) {
-        auditLogger.auditResponseMessage(request, response, assertion, null, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
-            NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE, Boolean.FALSE, webContextProperties,
-            NhincConstants.NHINC_XDR_SERVICE_NAME);
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/StandardInboundDocSubmission.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/StandardInboundDocSubmission.java
@@ -87,11 +87,9 @@ public class StandardInboundDocSubmission extends AbstractInboundDocSubmission {
     public RegistryResponseType documentRepositoryProvideAndRegisterDocumentSetB(
         ProvideAndRegisterDocumentSetRequestType body, AssertionType assertion, Properties webContextProperties) {
 
-        auditRequestFromNhin(body, assertion, webContextProperties);
-
         RegistryResponseType response = processDocSubmission(body, assertion, webContextProperties);
 
-        auditResponseToNhin(body, response, assertion, webContextProperties);
+        auditResponse(body, response, assertion, webContextProperties);
 
         return response;
     }
@@ -104,7 +102,6 @@ public class StandardInboundDocSubmission extends AbstractInboundDocSubmission {
         String localHCID = getLocalHCID();
         if (isPolicyValid(body, assertion, localHCID)) {
             try {
-                auditRequestToAdapter(body, assertion, webContextProperties);
                 getDocSubmissionUtils().convertDataToFileLocationIfEnabled(body);
                 response = sendToAdapter(body, assertion);
             } catch (LargePayloadException lpe) {
@@ -115,8 +112,6 @@ public class StandardInboundDocSubmission extends AbstractInboundDocSubmission {
             LOG.error("Failed policy check.  Sending error response.");
             response = msgUtils.createFailedPolicyCheckResponse();
         }
-
-        auditResponseFromAdapter(body, response, assertion, webContextProperties);
 
         return response;
     }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/PassthroughOutboundDocSubmission.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/PassthroughOutboundDocSubmission.java
@@ -26,14 +26,12 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.outbound;
 
-import gov.hhs.fha.nhinc.aspect.OutboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.common.nhinccommon.UrlInfoType;
 import gov.hhs.fha.nhinc.common.nhinccommonproxy.RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType;
 import gov.hhs.fha.nhinc.docsubmission.MessageGeneratorUtils;
-import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionBaseEventDescriptionBuilder;
 import gov.hhs.fha.nhinc.docsubmission.audit.DocSubmissionAuditLogger;
 import gov.hhs.fha.nhinc.docsubmission.entity.OutboundDocSubmissionDelegate;
 import gov.hhs.fha.nhinc.docsubmission.entity.OutboundDocSubmissionOrchestratable;
@@ -65,28 +63,19 @@ public class PassthroughOutboundDocSubmission implements OutboundDocSubmission {
         RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request = createAuditRequest(body, assertion,
             targetSystem);
 
-        auditRequestToNhin(request, assertion, request.getNhinTargetSystem());
+        auditRequest(request, assertion, request.getNhinTargetSystem());
 
         OutboundDocSubmissionOrchestratable dsOrchestratable = createOrchestratable(dsDelegate, body, targetSystem, assertion);
         RegistryResponseType response = ((OutboundDocSubmissionOrchestratable) dsDelegate.process(dsOrchestratable))
             .getResponse();
 
-        auditResponseFromNhin(request, response, assertion, request.getNhinTargetSystem());
-
         return response;
     }
 
-    private void auditRequestToNhin(RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request,
+    private void auditRequest(RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request,
         AssertionType assertion, NhinTargetSystemType target) {
         auditLogger.auditRequestMessage(request.getProvideAndRegisterDocumentSetRequest(), assertion, target,
             NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE, null,
-            NhincConstants.NHINC_XDR_SERVICE_NAME);
-    }
-
-    private void auditResponseFromNhin(RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request,
-        RegistryResponseType response, AssertionType assertion, NhinTargetSystemType target) {
-        auditLogger.auditResponseMessage(request.getProvideAndRegisterDocumentSetRequest(), response, assertion, target,
-            NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE, null,
             NhincConstants.NHINC_XDR_SERVICE_NAME);
     }
 

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/StandardOutboundDocSubmission.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/StandardOutboundDocSubmission.java
@@ -67,7 +67,7 @@ public class StandardOutboundDocSubmission implements OutboundDocSubmission {
         RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request = createRequestForInternalProcessing(
             body, targets, urlInfo);
         NhinTargetSystemType target = getMessageGeneratorUtils().convertFirstToNhinTargetSystemType(targets);
-        auditRequestFromAdapter(request, assertion, target);
+        auditRequest(request.getProvideAndRegisterDocumentSetRequest(), assertion, target);
 
         if (isPolicyValid(request, assertion)) {
             LOG.info("Policy check successful");
@@ -76,8 +76,6 @@ public class StandardOutboundDocSubmission implements OutboundDocSubmission {
             LOG.error("Failed policy check.  Sending error response.");
             response = MessageGeneratorUtils.getInstance().createFailedPolicyCheckResponse();
         }
-
-        auditResponseToAdapter(request, response, assertion, target);
 
         return response;
     }
@@ -188,15 +186,10 @@ public class StandardOutboundDocSubmission implements OutboundDocSubmission {
         gov.hhs.fha.nhinc.common.nhinccommonproxy.RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request,
         AssertionType assertion) {
 
-        auditRequestToNhin(request, assertion, request.getNhinTargetSystem());
-
         OutboundDocSubmissionDelegate dsDelegate = getOutboundDocSubmissionDelegate();
         OutboundDocSubmissionOrchestratable dsOrchestratable = createOrchestratable(dsDelegate, request, assertion);
         RegistryResponseType response = ((OutboundDocSubmissionOrchestratable) dsDelegate.process(dsOrchestratable)).
             getResponse();
-
-        auditResponseFromNhin(request.getProvideAndRegisterDocumentSetRequest(), response, assertion, request.
-            getNhinTargetSystem());
 
         return response;
     }
@@ -214,31 +207,9 @@ public class StandardOutboundDocSubmission implements OutboundDocSubmission {
         return dsOrchestratable;
     }
 
-    private void auditRequestFromAdapter(RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request,
-        AssertionType assertion, NhinTargetSystemType target) {
-        auditLogger.auditRequestMessage(request.getProvideAndRegisterDocumentSetRequest(), assertion, target,
-            NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, Boolean.TRUE, null,
-            NhincConstants.NHINC_XDR_SERVICE_NAME);
-    }
-
-    private void auditResponseToAdapter(RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request,
-        RegistryResponseType response, AssertionType assertion, NhinTargetSystemType target) {
-        auditLogger.auditResponseMessage(request.getProvideAndRegisterDocumentSetRequest(), response, assertion, target,
-            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, Boolean.TRUE, null,
-            NhincConstants.NHINC_XDR_SERVICE_NAME);
-    }
-
-    private void auditRequestToNhin(
-        gov.hhs.fha.nhinc.common.nhinccommonproxy.RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request,
-        AssertionType assertion, NhinTargetSystemType target) {
-        auditLogger.auditRequestMessage(request.getProvideAndRegisterDocumentSetRequest(), assertion, target,
-            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE, null,
-            NhincConstants.NHINC_XDR_SERVICE_NAME);
-    }
-
-    private void auditResponseFromNhin(ProvideAndRegisterDocumentSetRequestType request,
-        RegistryResponseType response, AssertionType assertion, NhinTargetSystemType target) {
-        auditLogger.auditResponseMessage(request, response, assertion, target, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
+    private void auditRequest(ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion,
+        NhinTargetSystemType target) {
+        auditLogger.auditRequestMessage(request, assertion, target, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
             NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE, null, NhincConstants.NHINC_XDR_SERVICE_NAME);
     }
 

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/PassthroughInboundDocSubmissionTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/PassthroughInboundDocSubmissionTest.java
@@ -26,17 +26,12 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.inbound;
 
-import java.lang.reflect.Method;
-
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
-import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.docsubmission.DocSubmissionUtils;
-import gov.hhs.fha.nhinc.docsubmission.XDRAuditLogger;
 import gov.hhs.fha.nhinc.docsubmission.adapter.proxy.AdapterDocSubmissionProxy;
 import gov.hhs.fha.nhinc.docsubmission.adapter.proxy.AdapterDocSubmissionProxyObjectFactory;
-import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionBaseEventDescriptionBuilder;
 import gov.hhs.fha.nhinc.docsubmission.audit.DocSubmissionAuditLogger;
 import gov.hhs.fha.nhinc.largefile.LargePayloadException;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
@@ -47,15 +42,11 @@ import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -88,9 +79,6 @@ public class PassthroughInboundDocSubmissionTest {
 
         assertSame(expectedResponse, actualResponse);
 
-        verify(auditLogger).auditRequestMessage(eq(request), eq(assertion), isNull(NhinTargetSystemType.class),
-            eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
-            eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.NHINC_XDR_SERVICE_NAME));
         verify(auditLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
             isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
@@ -119,9 +107,6 @@ public class PassthroughInboundDocSubmissionTest {
         assertEquals("urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error", actualResponse.getRegistryErrorList()
             .getRegistryError().get(0).getSeverity());
 
-        verify(auditLogger).auditRequestMessage(eq(request), eq(assertion), isNull(NhinTargetSystemType.class),
-            eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
-            eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.NHINC_XDR_SERVICE_NAME));
         verify(auditLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
             isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/StandardInboundDocSubmissionTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/StandardInboundDocSubmissionTest.java
@@ -112,11 +112,6 @@ public class StandardInboundDocSubmissionTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(auditLogger)
-            .auditRequestMessage(eq(request), eq(assertion), eq(target),
-                eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
-                eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.NHINC_XDR_SERVICE_NAME));
-
-        verify(auditLogger)
             .auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), eq(target),
                 eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
                 eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.NHINC_XDR_SERVICE_NAME));
@@ -149,10 +144,6 @@ public class StandardInboundDocSubmissionTest {
         assertEquals("urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error", actualResponse.getRegistryErrorList()
             .getRegistryError().get(0).getSeverity());
 
-        verify(auditLogger).auditRequestMessage(eq(request), eq(assertion), isNull(NhinTargetSystemType.class),
-            eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
-            eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.NHINC_XDR_SERVICE_NAME));
-
         verify(auditLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
             NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(
             NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties), eq(
@@ -176,10 +167,6 @@ public class StandardInboundDocSubmissionTest {
         assertEquals("urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Failure", actualResponse.getStatus());
         assertEquals("urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error", actualResponse.getRegistryErrorList()
             .getRegistryError().get(0).getSeverity());
-
-        verify(auditLogger).auditRequestMessage(eq(request), eq(assertion), isNull(NhinTargetSystemType.class),
-            eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
-            eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.NHINC_XDR_SERVICE_NAME));
 
         verify(auditLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
             NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/PassthroughOutboundDocSubmissionTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/PassthroughOutboundDocSubmissionTest.java
@@ -29,18 +29,12 @@ package gov.hhs.fha.nhinc.docsubmission.outbound;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import java.lang.reflect.Method;
-
-import gov.hhs.fha.nhinc.aspect.OutboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
-import gov.hhs.fha.nhinc.common.nhinccommon.UrlInfoType;
-import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionBaseEventDescriptionBuilder;
 import gov.hhs.fha.nhinc.docsubmission.audit.DocSubmissionAuditLogger;
 import gov.hhs.fha.nhinc.docsubmission.entity.OutboundDocSubmissionDelegate;
 import gov.hhs.fha.nhinc.docsubmission.entity.OutboundDocSubmissionOrchestratable;
-import gov.hhs.fha.nhinc.docsubmission.outbound.PassthroughOutboundDocSubmission;
 import gov.hhs.fha.nhinc.document.DocumentConstants;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 import java.util.Properties;
@@ -94,10 +88,6 @@ public class PassthroughOutboundDocSubmissionTest {
             {
                 oneOf(mockDocSubmissionLog).auditRequestMessage(
                     with(any(ProvideAndRegisterDocumentSetRequestType.class)), with(any(AssertionType.class)),
-                    with(any(NhinTargetSystemType.class)), with(any(String.class)), with(any(String.class)),
-                    with(any(Boolean.class)), with(any(Properties.class)), with(any(String.class)));
-                oneOf(mockDocSubmissionLog).auditResponseMessage(with(any(ProvideAndRegisterDocumentSetRequestType.class)),
-                    with(any(RegistryResponseType.class)), with(any(AssertionType.class)),
                     with(any(NhinTargetSystemType.class)), with(any(String.class)), with(any(String.class)),
                     with(any(Boolean.class)), with(any(Properties.class)), with(any(String.class)));
             }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/StandardOutboundDocSubmissionTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/StandardOutboundDocSubmissionTest.java
@@ -109,16 +109,7 @@ public class StandardOutboundDocSubmissionTest {
             assertion, targets, new UrlInfoType());
 
         verify(mockLogger).auditRequestMessage(eq(request), eq(assertion), eq(target),
-            eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_ENTITY_INTERFACE),
-            eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_SERVICE_NAME));
-        verify(mockLogger).auditRequestMessage(eq(request), eq(assertion), eq(target),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
-            eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_SERVICE_NAME));
-        verify(mockLogger).auditResponseMessage(eq(request), eq(successResponse), eq(assertion), eq(target),
-            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_ENTITY_INTERFACE),
-            eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_SERVICE_NAME));
-        verify(mockLogger).auditResponseMessage(eq(request), eq(successResponse), eq(assertion), eq(target),
-            eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_SERVICE_NAME));
 
         assertNotNull(actualResponse);
@@ -145,10 +136,7 @@ public class StandardOutboundDocSubmissionTest {
             assertion, targets, new UrlInfoType());
 
         verify(mockLogger).auditRequestMessage(eq(request), eq(assertion), eq(target),
-            eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_ENTITY_INTERFACE),
-            eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_SERVICE_NAME));
-        verify(mockLogger).auditResponseMessage(eq(request), eq(response), eq(assertion), eq(target),
-            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_ENTITY_INTERFACE),
+            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_SERVICE_NAME));
 
         assertNotNull(response);
@@ -169,10 +157,7 @@ public class StandardOutboundDocSubmissionTest {
             assertion, null, new UrlInfoType());
 
         verify(mockLogger).auditRequestMessage(eq(request), eq(assertion), isNull(NhinTargetSystemType.class),
-            eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_ENTITY_INTERFACE),
-            eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_SERVICE_NAME));
-        verify(mockLogger).auditResponseMessage(eq(request), eq(response), eq(assertion), isNull(NhinTargetSystemType.class),
-            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_ENTITY_INTERFACE),
+            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_SERVICE_NAME));
 
         assertNotNull(response);


### PR DESCRIPTION
1. Updated DS audit logging to audit request and response only once.
2. Updated unit tests to reflect code changes.
