### PR TITLE
FHAC-599: Refactoring of PatientDiscoveryAuditTransforms class

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NullChecker.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NullChecker.java
@@ -59,4 +59,8 @@ public class NullChecker {
         return (!isNullish(value));
     }
 
+    public static boolean isNullishIgnoreSpace(String value) {
+        return (value != null && !value.trim().isEmpty());
+    }
+
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/AbstractPatientDiscoveryAuditTransforms.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/AbstractPatientDiscoveryAuditTransforms.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.patientdiscovery.audit.transform;
+
+import com.services.nhinc.schema.auditmessage.AuditMessageType;
+import com.services.nhinc.schema.auditmessage.ParticipantObjectIdentificationType;
+import gov.hhs.fha.nhinc.audit.transform.AuditTransforms;
+import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryAuditTransformsConstants;
+import gov.hhs.fha.nhinc.patientdiscovery.parser.PRPAIN201305UV02Parser;
+import gov.hhs.fha.nhinc.transform.marshallers.JAXBContextHandler;
+import java.io.ByteArrayOutputStream;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import org.apache.log4j.Logger;
+import org.hl7.v3.PRPAIN201305UV02;
+
+/**
+ * AbstractPatientDiscoveryAuditTransforms encapsulate the common functionality used by both
+ * PatientDiscoveryAuditTransforms and PatientDiscoveryDeferredRequestAuditTransforms
+ *
+ * @author tjafri
+ */
+public abstract class AbstractPatientDiscoveryAuditTransforms<T, K> extends AuditTransforms<T, K> {
+
+    private static final Logger LOG = Logger.getLogger(AbstractPatientDiscoveryAuditTransforms.class);
+    private static final String JAXB_HL7_CONTEXT_NAME = "org.hl7.v3";
+
+    protected AuditMessageType createPatientParticipantObjectIdentification(AuditMessageType auditMsg, String aa,
+        String patientId) {
+        LOG.info("createPatientParticipantObjectIdentification()");
+        ParticipantObjectIdentificationType participantObject = createParticipantObjectIdentification(
+            PatientDiscoveryAuditTransformsConstants.PARTICIPANT_PATIENT_OBJ_TYPE_CODE_SYSTEM,
+            PatientDiscoveryAuditTransformsConstants.PARTICIPANT_PATIENT_OBJ_TYPE_CODE_ROLE,
+            PatientDiscoveryAuditTransformsConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE,
+            PatientDiscoveryAuditTransformsConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE_SYSTEM,
+            PatientDiscoveryAuditTransformsConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_DISPLAY_NAME);
+
+        if (aa != null && patientId != null && !aa.isEmpty() && !patientId.isEmpty()) {
+            participantObject.setParticipantObjectID(createPatientId(aa, patientId));
+        }
+
+        auditMsg.getParticipantObjectIdentification().add(participantObject);
+
+        return auditMsg;
+    }
+
+    protected static String createPatientId(String assigningAuthId, String patientId) {
+        LOG.info("createPatientId()");
+        return patientId + "^^^&" + assigningAuthId + "&ISO";
+    }
+
+    protected AuditMessageType getQueryParamsParticipantObjectIdentificationForRequest(PRPAIN201305UV02 request,
+        AuditMessageType auditMsg) throws JAXBException {
+        LOG.info("getQueryParamsParticipantObjectIdentificationForRequest()");
+        ParticipantObjectIdentificationType participantObject = buildBaseParticipantObjectIdentificationType(
+            PRPAIN201305UV02Parser.getQueryId(request));
+        participantObject.setParticipantObjectQuery(getParticipantObjectQueryForRequest(request));
+        auditMsg.getParticipantObjectIdentification().add(participantObject);
+        return auditMsg;
+    }
+
+    protected byte[] getParticipantObjectQueryForRequest(PRPAIN201305UV02 request) throws JAXBException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        if (request.getControlActProcess() != null && request.getControlActProcess().getQueryByParameter() != null) {
+            getMarshaller().marshal(request.getControlActProcess().getQueryByParameter(), baos);
+        }
+        return baos.toByteArray();
+    }
+
+    protected ParticipantObjectIdentificationType buildBaseParticipantObjectIdentificationType(
+        String participantObjectId) {
+        LOG.info("buildBaseParticipantObjectIdentificationType()");
+        ParticipantObjectIdentificationType participantObject = createParticipantObjectIdentification(
+            PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_SYSTEM,
+            PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_ROLE,
+            PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE,
+            PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE_SYSTEM,
+            PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_DISPLAY_NAME);
+        participantObject.setParticipantObjectID(participantObjectId);
+        return participantObject;
+    }
+
+    protected Marshaller getMarshaller() throws JAXBException {
+        return new JAXBContextHandler().getJAXBContext(JAXB_HL7_CONTEXT_NAME).createMarshaller();
+    }
+
+    @Override
+    protected String getServiceEventIdCodeRequestor() {
+        return PatientDiscoveryAuditTransformsConstants.EVENT_ID_CODE;
+    }
+
+    @Override
+    protected String getServiceEventIdCodeResponder() {
+        return PatientDiscoveryAuditTransformsConstants.EVENT_ID_CODE;
+    }
+
+    @Override
+    protected String getServiceEventCodeSystem() {
+        return PatientDiscoveryAuditTransformsConstants.EVENT_CODE_SYSTEM;
+    }
+
+    @Override
+    protected String getServiceEventDisplayRequestor() {
+        return PatientDiscoveryAuditTransformsConstants.EVENT_CODE_DISPLAY_REQUESTOR;
+    }
+
+    @Override
+    protected String getServiceEventDisplayResponder() {
+        return PatientDiscoveryAuditTransformsConstants.EVENT_CODE_DISPLAY_RESPONDER;
+    }
+
+    @Override
+    protected String getServiceEventTypeCode() {
+        return PatientDiscoveryAuditTransformsConstants.EVENT_TYPE_CODE;
+    }
+
+    @Override
+    protected String getServiceEventTypeCodeSystem() {
+        return PatientDiscoveryAuditTransformsConstants.EVENT_TYPE_CODE_SYSTEM;
+    }
+
+    @Override
+    protected String getServiceEventTypeCodeDisplayName() {
+        return PatientDiscoveryAuditTransformsConstants.EVENT_TYPE_CODE_DISPLAY_NAME;
+    }
+
+    @Override
+    protected String getServiceEventActionCodeRequestor() {
+        return PatientDiscoveryAuditTransformsConstants.EVENT_ACTION_CODE_REQUESTOR;
+    }
+
+    @Override
+    protected String getServiceEventActionCodeResponder() {
+        return PatientDiscoveryAuditTransformsConstants.EVENT_ACTION_CODE_RESPONDER;
+    }
+}

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/AbstractPatientDiscoveryAuditTransforms.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/AbstractPatientDiscoveryAuditTransforms.java
@@ -29,6 +29,7 @@ package gov.hhs.fha.nhinc.patientdiscovery.audit.transform;
 import com.services.nhinc.schema.auditmessage.AuditMessageType;
 import com.services.nhinc.schema.auditmessage.ParticipantObjectIdentificationType;
 import gov.hhs.fha.nhinc.audit.transform.AuditTransforms;
+import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryAuditTransformsConstants;
 import gov.hhs.fha.nhinc.patientdiscovery.parser.PRPAIN201305UV02Parser;
 import gov.hhs.fha.nhinc.patientdiscovery.parser.PRPAIN201306UV02Parser;
@@ -43,7 +44,8 @@ import org.hl7.v3.PRPAIN201306UV02;
 
 /**
  * AbstractPatientDiscoveryAuditTransforms encapsulate the common functionality used by both
- * PatientDiscoveryAuditTransforms and PatientDiscoveryDeferredRequestAuditTransforms
+ * PatientDiscoveryAuditTransforms, PatientDiscoveryDeferredRequestAuditTransforms and
+ * PatientDiscoveryDeferredResponseAuditTransforms
  *
  * @author tjafri
  */
@@ -163,13 +165,14 @@ public abstract class AbstractPatientDiscoveryAuditTransforms<T, K> extends Audi
         AuditMessageType auditMsg) {
 
         List<II> oII = PRPAIN201306UV02Parser.getPatientIds(response);
-        if (oII != null && oII.size() > 0) {
+        if (oII != null && !oII.isEmpty()) {
             for (II entry : oII) {
                 if (entry == null) {
                     createPatientParticipantObjectIdentification(auditMsg, null, null);
                 } else {
-                    createPatientParticipantObjectIdentification(auditMsg, isNotNullish(entry.getRoot()) ? entry.
-                        getRoot().trim() : null, isNotNullish(entry.getRoot()) ? entry.getExtension().trim() : null);
+                    createPatientParticipantObjectIdentification(auditMsg, NullChecker.isNullishIgnoreSpace(entry.
+                        getRoot()) ? entry.getRoot().trim() : null, NullChecker.isNullishIgnoreSpace(entry.
+                            getRoot()) ? entry.getExtension().trim() : null);
                 }
             }
         } else {
@@ -212,9 +215,5 @@ public abstract class AbstractPatientDiscoveryAuditTransforms<T, K> extends Audi
             getMarshaller().marshal(response.getControlActProcess().getQueryByParameter(), baos);
         }
         return baos.toByteArray();
-    }
-
-    private boolean isNotNullish(String value) {
-        return (value != null && !value.trim().isEmpty());
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransforms.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransforms.java
@@ -28,37 +28,31 @@ package gov.hhs.fha.nhinc.patientdiscovery.audit.transform;
 
 import com.services.nhinc.schema.auditmessage.AuditMessageType;
 import com.services.nhinc.schema.auditmessage.ParticipantObjectIdentificationType;
-import gov.hhs.fha.nhinc.audit.transform.AuditTransforms;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
-import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryAuditTransformsConstants;
-import gov.hhs.fha.nhinc.transform.marshallers.JAXBContextHandler;
+import gov.hhs.fha.nhinc.patientdiscovery.parser.PRPAIN201305UV02Parser;
+import gov.hhs.fha.nhinc.patientdiscovery.parser.PRPAIN201306UV02Parser;
 import java.io.ByteArrayOutputStream;
 import java.util.List;
 import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
 import org.apache.log4j.Logger;
 import org.hl7.v3.II;
 import org.hl7.v3.PRPAIN201305UV02;
 import org.hl7.v3.PRPAIN201306UV02;
-import org.hl7.v3.PRPAIN201306UV02MFMIMT700711UV01Subject1;
-import org.hl7.v3.PRPAMT201306UV02LivingSubjectId;
 
 /**
  * Patient Discovery audit transforms to support PD audit logging.
  *
  * @author achidamb
  */
-public class PatientDiscoveryAuditTransforms extends AuditTransforms<PRPAIN201305UV02, PRPAIN201306UV02> {
+public class PatientDiscoveryAuditTransforms extends AbstractPatientDiscoveryAuditTransforms<
+    PRPAIN201305UV02, PRPAIN201306UV02> {
 
     private static final Logger LOG = Logger.getLogger(PatientDiscoveryAuditTransforms.class);
-
-    private static final String JAXB_HL7_CONTEXT_NAME = "org.hl7.v3";
 
     @Override
     protected AuditMessageType getParticipantObjectIdentificationForRequest(PRPAIN201305UV02 request,
         AssertionType assertion, AuditMessageType auditMsg) {
 
-        // TODO: auditMsg should either use a builder, or modify in-method with no return
         auditMsg = getPatientParticipantObjectIdentificationForRequest(request, auditMsg);
         try {
             auditMsg = getQueryParamsParticipantObjectIdentificationForRequest(request, auditMsg);
@@ -90,7 +84,7 @@ public class PatientDiscoveryAuditTransforms extends AuditTransforms<PRPAIN20130
         AuditMessageType auditMsg) {
 
         // Set the Partipation Object Id (patient id)
-        II oII = getPatientIdFromRequest(request);
+        II oII = PRPAIN201305UV02Parser.getPatientId(request);
         if (oII != null && oII.getRoot() != null && oII.getExtension() != null && !oII.getRoot().isEmpty()
             && !oII.getExtension().isEmpty()) {
 
@@ -105,7 +99,7 @@ public class PatientDiscoveryAuditTransforms extends AuditTransforms<PRPAIN20130
     private AuditMessageType getPatientParticipantObjectIdentificationForResponse(PRPAIN201306UV02 response,
         AuditMessageType auditMsg) {
 
-        List<II> oII = getPatientIdFromResponse(response);
+        List<II> oII = PRPAIN201306UV02Parser.getPatientIds(response);
         if (oII != null && oII.size() > 0) {
             for (II entry : oII) {
                 if (entry != null && entry.getRoot() != null && entry.getExtension() != null
@@ -120,149 +114,14 @@ public class PatientDiscoveryAuditTransforms extends AuditTransforms<PRPAIN20130
         return auditMsg;
     }
 
-    private II getPatientIdFromRequest(PRPAIN201305UV02 request) {
-        II livingSubjectId = null;
-
-        // TODO: We should use a helper library to get elements nested this deeply
-        if (request != null && request.getControlActProcess() != null
-            && request.getControlActProcess().getQueryByParameter() != null
-            && request.getControlActProcess().getQueryByParameter().getValue() != null
-            && request.getControlActProcess().getQueryByParameter().getValue().getParameterList() != null
-            && request.getControlActProcess().getQueryByParameter().getValue().getParameterList()
-            .getLivingSubjectId() != null) {
-
-            List<PRPAMT201306UV02LivingSubjectId> ids = request.getControlActProcess().getQueryByParameter().getValue()
-                .getParameterList().getLivingSubjectId();
-
-            if (ids.size() == 1) {
-                livingSubjectId = getLivingSubjectId(ids.get(0));
-            } else if (ids.size() > 1) {
-                livingSubjectId = getLivingSubjectIdFromAuthorOrPerformerValue(request, ids);
-            }
-        } else {
-            LOG.error("PatientId doesn't exist in the received PRPAIN201305UV02 message");
-        }
-
-        return livingSubjectId;
-    }
-
-    private II getLivingSubjectIdFromAuthorOrPerformerValue(PRPAIN201305UV02 request,
-        List<PRPAMT201306UV02LivingSubjectId> ids) {
-
-        II livingSubjectId = null;
-
-        // Get assignedDevice root
-        if (request.getControlActProcess().getAuthorOrPerformer() != null
-            && !request.getControlActProcess().getAuthorOrPerformer().isEmpty()
-            && request.getControlActProcess().getAuthorOrPerformer().get(0) != null
-            && request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice() != null
-            && request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice().getValue() != null
-            && request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice().getValue()
-            .getId() != null
-            && !request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice().getValue().getId()
-            .isEmpty()
-            && request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice().getValue().getId()
-            .get(0) != null
-            && request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice().getValue().getId()
-            .get(0).getRoot() != null) {
-
-            String root = request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice()
-                .getValue().getId().get(0).getRoot();
-
-            // Compare assignedDevice root to each livingSubjectId root
-            for (PRPAMT201306UV02LivingSubjectId id : ids) {
-                II oII = getLivingSubjectId(id);
-
-                if (oII != null && oII.getRoot() != null && oII.getRoot().equals(root)) {
-                    livingSubjectId = oII;
-                    break;
-                }
-            }
-        } else {
-            livingSubjectId = getLivingSubjectId(ids.get(0));
-        }
-
-        return livingSubjectId;
-    }
-
-    private II getLivingSubjectId(PRPAMT201306UV02LivingSubjectId id) {
-        II oII = null;
-
-        if (id != null && id.getValue() != null) {
-            oII = id.getValue().get(0);
-        }
-
-        return oII;
-    }
-
-    private List<II> getPatientIdFromResponse(PRPAIN201306UV02 response) {
-        List<II> oIIs = null;
-        if (response != null && response.getControlActProcess() != null
-            && response.getControlActProcess().getSubject() != null) {
-
-            for (PRPAIN201306UV02MFMIMT700711UV01Subject1 subject : response.getControlActProcess().getSubject()) {
-                if (subject.getRegistrationEvent() != null && subject.getRegistrationEvent().getSubject1() != null
-                    && subject.getRegistrationEvent().getSubject1().getPatient() != null
-                    && subject.getRegistrationEvent().getSubject1().getPatient().getId() != null) {
-
-                    oIIs = subject.getRegistrationEvent().getSubject1().getPatient().getId();
-                } else {
-                    LOG.error("PatientId doesn't exist in the received PRPAIN201306UV02 message");
-                }
-            }
-        }
-        return oIIs;
-    }
-
-    private AuditMessageType createPatientParticipantObjectIdentification(AuditMessageType auditMsg, String aa,
-        String patientId) {
-
-        ParticipantObjectIdentificationType participantObject = createParticipantObjectIdentification(
-            PatientDiscoveryAuditTransformsConstants.PARTICIPANT_PATIENT_OBJ_TYPE_CODE_SYSTEM,
-            PatientDiscoveryAuditTransformsConstants.PARTICIPANT_PATIENT_OBJ_TYPE_CODE_ROLE,
-            PatientDiscoveryAuditTransformsConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE,
-            PatientDiscoveryAuditTransformsConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_CODE_SYSTEM,
-            PatientDiscoveryAuditTransformsConstants.PARTICIPANT_PATIENT_OBJ_ID_TYPE_DISPLAY_NAME);
-
-        if (aa != null && patientId != null && !aa.isEmpty() && !patientId.isEmpty()) {
-            participantObject.setParticipantObjectID(createPatientId(aa, patientId));
-        }
-
-        auditMsg.getParticipantObjectIdentification().add(participantObject);
-
-        return auditMsg;
-    }
-
-    private static String createPatientId(String assigningAuthId, String patientId) {
-        return patientId + "^^^&" + assigningAuthId + "&ISO";
-    }
-
-    private AuditMessageType getQueryParamsParticipantObjectIdentificationForRequest(PRPAIN201305UV02 request,
-        AuditMessageType auditMsg) throws JAXBException {
-
-        ParticipantObjectIdentificationType participantObject = buildBaseParticipantObjectIdentificationType(
-            getParticipantObjectId(request));
-        participantObject.setParticipantObjectQuery(getParticipantObjectQueryForRequest(request));
-        auditMsg.getParticipantObjectIdentification().add(participantObject);
-        return auditMsg;
-    }
-
     private AuditMessageType getQueryParamsParticipantObjectIdentificationForResponse(PRPAIN201306UV02 response,
         AuditMessageType auditMsg) throws JAXBException {
 
         ParticipantObjectIdentificationType participantObject = buildBaseParticipantObjectIdentificationType(
-            getParticipantObjectId(response));
+            PRPAIN201306UV02Parser.getQueryId(response));
         participantObject.setParticipantObjectQuery(getParticipantObjectQueryForResponse(response));
         auditMsg.getParticipantObjectIdentification().add(participantObject);
         return auditMsg;
-    }
-
-    private byte[] getParticipantObjectQueryForRequest(PRPAIN201305UV02 request) throws JAXBException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        if (request.getControlActProcess() != null && request.getControlActProcess().getQueryByParameter() != null) {
-            getMarshaller().marshal(request.getControlActProcess().getQueryByParameter(), baos);
-        }
-        return baos.toByteArray();
     }
 
     private byte[] getParticipantObjectQueryForResponse(PRPAIN201306UV02 response) throws JAXBException {
@@ -272,102 +131,4 @@ public class PatientDiscoveryAuditTransforms extends AuditTransforms<PRPAIN20130
         }
         return baos.toByteArray();
     }
-
-    private ParticipantObjectIdentificationType buildBaseParticipantObjectIdentificationType(
-        String participantObjectId) {
-
-        ParticipantObjectIdentificationType participantObject = createParticipantObjectIdentification(
-            PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_SYSTEM,
-            PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_ROLE,
-            PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE,
-            PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE_SYSTEM,
-            PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_DISPLAY_NAME);
-        participantObject.setParticipantObjectID(participantObjectId);
-        return participantObject;
-    }
-
-    private String getParticipantObjectId(PRPAIN201305UV02 request) {
-        String oid = null;
-
-        if (request != null
-            && request.getControlActProcess() != null
-            && request.getControlActProcess().getQueryByParameter() != null
-            && request.getControlActProcess().getQueryByParameter().getValue() != null
-            && request.getControlActProcess().getQueryByParameter().getValue().getQueryId() != null) {
-
-            oid = request.getControlActProcess().getQueryByParameter().getValue().getQueryId().getExtension();
-        }
-
-        return oid;
-    }
-
-    private String getParticipantObjectId(PRPAIN201306UV02 response) {
-        String oid = null;
-
-        if (response != null
-            && response.getControlActProcess() != null
-            && response.getControlActProcess().getQueryByParameter() != null
-            && response.getControlActProcess().getQueryByParameter().getValue() != null
-            && response.getControlActProcess().getQueryByParameter().getValue().getQueryId() != null) {
-
-            oid = response.getControlActProcess().getQueryByParameter().getValue().getQueryId().getExtension();
-        }
-
-        return oid;
-    }
-
-    private Marshaller getMarshaller() throws JAXBException {
-        return new JAXBContextHandler().getJAXBContext(JAXB_HL7_CONTEXT_NAME).createMarshaller();
-    }
-
-    @Override
-    protected String getServiceEventIdCodeRequestor() {
-        return PatientDiscoveryAuditTransformsConstants.EVENT_ID_CODE;
-    }
-
-    @Override
-    protected String getServiceEventIdCodeResponder() {
-        return PatientDiscoveryAuditTransformsConstants.EVENT_ID_CODE;
-    }
-
-    @Override
-    protected String getServiceEventCodeSystem() {
-        return PatientDiscoveryAuditTransformsConstants.EVENT_CODE_SYSTEM;
-    }
-
-    @Override
-    protected String getServiceEventDisplayRequestor() {
-        return PatientDiscoveryAuditTransformsConstants.EVENT_CODE_DISPLAY_REQUESTOR;
-    }
-
-    @Override
-    protected String getServiceEventDisplayResponder() {
-        return PatientDiscoveryAuditTransformsConstants.EVENT_CODE_DISPLAY_RESPONDER;
-    }
-
-    @Override
-    protected String getServiceEventTypeCode() {
-        return PatientDiscoveryAuditTransformsConstants.EVENT_TYPE_CODE;
-    }
-
-    @Override
-    protected String getServiceEventTypeCodeSystem() {
-        return PatientDiscoveryAuditTransformsConstants.EVENT_TYPE_CODE_SYSTEM;
-    }
-
-    @Override
-    protected String getServiceEventTypeCodeDisplayName() {
-        return PatientDiscoveryAuditTransformsConstants.EVENT_TYPE_CODE_DISPLAY_NAME;
-    }
-
-    @Override
-    protected String getServiceEventActionCodeRequestor() {
-        return PatientDiscoveryAuditTransformsConstants.EVENT_ACTION_CODE_REQUESTOR;
-    }
-
-    @Override
-    protected String getServiceEventActionCodeResponder() {
-        return PatientDiscoveryAuditTransformsConstants.EVENT_ACTION_CODE_RESPONDER;
-    }
-
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransforms.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransforms.java
@@ -27,15 +27,9 @@
 package gov.hhs.fha.nhinc.patientdiscovery.audit.transform;
 
 import com.services.nhinc.schema.auditmessage.AuditMessageType;
-import com.services.nhinc.schema.auditmessage.ParticipantObjectIdentificationType;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
-import gov.hhs.fha.nhinc.patientdiscovery.parser.PRPAIN201305UV02Parser;
-import gov.hhs.fha.nhinc.patientdiscovery.parser.PRPAIN201306UV02Parser;
-import java.io.ByteArrayOutputStream;
-import java.util.List;
 import javax.xml.bind.JAXBException;
 import org.apache.log4j.Logger;
-import org.hl7.v3.II;
 import org.hl7.v3.PRPAIN201305UV02;
 import org.hl7.v3.PRPAIN201306UV02;
 
@@ -78,57 +72,5 @@ public class PatientDiscoveryAuditTransforms extends AbstractPatientDiscoveryAud
         }
 
         return auditMsg;
-    }
-
-    private AuditMessageType getPatientParticipantObjectIdentificationForRequest(PRPAIN201305UV02 request,
-        AuditMessageType auditMsg) {
-
-        // Set the Partipation Object Id (patient id)
-        II oII = PRPAIN201305UV02Parser.getPatientId(request);
-        if (oII != null && oII.getRoot() != null && oII.getExtension() != null && !oII.getRoot().isEmpty()
-            && !oII.getExtension().isEmpty()) {
-
-            createPatientParticipantObjectIdentification(auditMsg, oII.getRoot(), oII.getExtension());
-        } else {
-            createPatientParticipantObjectIdentification(auditMsg, null, null);
-        }
-
-        return auditMsg;
-    }
-
-    private AuditMessageType getPatientParticipantObjectIdentificationForResponse(PRPAIN201306UV02 response,
-        AuditMessageType auditMsg) {
-
-        List<II> oII = PRPAIN201306UV02Parser.getPatientIds(response);
-        if (oII != null && oII.size() > 0) {
-            for (II entry : oII) {
-                if (entry != null && entry.getRoot() != null && entry.getExtension() != null
-                    && !entry.getRoot().isEmpty() && !entry.getExtension().isEmpty()) {
-                    createPatientParticipantObjectIdentification(auditMsg, entry.getRoot(), entry.getExtension());
-                }
-            }
-        } else {
-            createPatientParticipantObjectIdentification(auditMsg, null, null);
-        }
-
-        return auditMsg;
-    }
-
-    private AuditMessageType getQueryParamsParticipantObjectIdentificationForResponse(PRPAIN201306UV02 response,
-        AuditMessageType auditMsg) throws JAXBException {
-
-        ParticipantObjectIdentificationType participantObject = buildBaseParticipantObjectIdentificationType(
-            PRPAIN201306UV02Parser.getQueryId(response));
-        participantObject.setParticipantObjectQuery(getParticipantObjectQueryForResponse(response));
-        auditMsg.getParticipantObjectIdentification().add(participantObject);
-        return auditMsg;
-    }
-
-    private byte[] getParticipantObjectQueryForResponse(PRPAIN201306UV02 response) throws JAXBException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        if (response.getControlActProcess() != null && response.getControlActProcess().getQueryByParameter() != null) {
-            getMarshaller().marshal(response.getControlActProcess().getQueryByParameter(), baos);
-        }
-        return baos.toByteArray();
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201305UV02Parser.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201305UV02Parser.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.patientdiscovery.parser;
+
+import java.util.List;
+import org.apache.log4j.Logger;
+import org.hl7.v3.II;
+import org.hl7.v3.PRPAIN201305UV02;
+import org.hl7.v3.PRPAMT201306UV02LivingSubjectId;
+
+/**
+ * This is a utility class that parses the PRPAIN201305UV02 message and extract patientId and participantObjectId from
+ * it.
+ *
+ * @author tjafri
+ */
+public class PRPAIN201305UV02Parser {
+
+    private static final Logger LOG = Logger.getLogger(PRPAIN201305UV02Parser.class);
+
+    public static II getPatientId(PRPAIN201305UV02 request) {
+        LOG.info("getPatientId()");
+        II livingSubjectId = null;
+
+        if (request != null && request.getControlActProcess() != null
+            && request.getControlActProcess().getQueryByParameter() != null
+            && request.getControlActProcess().getQueryByParameter().getValue() != null
+            && request.getControlActProcess().getQueryByParameter().getValue().getParameterList() != null
+            && request.getControlActProcess().getQueryByParameter().getValue().getParameterList()
+            .getLivingSubjectId() != null) {
+
+            List<PRPAMT201306UV02LivingSubjectId> ids = request.getControlActProcess().getQueryByParameter().getValue()
+                .getParameterList().getLivingSubjectId();
+
+            if (ids.size() == 1) {
+                livingSubjectId = getLivingSubjectId(ids.get(0));
+            } else if (ids.size() > 1) {
+                livingSubjectId = getLivingSubjectIdFromAuthorOrPerformerValue(request, ids);
+            }
+        } else {
+            LOG.error("PatientId doesn't exist in the received PRPAIN201305UV02 message");
+        }
+
+        return livingSubjectId;
+    }
+
+    public static String getQueryId(PRPAIN201305UV02 request) {
+        LOG.info("getQueryId()");
+        String oid = null;
+
+        if (request != null
+            && request.getControlActProcess() != null
+            && request.getControlActProcess().getQueryByParameter() != null
+            && request.getControlActProcess().getQueryByParameter().getValue() != null
+            && request.getControlActProcess().getQueryByParameter().getValue().getQueryId() != null) {
+
+            oid = request.getControlActProcess().getQueryByParameter().getValue().getQueryId().getExtension();
+        }
+        return oid;
+    }
+
+    private static II getLivingSubjectIdFromAuthorOrPerformerValue(PRPAIN201305UV02 request,
+        List<PRPAMT201306UV02LivingSubjectId> ids) {
+
+        II livingSubjectId = null;
+
+        // Get assignedDevice root
+        if (request.getControlActProcess().getAuthorOrPerformer() != null
+            && !request.getControlActProcess().getAuthorOrPerformer().isEmpty()
+            && request.getControlActProcess().getAuthorOrPerformer().get(0) != null
+            && request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice() != null
+            && request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice().getValue() != null
+            && request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice().getValue()
+            .getId() != null
+            && !request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice().getValue().getId()
+            .isEmpty()
+            && request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice().getValue().getId()
+            .get(0) != null
+            && request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice().getValue().getId()
+            .get(0).getRoot() != null) {
+
+            String root = request.getControlActProcess().getAuthorOrPerformer().get(0).getAssignedDevice()
+                .getValue().getId().get(0).getRoot();
+
+            // Compare assignedDevice root to each livingSubjectId root
+            for (PRPAMT201306UV02LivingSubjectId id : ids) {
+                II oII = getLivingSubjectId(id);
+
+                if (oII != null && oII.getRoot() != null && oII.getRoot().equals(root)) {
+                    livingSubjectId = oII;
+                    break;
+                }
+            }
+        } else {
+            livingSubjectId = getLivingSubjectId(ids.get(0));
+        }
+
+        return livingSubjectId;
+    }
+
+    private static II getLivingSubjectId(PRPAMT201306UV02LivingSubjectId id) {
+        II oII = null;
+
+        if (id != null && id.getValue() != null) {
+            oII = id.getValue().get(0);
+        }
+
+        return oII;
+    }
+}

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201305UV02Parser.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201305UV02Parser.java
@@ -43,7 +43,6 @@ public class PRPAIN201305UV02Parser {
     private static final Logger LOG = Logger.getLogger(PRPAIN201305UV02Parser.class);
 
     public static II getPatientId(PRPAIN201305UV02 request) {
-        LOG.info("getPatientId()");
         II livingSubjectId = null;
 
         if (request != null && request.getControlActProcess() != null
@@ -55,7 +54,7 @@ public class PRPAIN201305UV02Parser {
 
             List<PRPAMT201306UV02LivingSubjectId> ids = request.getControlActProcess().getQueryByParameter().getValue()
                 .getParameterList().getLivingSubjectId();
-            if (ids != null) {
+            if (ids != null && !ids.isEmpty()) {
                 if (ids.size() == 1) {
                     livingSubjectId = getLivingSubjectId(ids.get(0));
                 } else if (ids.size() > 1) {
@@ -70,7 +69,6 @@ public class PRPAIN201305UV02Parser {
     }
 
     public static String getQueryId(PRPAIN201305UV02 request) {
-        LOG.info("getQueryId()");
         String oid = null;
 
         if (request != null
@@ -126,7 +124,7 @@ public class PRPAIN201305UV02Parser {
     private static II getLivingSubjectId(PRPAMT201306UV02LivingSubjectId id) {
         II oII = null;
 
-        if (id != null && id.getValue() != null && id.getValue().size() > 0) {
+        if (id != null && id.getValue() != null && !id.getValue().isEmpty()) {
             oII = id.getValue().get(0);
         }
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201305UV02Parser.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201305UV02Parser.java
@@ -55,11 +55,12 @@ public class PRPAIN201305UV02Parser {
 
             List<PRPAMT201306UV02LivingSubjectId> ids = request.getControlActProcess().getQueryByParameter().getValue()
                 .getParameterList().getLivingSubjectId();
-
-            if (ids.size() == 1) {
-                livingSubjectId = getLivingSubjectId(ids.get(0));
-            } else if (ids.size() > 1) {
-                livingSubjectId = getLivingSubjectIdFromAuthorOrPerformerValue(request, ids);
+            if (ids != null) {
+                if (ids.size() == 1) {
+                    livingSubjectId = getLivingSubjectId(ids.get(0));
+                } else if (ids.size() > 1) {
+                    livingSubjectId = getLivingSubjectIdFromAuthorOrPerformerValue(request, ids);
+                }
             }
         } else {
             LOG.error("PatientId doesn't exist in the received PRPAIN201305UV02 message");
@@ -125,7 +126,7 @@ public class PRPAIN201305UV02Parser {
     private static II getLivingSubjectId(PRPAMT201306UV02LivingSubjectId id) {
         II oII = null;
 
-        if (id != null && id.getValue() != null) {
+        if (id != null && id.getValue() != null && id.getValue().size() > 0) {
             oII = id.getValue().get(0);
         }
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201306UV02Parser.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201306UV02Parser.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.patientdiscovery.parser;
+
+import java.util.List;
+import org.apache.log4j.Logger;
+import org.hl7.v3.II;
+import org.hl7.v3.PRPAIN201306UV02;
+import org.hl7.v3.PRPAIN201306UV02MFMIMT700711UV01Subject1;
+
+/**
+ * This is a utility class that parses the PRPAIN201306UV02 message and extract patientId and participantObjectId from
+ * it.
+ *
+ * @author tjafri
+ */
+public class PRPAIN201306UV02Parser {
+
+    private static final Logger LOG = Logger.getLogger(PRPAIN201306UV02Parser.class);
+
+    public static String getQueryId(PRPAIN201306UV02 response) {
+        LOG.info("getQueryId()");
+        String oid = null;
+
+        if (response != null
+            && response.getControlActProcess() != null
+            && response.getControlActProcess().getQueryByParameter() != null
+            && response.getControlActProcess().getQueryByParameter().getValue() != null
+            && response.getControlActProcess().getQueryByParameter().getValue().getQueryId() != null) {
+
+            oid = response.getControlActProcess().getQueryByParameter().getValue().getQueryId().getExtension();
+        }
+
+        return oid;
+    }
+
+    public static List<II> getPatientIds(PRPAIN201306UV02 response) {
+        LOG.info("getPatientIds()");
+        List<II> oIIs = null;
+        if (response != null && response.getControlActProcess() != null
+            && response.getControlActProcess().getSubject() != null) {
+
+            for (PRPAIN201306UV02MFMIMT700711UV01Subject1 subject : response.getControlActProcess().getSubject()) {
+                if (subject.getRegistrationEvent() != null && subject.getRegistrationEvent().getSubject1() != null
+                    && subject.getRegistrationEvent().getSubject1().getPatient() != null
+                    && subject.getRegistrationEvent().getSubject1().getPatient().getId() != null) {
+
+                    oIIs = subject.getRegistrationEvent().getSubject1().getPatient().getId();
+                } else {
+                    LOG.error("PatientId doesn't exist in the received PRPAIN201306UV02 message");
+                }
+            }
+        }
+        return oIIs;
+    }
+}

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201306UV02Parser.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201306UV02Parser.java
@@ -26,6 +26,7 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.parser;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.log4j.Logger;
 import org.hl7.v3.II;
@@ -63,17 +64,17 @@ public class PRPAIN201306UV02Parser {
         List<II> oIIs = null;
         if (response != null && response.getControlActProcess() != null
             && response.getControlActProcess().getSubject() != null) {
-
+            oIIs = new ArrayList<>();
             for (PRPAIN201306UV02MFMIMT700711UV01Subject1 subject : response.getControlActProcess().getSubject()) {
                 if (subject.getRegistrationEvent() != null && subject.getRegistrationEvent().getSubject1() != null
                     && subject.getRegistrationEvent().getSubject1().getPatient() != null
                     && subject.getRegistrationEvent().getSubject1().getPatient().getId() != null) {
 
-                    oIIs = subject.getRegistrationEvent().getSubject1().getPatient().getId();
-                } else {
-                    LOG.error("PatientId doesn't exist in the received PRPAIN201306UV02 message");
+                    oIIs.addAll(subject.getRegistrationEvent().getSubject1().getPatient().getId());
                 }
             }
+        } else {
+            LOG.error("PatientId doesn't exist in the received PRPAIN201306UV02 message");
         }
         return oIIs;
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201306UV02Parser.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201306UV02Parser.java
@@ -44,7 +44,6 @@ public class PRPAIN201306UV02Parser {
     private static final Logger LOG = Logger.getLogger(PRPAIN201306UV02Parser.class);
 
     public static String getQueryId(PRPAIN201306UV02 response) {
-        LOG.info("getQueryId()");
         String oid = null;
 
         if (response != null
@@ -60,7 +59,6 @@ public class PRPAIN201306UV02Parser {
     }
 
     public static List<II> getPatientIds(PRPAIN201306UV02 response) {
-        LOG.info("getPatientIds()");
         List<II> oIIs = null;
         if (response != null && response.getControlActProcess() != null
             && response.getControlActProcess().getSubject() != null) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransformsTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransformsTest.java
@@ -36,7 +36,7 @@ import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.connectmgr.ConnectionManagerException;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryAuditTransformsConstants;
-import gov.hhs.fha.nhinc.patientdiscovery.parser.TestPatientDiscoveryMessageBuilder;
+import gov.hhs.fha.nhinc.patientdiscovery.parser.TestPatientDiscoveryMessageHelper;
 import java.net.UnknownHostException;
 import java.util.Properties;
 import org.hl7.v3.PRPAIN201305UV02;
@@ -114,7 +114,7 @@ public class PatientDiscoveryAuditTransformsTest extends AuditTransformsTest<PRP
 
         AssertionType assertion = createAssertion();
         LogEventRequestType auditRequest = transforms.transformRequestToAuditMsg(
-            TestPatientDiscoveryMessageBuilder.createPRPAIN201305UV02Request(), assertion, createNhinTarget(),
+            TestPatientDiscoveryMessageHelper.createPRPAIN201305UV02Request(), assertion, createNhinTarget(),
             NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, Boolean.TRUE,
             webContextProperties, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
 
@@ -160,8 +160,8 @@ public class PatientDiscoveryAuditTransformsTest extends AuditTransformsTest<PRP
 
         AssertionType assertion = createAssertion();
         LogEventRequestType auditRequest = transforms.transformResponseToAuditMsg(
-            TestPatientDiscoveryMessageBuilder.createPRPAIN201305UV02Request(),
-            TestPatientDiscoveryMessageBuilder.createPRPAIN201306UV02Response(), assertion, createNhinTarget(),
+            TestPatientDiscoveryMessageHelper.createPRPAIN201305UV02Request(),
+            TestPatientDiscoveryMessageHelper.createPRPAIN201306UV02Response(), assertion, createNhinTarget(),
             NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
             NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, Boolean.TRUE, webContextProperties,
             NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransformsTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransformsTest.java
@@ -34,44 +34,13 @@ import gov.hhs.fha.nhinc.common.auditlog.LogEventRequestType;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.connectmgr.ConnectionManagerException;
-import gov.hhs.fha.nhinc.mpilib.Identifier;
-import gov.hhs.fha.nhinc.mpilib.Identifiers;
-import gov.hhs.fha.nhinc.mpilib.Patient;
-import gov.hhs.fha.nhinc.mpilib.Patients;
-import gov.hhs.fha.nhinc.mpilib.PersonName;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryAuditTransformsConstants;
-import gov.hhs.fha.nhinc.util.HomeCommunityMap;
+import gov.hhs.fha.nhinc.patientdiscovery.parser.TestPatientDiscoveryMessageBuilder;
 import java.net.UnknownHostException;
-import java.util.List;
 import java.util.Properties;
-import javax.xml.bind.JAXBElement;
-import javax.xml.namespace.QName;
-import org.hl7.v3.ActClassControlAct;
-import org.hl7.v3.CD;
-import org.hl7.v3.CE;
-import org.hl7.v3.CS;
-import org.hl7.v3.ENExplicit;
-import org.hl7.v3.EnExplicitFamily;
-import org.hl7.v3.EnExplicitGiven;
-import org.hl7.v3.II;
-import org.hl7.v3.IVLTSExplicit;
 import org.hl7.v3.PRPAIN201305UV02;
-import org.hl7.v3.PRPAIN201305UV02QUQIMT021001UV01ControlActProcess;
 import org.hl7.v3.PRPAIN201306UV02;
-import org.hl7.v3.PRPAIN201306UV02MFMIMT700711UV01ControlActProcess;
-import org.hl7.v3.PRPAIN201306UV02MFMIMT700711UV01RegistrationEvent;
-import org.hl7.v3.PRPAIN201306UV02MFMIMT700711UV01Subject1;
-import org.hl7.v3.PRPAIN201306UV02MFMIMT700711UV01Subject2;
-import org.hl7.v3.PRPAMT201306UV02LivingSubjectAdministrativeGender;
-import org.hl7.v3.PRPAMT201306UV02LivingSubjectBirthTime;
-import org.hl7.v3.PRPAMT201306UV02LivingSubjectId;
-import org.hl7.v3.PRPAMT201306UV02LivingSubjectName;
-import org.hl7.v3.PRPAMT201306UV02ParameterList;
-import org.hl7.v3.PRPAMT201306UV02QueryByParameter;
-import org.hl7.v3.PRPAMT201310UV02Patient;
-import org.hl7.v3.ParticipationTargetSubject;
-import org.hl7.v3.XActMoodIntentEvent;
 import org.junit.After;
 import org.junit.AfterClass;
 import static org.junit.Assert.assertEquals;
@@ -144,10 +113,10 @@ public class PatientDiscoveryAuditTransformsTest extends AuditTransformsTest<PRP
         };
 
         AssertionType assertion = createAssertion();
-        LogEventRequestType auditRequest = transforms.transformRequestToAuditMsg(createPRPAIN201305UV02Request(),
-            assertion, createNhinTarget(), NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
-            NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, Boolean.TRUE, webContextProperties,
-            NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
+        LogEventRequestType auditRequest = transforms.transformRequestToAuditMsg(
+            TestPatientDiscoveryMessageBuilder.createPRPAIN201305UV02Request(), assertion, createNhinTarget(),
+            NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, Boolean.TRUE,
+            webContextProperties, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
 
         testGetEventIdentificationType(auditRequest, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, Boolean.TRUE);
         testGetActiveParticipantSource(auditRequest, Boolean.TRUE, webContextProperties, localIp);
@@ -190,8 +159,10 @@ public class PatientDiscoveryAuditTransformsTest extends AuditTransformsTest<PRP
         };
 
         AssertionType assertion = createAssertion();
-        LogEventRequestType auditRequest = transforms.transformResponseToAuditMsg(createPRPAIN201305UV02Request(),
-            createPRPAIN201306UV02Response(), assertion, createNhinTarget(), NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
+        LogEventRequestType auditRequest = transforms.transformResponseToAuditMsg(
+            TestPatientDiscoveryMessageBuilder.createPRPAIN201305UV02Request(),
+            TestPatientDiscoveryMessageBuilder.createPRPAIN201306UV02Response(), assertion, createNhinTarget(),
+            NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
             NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, Boolean.TRUE, webContextProperties,
             NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
 
@@ -259,275 +230,6 @@ public class PatientDiscoveryAuditTransformsTest extends AuditTransformsTest<PRP
             participantQuery.getParticipantObjectName());
         assertNotNull("ParticipantQuery.ParticipantObjectQuery is null",
             participantQuery.getParticipantObjectQuery());
-    }
-
-    private PRPAIN201305UV02 createPRPAIN201305UV02Request() {
-        PRPAIN201305UV02 request = new PRPAIN201305UV02();
-        request.setControlActProcess(createControlActProcess());
-        return request;
-    }
-
-    private PRPAIN201305UV02QUQIMT021001UV01ControlActProcess createControlActProcess() {
-        II subjectId = new II();
-        subjectId.setRoot("1.1");
-        subjectId.setExtension("D123401");
-
-        CD code = new CD();
-        code.setCode("PRPA_TE201306UV02");
-        code.setCodeSystem("2.16.840.1.113883.1.6");
-
-        PRPAIN201305UV02QUQIMT021001UV01ControlActProcess controlActProcess
-            = new PRPAIN201305UV02QUQIMT021001UV01ControlActProcess();
-        controlActProcess.setClassCode(ActClassControlAct.CACT);
-        controlActProcess.setMoodCode(XActMoodIntentEvent.EVN);
-        controlActProcess.setCode(code);
-        controlActProcess.setQueryByParameter(createQueryParams("Allen", "Wanderson", "M", "09-8-1971", subjectId));
-        return controlActProcess;
-    }
-
-    private static JAXBElement<PRPAMT201306UV02QueryByParameter> createQueryParams(String firstName, String lastName,
-        String gender, String birthTime, II subjectId) {
-
-        II id = new II();
-        id.setRoot("12345");
-
-        CS statusCode = new CS();
-        statusCode.setCode("new");
-
-        PRPAMT201306UV02QueryByParameter params = new PRPAMT201306UV02QueryByParameter();
-        params.setQueryId(id);
-        params.setStatusCode(statusCode);
-        params.setParameterList(createParamList(firstName, lastName, gender, birthTime, subjectId));
-
-        return new JAXBElement<>(new QName("urn:hl7-org:v3", "queryByParameter"),
-            PRPAMT201306UV02QueryByParameter.class, params);
-    }
-
-    private static PRPAMT201306UV02ParameterList createParamList(String firstName, String lastName, String gender,
-        String birthTime, II subjectId) {
-
-        PRPAMT201306UV02ParameterList paramList = new PRPAMT201306UV02ParameterList();
-
-        // Set the Subject Gender Code
-        paramList.getLivingSubjectAdministrativeGender().add(createGender(gender));
-
-        // Set the Subject Birth Time
-        paramList.getLivingSubjectBirthTime().add(createBirthTime(birthTime));
-
-        // Set the Subject Name
-        paramList.getLivingSubjectName().add(createName(firstName, lastName));
-
-        // Set the subject Id
-        paramList.getLivingSubjectId().add(createSubjectId(subjectId));
-
-        return paramList;
-    }
-
-    private static PRPAMT201306UV02LivingSubjectId createSubjectId(II subjectId) {
-        PRPAMT201306UV02LivingSubjectId id = new PRPAMT201306UV02LivingSubjectId();
-        if (subjectId != null) {
-            id.getValue().add(subjectId);
-        }
-
-        return id;
-    }
-
-    private static PRPAMT201306UV02LivingSubjectName createName(String firstName, String lastName) {
-        org.hl7.v3.ObjectFactory factory = new org.hl7.v3.ObjectFactory();
-        ENExplicit name = factory.createENExplicit();
-        List namelist = name.getContent();
-
-        if (lastName != null && lastName.length() > 0) {
-            EnExplicitFamily familyName = new EnExplicitFamily();
-            familyName.setPartType("FAM");
-            familyName.setContent(lastName);
-
-            namelist.add(factory.createENExplicitFamily(familyName));
-        }
-
-        if (firstName != null && firstName.length() > 0) {
-            EnExplicitGiven givenName = new EnExplicitGiven();
-            givenName.setPartType("GIV");
-            givenName.setContent(firstName);
-
-            namelist.add(factory.createENExplicitGiven(givenName));
-        }
-
-        PRPAMT201306UV02LivingSubjectName subjectName = new PRPAMT201306UV02LivingSubjectName();
-        subjectName.getValue().add(name);
-        return subjectName;
-    }
-
-    private static PRPAMT201306UV02LivingSubjectBirthTime createBirthTime(String birthTime) {
-        PRPAMT201306UV02LivingSubjectBirthTime subjectBirthTime = new PRPAMT201306UV02LivingSubjectBirthTime();
-        IVLTSExplicit bday = new IVLTSExplicit();
-
-        if (birthTime != null && birthTime.length() > 0) {
-            bday.setValue(birthTime);
-            subjectBirthTime.getValue().add(bday);
-        }
-
-        return subjectBirthTime;
-    }
-
-    private static PRPAMT201306UV02LivingSubjectAdministrativeGender createGender(String gender) {
-        PRPAMT201306UV02LivingSubjectAdministrativeGender adminGender
-            = new PRPAMT201306UV02LivingSubjectAdministrativeGender();
-
-        if (gender != null && gender.length() > 0) {
-            CE genderCode = new CE();
-            genderCode.setCode(gender);
-            adminGender.getValue().add(genderCode);
-        }
-
-        return adminGender;
-    }
-
-    public Patient createMpiPatient(String firstName, String lastName, String gender, String birthTime,
-        Identifier subjectId) {
-
-        Patient result = new Patient();
-
-        // Set the patient name
-        PersonName name = new PersonName();
-        name.setFirstName(firstName);
-        name.setLastName(lastName);
-        result.getNames().add(name);
-
-        // Set the patient gender
-        result.setGender(gender);
-
-        // Set the patient birth time
-        result.setDateOfBirth(birthTime);
-
-        // Set the patient Id
-        Identifiers ids = new Identifiers();
-        ids.add(subjectId);
-        result.setIdentifiers(ids);
-
-        return result;
-    }
-
-    private PRPAIN201306UV02 createPRPAIN201306UV02Response() {
-        PRPAIN201306UV02 response = new PRPAIN201306UV02();
-        response.setControlActProcess(createResponseControlActProcess());
-        return response;
-    }
-
-    private PRPAIN201306UV02MFMIMT700711UV01ControlActProcess createResponseControlActProcess() {
-        PRPAIN201305UV02 query = createPRPAIN201305UV02Request();
-
-        Patients patients = createPatients();
-
-        PRPAIN201306UV02MFMIMT700711UV01ControlActProcess controlActProcess
-            = new PRPAIN201306UV02MFMIMT700711UV01ControlActProcess();
-
-        controlActProcess.setMoodCode(XActMoodIntentEvent.EVN);
-        controlActProcess.setClassCode(ActClassControlAct.CACT);
-
-        CD code = new CD();
-        code.setCode("PRPA_TE201306UV02");
-        code.setCodeSystem("2.16.840.1.113883.1.6");
-        controlActProcess.setCode(code);
-
-        if (patients != null && !patients.isEmpty()) {
-            for (Patient patientEntry : patients) {
-                controlActProcess.getSubject().add(createSubject(patientEntry, query));
-            }
-        }
-
-        // Add in query parameters
-        if (query.getControlActProcess() != null && query.getControlActProcess().getQueryByParameter() != null
-            && query.getControlActProcess().getQueryByParameter().getValue() != null) {
-            controlActProcess.setQueryByParameter(query.getControlActProcess().getQueryByParameter());
-        }
-        // Set original QueryByParameter in response
-        controlActProcess.setQueryByParameter(query.getControlActProcess().getQueryByParameter());
-        return controlActProcess;
-    }
-
-    private static PRPAIN201306UV02MFMIMT700711UV01Subject1 createSubject(Patient patient, PRPAIN201305UV02 query) {
-        PRPAIN201306UV02MFMIMT700711UV01Subject1 subject = new PRPAIN201306UV02MFMIMT700711UV01Subject1();
-        subject.getTypeCode().add("SUBJ");
-        subject.setRegistrationEvent(createRegEvent(patient, query));
-
-        return subject;
-    }
-
-    private static PRPAIN201306UV02MFMIMT700711UV01RegistrationEvent createRegEvent(Patient patient,
-        PRPAIN201305UV02 query) {
-
-        II id = new II();
-        id.getNullFlavor().add("NA");
-
-        CS statusCode = new CS();
-        statusCode.setCode("active");
-
-        PRPAIN201306UV02MFMIMT700711UV01RegistrationEvent regEvent
-            = new PRPAIN201306UV02MFMIMT700711UV01RegistrationEvent();
-
-        regEvent.getMoodCode().add("EVN");
-        regEvent.getClassCode().add("REG");
-        regEvent.getId().add(id);
-        regEvent.setStatusCode(statusCode);
-        regEvent.setSubject1(createSubject1(patient, query));
-
-        return regEvent;
-    }
-
-    private static PRPAIN201306UV02MFMIMT700711UV01Subject2 createSubject1(Patient patient, PRPAIN201305UV02 query) {
-        PRPAIN201306UV02MFMIMT700711UV01Subject2 subject = new PRPAIN201306UV02MFMIMT700711UV01Subject2();
-        subject.setTypeCode(ParticipationTargetSubject.SBJ);
-        // Add in patient
-        subject.setPatient(createPatient(patient, query));
-
-        return subject;
-    }
-
-    private static PRPAMT201310UV02Patient createPatient(Patient patient, PRPAIN201305UV02 query) {
-        CS statusCode = new CS();
-        statusCode.setCode("SD");
-
-        PRPAMT201310UV02Patient subjectPatient = new PRPAMT201310UV02Patient();
-        subjectPatient.getClassCode().add("PAT");
-        subjectPatient.setStatusCode(statusCode);
-        // Add in patient id
-        subjectPatient.getId().add(createSubjectId(patient));
-        return subjectPatient;
-    }
-
-    private static II createSubjectId(Patient patient) {
-        II id = new II();
-
-        if (patient.getIdentifiers() != null && !patient.getIdentifiers().isEmpty()
-            && patient.getIdentifiers().get(0) != null) {
-
-            Identifier subjectId = patient.getIdentifiers().get(0);
-
-            if (subjectId.getOrganizationId() != null && subjectId.getOrganizationId().length() > 0) {
-                id.setRoot(HomeCommunityMap.formatHomeCommunityId(subjectId.getOrganizationId()));
-            }
-
-            if (subjectId.getId() != null && subjectId.getId().length() > 0) {
-                id.setExtension(patient.getIdentifiers().get(0).getId());
-            }
-        }
-
-        return id;
-    }
-
-    private Identifier createIdentifier() {
-        Identifier subjectId = new Identifier();
-        subjectId.setId("D123401");
-        subjectId.setOrganizationId("1.1");
-        return subjectId;
-    }
-
-    private Patients createPatients() {
-        Patient patient = createMpiPatient("Gallow", "Younger", "M", "08-20-1976", createIdentifier());
-        Patients patients = new Patients();
-        patients.add(patient);
-        return patients;
     }
 
     @Override

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransformsTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransformsTest.java
@@ -113,10 +113,11 @@ public class PatientDiscoveryAuditTransformsTest extends AuditTransformsTest<PRP
         };
 
         AssertionType assertion = createAssertion();
-        LogEventRequestType auditRequest = transforms.transformRequestToAuditMsg(
-            TestPatientDiscoveryMessageHelper.createPRPAIN201305UV02Request(), assertion, createNhinTarget(),
-            NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, Boolean.TRUE,
-            webContextProperties, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
+        LogEventRequestType auditRequest = transforms.transformRequestToAuditMsg(TestPatientDiscoveryMessageHelper.
+            createPRPAIN201305UV02Request("Gallow", "Younger", "M", "01-12-2967", "1.1", "D123401", "2.2",
+                "abd3453dcd24wkkks545"), assertion, createNhinTarget(), NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
+            NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, Boolean.TRUE, webContextProperties,
+            NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
 
         testGetEventIdentificationType(auditRequest, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, Boolean.TRUE);
         testGetActiveParticipantSource(auditRequest, Boolean.TRUE, webContextProperties, localIp);
@@ -160,9 +161,10 @@ public class PatientDiscoveryAuditTransformsTest extends AuditTransformsTest<PRP
 
         AssertionType assertion = createAssertion();
         LogEventRequestType auditRequest = transforms.transformResponseToAuditMsg(
-            TestPatientDiscoveryMessageHelper.createPRPAIN201305UV02Request(),
-            TestPatientDiscoveryMessageHelper.createPRPAIN201306UV02Response(), assertion, createNhinTarget(),
-            NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
+            TestPatientDiscoveryMessageHelper.createPRPAIN201305UV02Request("Gallow", "Younger", "M", "01-12-2967",
+                "1.1", "D123401", "2.2", "abd3453dcd24wkkks545"), TestPatientDiscoveryMessageHelper.
+            createPRPAIN201306UV02Response("Gallow", "Younger", "M", "01-12-2967", "1.1", "D123401", "2.2",
+                "abd3453dcd24wkkks545"), assertion, createNhinTarget(), NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
             NhincConstants.AUDIT_LOG_ENTITY_INTERFACE, Boolean.TRUE, webContextProperties,
             NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201305UV02ParserTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201305UV02ParserTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.patientdiscovery.parser;
+
+import org.hl7.v3.II;
+import org.hl7.v3.PRPAIN201305UV02;
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author tjafri
+ */
+public class PRPAIN201305UV02ParserTest {
+
+    private PRPAIN201305UV02 request;
+
+    @Before
+    public void setup() {
+        request = TestPatientDiscoveryMessageBuilder.createPRPAIN201305UV02Request();
+    }
+
+    @Test
+    public void testPatientId() {
+        II objPid = PRPAIN201305UV02Parser.getPatientId(request);
+        assertEquals("PatientId Root mismatch", TestPatientDiscoveryMessageBuilder.ROOT, objPid.getRoot());
+        assertEquals("PatientId Extension mismatch", TestPatientDiscoveryMessageBuilder.EXTENSION,
+            objPid.getExtension());
+    }
+
+    @Test
+    public void testParticipantObjectId() {
+        String oid = PRPAIN201305UV02Parser.getQueryId(request);
+        assertEquals("QueryId mismatch", TestPatientDiscoveryMessageBuilder.QUERY_ID_EXTENSION, oid);
+    }
+}

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201305UV02ParserTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201305UV02ParserTest.java
@@ -27,9 +27,7 @@
 package gov.hhs.fha.nhinc.patientdiscovery.parser;
 
 import org.hl7.v3.II;
-import org.hl7.v3.PRPAIN201305UV02;
 import static org.junit.Assert.assertEquals;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -38,16 +36,10 @@ import org.junit.Test;
  */
 public class PRPAIN201305UV02ParserTest {
 
-    private PRPAIN201305UV02 request;
-
-    @Before
-    public void setup() {
-        request = TestPatientDiscoveryMessageHelper.createPRPAIN201305UV02Request();
-    }
-
     @Test
     public void testPatientId() {
-        II objPid = PRPAIN201305UV02Parser.getPatientId(request);
+        II objPid = PRPAIN201305UV02Parser.getPatientId(
+            TestPatientDiscoveryMessageHelper.createPRPAIN201305UV02Request());
         assertEquals("PatientId Root mismatch", TestPatientDiscoveryMessageHelper.ROOT, objPid.getRoot());
         assertEquals("PatientId Extension mismatch", TestPatientDiscoveryMessageHelper.EXTENSION,
             objPid.getExtension());
@@ -55,7 +47,7 @@ public class PRPAIN201305UV02ParserTest {
 
     @Test
     public void testParticipantObjectId() {
-        String oid = PRPAIN201305UV02Parser.getQueryId(request);
-        assertEquals("QueryId mismatch", TestPatientDiscoveryMessageHelper.QUERY_ID_EXTENSION, oid);
+        assertEquals("QueryId mismatch", TestPatientDiscoveryMessageHelper.QUERY_ID_EXTENSION,
+            PRPAIN201305UV02Parser.getQueryId(TestPatientDiscoveryMessageHelper.createPRPAIN201305UV02Request()));
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201305UV02ParserTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201305UV02ParserTest.java
@@ -42,20 +42,20 @@ public class PRPAIN201305UV02ParserTest {
 
     @Before
     public void setup() {
-        request = TestPatientDiscoveryMessageBuilder.createPRPAIN201305UV02Request();
+        request = TestPatientDiscoveryMessageHelper.createPRPAIN201305UV02Request();
     }
 
     @Test
     public void testPatientId() {
         II objPid = PRPAIN201305UV02Parser.getPatientId(request);
-        assertEquals("PatientId Root mismatch", TestPatientDiscoveryMessageBuilder.ROOT, objPid.getRoot());
-        assertEquals("PatientId Extension mismatch", TestPatientDiscoveryMessageBuilder.EXTENSION,
+        assertEquals("PatientId Root mismatch", TestPatientDiscoveryMessageHelper.ROOT, objPid.getRoot());
+        assertEquals("PatientId Extension mismatch", TestPatientDiscoveryMessageHelper.EXTENSION,
             objPid.getExtension());
     }
 
     @Test
     public void testParticipantObjectId() {
         String oid = PRPAIN201305UV02Parser.getQueryId(request);
-        assertEquals("QueryId mismatch", TestPatientDiscoveryMessageBuilder.QUERY_ID_EXTENSION, oid);
+        assertEquals("QueryId mismatch", TestPatientDiscoveryMessageHelper.QUERY_ID_EXTENSION, oid);
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201305UV02ParserTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201305UV02ParserTest.java
@@ -39,15 +39,16 @@ public class PRPAIN201305UV02ParserTest {
     @Test
     public void testPatientId() {
         II objPid = PRPAIN201305UV02Parser.getPatientId(
-            TestPatientDiscoveryMessageHelper.createPRPAIN201305UV02Request());
-        assertEquals("PatientId Root mismatch", TestPatientDiscoveryMessageHelper.ROOT, objPid.getRoot());
-        assertEquals("PatientId Extension mismatch", TestPatientDiscoveryMessageHelper.EXTENSION,
-            objPid.getExtension());
+            TestPatientDiscoveryMessageHelper.createPRPAIN201305UV02Request("Gallow", "Younger", "M", "01-12-2967",
+                "1.1", "D12345", "2.2", "abd3453dcd24wkkks545"));
+        assertEquals("PatientId Root mismatch", "1.1", objPid.getRoot());
+        assertEquals("PatientId Extension mismatch", "D12345", objPid.getExtension());
     }
 
     @Test
     public void testParticipantObjectId() {
-        assertEquals("QueryId mismatch", TestPatientDiscoveryMessageHelper.QUERY_ID_EXTENSION,
-            PRPAIN201305UV02Parser.getQueryId(TestPatientDiscoveryMessageHelper.createPRPAIN201305UV02Request()));
+        assertEquals("QueryId mismatch", "abd3453dcd24wkkks545", PRPAIN201305UV02Parser.getQueryId(
+            TestPatientDiscoveryMessageHelper.createPRPAIN201305UV02Request("Gallow", "Younger", "M", "01-12-2967",
+                "1.1", "D12345", "2.2", "abd3453dcd24wkkks545")));
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201306UV02ParserTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201306UV02ParserTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.patientdiscovery.parser;
+
+import java.util.List;
+import org.hl7.v3.II;
+import org.hl7.v3.PRPAIN201306UV02;
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author tjafri
+ */
+public class PRPAIN201306UV02ParserTest {
+
+    private PRPAIN201306UV02 response;
+
+    @Before
+    public void setup() {
+        response = TestPatientDiscoveryMessageBuilder.createPRPAIN201306UV02Response();
+    }
+
+    @Test
+    public void testQueryId() {
+        String queryId = PRPAIN201306UV02Parser.getQueryId(response);
+        assertEquals("QueryId mismatch", queryId, TestPatientDiscoveryMessageBuilder.QUERY_ID_EXTENSION);
+    }
+
+    @Test
+    public void testPatientId() {
+        List<II> pids = PRPAIN201306UV02Parser.getPatientIds(response);
+        assertEquals("Response patientIds size mismatch", pids.size(), 1);
+        assertEquals("Response patientId extension mismatch", pids.get(0).getExtension(),
+            TestPatientDiscoveryMessageBuilder.EXTENSION);
+        assertEquals("Response patientId root mismatch", pids.get(0).getRoot(),
+            TestPatientDiscoveryMessageBuilder.ROOT);
+    }
+}

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201306UV02ParserTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201306UV02ParserTest.java
@@ -40,17 +40,17 @@ public class PRPAIN201306UV02ParserTest {
     @Test
     public void testQueryId() {
         assertEquals("QueryId mismatch", PRPAIN201306UV02Parser.getQueryId(TestPatientDiscoveryMessageHelper.
-            createPRPAIN201306UV02Response()), TestPatientDiscoveryMessageHelper.QUERY_ID_EXTENSION);
+            createPRPAIN201306UV02Response("Gallow", "Younger", "M", "01-12-2967", "1.1", "D12345", "2.2",
+                "abd3453dcd24wkkks545")), "abd3453dcd24wkkks545");
     }
 
     @Test
     public void testPatientId() {
-        List<II> pids = PRPAIN201306UV02Parser.getPatientIds(
-            TestPatientDiscoveryMessageHelper.createPRPAIN201306UV02Response());
+        List<II> pids = PRPAIN201306UV02Parser.getPatientIds(TestPatientDiscoveryMessageHelper.
+            createPRPAIN201306UV02Response("Gallow", "Younger", "M", "01-12-2967", "1.1", "D12345", "2.2",
+                "abd3453dcd24wkkks545"));
         assertEquals("Response patientIds size mismatch", pids.size(), 1);
-        assertEquals("Response patientId extension mismatch", pids.get(0).getExtension(),
-            TestPatientDiscoveryMessageHelper.EXTENSION);
-        assertEquals("Response patientId root mismatch", pids.get(0).getRoot(),
-            TestPatientDiscoveryMessageHelper.ROOT);
+        assertEquals("Response patientId extension mismatch", pids.get(0).getExtension(), "D12345");
+        assertEquals("Response patientId root mismatch", pids.get(0).getRoot(), "1.1");
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201306UV02ParserTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201306UV02ParserTest.java
@@ -43,13 +43,13 @@ public class PRPAIN201306UV02ParserTest {
 
     @Before
     public void setup() {
-        response = TestPatientDiscoveryMessageBuilder.createPRPAIN201306UV02Response();
+        response = TestPatientDiscoveryMessageHelper.createPRPAIN201306UV02Response();
     }
 
     @Test
     public void testQueryId() {
         String queryId = PRPAIN201306UV02Parser.getQueryId(response);
-        assertEquals("QueryId mismatch", queryId, TestPatientDiscoveryMessageBuilder.QUERY_ID_EXTENSION);
+        assertEquals("QueryId mismatch", queryId, TestPatientDiscoveryMessageHelper.QUERY_ID_EXTENSION);
     }
 
     @Test
@@ -57,8 +57,8 @@ public class PRPAIN201306UV02ParserTest {
         List<II> pids = PRPAIN201306UV02Parser.getPatientIds(response);
         assertEquals("Response patientIds size mismatch", pids.size(), 1);
         assertEquals("Response patientId extension mismatch", pids.get(0).getExtension(),
-            TestPatientDiscoveryMessageBuilder.EXTENSION);
+            TestPatientDiscoveryMessageHelper.EXTENSION);
         assertEquals("Response patientId root mismatch", pids.get(0).getRoot(),
-            TestPatientDiscoveryMessageBuilder.ROOT);
+            TestPatientDiscoveryMessageHelper.ROOT);
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201306UV02ParserTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201306UV02ParserTest.java
@@ -28,9 +28,7 @@ package gov.hhs.fha.nhinc.patientdiscovery.parser;
 
 import java.util.List;
 import org.hl7.v3.II;
-import org.hl7.v3.PRPAIN201306UV02;
 import static org.junit.Assert.assertEquals;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -39,22 +37,16 @@ import org.junit.Test;
  */
 public class PRPAIN201306UV02ParserTest {
 
-    private PRPAIN201306UV02 response;
-
-    @Before
-    public void setup() {
-        response = TestPatientDiscoveryMessageHelper.createPRPAIN201306UV02Response();
-    }
-
     @Test
     public void testQueryId() {
-        String queryId = PRPAIN201306UV02Parser.getQueryId(response);
-        assertEquals("QueryId mismatch", queryId, TestPatientDiscoveryMessageHelper.QUERY_ID_EXTENSION);
+        assertEquals("QueryId mismatch", PRPAIN201306UV02Parser.getQueryId(TestPatientDiscoveryMessageHelper.
+            createPRPAIN201306UV02Response()), TestPatientDiscoveryMessageHelper.QUERY_ID_EXTENSION);
     }
 
     @Test
     public void testPatientId() {
-        List<II> pids = PRPAIN201306UV02Parser.getPatientIds(response);
+        List<II> pids = PRPAIN201306UV02Parser.getPatientIds(
+            TestPatientDiscoveryMessageHelper.createPRPAIN201306UV02Response());
         assertEquals("Response patientIds size mismatch", pids.size(), 1);
         assertEquals("Response patientId extension mismatch", pids.get(0).getExtension(),
             TestPatientDiscoveryMessageHelper.EXTENSION);

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/TestPatientDiscoveryMessageBuilder.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/TestPatientDiscoveryMessageBuilder.java
@@ -1,0 +1,323 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package gov.hhs.fha.nhinc.patientdiscovery.parser;
+
+import gov.hhs.fha.nhinc.mpilib.Identifier;
+import gov.hhs.fha.nhinc.mpilib.Identifiers;
+import gov.hhs.fha.nhinc.mpilib.Patient;
+import gov.hhs.fha.nhinc.mpilib.Patients;
+import gov.hhs.fha.nhinc.mpilib.PersonName;
+import gov.hhs.fha.nhinc.util.HomeCommunityMap;
+import java.util.List;
+import javax.xml.bind.JAXBElement;
+import javax.xml.namespace.QName;
+import org.hl7.v3.ActClassControlAct;
+import org.hl7.v3.CD;
+import org.hl7.v3.CE;
+import org.hl7.v3.CS;
+import org.hl7.v3.ENExplicit;
+import org.hl7.v3.EnExplicitFamily;
+import org.hl7.v3.EnExplicitGiven;
+import org.hl7.v3.II;
+import org.hl7.v3.IVLTSExplicit;
+import org.hl7.v3.PRPAIN201305UV02;
+import org.hl7.v3.PRPAIN201305UV02QUQIMT021001UV01ControlActProcess;
+import org.hl7.v3.PRPAIN201306UV02;
+import org.hl7.v3.PRPAIN201306UV02MFMIMT700711UV01ControlActProcess;
+import org.hl7.v3.PRPAIN201306UV02MFMIMT700711UV01RegistrationEvent;
+import org.hl7.v3.PRPAIN201306UV02MFMIMT700711UV01Subject1;
+import org.hl7.v3.PRPAIN201306UV02MFMIMT700711UV01Subject2;
+import org.hl7.v3.PRPAMT201306UV02LivingSubjectAdministrativeGender;
+import org.hl7.v3.PRPAMT201306UV02LivingSubjectBirthTime;
+import org.hl7.v3.PRPAMT201306UV02LivingSubjectId;
+import org.hl7.v3.PRPAMT201306UV02LivingSubjectName;
+import org.hl7.v3.PRPAMT201306UV02ParameterList;
+import org.hl7.v3.PRPAMT201306UV02QueryByParameter;
+import org.hl7.v3.PRPAMT201310UV02Patient;
+import org.hl7.v3.ParticipationTargetSubject;
+import org.hl7.v3.XActMoodIntentEvent;
+
+/**
+ *
+ * @author tjafri
+ */
+public class TestPatientDiscoveryMessageBuilder {
+
+    public static final String ROOT = "1.1";
+    public static final String EXTENSION = "D123401";
+    public static final String QUERY_ID_ROOT = "2.2";
+    public static final String QUERY_ID_EXTENSION = "abd3453dcd24wkkks545";
+
+    public static PRPAIN201305UV02 createPRPAIN201305UV02Request() {
+        PRPAIN201305UV02 request = new PRPAIN201305UV02();
+        request.setControlActProcess(createControlActProcess());
+        return request;
+    }
+
+    public static PRPAIN201306UV02 createPRPAIN201306UV02Response() {
+        PRPAIN201306UV02 response = new PRPAIN201306UV02();
+        response.setControlActProcess(createResponseControlActProcess());
+        return response;
+    }
+
+    private static PRPAIN201305UV02QUQIMT021001UV01ControlActProcess createControlActProcess() {
+        II subjectId = new II();
+        subjectId.setRoot(ROOT);
+        subjectId.setExtension(EXTENSION);
+
+        CD code = new CD();
+        code.setCode("PRPA_TE201306UV02");
+        code.setCodeSystem("2.16.840.1.113883.1.6");
+
+        PRPAIN201305UV02QUQIMT021001UV01ControlActProcess controlActProcess
+            = new PRPAIN201305UV02QUQIMT021001UV01ControlActProcess();
+        controlActProcess.setClassCode(ActClassControlAct.CACT);
+        controlActProcess.setMoodCode(XActMoodIntentEvent.EVN);
+        controlActProcess.setCode(code);
+        controlActProcess.setQueryByParameter(createQueryParams("Allen", "Wanderson", "M", "09-8-1971", subjectId));
+        return controlActProcess;
+    }
+
+    private static JAXBElement<PRPAMT201306UV02QueryByParameter> createQueryParams(String firstName, String lastName,
+        String gender, String birthTime, II subjectId) {
+
+        II id = new II();
+        id.setRoot(QUERY_ID_ROOT);
+        id.setExtension(QUERY_ID_EXTENSION);
+        CS statusCode = new CS();
+        statusCode.setCode("new");
+
+        PRPAMT201306UV02QueryByParameter params = new PRPAMT201306UV02QueryByParameter();
+        params.setQueryId(id);
+        params.setStatusCode(statusCode);
+        params.setParameterList(createParamList(firstName, lastName, gender, birthTime, subjectId));
+
+        return new JAXBElement<>(new QName("urn:hl7-org:v3", "queryByParameter"),
+            PRPAMT201306UV02QueryByParameter.class, params);
+    }
+
+    private static PRPAMT201306UV02ParameterList createParamList(String firstName, String lastName, String gender,
+        String birthTime, II subjectId) {
+
+        PRPAMT201306UV02ParameterList paramList = new PRPAMT201306UV02ParameterList();
+
+        // Set the Subject Gender Code
+        paramList.getLivingSubjectAdministrativeGender().add(createGender(gender));
+
+        // Set the Subject Birth Time
+        paramList.getLivingSubjectBirthTime().add(createBirthTime(birthTime));
+
+        // Set the Subject Name
+        paramList.getLivingSubjectName().add(createName(firstName, lastName));
+
+        // Set the subject Id
+        paramList.getLivingSubjectId().add(createSubjectId(subjectId));
+
+        return paramList;
+    }
+
+    private static PRPAMT201306UV02LivingSubjectId createSubjectId(II subjectId) {
+        PRPAMT201306UV02LivingSubjectId id = new PRPAMT201306UV02LivingSubjectId();
+        if (subjectId != null) {
+            id.getValue().add(subjectId);
+        }
+
+        return id;
+    }
+
+    private static PRPAMT201306UV02LivingSubjectName createName(String firstName, String lastName) {
+        org.hl7.v3.ObjectFactory factory = new org.hl7.v3.ObjectFactory();
+        ENExplicit name = factory.createENExplicit();
+        List namelist = name.getContent();
+
+        if (lastName != null && lastName.length() > 0) {
+            EnExplicitFamily familyName = new EnExplicitFamily();
+            familyName.setPartType("FAM");
+            familyName.setContent(lastName);
+
+            namelist.add(factory.createENExplicitFamily(familyName));
+        }
+
+        if (firstName != null && firstName.length() > 0) {
+            EnExplicitGiven givenName = new EnExplicitGiven();
+            givenName.setPartType("GIV");
+            givenName.setContent(firstName);
+
+            namelist.add(factory.createENExplicitGiven(givenName));
+        }
+
+        PRPAMT201306UV02LivingSubjectName subjectName = new PRPAMT201306UV02LivingSubjectName();
+        subjectName.getValue().add(name);
+        return subjectName;
+    }
+
+    private static PRPAMT201306UV02LivingSubjectBirthTime createBirthTime(String birthTime) {
+        PRPAMT201306UV02LivingSubjectBirthTime subjectBirthTime = new PRPAMT201306UV02LivingSubjectBirthTime();
+        IVLTSExplicit bday = new IVLTSExplicit();
+
+        if (birthTime != null && birthTime.length() > 0) {
+            bday.setValue(birthTime);
+            subjectBirthTime.getValue().add(bday);
+        }
+
+        return subjectBirthTime;
+    }
+
+    private static PRPAMT201306UV02LivingSubjectAdministrativeGender createGender(String gender) {
+        PRPAMT201306UV02LivingSubjectAdministrativeGender adminGender
+            = new PRPAMT201306UV02LivingSubjectAdministrativeGender();
+
+        if (gender != null && gender.length() > 0) {
+            CE genderCode = new CE();
+            genderCode.setCode(gender);
+            adminGender.getValue().add(genderCode);
+        }
+
+        return adminGender;
+    }
+
+    private static PRPAIN201306UV02MFMIMT700711UV01ControlActProcess createResponseControlActProcess() {
+        PRPAIN201305UV02 query = createPRPAIN201305UV02Request();
+
+        Patients patients = createPatients();
+
+        PRPAIN201306UV02MFMIMT700711UV01ControlActProcess controlActProcess
+            = new PRPAIN201306UV02MFMIMT700711UV01ControlActProcess();
+
+        controlActProcess.setMoodCode(XActMoodIntentEvent.EVN);
+        controlActProcess.setClassCode(ActClassControlAct.CACT);
+
+        CD code = new CD();
+        code.setCode("PRPA_TE201306UV02");
+        code.setCodeSystem("2.16.840.1.113883.1.6");
+        controlActProcess.setCode(code);
+
+        if (patients != null && !patients.isEmpty()) {
+            for (Patient patientEntry : patients) {
+                controlActProcess.getSubject().add(createSubject(patientEntry, query));
+            }
+        }
+
+        // Add in query parameters
+        if (query.getControlActProcess() != null && query.getControlActProcess().getQueryByParameter() != null
+            && query.getControlActProcess().getQueryByParameter().getValue() != null) {
+            controlActProcess.setQueryByParameter(query.getControlActProcess().getQueryByParameter());
+        }
+        // Set original QueryByParameter in response
+        controlActProcess.setQueryByParameter(query.getControlActProcess().getQueryByParameter());
+        return controlActProcess;
+    }
+
+    private static PRPAIN201306UV02MFMIMT700711UV01Subject1 createSubject(Patient patient, PRPAIN201305UV02 query) {
+        PRPAIN201306UV02MFMIMT700711UV01Subject1 subject = new PRPAIN201306UV02MFMIMT700711UV01Subject1();
+        subject.getTypeCode().add("SUBJ");
+        subject.setRegistrationEvent(createRegEvent(patient, query));
+
+        return subject;
+    }
+
+    private static PRPAIN201306UV02MFMIMT700711UV01RegistrationEvent createRegEvent(Patient patient,
+        PRPAIN201305UV02 query) {
+
+        II id = new II();
+        id.getNullFlavor().add("NA");
+
+        CS statusCode = new CS();
+        statusCode.setCode("active");
+
+        PRPAIN201306UV02MFMIMT700711UV01RegistrationEvent regEvent
+            = new PRPAIN201306UV02MFMIMT700711UV01RegistrationEvent();
+
+        regEvent.getMoodCode().add("EVN");
+        regEvent.getClassCode().add("REG");
+        regEvent.getId().add(id);
+        regEvent.setStatusCode(statusCode);
+        regEvent.setSubject1(createSubject1(patient, query));
+
+        return regEvent;
+    }
+
+    private static PRPAIN201306UV02MFMIMT700711UV01Subject2 createSubject1(Patient patient, PRPAIN201305UV02 query) {
+        PRPAIN201306UV02MFMIMT700711UV01Subject2 subject = new PRPAIN201306UV02MFMIMT700711UV01Subject2();
+        subject.setTypeCode(ParticipationTargetSubject.SBJ);
+        // Add in patient
+        subject.setPatient(createPatient(patient, query));
+
+        return subject;
+    }
+
+    private static PRPAMT201310UV02Patient createPatient(Patient patient, PRPAIN201305UV02 query) {
+        CS statusCode = new CS();
+        statusCode.setCode("SD");
+
+        PRPAMT201310UV02Patient subjectPatient = new PRPAMT201310UV02Patient();
+        subjectPatient.getClassCode().add("PAT");
+        subjectPatient.setStatusCode(statusCode);
+        // Add in patient id
+        subjectPatient.getId().add(createSubjectId(patient));
+        return subjectPatient;
+    }
+
+    private static II createSubjectId(Patient patient) {
+        II id = new II();
+
+        if (patient.getIdentifiers() != null && !patient.getIdentifiers().isEmpty()
+            && patient.getIdentifiers().get(0) != null) {
+
+            Identifier subjectId = patient.getIdentifiers().get(0);
+
+            if (subjectId.getOrganizationId() != null && subjectId.getOrganizationId().length() > 0) {
+                id.setRoot(HomeCommunityMap.formatHomeCommunityId(subjectId.getOrganizationId()));
+            }
+
+            if (subjectId.getId() != null && subjectId.getId().length() > 0) {
+                id.setExtension(patient.getIdentifiers().get(0).getId());
+            }
+        }
+
+        return id;
+    }
+
+    private static Identifier createIdentifier() {
+        Identifier subjectId = new Identifier();
+        subjectId.setId("D123401");
+        subjectId.setOrganizationId("1.1");
+        return subjectId;
+    }
+
+    private static Patients createPatients() {
+        Patient patient = createMpiPatient("Gallow", "Younger", "M", "08-20-1976", createIdentifier());
+        Patients patients = new Patients();
+        patients.add(patient);
+        return patients;
+    }
+
+    private static Patient createMpiPatient(String firstName, String lastName, String gender, String birthTime,
+        Identifier subjectId) {
+
+        Patient result = new Patient();
+
+        // Set the patient name
+        PersonName name = new PersonName();
+        name.setFirstName(firstName);
+        name.setLastName(lastName);
+        result.getNames().add(name);
+
+        // Set the patient gender
+        result.setGender(gender);
+
+        // Set the patient birth time
+        result.setDateOfBirth(birthTime);
+
+        // Set the patient Id
+        Identifiers ids = new Identifiers();
+        ids.add(subjectId);
+        result.setIdentifiers(ids);
+
+        return result;
+    }
+
+}

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/TestPatientDiscoveryMessageBuilder.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/TestPatientDiscoveryMessageBuilder.java
@@ -1,7 +1,28 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package gov.hhs.fha.nhinc.patientdiscovery.parser;
 
@@ -41,6 +62,7 @@ import org.hl7.v3.ParticipationTargetSubject;
 import org.hl7.v3.XActMoodIntentEvent;
 
 /**
+ * The class is used to create PD request and response messages to facilitate testing.
  *
  * @author tjafri
  */

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/TestPatientDiscoveryMessageHelper.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/TestPatientDiscoveryMessageHelper.java
@@ -66,7 +66,7 @@ import org.hl7.v3.XActMoodIntentEvent;
  *
  * @author tjafri
  */
-public class TestPatientDiscoveryMessageBuilder {
+public class TestPatientDiscoveryMessageHelper {
 
     public static final String ROOT = "1.1";
     public static final String EXTENSION = "D123401";

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/TestPatientDiscoveryMessageHelper.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/TestPatientDiscoveryMessageHelper.java
@@ -67,56 +67,73 @@ import org.hl7.v3.XActMoodIntentEvent;
  */
 public class TestPatientDiscoveryMessageHelper {
 
-    public static final String ROOT = "1.1";
-    public static final String EXTENSION = "D123401";
-    public static final String QUERY_ID_ROOT = "2.2";
-    public static final String QUERY_ID_EXTENSION = "abd3453dcd24wkkks545";
+    private static final String CNTRL_CODE = "PRPA_TE201306UV02";
+    private static final String CNTRL_CODE_SYSTEM = "2.16.840.1.113883.1.6";
+    private static final String CNTRL_SUBJ_TYPECODE = "SUBJ";
+    private static final String STATUS_CD = "active";
+    private static final String REG_MOOD_CODE = "EVN";
+    private static final String REG_CLASS_CODE = "REG";
+    private static final String QUERY_BY_PARAMETER_TAG = "queryByParameter";
+    private static final String NAMESPACE_FOR_QUERY_BY_PARAMETER = "urn:hl7-org:v3";
+    private static final String NEW = "new";
+    private static final String NA = "NA";
+    private static final String FAMILY_NAME_CODE = "FAM";
+    private static final String GIVEN_NAME_CODE = "GIV";
+    private static final String SUBJ_PATIENT_STATUS_CODE = "SD";
+    private static final String SUBJ_PATIENT_CLASS_CODE = "PAT";
 
-    public static PRPAIN201305UV02 createPRPAIN201305UV02Request() {
+    public static PRPAIN201305UV02 createPRPAIN201305UV02Request(String firstName, String lastName, String gender,
+        String birthTime, String root, String extension, String queryIdRoot, String queryIdExtension) {
         PRPAIN201305UV02 request = new PRPAIN201305UV02();
-        request.setControlActProcess(createControlActProcess());
+        request.setControlActProcess(createControlActProcess(firstName, lastName, gender, birthTime, root, extension,
+            queryIdRoot, queryIdExtension));
         return request;
     }
 
-    public static PRPAIN201306UV02 createPRPAIN201306UV02Response() {
+    public static PRPAIN201306UV02 createPRPAIN201306UV02Response(String firstName, String lastName, String gender,
+        String birthTime, String root, String extension, String queryIdRoot, String queryIdExtension) {
         PRPAIN201306UV02 response = new PRPAIN201306UV02();
-        response.setControlActProcess(createResponseControlActProcess());
+        response.setControlActProcess(createResponseControlActProcess(firstName, lastName, gender, birthTime, root,
+            extension, queryIdRoot, queryIdExtension));
         return response;
     }
 
-    private static PRPAIN201305UV02QUQIMT021001UV01ControlActProcess createControlActProcess() {
+    private static PRPAIN201305UV02QUQIMT021001UV01ControlActProcess createControlActProcess(String firstName,
+        String lastName, String gender, String birthTime, String root, String extension, String queryIdRoot,
+        String queryIdExtension) {
         II subjectId = new II();
-        subjectId.setRoot(ROOT);
-        subjectId.setExtension(EXTENSION);
+        subjectId.setRoot(root);
+        subjectId.setExtension(extension);
 
         CD code = new CD();
-        code.setCode("PRPA_TE201306UV02");
-        code.setCodeSystem("2.16.840.1.113883.1.6");
+        code.setCode(CNTRL_CODE);
+        code.setCodeSystem(CNTRL_CODE_SYSTEM);
 
         PRPAIN201305UV02QUQIMT021001UV01ControlActProcess controlActProcess
             = new PRPAIN201305UV02QUQIMT021001UV01ControlActProcess();
         controlActProcess.setClassCode(ActClassControlAct.CACT);
         controlActProcess.setMoodCode(XActMoodIntentEvent.EVN);
         controlActProcess.setCode(code);
-        controlActProcess.setQueryByParameter(createQueryParams("Allen", "Wanderson", "M", "09-8-1971", subjectId));
+        controlActProcess.setQueryByParameter(createQueryParams(firstName, lastName, gender, birthTime, subjectId,
+            queryIdRoot, queryIdExtension));
         return controlActProcess;
     }
 
     private static JAXBElement<PRPAMT201306UV02QueryByParameter> createQueryParams(String firstName, String lastName,
-        String gender, String birthTime, II subjectId) {
+        String gender, String birthTime, II subjectId, String queryIdRoot, String queryIdExtension) {
 
         II id = new II();
-        id.setRoot(QUERY_ID_ROOT);
-        id.setExtension(QUERY_ID_EXTENSION);
+        id.setRoot(queryIdRoot);
+        id.setExtension(queryIdExtension);
         CS statusCode = new CS();
-        statusCode.setCode("new");
+        statusCode.setCode(NEW);
 
         PRPAMT201306UV02QueryByParameter params = new PRPAMT201306UV02QueryByParameter();
         params.setQueryId(id);
         params.setStatusCode(statusCode);
         params.setParameterList(createParamList(firstName, lastName, gender, birthTime, subjectId));
 
-        return new JAXBElement<>(new QName("urn:hl7-org:v3", "queryByParameter"),
+        return new JAXBElement<>(new QName(NAMESPACE_FOR_QUERY_BY_PARAMETER, QUERY_BY_PARAMETER_TAG),
             PRPAMT201306UV02QueryByParameter.class, params);
     }
 
@@ -133,10 +150,7 @@ public class TestPatientDiscoveryMessageHelper {
 
     private static PRPAMT201306UV02LivingSubjectId createSubjectId(II subjectId) {
         PRPAMT201306UV02LivingSubjectId id = new PRPAMT201306UV02LivingSubjectId();
-        if (subjectId != null) {
-            id.getValue().add(subjectId);
-        }
-
+        id.getValue().add(subjectId);
         return id;
     }
 
@@ -146,7 +160,7 @@ public class TestPatientDiscoveryMessageHelper {
 
         if (lastName != null && lastName.length() > 0) {
             EnExplicitFamily familyName = new EnExplicitFamily();
-            familyName.setPartType("FAM");
+            familyName.setPartType(FAMILY_NAME_CODE);
             familyName.setContent(lastName);
 
             name.getContent().add(factory.createENExplicitFamily(familyName));
@@ -154,7 +168,7 @@ public class TestPatientDiscoveryMessageHelper {
 
         if (firstName != null && firstName.length() > 0) {
             EnExplicitGiven givenName = new EnExplicitGiven();
-            givenName.setPartType("GIV");
+            givenName.setPartType(GIVEN_NAME_CODE);
             givenName.setContent(firstName);
 
             name.getContent().add(factory.createENExplicitGiven(givenName));
@@ -190,10 +204,13 @@ public class TestPatientDiscoveryMessageHelper {
         return adminGender;
     }
 
-    private static PRPAIN201306UV02MFMIMT700711UV01ControlActProcess createResponseControlActProcess() {
-        PRPAIN201305UV02 query = createPRPAIN201305UV02Request();
+    private static PRPAIN201306UV02MFMIMT700711UV01ControlActProcess createResponseControlActProcess(String firstName,
+        String lastName, String gender, String birthTime, String root, String extension, String queryIdRoot,
+        String queryIdExtension) {
+        PRPAIN201305UV02 query = createPRPAIN201305UV02Request(firstName, lastName, gender, birthTime, root, extension,
+            queryIdRoot, queryIdExtension);
 
-        Patients patients = createPatients();
+        Patients patients = createPatients(firstName, lastName, gender, birthTime, root, extension);
 
         PRPAIN201306UV02MFMIMT700711UV01ControlActProcess controlActProcess
             = new PRPAIN201306UV02MFMIMT700711UV01ControlActProcess();
@@ -202,8 +219,8 @@ public class TestPatientDiscoveryMessageHelper {
         controlActProcess.setClassCode(ActClassControlAct.CACT);
 
         CD code = new CD();
-        code.setCode("PRPA_TE201306UV02");
-        code.setCodeSystem("2.16.840.1.113883.1.6");
+        code.setCode(CNTRL_CODE);
+        code.setCodeSystem(CNTRL_CODE_SYSTEM);
         controlActProcess.setCode(code);
 
         if (patients != null && !patients.isEmpty()) {
@@ -224,7 +241,7 @@ public class TestPatientDiscoveryMessageHelper {
 
     private static PRPAIN201306UV02MFMIMT700711UV01Subject1 createSubject(Patient patient, PRPAIN201305UV02 query) {
         PRPAIN201306UV02MFMIMT700711UV01Subject1 subject = new PRPAIN201306UV02MFMIMT700711UV01Subject1();
-        subject.getTypeCode().add("SUBJ");
+        subject.getTypeCode().add(CNTRL_SUBJ_TYPECODE);
         subject.setRegistrationEvent(createRegEvent(patient, query));
 
         return subject;
@@ -234,16 +251,16 @@ public class TestPatientDiscoveryMessageHelper {
         PRPAIN201305UV02 query) {
 
         II id = new II();
-        id.getNullFlavor().add("NA");
+        id.getNullFlavor().add(NA);
 
         CS statusCode = new CS();
-        statusCode.setCode("active");
+        statusCode.setCode(STATUS_CD);
 
         PRPAIN201306UV02MFMIMT700711UV01RegistrationEvent regEvent
             = new PRPAIN201306UV02MFMIMT700711UV01RegistrationEvent();
 
-        regEvent.getMoodCode().add("EVN");
-        regEvent.getClassCode().add("REG");
+        regEvent.getMoodCode().add(REG_MOOD_CODE);
+        regEvent.getClassCode().add(REG_CLASS_CODE);
         regEvent.getId().add(id);
         regEvent.setStatusCode(statusCode);
         regEvent.setSubject1(createSubject1(patient, query));
@@ -260,10 +277,10 @@ public class TestPatientDiscoveryMessageHelper {
 
     private static PRPAMT201310UV02Patient createPatient(Patient patient, PRPAIN201305UV02 query) {
         CS statusCode = new CS();
-        statusCode.setCode("SD");
+        statusCode.setCode(SUBJ_PATIENT_STATUS_CODE);
 
         PRPAMT201310UV02Patient subjectPatient = new PRPAMT201310UV02Patient();
-        subjectPatient.getClassCode().add("PAT");
+        subjectPatient.getClassCode().add(SUBJ_PATIENT_CLASS_CODE);
         subjectPatient.setStatusCode(statusCode);
         subjectPatient.getId().add(createSubjectId(patient));
         return subjectPatient;
@@ -296,10 +313,10 @@ public class TestPatientDiscoveryMessageHelper {
         return subjectId;
     }
 
-    private static Patients createPatients() {
-        Patient patient = createMpiPatient("Gallow", "Younger", "M", "08-20-1976", createIdentifier(EXTENSION, ROOT));
+    private static Patients createPatients(String firstName,
+        String lastName, String gender, String birthTime, String root, String extension) {
         Patients patients = new Patients();
-        patients.add(patient);
+        patients.add(createMpiPatient(firstName, lastName, gender, birthTime, createIdentifier(extension, root)));
         return patients;
     }
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/TestPatientDiscoveryMessageHelper.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/parser/TestPatientDiscoveryMessageHelper.java
@@ -32,7 +32,6 @@ import gov.hhs.fha.nhinc.mpilib.Patient;
 import gov.hhs.fha.nhinc.mpilib.Patients;
 import gov.hhs.fha.nhinc.mpilib.PersonName;
 import gov.hhs.fha.nhinc.util.HomeCommunityMap;
-import java.util.List;
 import javax.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 import org.hl7.v3.ActClassControlAct;
@@ -125,19 +124,10 @@ public class TestPatientDiscoveryMessageHelper {
         String birthTime, II subjectId) {
 
         PRPAMT201306UV02ParameterList paramList = new PRPAMT201306UV02ParameterList();
-
-        // Set the Subject Gender Code
         paramList.getLivingSubjectAdministrativeGender().add(createGender(gender));
-
-        // Set the Subject Birth Time
         paramList.getLivingSubjectBirthTime().add(createBirthTime(birthTime));
-
-        // Set the Subject Name
         paramList.getLivingSubjectName().add(createName(firstName, lastName));
-
-        // Set the subject Id
         paramList.getLivingSubjectId().add(createSubjectId(subjectId));
-
         return paramList;
     }
 
@@ -153,14 +143,13 @@ public class TestPatientDiscoveryMessageHelper {
     private static PRPAMT201306UV02LivingSubjectName createName(String firstName, String lastName) {
         org.hl7.v3.ObjectFactory factory = new org.hl7.v3.ObjectFactory();
         ENExplicit name = factory.createENExplicit();
-        List namelist = name.getContent();
 
         if (lastName != null && lastName.length() > 0) {
             EnExplicitFamily familyName = new EnExplicitFamily();
             familyName.setPartType("FAM");
             familyName.setContent(lastName);
 
-            namelist.add(factory.createENExplicitFamily(familyName));
+            name.getContent().add(factory.createENExplicitFamily(familyName));
         }
 
         if (firstName != null && firstName.length() > 0) {
@@ -168,7 +157,7 @@ public class TestPatientDiscoveryMessageHelper {
             givenName.setPartType("GIV");
             givenName.setContent(firstName);
 
-            namelist.add(factory.createENExplicitGiven(givenName));
+            name.getContent().add(factory.createENExplicitGiven(givenName));
         }
 
         PRPAMT201306UV02LivingSubjectName subjectName = new PRPAMT201306UV02LivingSubjectName();
@@ -265,9 +254,7 @@ public class TestPatientDiscoveryMessageHelper {
     private static PRPAIN201306UV02MFMIMT700711UV01Subject2 createSubject1(Patient patient, PRPAIN201305UV02 query) {
         PRPAIN201306UV02MFMIMT700711UV01Subject2 subject = new PRPAIN201306UV02MFMIMT700711UV01Subject2();
         subject.setTypeCode(ParticipationTargetSubject.SBJ);
-        // Add in patient
         subject.setPatient(createPatient(patient, query));
-
         return subject;
     }
 
@@ -278,7 +265,6 @@ public class TestPatientDiscoveryMessageHelper {
         PRPAMT201310UV02Patient subjectPatient = new PRPAMT201310UV02Patient();
         subjectPatient.getClassCode().add("PAT");
         subjectPatient.setStatusCode(statusCode);
-        // Add in patient id
         subjectPatient.getId().add(createSubjectId(patient));
         return subjectPatient;
     }
@@ -303,15 +289,15 @@ public class TestPatientDiscoveryMessageHelper {
         return id;
     }
 
-    private static Identifier createIdentifier() {
+    private static Identifier createIdentifier(String extId, String rootId) {
         Identifier subjectId = new Identifier();
-        subjectId.setId("D123401");
-        subjectId.setOrganizationId("1.1");
+        subjectId.setId(extId);
+        subjectId.setOrganizationId(rootId);
         return subjectId;
     }
 
     private static Patients createPatients() {
-        Patient patient = createMpiPatient("Gallow", "Younger", "M", "08-20-1976", createIdentifier());
+        Patient patient = createMpiPatient("Gallow", "Younger", "M", "08-20-1976", createIdentifier(EXTENSION, ROOT));
         Patients patients = new Patients();
         patients.add(patient);
         return patients;
@@ -322,24 +308,15 @@ public class TestPatientDiscoveryMessageHelper {
 
         Patient result = new Patient();
 
-        // Set the patient name
         PersonName name = new PersonName();
         name.setFirstName(firstName);
         name.setLastName(lastName);
         result.getNames().add(name);
-
-        // Set the patient gender
         result.setGender(gender);
-
-        // Set the patient birth time
         result.setDateOfBirth(birthTime);
-
-        // Set the patient Id
         Identifiers ids = new Identifiers();
         ids.add(subjectId);
         result.setIdentifiers(ids);
-
         return result;
     }
-
 }


### PR DESCRIPTION
1. Refactored PatientDiscoveryAuditTransforms class and moved the common audit functionality into an Abstract class.
2. Move the PD message(request and response) parsing code to separate classes for reuse.
