### PR TITLE
FHAC-601:PatientDiscoveryDeferredResponse AuditTransformer to build ATNA complain Audit blob

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/server/BaseService.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/server/BaseService.java
@@ -99,23 +99,6 @@ public abstract class BaseService {
     }
 
     /**
-     * Returns the local client host address
-     *
-     * @param context
-     * @return
-     */
-    protected String getLocalAddress(WebServiceContext context) {
-        String remoteAddress = null;
-        if (context != null && context.getMessageContext() != null
-            && context.getMessageContext().get(AbstractHTTPDestination.HTTP_REQUEST) != null) {
-            HttpServletRequest httpServletRequest
-                = (HttpServletRequest) context.getMessageContext().get(AbstractHTTPDestination.HTTP_REQUEST);
-            remoteAddress = httpServletRequest.getLocalAddr();
-        }
-        return remoteAddress;
-    }
-
-    /**
      * Returns the called Web Service URL
      *
      * @param context
@@ -156,9 +139,6 @@ public abstract class BaseService {
 
             //add Remote Server address or Host
             webContextProperties.put(NhincConstants.REMOTE_HOST_ADDRESS, getRemoteAddress(context));
-
-            //add Local Server address or Host
-            webContextProperties.put(NhincConstants.LOCAL_HOST_ADDRESS, getLocalAddress(context));
 
             //Get Inbound Message ReplyTo Header
             webContextProperties.put(NhincConstants.INBOUND_REPLY_TO, getInboundReplyToHeader(context));

--- a/Product/Production/Gateway/PatientDiscovery_10/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/_10/gateway/ws/NhinPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Gateway/PatientDiscovery_10/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/_10/gateway/ws/NhinPatientDiscoveryDeferredResponse.java
@@ -44,7 +44,7 @@ import org.hl7.v3.PRPAIN201306UV02;
 @Addressing(enabled = true)
 @BindingType(value = javax.xml.ws.soap.SOAPBinding.SOAP12HTTP_BINDING)
 public class NhinPatientDiscoveryDeferredResponse extends BaseService implements
-        RespondingGatewayDeferredResponsePortType {
+    RespondingGatewayDeferredResponsePortType {
 
     private InboundPatientDiscoveryDeferredResponse inboundPatientDiscoveryResponse;
 
@@ -64,12 +64,13 @@ public class NhinPatientDiscoveryDeferredResponse extends BaseService implements
      * @return the response message to the Nhin
      */
     @InboundMessageEvent(beforeBuilder = PRPAIN201306UV02EventDescriptionBuilder.class,
-            afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
-            serviceType = "Patient Discovery Deferred Response", version = "1.0")
+        afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
+        serviceType = "Patient Discovery Deferred Response", version = "1.0")
     public org.hl7.v3.MCCIIN000002UV01 respondingGatewayDeferredPRPAIN201306UV02(PRPAIN201306UV02 body) {
         AssertionType assertion = getAssertion(context, null);
 
-        return inboundPatientDiscoveryResponse.respondingGatewayDeferredPRPAIN201306UV02(body, assertion);
+        return inboundPatientDiscoveryResponse.respondingGatewayDeferredPRPAIN201306UV02(body, assertion,
+            getWebContextProperties(context));
     }
 
     @Resource
@@ -78,7 +79,7 @@ public class NhinPatientDiscoveryDeferredResponse extends BaseService implements
     }
 
     public void setInboundPatientDiscoveryResponse(
-            InboundPatientDiscoveryDeferredResponse inboundPatientDiscoveryResponse) {
+        InboundPatientDiscoveryDeferredResponse inboundPatientDiscoveryResponse) {
         this.inboundPatientDiscoveryResponse = inboundPatientDiscoveryResponse;
     }
 

--- a/Product/Production/Gateway/PatientDiscovery_10/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/_10/gateway/ws/PatientDiscoveryDeferredResponseSpringContextTest.java
+++ b/Product/Production/Gateway/PatientDiscovery_10/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/_10/gateway/ws/PatientDiscoveryDeferredResponseSpringContextTest.java
@@ -66,7 +66,7 @@ public class PatientDiscoveryDeferredResponseSpringContextTest {
     StandardInboundPatientDiscoveryDeferredResponse stdInboundPDRespOrchImpl;
 
     @Autowired
-    StandardInboundPatientDiscoveryDeferredResponse ptInboundPDRespOrchImpl;
+    PassthroughInboundPatientDiscoveryDeferredResponse ptInboundPDRespOrchImpl;
 
     @Autowired
     PassthroughOutboundPatientDiscoveryDeferredResponse ptOutboundPDRespOrchImpl;

--- a/Product/Production/Gateway/PatientDiscovery_10/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/_10/gateway/ws/PatientDiscoveryDeferredResponseSpringContextTest.java
+++ b/Product/Production/Gateway/PatientDiscovery_10/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/_10/gateway/ws/PatientDiscoveryDeferredResponseSpringContextTest.java
@@ -47,7 +47,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  *
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = { "/patientdiscovery/_10/applicationContext.xml" })
+@ContextConfiguration(locations = {"/patientdiscovery/_10/applicationContext.xml"})
 public class PatientDiscoveryDeferredResponseSpringContextTest {
 
     @Autowired

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
@@ -572,8 +572,7 @@ public abstract class AuditTransforms<T, K> {
     protected void setRequest(T request) {
         this.request = request;
     }
-
-    //PD Deferred Response services require incoming Request
+    
     protected T getRequest() {
         return request;
     }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
@@ -76,6 +76,8 @@ public abstract class AuditTransforms<T, K> {
 
     private static final Logger LOG = Logger.getLogger(AuditTransforms.class);
 
+    private T request;
+
     /**
      * Build an AuditLog Request Message from request
      *
@@ -92,6 +94,7 @@ public abstract class AuditTransforms<T, K> {
     public final LogEventRequestType transformRequestToAuditMsg(T request, AssertionType assertion,
         NhinTargetSystemType target, String direction, String _interface, boolean isRequesting,
         Properties webContextProperties, String serviceName) {
+        setRequest(request);
 
         // TODO: auditMsg should either use a builder, or modify in-method with no return
         AuditMessageType auditMsg = createBaseAuditMessage(assertion, target, isRequesting, webContextProperties,
@@ -119,7 +122,7 @@ public abstract class AuditTransforms<T, K> {
     public final LogEventRequestType transformResponseToAuditMsg(T request, K response, AssertionType assertion,
         NhinTargetSystemType target, String direction, String _interface, boolean isRequesting,
         Properties webContextProperties, String serviceName) {
-
+        setRequest(request);
         // TODO: auditMsg should either use a builder, or modify in-method with no return
         AuditMessageType auditMsg = createBaseAuditMessage(assertion, target, isRequesting, webContextProperties,
             serviceName);
@@ -157,7 +160,7 @@ public abstract class AuditTransforms<T, K> {
         return createAuditSourceIdentification(hcid, HomeCommunityMap.getHomeCommunityName(hcid));
     }
 
-    private ActiveParticipant getActiveParticipant(UserType oUserInfo) {
+    protected ActiveParticipant getActiveParticipant(UserType oUserInfo) {
         // Create Active Participant Section
         // create a method to call the AuditDataTransformHelper - one expectation
         ActiveParticipant participant = createActiveParticipantFromUser(oUserInfo);
@@ -267,14 +270,14 @@ public abstract class AuditTransforms<T, K> {
     protected ActiveParticipant getActiveParticipantSource(NhinTargetSystemType target, String serviceName,
         boolean isRequesting, Properties webContextProperties) {
 
-        String hostAddress = isRequesting ? getLocalHostAddress() : getRemoteHostAddress(webContextProperties);
+        String ipOrHost = isRequesting ? getLocalHostAddress() : getRemoteHostAddress(webContextProperties);
 
         AuditMessageType.ActiveParticipant participant = new AuditMessageType.ActiveParticipant();
         participant.setUserID(isRequesting ? NhincConstants.WSA_REPLY_TO
             : getInboundReplyToFromHeader(webContextProperties));
         participant.setAlternativeUserID(ManagementFactory.getRuntimeMXBean().getName());
-        participant.setNetworkAccessPointID(hostAddress);
-        participant.setNetworkAccessPointTypeCode(getNetworkAccessPointTypeCode(hostAddress));
+        participant.setNetworkAccessPointID(ipOrHost);
+        participant.setNetworkAccessPointTypeCode(getNetworkAccessPointTypeCode(ipOrHost));
         participant.getRoleIDCode().add(AuditDataTransformHelper.createCodeValueType(
             AuditTransformsConstants.ACTIVE_PARTICIPANT_ROLE_CODE_SOURCE, null,
             AuditTransformsConstants.ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME,
@@ -374,15 +377,6 @@ public abstract class AuditTransforms<T, K> {
             }
         }
         return AuditTransformsConstants.ACTIVE_PARTICIPANT_USER_ID_SOURCE;
-    }
-
-    protected String getLocalAddressFromProperties(Properties webContextProperties) {
-        if (webContextProperties != null && !webContextProperties.isEmpty() && webContextProperties.getProperty(
-            NhincConstants.LOCAL_HOST_ADDRESS) != null) {
-
-            return webContextProperties.getProperty(NhincConstants.LOCAL_HOST_ADDRESS);
-        }
-        return AuditTransformsConstants.ACTIVE_PARTICIPANT_UNKNOWN_IP_ADDRESS;
     }
 
     protected String getInboundReplyToFromHeader(Properties webContextProperties) {
@@ -513,7 +507,9 @@ public abstract class AuditTransforms<T, K> {
         // Active Participant for human requester only required for requesting gateway
         if (isRequesting) {
             ActiveParticipant participantHumanFactor = getActiveParticipant(assertion.getUserInfo());
-            auditMsg.getActiveParticipant().add(participantHumanFactor);
+            if (participantHumanFactor != null) {
+                auditMsg.getActiveParticipant().add(participantHumanFactor);
+            }
         }
         ActiveParticipant participantSource = getActiveParticipantSource(target, serviceName, isRequesting,
             webContextProperties);
@@ -544,7 +540,7 @@ public abstract class AuditTransforms<T, K> {
         return result;
     }
 
-    private ConnectionManagerCache getConnectionManagerCache() {
+    protected ConnectionManagerCache getConnectionManagerCache() {
         return ConnectionManagerCache.getInstance();
     }
 
@@ -571,5 +567,15 @@ public abstract class AuditTransforms<T, K> {
     protected abstract String getServiceEventActionCodeRequestor();
 
     protected abstract String getServiceEventActionCodeResponder();
+
+    //PD Deferred Response services require incoming Request. so getters and setters are created.
+    protected void setRequest(T request) {
+        this.request = request;
+    }
+
+    //PD Deferred Response services require incoming Request
+    protected T getRequest() {
+        return request;
+    }
 
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
@@ -572,7 +572,7 @@ public abstract class AuditTransforms<T, K> {
     protected void setRequest(T request) {
         this.request = request;
     }
-    
+
     protected T getRequest() {
         return request;
     }

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformsTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformsTest.java
@@ -190,7 +190,7 @@ public abstract class AuditTransformsTest<T, K> {
         }
 
         assertEquals("NetworkAccessPointID mismatch", ipOrHost, sourceActiveParticipant.getNetworkAccessPointID());
-        assertEquals("SourceActiveParticipant requestor flag mismatch", isRequesting,
+        assertEquals("SourceActiveParticipant requestor flag mismatch", Boolean.TRUE,
             sourceActiveParticipant.isUserIsRequestor());
         assertEquals("NetworkAccessPointTypeCode mismatch",
             getAuditTransforms().getNetworkAccessPointTypeCode(ipOrHost),
@@ -251,7 +251,7 @@ public abstract class AuditTransformsTest<T, K> {
         }
 
         assertEquals("UserID mismatch", userId, destinationActiveParticipant.getUserID());
-        assertEquals("DestinationActiveParticipant requestor flag mismatch", !isRequesting,
+        assertEquals("DestinationActiveParticipant requestor flag mismatch", Boolean.FALSE,
             destinationActiveParticipant.isUserIsRequestor());
         assertEquals("NetworkAccessPointID mismatch", localIp, destinationActiveParticipant.getNetworkAccessPointID());
         assertEquals("NetworkAccessPointTypeCode mismatch", AuditTransformsConstants.NETWORK_ACCESSOR_PT_TYPE_CODE_IP,

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/audit/transform/COREX12BatchSubmissionAuditTransforms.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/audit/transform/COREX12BatchSubmissionAuditTransforms.java
@@ -38,8 +38,8 @@ import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeBatchSubmissionResponse;
  *
  * @author achidamb
  */
-public class COREX12BatchSubmissionAuditTransforms extends COREX12AuditTransforms<COREEnvelopeBatchSubmission, 
-    COREEnvelopeBatchSubmissionResponse> {
+public class COREX12BatchSubmissionAuditTransforms extends
+    COREX12AuditTransforms<COREEnvelopeBatchSubmission, COREEnvelopeBatchSubmissionResponse> {
 
     private static final Logger LOG = Logger.getLogger(COREX12BatchSubmissionAuditTransforms.class);
 
@@ -58,7 +58,8 @@ public class COREX12BatchSubmissionAuditTransforms extends COREX12AuditTransform
                 getMarshaller().marshal(element, baOutStrm);
                 bObject = baOutStrm.toByteArray();
             } catch (JAXBException ex) {
-                LOG.error("Error while Marshalling COREEnvelopeBatchSubmission Request:  " + ex.getMessage(), ex);
+                LOG.error("Error while Marshalling COREEnvelopeBatchSubmission Request:  "
+                    + ex.getLocalizedMessage(), ex);
             }
         }
         return bObject;
@@ -79,7 +80,8 @@ public class COREX12BatchSubmissionAuditTransforms extends COREX12AuditTransform
                 getMarshaller().marshal(element, baOutStrm);
                 bObject = baOutStrm.toByteArray();
             } catch (JAXBException ex) {
-                LOG.error("Error while Marshalling COREEnvelopeBatchSubmission Response:  " + ex.getMessage(), ex);
+                LOG.error("Error while Marshalling COREEnvelopeBatchSubmission Response:  "
+                    + ex.getLocalizedMessage(), ex);
             }
         }
         return bObject;

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/audit/transform/COREX12BatchSubmissionAuditTransforms.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/audit/transform/COREX12BatchSubmissionAuditTransforms.java
@@ -38,7 +38,8 @@ import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeBatchSubmissionResponse;
  *
  * @author achidamb
  */
-public class COREX12BatchSubmissionAuditTransforms extends COREX12AuditTransforms<COREEnvelopeBatchSubmission, COREEnvelopeBatchSubmissionResponse> {
+public class COREX12BatchSubmissionAuditTransforms extends COREX12AuditTransforms<COREEnvelopeBatchSubmission, 
+    COREEnvelopeBatchSubmissionResponse> {
 
     private static final Logger LOG = Logger.getLogger(COREX12BatchSubmissionAuditTransforms.class);
 

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/audit/transform/COREX12RealTimeAuditTransforms.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/audit/transform/COREX12RealTimeAuditTransforms.java
@@ -38,7 +38,8 @@ import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeRealTimeResponse;
  *
  * @author achidamb
  */
-public class COREX12RealTimeAuditTransforms extends COREX12AuditTransforms<COREEnvelopeRealTimeRequest, COREEnvelopeRealTimeResponse> {
+public class COREX12RealTimeAuditTransforms extends
+    COREX12AuditTransforms<COREEnvelopeRealTimeRequest, COREEnvelopeRealTimeResponse> {
 
     private static final Logger LOG = Logger.getLogger(COREX12RealTimeAuditTransforms.class);
 
@@ -57,7 +58,8 @@ public class COREX12RealTimeAuditTransforms extends COREX12AuditTransforms<COREE
                 getMarshaller().marshal(element, baOutStrm);
                 bObject = baOutStrm.toByteArray();
             } catch (JAXBException ex) {
-                LOG.error("Error while marshalling COREEnvelopeRealTimeRequest Request: " + ex.getMessage(), ex);
+                LOG.error("Error while marshalling COREEnvelopeRealTimeRequest Request: "
+                    + ex.getLocalizedMessage(), ex);
             }
         }
         return bObject;
@@ -78,7 +80,8 @@ public class COREX12RealTimeAuditTransforms extends COREX12AuditTransforms<COREE
                 getMarshaller().marshal(element, baOutStrm);
                 bObject = baOutStrm.toByteArray();
             } catch (JAXBException ex) {
-                LOG.error("Error while marshalling COREEnvelopeRealTimeResponse Response: " + ex.getMessage(), ex);
+                LOG.error("Error while marshalling COREEnvelopeRealTimeResponse Response: "
+                    + ex.getLocalizedMessage(), ex);
             }
         }
         return bObject;

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryDeferredResponseAuditLogger.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryDeferredResponseAuditLogger.java
@@ -1,0 +1,26 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+package gov.hhs.fha.nhinc.patientdiscovery.audit;
+
+import gov.hhs.fha.nhinc.audit.AuditLogger;
+import gov.hhs.fha.nhinc.audit.transform.AuditTransforms;
+import gov.hhs.fha.nhinc.patientdiscovery.audit.transform.PatientDiscoveryDeferredResponseAuditTransforms;
+import org.hl7.v3.MCCIIN000002UV01;
+import org.hl7.v3.PRPAIN201306UV02;
+
+/**
+ *
+ * @author achidamb
+ */
+public class PatientDiscoveryDeferredResponseAuditLogger extends AuditLogger<PRPAIN201306UV02, MCCIIN000002UV01>  {
+    
+     @Override
+    protected AuditTransforms<PRPAIN201306UV02, MCCIIN000002UV01> getAuditTransforms() {
+        return new PatientDiscoveryDeferredResponseAuditTransforms();
+    }
+    
+}

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryDeferredResponseAuditLogger.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryDeferredResponseAuditLogger.java
@@ -24,7 +24,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package gov.hhs.fha.nhinc.patientdiscovery.audit;
 
 import gov.hhs.fha.nhinc.audit.AuditLogger;
@@ -37,11 +36,11 @@ import org.hl7.v3.PRPAIN201306UV02;
  *
  * @author achidamb
  */
-public class PatientDiscoveryDeferredResponseAuditLogger extends AuditLogger<PRPAIN201306UV02, MCCIIN000002UV01>  {
-    
-     @Override
+public class PatientDiscoveryDeferredResponseAuditLogger extends AuditLogger<PRPAIN201306UV02, MCCIIN000002UV01> {
+
+    @Override
     protected AuditTransforms<PRPAIN201306UV02, MCCIIN000002UV01> getAuditTransforms() {
         return new PatientDiscoveryDeferredResponseAuditTransforms();
     }
-    
+
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryDeferredResponseAuditLogger.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/PatientDiscoveryDeferredResponseAuditLogger.java
@@ -1,7 +1,28 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 package gov.hhs.fha.nhinc.patientdiscovery.audit;

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/AbstractPatientDiscoveryAuditTransforms.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/AbstractPatientDiscoveryAuditTransforms.java
@@ -29,6 +29,7 @@ package gov.hhs.fha.nhinc.patientdiscovery.audit.transform;
 import com.services.nhinc.schema.auditmessage.AuditMessageType;
 import com.services.nhinc.schema.auditmessage.ParticipantObjectIdentificationType;
 import gov.hhs.fha.nhinc.audit.transform.AuditTransforms;
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryAuditTransformsConstants;
 import gov.hhs.fha.nhinc.patientdiscovery.parser.PRPAIN201305UV02Parser;
@@ -48,6 +49,8 @@ import org.hl7.v3.PRPAIN201306UV02;
  * PatientDiscoveryDeferredResponseAuditTransforms
  *
  * @author tjafri
+ * @param <T>
+ * @param <K>
  */
 public abstract class AbstractPatientDiscoveryAuditTransforms<T, K> extends AuditTransforms<T, K> {
 
@@ -75,6 +78,23 @@ public abstract class AbstractPatientDiscoveryAuditTransforms<T, K> extends Audi
     protected static String createPatientId(String assigningAuthId, String patientId) {
         return patientId + "^^^&" + assigningAuthId + "&ISO";
     }
+
+    @Override
+    protected abstract AuditMessageType getParticipantObjectIdentificationForRequest(T request, AssertionType assertion,
+        AuditMessageType auditMsg);
+
+    /**
+     * Adds Participant Object Identification information to auditMsg
+     *
+     * @param request
+     * @param response
+     * @param assertion
+     * @param auditMsg
+     * @return
+     */
+    @Override
+    protected abstract AuditMessageType getParticipantObjectIdentificationForResponse(T request, K response,
+        AssertionType assertion, AuditMessageType auditMsg);
 
     protected AuditMessageType getQueryParamsParticipantObjectIdentificationForRequest(PRPAIN201305UV02 request,
         AuditMessageType auditMsg) throws JAXBException {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredResponseAuditTransforms.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredResponseAuditTransforms.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.patientdiscovery.audit.transform;
+
+import com.services.nhinc.schema.auditmessage.AuditMessageType;
+import gov.hhs.fha.nhinc.audit.AuditTransformsConstants;
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunityType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.common.nhinccommon.UserType;
+import gov.hhs.fha.nhinc.connectmgr.ConnectionManagerException;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.patientdiscovery.MessageGeneratorUtils;
+import gov.hhs.fha.nhinc.patientdiscovery.parser.PRPAIN201306UV02Parser;
+import gov.hhs.fha.nhinc.properties.PropertyAccessException;
+import gov.hhs.fha.nhinc.properties.PropertyAccessor;
+import gov.hhs.fha.nhinc.transform.audit.AuditDataTransformHelper;
+import java.lang.management.ManagementFactory;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Properties;
+import javax.xml.bind.JAXBException;
+import org.apache.log4j.Logger;
+import org.hl7.v3.MCCIIN000002UV01;
+import org.hl7.v3.PRPAIN201306UV02;
+
+/**
+ *
+ * @author achidamb
+ */
+public class PatientDiscoveryDeferredResponseAuditTransforms extends AbstractPatientDiscoveryAuditTransforms<PRPAIN201306UV02, 
+    MCCIIN000002UV01> {
+
+    private static final Logger LOG = Logger.getLogger(PatientDiscoveryDeferredResponseAuditTransforms.class);
+
+    public PatientDiscoveryDeferredResponseAuditTransforms() {
+        
+    }
+
+    @Override
+    protected AuditMessageType getParticipantObjectIdentificationForRequest(PRPAIN201306UV02 request,
+        AssertionType assertion, AuditMessageType auditMsg) {
+        auditMsg = getPatientParticipantObjectIdentificationForResponse(request, auditMsg);
+        try {
+            auditMsg = getQueryParamsParticipantObjectIdentificationForResponse(request, auditMsg);
+        } catch (JAXBException ex) {
+            if (LOG.isDebugEnabled()) {
+            LOG.error("Error while creating ParticipantObjectIdentificationQueryByParameters segment : "
+                + ex.getLocalizedMessage(), ex);
+            }
+        }
+
+        return auditMsg;
+    }
+
+    @Override
+    protected AuditMessageType getParticipantObjectIdentificationForResponse(PRPAIN201306UV02 request,
+        MCCIIN000002UV01 response, AssertionType assertion, AuditMessageType auditMsg) {
+        auditMsg = getPatientParticipantObjectIdentificationForResponse(request, auditMsg);
+
+        try {
+            auditMsg = getQueryParamsParticipantObjectIdentificationForResponse(request, auditMsg);
+        } catch (JAXBException ex) {
+            LOG.error("Error while creating ParticipantObjectIdentificationQueryByParameters segment : "
+                + ex.getLocalizedMessage(), ex);
+        }
+
+        return auditMsg;
+    }
+    
+    @Override
+    protected AuditMessageType.ActiveParticipant getActiveParticipant(UserType oUserInfo) {
+        return null;
+    }
+    
+    @Override
+    protected AuditMessageType.ActiveParticipant getActiveParticipantSource(NhinTargetSystemType target, String serviceName,
+        boolean isRequesting, Properties webContextProperties) {
+
+        String ipOrHost = isRequesting ? getPDDeferredRequestInitiatorAdress() : getLocalHostAddress();
+
+        AuditMessageType.ActiveParticipant participant = new AuditMessageType.ActiveParticipant();
+        participant.setUserID(isRequesting ? NhincConstants.WSA_REPLY_TO
+            : getInboundReplyToFromHeader(webContextProperties));
+        participant.setAlternativeUserID(ManagementFactory.getRuntimeMXBean().getName());
+        participant.setNetworkAccessPointID(ipOrHost);
+        participant.setNetworkAccessPointTypeCode(getNetworkAccessPointTypeCode(ipOrHost));
+        participant.getRoleIDCode().add(AuditDataTransformHelper.createCodeValueType(
+            AuditTransformsConstants.ACTIVE_PARTICIPANT_ROLE_CODE_SOURCE, null,
+            AuditTransformsConstants.ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME,
+            AuditTransformsConstants.ACTIVE_PARTICIPANT_ROLE_CODE_SOURCE_DISPLAY_NAME));
+        participant.setUserIsRequestor(Boolean.TRUE);
+        return participant;
+
+    }
+    
+    @Override
+    protected AuditMessageType.ActiveParticipant getActiveParticipantDestination(NhinTargetSystemType target, 
+        boolean isRequesting, Properties webContextProperties, String serviceName) {
+
+        String url;
+        String ipOrHost;
+
+        AuditMessageType.ActiveParticipant participant = new AuditMessageType.ActiveParticipant();
+
+            url = isRequesting ? getWebServiceUrlFromRemoteObject(getLocalHCIDNhinTarget(),
+                NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME): getWebServiceUrlFromRemoteObject(
+                    convertToNhinTarget(PRPAIN201306UV02Parser.getSenderHcid(getRequest())),
+                    NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME );
+        if (url != null) {
+            try {
+                participant.setUserID(url);
+                ipOrHost = new URL(url).getHost();
+                participant.setNetworkAccessPointID(ipOrHost);
+                participant.setNetworkAccessPointTypeCode(getNetworkAccessPointTypeCode(ipOrHost));
+            } catch (MalformedURLException ex) {
+                LOG.error("Couldn't parse the given NetworkAccessPointID as a URL: " + ex.getLocalizedMessage(), ex);
+                // The url is null or not a valid url; for now, set the user id to anonymous
+                participant.setUserID(AuditTransformsConstants.ACTIVE_PARTICIPANT_USER_ID_SOURCE);
+                // TODO: For now, hardcode the value to localhost; need to find out if this needs to be set
+                participant.setNetworkAccessPointTypeCode(AuditTransformsConstants.NETWORK_ACCESSOR_PT_TYPE_CODE_NAME);
+                participant.setNetworkAccessPointID(AuditTransformsConstants.ACTIVE_PARTICIPANT_UNKNOWN_IP_ADDRESS);
+            }
+        }
+        if (!isRequesting) {
+            participant.setAlternativeUserID(ManagementFactory.getRuntimeMXBean().getName());
+        }
+        participant.setUserIsRequestor(Boolean.FALSE);
+        participant.getRoleIDCode().add(AuditDataTransformHelper.createCodeValueType(
+            AuditTransformsConstants.ACTIVE_PARTICIPANT_ROLE_CODE_DEST, null,
+            AuditTransformsConstants.ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME,
+            AuditTransformsConstants.ACTIVE_PARTICIPANT_ROLE_CODE_DESTINATION_DISPLAY_NAME));
+
+        return participant;
+    }
+
+
+    
+    protected String getPDDeferredRequestInitiatorAdress() {
+        String ipOrHost;
+        try {
+            String hcid = PRPAIN201306UV02Parser.getReceiverHCID(getRequest());
+            ipOrHost = new URL(getWebServiceUrlFromRemoteObject(MessageGeneratorUtils.getInstance().
+                convertToNhinTargetSystemType(createNhinTargetCommunity(hcid)),
+                NhincConstants.PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME)).getHost();
+            return ipOrHost;
+        } catch (MalformedURLException ex) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Exception while Reading Url for the PatientDiscovery Deferred Request Service Endpoint: "
+                    + ex.getMessage(), ex);
+            }
+        }
+        return AuditTransformsConstants.ACTIVE_PARTICIPANT_UNKNOWN_IP_ADDRESS;
+    }
+
+    @Override
+    protected String getWebServiceUrlFromRemoteObject(NhinTargetSystemType target, String serviceName) {
+        try {
+            return getConnectionManagerCache().getEndpointURLFromNhinTarget(target,
+                NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME); 
+        } catch (ConnectionManagerException ex) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Exception while Reading Url for the PatientDiscovery Deferred Response Service Endpoint: "
+                    + ex.getMessage(), ex);
+            }
+        }
+        return AuditTransformsConstants.ACTIVE_PARTICIPANT_USER_ID_SOURCE;
+    }
+
+    private NhinTargetCommunityType createNhinTargetCommunity(String hcid) {
+        NhinTargetCommunityType target = new NhinTargetCommunityType();
+        HomeCommunityType homecommunity = new HomeCommunityType();
+        homecommunity.setHomeCommunityId(hcid);
+        target.setHomeCommunity(homecommunity);
+        return target;
+    }
+
+    private NhinTargetSystemType getLocalHCIDNhinTarget() {
+        String hcid = null;
+        try {
+            hcid = PropertyAccessor.getInstance().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE, 
+                NhincConstants.HOME_COMMUNITY_ID_PROPERTY);
+        } catch (PropertyAccessException ex) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Exception while reading local hcid from "+ NhincConstants.GATEWAY_PROPERTY_FILE + 
+                    ex.getMessage(), ex);
+            }
+        }
+        return convertToNhinTarget(hcid);
+    }
+    
+    private NhinTargetSystemType convertToNhinTarget(String hcid) {
+        return MessageGeneratorUtils.getInstance().convertToNhinTargetSystemType(createNhinTargetCommunity(hcid));
+    }
+
+}

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredResponseAuditTransforms.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredResponseAuditTransforms.java
@@ -53,13 +53,13 @@ import org.hl7.v3.PRPAIN201306UV02;
  *
  * @author achidamb
  */
-public class PatientDiscoveryDeferredResponseAuditTransforms extends AbstractPatientDiscoveryAuditTransforms<PRPAIN201306UV02, 
-    MCCIIN000002UV01> {
+public class PatientDiscoveryDeferredResponseAuditTransforms extends
+    AbstractPatientDiscoveryAuditTransforms<PRPAIN201306UV02, MCCIIN000002UV01> {
 
     private static final Logger LOG = Logger.getLogger(PatientDiscoveryDeferredResponseAuditTransforms.class);
 
     public PatientDiscoveryDeferredResponseAuditTransforms() {
-        
+
     }
 
     @Override
@@ -69,10 +69,8 @@ public class PatientDiscoveryDeferredResponseAuditTransforms extends AbstractPat
         try {
             auditMsg = getQueryParamsParticipantObjectIdentificationForResponse(request, auditMsg);
         } catch (JAXBException ex) {
-            if (LOG.isDebugEnabled()) {
             LOG.error("Error while creating ParticipantObjectIdentificationQueryByParameters segment : "
                 + ex.getLocalizedMessage(), ex);
-            }
         }
 
         return auditMsg;
@@ -92,17 +90,17 @@ public class PatientDiscoveryDeferredResponseAuditTransforms extends AbstractPat
 
         return auditMsg;
     }
-    
+
     @Override
     protected AuditMessageType.ActiveParticipant getActiveParticipant(UserType oUserInfo) {
         return null;
     }
-    
-    @Override
-    protected AuditMessageType.ActiveParticipant getActiveParticipantSource(NhinTargetSystemType target, String serviceName,
-        boolean isRequesting, Properties webContextProperties) {
 
-        String ipOrHost = isRequesting ? getPDDeferredRequestInitiatorAdress() : getLocalHostAddress();
+    @Override
+    protected AuditMessageType.ActiveParticipant getActiveParticipantSource(NhinTargetSystemType target,
+        String serviceName, boolean isRequesting, Properties webContextProperties) {
+
+        String ipOrHost = isRequesting ? getPDDeferredRequestInitiatorAddress() : getLocalHostAddress();
 
         AuditMessageType.ActiveParticipant participant = new AuditMessageType.ActiveParticipant();
         participant.setUserID(isRequesting ? NhincConstants.WSA_REPLY_TO
@@ -118,9 +116,9 @@ public class PatientDiscoveryDeferredResponseAuditTransforms extends AbstractPat
         return participant;
 
     }
-    
+
     @Override
-    protected AuditMessageType.ActiveParticipant getActiveParticipantDestination(NhinTargetSystemType target, 
+    protected AuditMessageType.ActiveParticipant getActiveParticipantDestination(NhinTargetSystemType target,
         boolean isRequesting, Properties webContextProperties, String serviceName) {
 
         String url;
@@ -128,10 +126,10 @@ public class PatientDiscoveryDeferredResponseAuditTransforms extends AbstractPat
 
         AuditMessageType.ActiveParticipant participant = new AuditMessageType.ActiveParticipant();
 
-            url = isRequesting ? getWebServiceUrlFromRemoteObject(getLocalHCIDNhinTarget(),
-                NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME): getWebServiceUrlFromRemoteObject(
-                    convertToNhinTarget(PRPAIN201306UV02Parser.getSenderHcid(getRequest())),
-                    NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME );
+        url = isRequesting ? getWebServiceUrlFromRemoteObject(getLocalHCIDNhinTarget(),
+            NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME) : getWebServiceUrlFromRemoteObject(
+                convertToNhinTarget(PRPAIN201306UV02Parser.getSenderHcid(getRequest())),
+                NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
         if (url != null) {
             try {
                 participant.setUserID(url);
@@ -159,21 +157,15 @@ public class PatientDiscoveryDeferredResponseAuditTransforms extends AbstractPat
         return participant;
     }
 
-
-    
-    protected String getPDDeferredRequestInitiatorAdress() {
-        String ipOrHost;
+    protected String getPDDeferredRequestInitiatorAddress() {
         try {
             String hcid = PRPAIN201306UV02Parser.getReceiverHCID(getRequest());
-            ipOrHost = new URL(getWebServiceUrlFromRemoteObject(MessageGeneratorUtils.getInstance().
+            return new URL(getWebServiceUrlFromRemoteObject(MessageGeneratorUtils.getInstance().
                 convertToNhinTargetSystemType(createNhinTargetCommunity(hcid)),
                 NhincConstants.PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME)).getHost();
-            return ipOrHost;
         } catch (MalformedURLException ex) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Exception while Reading Url for the PatientDiscovery Deferred Request Service Endpoint: "
-                    + ex.getMessage(), ex);
-            }
+            LOG.error("Exception while Reading Url for the PatientDiscovery Deferred Request Service Endpoint: "
+                + ex.getLocalizedMessage(), ex);
         }
         return AuditTransformsConstants.ACTIVE_PARTICIPANT_UNKNOWN_IP_ADDRESS;
     }
@@ -182,12 +174,10 @@ public class PatientDiscoveryDeferredResponseAuditTransforms extends AbstractPat
     protected String getWebServiceUrlFromRemoteObject(NhinTargetSystemType target, String serviceName) {
         try {
             return getConnectionManagerCache().getEndpointURLFromNhinTarget(target,
-                NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME); 
+                NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
         } catch (ConnectionManagerException ex) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Exception while Reading Url for the PatientDiscovery Deferred Response Service Endpoint: "
-                    + ex.getMessage(), ex);
-            }
+            LOG.error("Exception while Reading Url for the PatientDiscovery Deferred Response Service Endpoint: "
+                + ex.getLocalizedMessage(), ex);
         }
         return AuditTransformsConstants.ACTIVE_PARTICIPANT_USER_ID_SOURCE;
     }
@@ -203,17 +193,15 @@ public class PatientDiscoveryDeferredResponseAuditTransforms extends AbstractPat
     private NhinTargetSystemType getLocalHCIDNhinTarget() {
         String hcid = null;
         try {
-            hcid = PropertyAccessor.getInstance().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE, 
+            hcid = PropertyAccessor.getInstance().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE,
                 NhincConstants.HOME_COMMUNITY_ID_PROPERTY);
         } catch (PropertyAccessException ex) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Exception while reading local hcid from "+ NhincConstants.GATEWAY_PROPERTY_FILE + 
-                    ex.getMessage(), ex);
-            }
+            LOG.error("Exception while reading local hcid from " + NhincConstants.GATEWAY_PROPERTY_FILE
+                + ex.getLocalizedMessage(), ex);
         }
         return convertToNhinTarget(hcid);
     }
-    
+
     private NhinTargetSystemType convertToNhinTarget(String hcid) {
         return MessageGeneratorUtils.getInstance().convertToNhinTargetSystemType(createNhinTargetCommunity(hcid));
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/entity/deferred/response/OutboundPatientDiscoveryDeferredResponseStrategyImpl_g0.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/entity/deferred/response/OutboundPatientDiscoveryDeferredResponseStrategyImpl_g0.java
@@ -26,18 +26,13 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.entity.deferred.response;
 
-import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
-import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.orchestration.Orchestratable;
 import gov.hhs.fha.nhinc.orchestration.OrchestrationStrategy;
-import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryAuditLogger;
-import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryAuditor;
 import gov.hhs.fha.nhinc.patientdiscovery.nhin.deferred.response.proxy.NhinPatientDiscoveryDeferredRespProxy;
 import gov.hhs.fha.nhinc.patientdiscovery.nhin.deferred.response.proxy.NhinPatientDiscoveryDeferredRespProxyObjectFactory;
 
 import org.apache.log4j.Logger;
 import org.hl7.v3.MCCIIN000002UV01;
-import org.hl7.v3.PRPAIN201306UV02;
 
 /**
  * @author akong
@@ -64,7 +59,6 @@ public class OutboundPatientDiscoveryDeferredResponseStrategyImpl_g0 implements 
         }
 
         if (message instanceof OutboundPatientDiscoveryDeferredResponseOrchestratable) {
-            auditRequestToNhin(message.getRequest(), message.getAssertion());
 
             NhinPatientDiscoveryDeferredRespProxy nhinPatientDiscovery = new NhinPatientDiscoveryDeferredRespProxyObjectFactory()
                     .getNhinPatientDiscoveryAsyncRespProxy();
@@ -73,7 +67,6 @@ public class OutboundPatientDiscoveryDeferredResponseStrategyImpl_g0 implements 
                     message.getAssertion(), message.getTarget());
             message.setResponse(response);
 
-            auditResponseFromNhin(message.getResponse(), message.getAssertion());
         } else {
             LOG.error(
                     "OutboundPatientDiscoveryDeferredResponseStrategyImpl_g0 received a message "
@@ -82,14 +75,4 @@ public class OutboundPatientDiscoveryDeferredResponseStrategyImpl_g0 implements 
        	LOG.debug("End OutboundPatientDiscoveryDeferredResponseStrategyImpl_g0.process");
     }
 
-    private void auditRequestToNhin(PRPAIN201306UV02 request, AssertionType assertion) {
-        PatientDiscoveryAuditor auditLog = new PatientDiscoveryAuditLogger();
-        auditLog.auditNhinDeferred201306(request, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
-    }
-
-    private void auditResponseFromNhin(MCCIIN000002UV01 resp, AssertionType assertion) {
-        PatientDiscoveryAuditor auditLog = new PatientDiscoveryAuditLogger();
-        auditLog.auditAck(resp, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
-                NhincConstants.AUDIT_LOG_NHIN_INTERFACE);
-    }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/entity/deferred/response/OutboundPatientDiscoveryDeferredResponseStrategyImpl_g0.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/entity/deferred/response/OutboundPatientDiscoveryDeferredResponseStrategyImpl_g0.java
@@ -60,19 +60,19 @@ public class OutboundPatientDiscoveryDeferredResponseStrategyImpl_g0 implements 
 
         if (message instanceof OutboundPatientDiscoveryDeferredResponseOrchestratable) {
 
-            NhinPatientDiscoveryDeferredRespProxy nhinPatientDiscovery = new NhinPatientDiscoveryDeferredRespProxyObjectFactory()
-                    .getNhinPatientDiscoveryAsyncRespProxy();
+            NhinPatientDiscoveryDeferredRespProxy nhinPatientDiscovery
+                = new NhinPatientDiscoveryDeferredRespProxyObjectFactory().getNhinPatientDiscoveryAsyncRespProxy();
 
             MCCIIN000002UV01 response = nhinPatientDiscovery.respondingGatewayPRPAIN201306UV02(message.getRequest(),
-                    message.getAssertion(), message.getTarget());
+                message.getAssertion(), message.getTarget());
             message.setResponse(response);
 
         } else {
             LOG.error(
-                    "OutboundPatientDiscoveryDeferredResponseStrategyImpl_g0 received a message "
-                            + "which was not of type OutboundPatientDiscoveryDeferredResponseOrchestratable.");
+                "OutboundPatientDiscoveryDeferredResponseStrategyImpl_g0 received a message "
+                + "which was not of type OutboundPatientDiscoveryDeferredResponseOrchestratable.");
         }
-       	LOG.debug("End OutboundPatientDiscoveryDeferredResponseStrategyImpl_g0.process");
+        LOG.debug("End OutboundPatientDiscoveryDeferredResponseStrategyImpl_g0.process");
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/AbstractInboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/AbstractInboundPatientDiscoveryDeferredResponse.java
@@ -41,7 +41,7 @@ import org.hl7.v3.PRPAIN201306UV02;
  *
  */
 public abstract class AbstractInboundPatientDiscoveryDeferredResponse implements
-        InboundPatientDiscoveryDeferredResponse {
+    InboundPatientDiscoveryDeferredResponse {
 
     private final GenericFactory<AdapterPatientDiscoveryDeferredRespProxy> proxyFactory;
 
@@ -54,17 +54,17 @@ public abstract class AbstractInboundPatientDiscoveryDeferredResponse implements
     }
 
     public AbstractInboundPatientDiscoveryDeferredResponse(
-            GenericFactory<AdapterPatientDiscoveryDeferredRespProxy> factory) {
+        GenericFactory<AdapterPatientDiscoveryDeferredRespProxy> factory) {
         proxyFactory = factory;
     }
 
     @Override
-    public MCCIIN000002UV01 respondingGatewayDeferredPRPAIN201306UV02(PRPAIN201306UV02 request, AssertionType assertion, 
+    public MCCIIN000002UV01 respondingGatewayDeferredPRPAIN201306UV02(PRPAIN201306UV02 request, AssertionType assertion,
         Properties webContextProperties) {
 
         MCCIIN000002UV01 response = process(request, assertion);
 
-        auditResponseToNhin(request,response, assertion, webContextProperties);
+        auditResponseToNhin(request, response, assertion, webContextProperties);
 
         return response;
     }
@@ -75,10 +75,10 @@ public abstract class AbstractInboundPatientDiscoveryDeferredResponse implements
         return proxy.processPatientDiscoveryAsyncResp(request, assertion);
     }
 
-    protected void auditResponseToNhin(PRPAIN201306UV02 request, MCCIIN000002UV01 response, AssertionType assertion, 
+    protected void auditResponseToNhin(PRPAIN201306UV02 request, MCCIIN000002UV01 response, AssertionType assertion,
         Properties webContextProperties) {
-        getAuditLogger().auditResponseMessage(request, response, assertion, null, 
-            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE, 
+        getAuditLogger().auditResponseMessage(request, response, assertion, null,
+            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE,
             webContextProperties, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
     }
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/AbstractInboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/AbstractInboundPatientDiscoveryDeferredResponse.java
@@ -29,10 +29,10 @@ package gov.hhs.fha.nhinc.patientdiscovery.inbound.deferred.response;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.generic.GenericFactory;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
-import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryAuditor;
 import gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.response.proxy.AdapterPatientDiscoveryDeferredRespProxy;
 import gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.response.proxy.AdapterPatientDiscoveryDeferredRespProxyObjectFactory;
-
+import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryDeferredResponseAuditLogger;
+import java.util.Properties;
 import org.hl7.v3.MCCIIN000002UV01;
 import org.hl7.v3.PRPAIN201306UV02;
 
@@ -47,7 +47,7 @@ public abstract class AbstractInboundPatientDiscoveryDeferredResponse implements
 
     abstract MCCIIN000002UV01 process(PRPAIN201306UV02 request, AssertionType assertion);
 
-    abstract PatientDiscoveryAuditor getAuditLogger();
+    abstract PatientDiscoveryDeferredResponseAuditLogger getAuditLogger();
 
     public AbstractInboundPatientDiscoveryDeferredResponse() {
         proxyFactory = new AdapterPatientDiscoveryDeferredRespProxyObjectFactory();
@@ -59,12 +59,12 @@ public abstract class AbstractInboundPatientDiscoveryDeferredResponse implements
     }
 
     @Override
-    public MCCIIN000002UV01 respondingGatewayDeferredPRPAIN201306UV02(PRPAIN201306UV02 request, AssertionType assertion) {
-        auditRequestFromNhin(request, assertion);
+    public MCCIIN000002UV01 respondingGatewayDeferredPRPAIN201306UV02(PRPAIN201306UV02 request, AssertionType assertion, 
+        Properties webContextProperties) {
 
         MCCIIN000002UV01 response = process(request, assertion);
 
-        auditResponseToNhin(response, assertion);
+        auditResponseToNhin(request,response, assertion, webContextProperties);
 
         return response;
     }
@@ -75,13 +75,11 @@ public abstract class AbstractInboundPatientDiscoveryDeferredResponse implements
         return proxy.processPatientDiscoveryAsyncResp(request, assertion);
     }
 
-    protected void auditRequestFromNhin(PRPAIN201306UV02 request, AssertionType assertion) {
-        getAuditLogger().auditNhinDeferred201306(request, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
-    }
-
-    protected void auditResponseToNhin(MCCIIN000002UV01 response, AssertionType assertion) {
-        getAuditLogger().auditAck(response, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
-                NhincConstants.AUDIT_LOG_NHIN_INTERFACE);
+    protected void auditResponseToNhin(PRPAIN201306UV02 request, MCCIIN000002UV01 response, AssertionType assertion, 
+        Properties webContextProperties) {
+        getAuditLogger().auditResponseMessage(request, response, assertion, null, 
+            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE, 
+            webContextProperties, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/InboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/InboundPatientDiscoveryDeferredResponse.java
@@ -37,6 +37,6 @@ import org.hl7.v3.PRPAIN201306UV02;
  */
 public interface InboundPatientDiscoveryDeferredResponse {
 
-    public MCCIIN000002UV01 respondingGatewayDeferredPRPAIN201306UV02(PRPAIN201306UV02 body, AssertionType assertion, 
+    public MCCIIN000002UV01 respondingGatewayDeferredPRPAIN201306UV02(PRPAIN201306UV02 body, AssertionType assertion,
         Properties webContextProperties);
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/InboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/InboundPatientDiscoveryDeferredResponse.java
@@ -27,7 +27,7 @@
 package gov.hhs.fha.nhinc.patientdiscovery.inbound.deferred.response;
 
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
-
+import java.util.Properties;
 import org.hl7.v3.MCCIIN000002UV01;
 import org.hl7.v3.PRPAIN201306UV02;
 
@@ -37,5 +37,6 @@ import org.hl7.v3.PRPAIN201306UV02;
  */
 public interface InboundPatientDiscoveryDeferredResponse {
 
-    public MCCIIN000002UV01 respondingGatewayDeferredPRPAIN201306UV02(PRPAIN201306UV02 body, AssertionType assertion);
+    public MCCIIN000002UV01 respondingGatewayDeferredPRPAIN201306UV02(PRPAIN201306UV02 body, AssertionType assertion, 
+        Properties webContextProperties);
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/PassthroughInboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/PassthroughInboundPatientDiscoveryDeferredResponse.java
@@ -28,9 +28,8 @@ package gov.hhs.fha.nhinc.patientdiscovery.inbound.deferred.response;
 
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.generic.GenericFactory;
-import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryAuditLogger;
-import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryAuditor;
 import gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.response.proxy.AdapterPatientDiscoveryDeferredRespProxy;
+import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryDeferredResponseAuditLogger;
 
 import org.hl7.v3.MCCIIN000002UV01;
 import org.hl7.v3.PRPAIN201306UV02;
@@ -41,13 +40,13 @@ import org.hl7.v3.PRPAIN201306UV02;
  */
 public class PassthroughInboundPatientDiscoveryDeferredResponse extends AbstractInboundPatientDiscoveryDeferredResponse {
 
-    private final PatientDiscoveryAuditor auditLogger;
+    private PatientDiscoveryDeferredResponseAuditLogger auditLogger;
 
     /**
      * Constructor.
      */
     public PassthroughInboundPatientDiscoveryDeferredResponse() {
-        auditLogger = new PatientDiscoveryAuditLogger();
+        auditLogger = new PatientDiscoveryDeferredResponseAuditLogger();
     }
 
     /**
@@ -57,7 +56,7 @@ public class PassthroughInboundPatientDiscoveryDeferredResponse extends Abstract
      * @param auditLogger
      */
     public PassthroughInboundPatientDiscoveryDeferredResponse(
-            GenericFactory<AdapterPatientDiscoveryDeferredRespProxy> proxyFactory, PatientDiscoveryAuditor auditLogger) {
+            GenericFactory<AdapterPatientDiscoveryDeferredRespProxy> proxyFactory, PatientDiscoveryDeferredResponseAuditLogger auditLogger) {
         super(proxyFactory);
         this.auditLogger = auditLogger;
     }
@@ -84,7 +83,7 @@ public class PassthroughInboundPatientDiscoveryDeferredResponse extends Abstract
      * getAuditLogger()
      */
     @Override
-    PatientDiscoveryAuditor getAuditLogger() {
+    PatientDiscoveryDeferredResponseAuditLogger getAuditLogger() {
         return auditLogger;
     }
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/PassthroughInboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/PassthroughInboundPatientDiscoveryDeferredResponse.java
@@ -38,7 +38,8 @@ import org.hl7.v3.PRPAIN201306UV02;
  * @author akong
  *
  */
-public class PassthroughInboundPatientDiscoveryDeferredResponse extends AbstractInboundPatientDiscoveryDeferredResponse {
+public class PassthroughInboundPatientDiscoveryDeferredResponse extends
+    AbstractInboundPatientDiscoveryDeferredResponse {
 
     private PatientDiscoveryDeferredResponseAuditLogger auditLogger;
 
@@ -56,7 +57,8 @@ public class PassthroughInboundPatientDiscoveryDeferredResponse extends Abstract
      * @param auditLogger
      */
     public PassthroughInboundPatientDiscoveryDeferredResponse(
-            GenericFactory<AdapterPatientDiscoveryDeferredRespProxy> proxyFactory, PatientDiscoveryDeferredResponseAuditLogger auditLogger) {
+        GenericFactory<AdapterPatientDiscoveryDeferredRespProxy> proxyFactory,
+        PatientDiscoveryDeferredResponseAuditLogger auditLogger) {
         super(proxyFactory);
         this.auditLogger = auditLogger;
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/StandardInboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/StandardInboundPatientDiscoveryDeferredResponse.java
@@ -79,10 +79,10 @@ public class StandardInboundPatientDiscoveryDeferredResponse extends AbstractInb
      * @param auditLogger
      */
     public StandardInboundPatientDiscoveryDeferredResponse(
-            PolicyChecker<RespondingGatewayPRPAIN201306UV02RequestType, PRPAIN201306UV02> policyChecker,
-            ResponseFactory responseFactory, PatientDiscovery201306Processor msgProcessor,
-            GenericFactory<AdapterPatientDiscoveryDeferredRespProxy> proxyFactory,
-            PDDeferredCorrelationDao pdCorrelationDao, PatientDiscoveryDeferredResponseAuditLogger auditLogger) {
+        PolicyChecker<RespondingGatewayPRPAIN201306UV02RequestType, PRPAIN201306UV02> policyChecker,
+        ResponseFactory responseFactory, PatientDiscovery201306Processor msgProcessor,
+        GenericFactory<AdapterPatientDiscoveryDeferredRespProxy> proxyFactory,
+        PDDeferredCorrelationDao pdCorrelationDao, PatientDiscoveryDeferredResponseAuditLogger auditLogger) {
         super(proxyFactory);
         this.policyChecker = policyChecker;
         this.responseFactory = responseFactory;
@@ -115,7 +115,6 @@ public class StandardInboundPatientDiscoveryDeferredResponse extends AbstractInb
     MCCIIN000002UV01 process(PRPAIN201306UV02 request, AssertionType assertion) {
         MCCIIN000002UV01 response = new MCCIIN000002UV01();
         String ackMsg = "";
-
 
         if (isPolicyValid(request, assertion)) {
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/StandardInboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/StandardInboundPatientDiscoveryDeferredResponse.java
@@ -29,21 +29,19 @@ package gov.hhs.fha.nhinc.patientdiscovery.inbound.deferred.response;
 import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.generic.GenericFactory;
-import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.patientcorrelation.nhinc.dao.PDDeferredCorrelationDao;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscovery201306PolicyChecker;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscovery201306Processor;
-import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryAuditLogger;
-import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryAuditor;
 import gov.hhs.fha.nhinc.patientdiscovery.PolicyChecker;
 import gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.response.proxy.AdapterPatientDiscoveryDeferredRespProxy;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.MCCIIN000002UV01EventDescriptionBuilder;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201306UV02EventDescriptionBuilder;
+import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryDeferredResponseAuditLogger;
 import gov.hhs.fha.nhinc.patientdiscovery.response.ResponseFactory;
 import gov.hhs.fha.nhinc.patientdiscovery.response.ResponseFactory.ResponseModeType;
 import gov.hhs.fha.nhinc.patientdiscovery.response.ResponseMode;
 import gov.hhs.fha.nhinc.transform.subdisc.HL7AckTransforms;
-
+import java.util.Properties;
 import org.apache.log4j.Logger;
 import org.hl7.v3.II;
 import org.hl7.v3.MCCIIN000002UV01;
@@ -56,7 +54,7 @@ public class StandardInboundPatientDiscoveryDeferredResponse extends AbstractInb
     private final ResponseFactory responseFactory;
     private final PatientDiscovery201306Processor msgProcessor;
     private final PDDeferredCorrelationDao pdCorrelationDao;
-    private final PatientDiscoveryAuditor auditLogger;
+    private final PatientDiscoveryDeferredResponseAuditLogger auditLogger;
     private static final Logger LOG = Logger.getLogger(StandardInboundPatientDiscoveryDeferredResponse.class);
 
     /**
@@ -67,7 +65,7 @@ public class StandardInboundPatientDiscoveryDeferredResponse extends AbstractInb
         responseFactory = new ResponseFactory();
         msgProcessor = new PatientDiscovery201306Processor();
         pdCorrelationDao = new PDDeferredCorrelationDao();
-        auditLogger = new PatientDiscoveryAuditLogger();
+        auditLogger = new PatientDiscoveryDeferredResponseAuditLogger();
     }
 
     /**
@@ -76,16 +74,15 @@ public class StandardInboundPatientDiscoveryDeferredResponse extends AbstractInb
      * @param policyChecker
      * @param responseFactory
      * @param msgProcessor
+     * @param proxyFactory
      * @param pdCorrelationDao
-     * @param passthroughPatientDiscovery
      * @param auditLogger
-     * @param LOG
      */
     public StandardInboundPatientDiscoveryDeferredResponse(
             PolicyChecker<RespondingGatewayPRPAIN201306UV02RequestType, PRPAIN201306UV02> policyChecker,
             ResponseFactory responseFactory, PatientDiscovery201306Processor msgProcessor,
             GenericFactory<AdapterPatientDiscoveryDeferredRespProxy> proxyFactory,
-            PDDeferredCorrelationDao pdCorrelationDao, PatientDiscoveryAuditor auditLogger) {
+            PDDeferredCorrelationDao pdCorrelationDao, PatientDiscoveryDeferredResponseAuditLogger auditLogger) {
         super(proxyFactory);
         this.policyChecker = policyChecker;
         this.responseFactory = responseFactory;
@@ -96,12 +93,12 @@ public class StandardInboundPatientDiscoveryDeferredResponse extends AbstractInb
 
     @Override
     @InboundProcessingEvent(beforeBuilder = PRPAIN201306UV02EventDescriptionBuilder.class, afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class, serviceType = "Patient Discovery Deferred Response", version = "1.0")
-    public MCCIIN000002UV01 respondingGatewayDeferredPRPAIN201306UV02(PRPAIN201306UV02 request, AssertionType assertion) {
-        auditRequestFromNhin(request, assertion);
+    public MCCIIN000002UV01 respondingGatewayDeferredPRPAIN201306UV02(PRPAIN201306UV02 request, AssertionType assertion,
+        Properties webContextProperties) {
 
         MCCIIN000002UV01 response = process(request, assertion);
 
-        auditResponseToNhin(response, assertion);
+        auditResponseToNhin(request, response, assertion, webContextProperties);
 
         return response;
     }
@@ -119,7 +116,6 @@ public class StandardInboundPatientDiscoveryDeferredResponse extends AbstractInb
         MCCIIN000002UV01 response = new MCCIIN000002UV01();
         String ackMsg = "";
 
-        auditRequestToAdapter(request, assertion);
 
         if (isPolicyValid(request, assertion)) {
 
@@ -137,8 +133,6 @@ public class StandardInboundPatientDiscoveryDeferredResponse extends AbstractInb
             response = HL7AckTransforms.createAckErrorFrom201306(request, ackMsg);
         }
 
-        auditResponseFromAdapter(response, assertion);
-
         return response;
     }
 
@@ -150,7 +144,7 @@ public class StandardInboundPatientDiscoveryDeferredResponse extends AbstractInb
      * getAuditLogger()
      */
     @Override
-    PatientDiscoveryAuditor getAuditLogger() {
+    PatientDiscoveryDeferredResponseAuditLogger getAuditLogger() {
         return auditLogger;
     }
 
@@ -186,14 +180,5 @@ public class StandardInboundPatientDiscoveryDeferredResponse extends AbstractInb
             ResponseMode respProcessor = responseFactory.getResponseMode();
             respProcessor.processResponse(request, assertion, patientId);
         }
-    }
-
-    protected void auditRequestToAdapter(PRPAIN201306UV02 request, AssertionType assertion) {
-        getAuditLogger().auditAdapterDeferred201306(request, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
-    }
-
-    protected void auditResponseFromAdapter(MCCIIN000002UV01 response, AssertionType assertion) {
-        getAuditLogger().auditAck(response, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
-                NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE);
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/AbstractOutboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/AbstractOutboundPatientDiscoveryDeferredResponse.java
@@ -66,8 +66,8 @@ public abstract class AbstractOutboundPatientDiscoveryDeferredResponse implement
 
     protected MCCIIN000002UV01 sendToNhin(OutboundPatientDiscoveryDeferredResponseDelegate delegate,
         PRPAIN201306UV02 request, AssertionType assertion, NhinTargetSystemType target) {
-        OutboundPatientDiscoveryDeferredResponseOrchestratable orchestratable = 
-            new OutboundPatientDiscoveryDeferredResponseOrchestratable(delegate);
+        OutboundPatientDiscoveryDeferredResponseOrchestratable orchestratable
+            = new OutboundPatientDiscoveryDeferredResponseOrchestratable(delegate);
         orchestratable.setAssertion(assertion);
         orchestratable.setRequest(request);
         orchestratable.setTarget(target);

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/OutboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/OutboundPatientDiscoveryDeferredResponse.java
@@ -39,5 +39,5 @@ import org.hl7.v3.PRPAIN201306UV02;
 public interface OutboundPatientDiscoveryDeferredResponse {
 
     public abstract MCCIIN000002UV01 processPatientDiscoveryAsyncResp(PRPAIN201306UV02 body, AssertionType assertion,
-            NhinTargetCommunitiesType target);
+        NhinTargetCommunitiesType target);
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/PassthroughOutboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/PassthroughOutboundPatientDiscoveryDeferredResponse.java
@@ -36,7 +36,7 @@ import org.hl7.v3.MCCIIN000002UV01;
 import org.hl7.v3.PRPAIN201306UV02;
 
 public class PassthroughOutboundPatientDiscoveryDeferredResponse extends
-        AbstractOutboundPatientDiscoveryDeferredResponse {
+    AbstractOutboundPatientDiscoveryDeferredResponse {
 
     private static final MessageGeneratorUtils msgUtils = MessageGeneratorUtils.getInstance();
 
@@ -57,8 +57,7 @@ public class PassthroughOutboundPatientDiscoveryDeferredResponse extends
      * @param delegate
      * @param auditLogger
      */
-    public PassthroughOutboundPatientDiscoveryDeferredResponse(OutboundPatientDiscoveryDeferredResponseDelegate delegate, 
-        PatientDiscoveryDeferredResponseAuditLogger auditLogger) {
+    public PassthroughOutboundPatientDiscoveryDeferredResponse(OutboundPatientDiscoveryDeferredResponseDelegate delegate, PatientDiscoveryDeferredResponseAuditLogger auditLogger) {
         this.delegate = delegate;
         this.auditLogger = auditLogger;
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/PassthroughOutboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/PassthroughOutboundPatientDiscoveryDeferredResponse.java
@@ -30,10 +30,8 @@ import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.patientdiscovery.MessageGeneratorUtils;
-import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryAuditLogger;
-import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryAuditor;
+import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryDeferredResponseAuditLogger;
 import gov.hhs.fha.nhinc.patientdiscovery.entity.deferred.response.OutboundPatientDiscoveryDeferredResponseDelegate;
-
 import org.hl7.v3.MCCIIN000002UV01;
 import org.hl7.v3.PRPAIN201306UV02;
 
@@ -42,7 +40,7 @@ public class PassthroughOutboundPatientDiscoveryDeferredResponse extends
 
     private static final MessageGeneratorUtils msgUtils = MessageGeneratorUtils.getInstance();
 
-    private final PatientDiscoveryAuditor auditLogger;
+    private final PatientDiscoveryDeferredResponseAuditLogger auditLogger;
     private final OutboundPatientDiscoveryDeferredResponseDelegate delegate;
 
     /**
@@ -50,7 +48,7 @@ public class PassthroughOutboundPatientDiscoveryDeferredResponse extends
      */
     public PassthroughOutboundPatientDiscoveryDeferredResponse() {
         delegate = new OutboundPatientDiscoveryDeferredResponseDelegate();
-        auditLogger = new PatientDiscoveryAuditLogger();
+        auditLogger = new PatientDiscoveryDeferredResponseAuditLogger();
     }
 
     /**
@@ -59,8 +57,8 @@ public class PassthroughOutboundPatientDiscoveryDeferredResponse extends
      * @param delegate
      * @param auditLogger
      */
-    public PassthroughOutboundPatientDiscoveryDeferredResponse(
-            OutboundPatientDiscoveryDeferredResponseDelegate delegate, PatientDiscoveryAuditor auditLogger) {
+    public PassthroughOutboundPatientDiscoveryDeferredResponse(OutboundPatientDiscoveryDeferredResponseDelegate delegate, 
+        PatientDiscoveryDeferredResponseAuditLogger auditLogger) {
         this.delegate = delegate;
         this.auditLogger = auditLogger;
     }
@@ -76,7 +74,7 @@ public class PassthroughOutboundPatientDiscoveryDeferredResponse extends
     @Override
     MCCIIN000002UV01 process(PRPAIN201306UV02 request, AssertionType assertion, NhinTargetCommunitiesType target) {
         NhinTargetSystemType targetSystem = msgUtils.convertFirstToNhinTargetSystemType(target);
-
+        auditRequest(request, assertion, target);
         return sendToNhin(delegate, request, assertion, targetSystem);
     }
 
@@ -88,7 +86,7 @@ public class PassthroughOutboundPatientDiscoveryDeferredResponse extends
      * #getAuditLogger()
      */
     @Override
-    PatientDiscoveryAuditor getAuditLogger() {
+    PatientDiscoveryDeferredResponseAuditLogger getAuditLogger() {
         return auditLogger;
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/StandardOutboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/StandardOutboundPatientDiscoveryDeferredResponse.java
@@ -81,9 +81,9 @@ public class StandardOutboundPatientDiscoveryDeferredResponse extends AbstractOu
      * @param connectionManager
      */
     public StandardOutboundPatientDiscoveryDeferredResponse(
-            PolicyChecker<RespondingGatewayPRPAIN201306UV02RequestType, PRPAIN201306UV02> policyChecker,
-            PatientDiscovery201306Processor pd201306Processor, PatientDiscoveryDeferredResponseAuditLogger auditLogger,
-            OutboundPatientDiscoveryDeferredResponseDelegate delegate, ConnectionManagerCache connectionManager) {
+        PolicyChecker<RespondingGatewayPRPAIN201306UV02RequestType, PRPAIN201306UV02> policyChecker,
+        PatientDiscovery201306Processor pd201306Processor, PatientDiscoveryDeferredResponseAuditLogger auditLogger,
+        OutboundPatientDiscoveryDeferredResponseDelegate delegate, ConnectionManagerCache connectionManager) {
         this.policyChecker = policyChecker;
         this.pd201306Processor = pd201306Processor;
         this.auditLogger = auditLogger;
@@ -94,7 +94,7 @@ public class StandardOutboundPatientDiscoveryDeferredResponse extends AbstractOu
     @Override
     @OutboundProcessingEvent(beforeBuilder = PRPAIN201306UV02EventDescriptionBuilder.class, afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class, serviceType = "Patient Discovery Deferred Response", version = "1.0")
     public MCCIIN000002UV01 processPatientDiscoveryAsyncResp(PRPAIN201306UV02 request, AssertionType assertion,
-            NhinTargetCommunitiesType target) {
+        NhinTargetCommunitiesType target) {
         MCCIIN000002UV01 response = process(request, assertion, target);
 
         return response;
@@ -118,7 +118,7 @@ public class StandardOutboundPatientDiscoveryDeferredResponse extends AbstractOu
             for (UrlInfo urlInfo : urlInfoList) {
 
                 RespondingGatewayPRPAIN201306UV02RequestType newRequest = createNewRequestForSingleTarget(body,
-                        assertion, targets, urlInfo.getHcid());
+                    assertion, targets, urlInfo.getHcid());
 
                 if (isPolicyValid(newRequest)) {
                     ack = sendToNhin(newRequest, urlInfo);
@@ -151,10 +151,10 @@ public class StandardOutboundPatientDiscoveryDeferredResponse extends AbstractOu
 
         try {
             urlInfoList = connectionManager.getEndpointURLFromNhinTargetCommunities(targetCommunities,
-                    NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
+                NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
         } catch (ConnectionManagerException ex) {
             LOG.error("Failed to obtain target URLs for service "
-                    + NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME + ex.getMessage(), ex);
+                + NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME + ex.getLocalizedMessage(), ex);
             return null;
         }
 
@@ -162,7 +162,7 @@ public class StandardOutboundPatientDiscoveryDeferredResponse extends AbstractOu
     }
 
     private RespondingGatewayPRPAIN201306UV02RequestType createNewRequestForSingleTarget(PRPAIN201306UV02 body,
-            AssertionType assertion, NhinTargetCommunitiesType targets, String hcid) {
+        AssertionType assertion, NhinTargetCommunitiesType targets, String hcid) {
 
         PRPAIN201306UV02 new201306 = pd201306Processor.createNewRequest(body, hcid);
         return msgUtils.createRespondingGatewayRequest(new201306, assertion, targets);
@@ -175,7 +175,7 @@ public class StandardOutboundPatientDiscoveryDeferredResponse extends AbstractOu
     private MCCIIN000002UV01 sendToNhin(RespondingGatewayPRPAIN201306UV02RequestType request, UrlInfo urlInfo) {
 
         NhinTargetSystemType targetSystemType = msgUtils
-                .createNhinTargetSystemType(urlInfo.getUrl(), urlInfo.getHcid());
+            .createNhinTargetSystemType(urlInfo.getUrl(), urlInfo.getHcid());
 
         return sendToNhin(delegate, request.getPRPAIN201306UV02(), request.getAssertion(), targetSystemType);
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201306UV02Parser.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201306UV02Parser.java
@@ -26,6 +26,7 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.parser;
 
+import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.log4j.Logger;
@@ -75,5 +76,72 @@ public class PRPAIN201306UV02Parser {
             LOG.error("PatientId doesn't exist in the received PRPAIN201306UV02 message");
         }
         return oIIs;
+    }
+
+    public static String getSenderHcid(PRPAIN201306UV02 response) {
+        String id = null;
+        if (response != null && response.getSender() != null && response.getSender() != null
+            && response.getSender().getDevice() != null && response.getSender().getDevice().
+            getAsAgent() != null
+            && response.getSender().getDevice().getAsAgent().getValue() != null
+            && response.getSender().getDevice().getAsAgent().getValue().getRepresentedOrganization() != null
+            && response.getSender().getDevice().getAsAgent().getValue().getRepresentedOrganization().getValue().
+            getId() != null
+            && !response.getSender().getDevice().getAsAgent().getValue().getRepresentedOrganization().getValue()
+            .getId().isEmpty()
+            && response.getSender().getDevice().getAsAgent().getValue().getRepresentedOrganization().getValue()
+            .getId().get(0) != null
+            && response.getSender().getDevice().getAsAgent().getValue().getRepresentedOrganization().getValue()
+            .getId().get(0).getRoot() != null
+            && !response.getSender().getDevice().getAsAgent().getValue().getRepresentedOrganization().getValue()
+            .getId().get(0).getRoot().isEmpty()) {
+            id = response.getSender().getDevice().getAsAgent().getValue().getRepresentedOrganization()
+                .getValue().getId().get(0).getRoot();
+        } 
+        //If representedOrganization Id root is null get id from device
+        if(NullChecker.isNullish(id)) {
+            if (response != null && response.getSender() != null && response.getSender() != null
+            && response.getSender().getDevice() != null  && response.getSender().getDevice().getId() != null
+            && response.getSender().getDevice().getId().get(0) != null 
+            && response.getSender().getDevice().getId().get(0).getRoot() != null
+            && !response.getSender().getDevice().getId().get(0).getRoot().isEmpty()) {
+                id = response.getSender().getDevice().getId().get(0).getRoot();
+            }
+        }
+        return id;
+    }
+
+    public static String getReceiverHCID(PRPAIN201306UV02 response) {
+        String id = null;
+        if (response != null && response.getReceiver() != null && response.getReceiver().get(0) != null
+            && response.getReceiver().get(0).getDevice() != null && response.getReceiver().get(0).getDevice().
+            getAsAgent() != null
+            && response.getReceiver().get(0).getDevice().getAsAgent().getValue() != null
+            && response.getReceiver().get(0).getDevice().getAsAgent().getValue().getRepresentedOrganization() != null
+            && response.getReceiver().get(0).getDevice().getAsAgent().getValue().getRepresentedOrganization()
+                .getValue().getId() != null
+            && !response.getReceiver().get(0).getDevice().getAsAgent().getValue().getRepresentedOrganization()
+                .getValue().getId().isEmpty()
+            && response.getReceiver().get(0).getDevice().getAsAgent().getValue().getRepresentedOrganization()
+                .getValue().getId().get(0) != null
+            && response.getReceiver().get(0).getDevice().getAsAgent().getValue().getRepresentedOrganization()
+                .getValue().getId().get(0).getRoot() != null
+            && !response.getReceiver().get(0).getDevice().getAsAgent().getValue().getRepresentedOrganization()
+                .getValue().getId().get(0).getRoot().isEmpty()) {
+            id = response.getReceiver().get(0).getDevice().getAsAgent().getValue().getRepresentedOrganization()
+                .getValue().getId().get(0).getRoot();
+        }
+        //If representedOrganization Id root is null get id from device
+        if (NullChecker.isNullish(id)) {
+           if (response != null && response.getReceiver() != null && response.getReceiver().get(0) != null
+            && response.getReceiver().get(0).getDevice() != null 
+            && response.getReceiver().get(0).getDevice().getId() != null 
+            && response.getReceiver().get(0).getDevice().getId().get(0) != null
+            && response.getReceiver().get(0).getDevice().getId().get(0).getRoot() != null 
+            && !response.getReceiver().get(0).getDevice().getId().get(0).getRoot().isEmpty()) {
+               id = response.getReceiver().get(0).getDevice().getId().get(0).getRoot();
+           }
+        }
+        return id;
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201306UV02Parser.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/parser/PRPAIN201306UV02Parser.java
@@ -97,14 +97,14 @@ public class PRPAIN201306UV02Parser {
             .getId().get(0).getRoot().isEmpty()) {
             id = response.getSender().getDevice().getAsAgent().getValue().getRepresentedOrganization()
                 .getValue().getId().get(0).getRoot();
-        } 
+        }
         //If representedOrganization Id root is null get id from device
-        if(NullChecker.isNullish(id)) {
+        if (NullChecker.isNullish(id)) {
             if (response != null && response.getSender() != null && response.getSender() != null
-            && response.getSender().getDevice() != null  && response.getSender().getDevice().getId() != null
-            && response.getSender().getDevice().getId().get(0) != null 
-            && response.getSender().getDevice().getId().get(0).getRoot() != null
-            && !response.getSender().getDevice().getId().get(0).getRoot().isEmpty()) {
+                && response.getSender().getDevice() != null && response.getSender().getDevice().getId() != null
+                && response.getSender().getDevice().getId().get(0) != null
+                && response.getSender().getDevice().getId().get(0).getRoot() != null
+                && !response.getSender().getDevice().getId().get(0).getRoot().isEmpty()) {
                 id = response.getSender().getDevice().getId().get(0).getRoot();
             }
         }
@@ -119,28 +119,28 @@ public class PRPAIN201306UV02Parser {
             && response.getReceiver().get(0).getDevice().getAsAgent().getValue() != null
             && response.getReceiver().get(0).getDevice().getAsAgent().getValue().getRepresentedOrganization() != null
             && response.getReceiver().get(0).getDevice().getAsAgent().getValue().getRepresentedOrganization()
-                .getValue().getId() != null
+            .getValue().getId() != null
             && !response.getReceiver().get(0).getDevice().getAsAgent().getValue().getRepresentedOrganization()
-                .getValue().getId().isEmpty()
+            .getValue().getId().isEmpty()
             && response.getReceiver().get(0).getDevice().getAsAgent().getValue().getRepresentedOrganization()
-                .getValue().getId().get(0) != null
+            .getValue().getId().get(0) != null
             && response.getReceiver().get(0).getDevice().getAsAgent().getValue().getRepresentedOrganization()
-                .getValue().getId().get(0).getRoot() != null
+            .getValue().getId().get(0).getRoot() != null
             && !response.getReceiver().get(0).getDevice().getAsAgent().getValue().getRepresentedOrganization()
-                .getValue().getId().get(0).getRoot().isEmpty()) {
+            .getValue().getId().get(0).getRoot().isEmpty()) {
             id = response.getReceiver().get(0).getDevice().getAsAgent().getValue().getRepresentedOrganization()
                 .getValue().getId().get(0).getRoot();
         }
         //If representedOrganization Id root is null get id from device
         if (NullChecker.isNullish(id)) {
-           if (response != null && response.getReceiver() != null && response.getReceiver().get(0) != null
-            && response.getReceiver().get(0).getDevice() != null 
-            && response.getReceiver().get(0).getDevice().getId() != null 
-            && response.getReceiver().get(0).getDevice().getId().get(0) != null
-            && response.getReceiver().get(0).getDevice().getId().get(0).getRoot() != null 
-            && !response.getReceiver().get(0).getDevice().getId().get(0).getRoot().isEmpty()) {
-               id = response.getReceiver().get(0).getDevice().getId().get(0).getRoot();
-           }
+            if (response != null && response.getReceiver() != null && response.getReceiver().get(0) != null
+                && response.getReceiver().get(0).getDevice() != null
+                && response.getReceiver().get(0).getDevice().getId() != null
+                && response.getReceiver().get(0).getDevice().getId().get(0) != null
+                && response.getReceiver().get(0).getDevice().getId().get(0).getRoot() != null
+                && !response.getReceiver().get(0).getDevice().getId().get(0).getRoot().isEmpty()) {
+                id = response.getReceiver().get(0).getDevice().getId().get(0).getRoot();
+            }
         }
         return id;
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransformsTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransformsTest.java
@@ -165,13 +165,13 @@ public class PatientDiscoveryAuditTransformsTest extends AuditTransformsTest<PRP
                 "1.1", "D123401", "2.2", "abd3453dcd24wkkks545"), TestPatientDiscoveryMessageHelper.
             createPRPAIN201306UV02Response("Gallow", "Younger", "M", "01-12-2967", "1.1", "D123401", "2.2",
                 "abd3453dcd24wkkks545"), assertion, createNhinTarget(), NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
-            NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE, webContextProperties,
+            NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE, webContextProperties,
             NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
 
         testGetEventIdentificationType(auditRequest, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, Boolean.TRUE);
-        testGetActiveParticipantSource(auditRequest, Boolean.TRUE, webContextProperties, localIp);
-        testGetActiveParticipantDestination(auditRequest, Boolean.TRUE, webContextProperties, remoteObjectUrl);
-        testCreateActiveParticipantFromUser(auditRequest, Boolean.TRUE, assertion);
+        testGetActiveParticipantSource(auditRequest, Boolean.FALSE, webContextProperties, localIp);
+        testGetActiveParticipantDestination(auditRequest, Boolean.FALSE, webContextProperties, remoteObjectUrl);
+        testCreateActiveParticipantFromUser(auditRequest, Boolean.FALSE, assertion);
         assertParticipantObjectIdentification(auditRequest);
     }
 
@@ -214,19 +214,19 @@ public class PatientDiscoveryAuditTransformsTest extends AuditTransformsTest<PRP
         assertSame("ParticipantQuery.ParticipantObjectTypeCode object reference mismatch",
             PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_SYSTEM,
             participantQuery.getParticipantObjectTypeCode());
-        assertSame("ParticipantPatient.ParticipantObjectTypeCodeRole object reference mismatch",
+        assertSame("ParticipantQuery.ParticipantObjectTypeCodeRole object reference mismatch",
             PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_ROLE,
             participantQuery.getParticipantObjectTypeCodeRole());
-        assertEquals("ParticipantPatient.ParticipantObjectIDTypeCode.Code mismatch",
+        assertEquals("ParticipantQuery.ParticipantObjectIDTypeCode.Code mismatch",
             PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE,
             participantQuery.getParticipantObjectIDTypeCode().getCode());
-        assertEquals("ParticipantPatient.ParticipantObjectIDTypeCode.CodeSystemName mismatch",
+        assertEquals("ParticipantQuery.ParticipantObjectIDTypeCode.CodeSystemName mismatch",
             PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE_SYSTEM,
             participantQuery.getParticipantObjectIDTypeCode().getCodeSystemName());
-        assertEquals("ParticipantPatient.ParticipantObjectIDTypeCode.DisplayName mismatch",
+        assertEquals("ParticipantQuery.ParticipantObjectIDTypeCode.DisplayName mismatch",
             PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_DISPLAY_NAME,
             participantQuery.getParticipantObjectIDTypeCode().getDisplayName());
-        assertNull("ParticipantPatient.ParticipantObjectName is not null",
+        assertNull("ParticipantQuery.ParticipantObjectName is not null",
             participantPatient.getParticipantObjectName());
         assertNull("ParticipantQuery.ParticipantObjectName is not null",
             participantQuery.getParticipantObjectName());

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredResponseAuditTransformsTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredResponseAuditTransformsTest.java
@@ -1,7 +1,28 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package gov.hhs.fha.nhinc.patientdiscovery.audit.transform;
 
@@ -34,7 +55,7 @@ import org.junit.Test;
  */
 public class PatientDiscoveryDeferredResponseAuditTransformsTest extends AuditTransformsTest<PRPAIN201306UV02, MCCIIN000002UV01> {
 
-    /*@Test
+    @Test
      public void transformRequestToAuditMsg() throws ConnectionManagerException, UnknownHostException {
      final String localIp = "10.10.10.10";
      final String remoteIp = "16.14.13.12";
@@ -71,7 +92,7 @@ public class PatientDiscoveryDeferredResponseAuditTransformsTest extends AuditTr
      LogEventRequestType auditRequest = transforms.transformRequestToAuditMsg(TestPatientDiscoveryMessageHelper.
      createPRPAIN201305UV02Request("Gallow", "Younger", "M", "01-12-2967", "1.1", "D123401", "2.2",
      "abd3453dcd24wkkks545"), assertion, createNhinTarget(), NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
-     NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE, webContextProperties,
+     NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE, webContextProperties,
      NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
 
      testGetEventIdentificationType(auditRequest, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME,
@@ -80,7 +101,7 @@ public class PatientDiscoveryDeferredResponseAuditTransformsTest extends AuditTr
      testGetActiveParticipantDestination(auditRequest, Boolean.TRUE, webContextProperties, remoteObjectUrl);
      testCreateActiveParticipantFromUser(auditRequest, Boolean.TRUE, assertion);
      assertParticipantObjectIdentification(auditRequest);
-     }*/
+     }
     /**
      *
      * @throws ConnectionManagerException
@@ -187,19 +208,19 @@ public class PatientDiscoveryDeferredResponseAuditTransformsTest extends AuditTr
         assertSame("ParticipantQuery.ParticipantObjectTypeCode object reference mismatch",
             PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_SYSTEM,
             participantQuery.getParticipantObjectTypeCode());
-        assertSame("ParticipantPatient.ParticipantObjectTypeCodeRole object reference mismatch",
+        assertSame("ParticipantQuery.ParticipantObjectTypeCodeRole object reference mismatch",
             PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_TYPE_CODE_ROLE,
             participantQuery.getParticipantObjectTypeCodeRole());
-        assertEquals("ParticipantPatient.ParticipantObjectIDTypeCode.Code mismatch",
+        assertEquals("ParticipantQuery.ParticipantObjectTypeCodeRole.Code mismatch",
             PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE,
             participantQuery.getParticipantObjectIDTypeCode().getCode());
-        assertEquals("ParticipantPatient.ParticipantObjectIDTypeCode.CodeSystemName mismatch",
+        assertEquals("ParticipantQuery.ParticipantObjectIDTypeCode.CodeSystemName mismatch",
             PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_CODE_SYSTEM,
             participantQuery.getParticipantObjectIDTypeCode().getCodeSystemName());
-        assertEquals("ParticipantPatient.ParticipantObjectIDTypeCode.DisplayName mismatch",
+        assertEquals("ParticipantQuery.ParticipantObjectIDTypeCode.DisplayName mismatch",
             PatientDiscoveryAuditTransformsConstants.PARTICIPANT_QUERYPARAMS_OBJ_ID_TYPE_DISPLAY_NAME,
             participantQuery.getParticipantObjectIDTypeCode().getDisplayName());
-        assertNull("ParticipantPatient.ParticipantObjectName is not null",
+        assertNull("ParticipantQuery.ParticipantObjectName is not null",
             participantPatient.getParticipantObjectName());
         assertNull("ParticipantQuery.ParticipantObjectName is not null",
             participantQuery.getParticipantObjectName());

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredResponseAuditTransformsTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredResponseAuditTransformsTest.java
@@ -46,7 +46,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -56,61 +55,68 @@ import org.junit.Test;
 public class PatientDiscoveryDeferredResponseAuditTransformsTest extends AuditTransformsTest<PRPAIN201306UV02, MCCIIN000002UV01> {
 
     @Test
-     public void transformRequestToAuditMsg() throws ConnectionManagerException, UnknownHostException {
-     final String localIp = "10.10.10.10";
-     final String remoteIp = "16.14.13.12";
-     final String remoteObjectUrl = "http://" + remoteIp + ":9090/source/AuditService";
-     final String wsRequestUrl = "http://" + remoteIp + ":9090/AuditService";
+    public void transformRequestToAuditMsg() throws ConnectionManagerException, UnknownHostException {
+        final String localIp = "10.10.10.10";
+        final String remoteIp = "16.14.13.12";
+        final String remoteObjectUrl = "http://" + remoteIp + ":9090/source/AuditService";
+        final String wsRequestUrl = "http://" + remoteIp + ":9090/AuditService";
 
-     Properties webContextProperties = new Properties();
-     webContextProperties.setProperty(NhincConstants.WEB_SERVICE_REQUEST_URL, wsRequestUrl);
-     webContextProperties.setProperty(NhincConstants.REMOTE_HOST_ADDRESS, remoteIp);
+        Properties webContextProperties = new Properties();
+        webContextProperties.setProperty(NhincConstants.WEB_SERVICE_REQUEST_URL, wsRequestUrl);
+        webContextProperties.setProperty(NhincConstants.REMOTE_HOST_ADDRESS, remoteIp);
 
-     PatientDiscoveryAuditTransforms transforms = new PatientDiscoveryAuditTransforms() {
-     @Override
-     protected String getLocalHostAddress() {
-     return localIp;
-     }
+        PatientDiscoveryDeferredResponseAuditTransforms transforms
+            = new PatientDiscoveryDeferredResponseAuditTransforms() {
+                @Override
+                protected String getLocalHostAddress() {
+                    return remoteIp;
+                }
 
-     @Override
-     protected String getRemoteHostAddress(Properties webContextProperties) {
-     if (webContextProperties != null && !webContextProperties.isEmpty() && webContextProperties
-     .getProperty(NhincConstants.REMOTE_HOST_ADDRESS) != null) {
+                @Override
+                protected String getRemoteHostAddress(Properties webContextProperties) {
+                    if (webContextProperties != null && !webContextProperties.isEmpty() && webContextProperties
+                    .getProperty(NhincConstants.REMOTE_HOST_ADDRESS) != null) {
 
-     return webContextProperties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS);
-     }
-     return AuditTransformsConstants.ACTIVE_PARTICIPANT_UNKNOWN_IP_ADDRESS;
-     }
+                        return webContextProperties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS);
+                    }
+                    return AuditTransformsConstants.ACTIVE_PARTICIPANT_UNKNOWN_IP_ADDRESS;
+                }
 
-     @Override
-     protected String getWebServiceUrlFromRemoteObject(NhinTargetSystemType target, String serviceName) {
-     return remoteObjectUrl;
-     }
-     };
+                @Override
+                protected String getWebServiceUrlFromRemoteObject(NhinTargetSystemType target, String serviceName) {
+                    return remoteObjectUrl;
+                }
 
-     AssertionType assertion = createAssertion();
-     LogEventRequestType auditRequest = transforms.transformRequestToAuditMsg(TestPatientDiscoveryMessageHelper.
-     createPRPAIN201305UV02Request("Gallow", "Younger", "M", "01-12-2967", "1.1", "D123401", "2.2",
-     "abd3453dcd24wkkks545"), assertion, createNhinTarget(), NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
-     NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE, webContextProperties,
-     NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
+                @Override
+                protected String getPDDeferredRequestInitiatorAddress() {
+                    return localIp;
+                }
+            };
 
-     testGetEventIdentificationType(auditRequest, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME,
-     Boolean.TRUE);
-     testGetActiveParticipantSource(auditRequest, Boolean.TRUE, webContextProperties, localIp);
-     testGetActiveParticipantDestination(auditRequest, Boolean.TRUE, webContextProperties, remoteObjectUrl);
-     testCreateActiveParticipantFromUser(auditRequest, Boolean.TRUE, assertion);
-     assertParticipantObjectIdentification(auditRequest);
-     }
+        AssertionType assertion = createAssertion();
+        LogEventRequestType auditRequest = transforms.transformRequestToAuditMsg(
+            TestPatientDiscoveryMessageHelper.createPRPAIN201306UV02Response("Gallow", "Younger", "M", "01-12-2967",
+                "1.1", "D123401", "2.2", "abd3453dcd24wkkks545"), assertion, createNhinTarget(),
+            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE,
+            webContextProperties, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
+
+        testGetEventIdentificationType(auditRequest, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME,
+            Boolean.TRUE);
+        testGetActiveParticipantSource(auditRequest, Boolean.TRUE, webContextProperties, localIp);
+        testGetActiveParticipantDestination(auditRequest, Boolean.TRUE, webContextProperties, remoteObjectUrl);
+        assertParticipantObjectIdentification(auditRequest);
+    }
+
     /**
      *
      * @throws ConnectionManagerException
      * @throws UnknownHostException
      */
     @Test
-    @Ignore
     public void transformResponseToAuditMsg() throws ConnectionManagerException, UnknownHostException {
+        //Local Ip Address
         final String localIp = "10.10.10.10";
+        //Destination Ip Address
         final String remoteIp = "16.14.13.12";
         final String remoteObjectUrl = "http://" + remoteIp + ":9090/source/AuditService";
         final String wsRequestUrl = "http://" + remoteIp + ":9090/AuditService";
@@ -123,7 +129,7 @@ public class PatientDiscoveryDeferredResponseAuditTransformsTest extends AuditTr
         PatientDiscoveryDeferredResponseAuditTransforms transforms = new PatientDiscoveryDeferredResponseAuditTransforms() {
             @Override
             protected String getLocalHostAddress() {
-                return localIp;
+                return remoteIp;
             }
 
             @Override
@@ -150,8 +156,14 @@ public class PatientDiscoveryDeferredResponseAuditTransformsTest extends AuditTr
 
             @Override
             protected String getWebServiceUrlFromRemoteObject(NhinTargetSystemType target, String serviceName) {
-                return remoteObjectUrl;
+                return wsRequestUrl;
             }
+
+            @Override
+            protected String getPDDeferredRequestInitiatorAddress() {
+                return localIp;
+            }
+
         };
 
         AssertionType assertion = createAssertion();
@@ -162,7 +174,7 @@ public class PatientDiscoveryDeferredResponseAuditTransformsTest extends AuditTr
             webContextProperties, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
 
         testGetEventIdentificationType(auditRequest, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME,
-            Boolean.TRUE);
+            Boolean.FALSE);
         testGetActiveParticipantSource(auditRequest, Boolean.FALSE, webContextProperties, localIp);
         testGetActiveParticipantDestination(auditRequest, Boolean.FALSE, webContextProperties, remoteObjectUrl);
         testCreateActiveParticipantFromUser(auditRequest, Boolean.FALSE, assertion);

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredResponseAuditTransformsTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredResponseAuditTransformsTest.java
@@ -1,28 +1,7 @@
 /*
- * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above
- *       copyright notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the documentation
- *       and/or other materials provided with the distribution.
- *     * Neither the name of the United States Government nor the
- *       names of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
- * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
  */
 package gov.hhs.fha.nhinc.patientdiscovery.audit.transform;
 
@@ -39,94 +18,76 @@ import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryAuditTransformsC
 import gov.hhs.fha.nhinc.patientdiscovery.parser.TestPatientDiscoveryMessageHelper;
 import java.net.UnknownHostException;
 import java.util.Properties;
-import org.hl7.v3.PRPAIN201305UV02;
+import org.hl7.v3.MCCIIN000002UV01;
 import org.hl7.v3.PRPAIN201306UV02;
-import org.junit.After;
-import org.junit.AfterClass;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  *
  * @author achidamb
  */
-public class PatientDiscoveryAuditTransformsTest extends AuditTransformsTest<PRPAIN201305UV02, PRPAIN201306UV02> {
+public class PatientDiscoveryDeferredResponseAuditTransformsTest extends AuditTransformsTest<PRPAIN201306UV02, MCCIIN000002UV01> {
 
-    public PatientDiscoveryAuditTransformsTest() {
-    }
+    /*@Test
+     public void transformRequestToAuditMsg() throws ConnectionManagerException, UnknownHostException {
+     final String localIp = "10.10.10.10";
+     final String remoteIp = "16.14.13.12";
+     final String remoteObjectUrl = "http://" + remoteIp + ":9090/source/AuditService";
+     final String wsRequestUrl = "http://" + remoteIp + ":9090/AuditService";
 
-    @BeforeClass
-    public static void setUpClass() {
-    }
+     Properties webContextProperties = new Properties();
+     webContextProperties.setProperty(NhincConstants.WEB_SERVICE_REQUEST_URL, wsRequestUrl);
+     webContextProperties.setProperty(NhincConstants.REMOTE_HOST_ADDRESS, remoteIp);
 
-    @AfterClass
-    public static void tearDownClass() {
-    }
+     PatientDiscoveryAuditTransforms transforms = new PatientDiscoveryAuditTransforms() {
+     @Override
+     protected String getLocalHostAddress() {
+     return localIp;
+     }
 
-    @Before
-    @Override
-    public void setUp() {
-    }
+     @Override
+     protected String getRemoteHostAddress(Properties webContextProperties) {
+     if (webContextProperties != null && !webContextProperties.isEmpty() && webContextProperties
+     .getProperty(NhincConstants.REMOTE_HOST_ADDRESS) != null) {
 
-    @After
-    @Override
-    public void tearDown() {
-    }
+     return webContextProperties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS);
+     }
+     return AuditTransformsConstants.ACTIVE_PARTICIPANT_UNKNOWN_IP_ADDRESS;
+     }
 
+     @Override
+     protected String getWebServiceUrlFromRemoteObject(NhinTargetSystemType target, String serviceName) {
+     return remoteObjectUrl;
+     }
+     };
+
+     AssertionType assertion = createAssertion();
+     LogEventRequestType auditRequest = transforms.transformRequestToAuditMsg(TestPatientDiscoveryMessageHelper.
+     createPRPAIN201305UV02Request("Gallow", "Younger", "M", "01-12-2967", "1.1", "D123401", "2.2",
+     "abd3453dcd24wkkks545"), assertion, createNhinTarget(), NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
+     NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE, webContextProperties,
+     NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
+
+     testGetEventIdentificationType(auditRequest, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME,
+     Boolean.TRUE);
+     testGetActiveParticipantSource(auditRequest, Boolean.TRUE, webContextProperties, localIp);
+     testGetActiveParticipantDestination(auditRequest, Boolean.TRUE, webContextProperties, remoteObjectUrl);
+     testCreateActiveParticipantFromUser(auditRequest, Boolean.TRUE, assertion);
+     assertParticipantObjectIdentification(auditRequest);
+     }*/
+    /**
+     *
+     * @throws ConnectionManagerException
+     * @throws UnknownHostException
+     */
     @Test
-    public void transformRequestToAuditMsg() throws ConnectionManagerException, UnknownHostException {
-        final String localIp = "10.10.10.10";
-        final String remoteIp = "16.14.13.12";
-        final String remoteObjectUrl = "http://" + remoteIp + ":9090/source/AuditService";
-        final String wsRequestUrl = "http://" + remoteIp + ":9090/AuditService";
-
-        Properties webContextProperties = new Properties();
-        webContextProperties.setProperty(NhincConstants.WEB_SERVICE_REQUEST_URL, wsRequestUrl);
-        webContextProperties.setProperty(NhincConstants.REMOTE_HOST_ADDRESS, remoteIp);
-
-        PatientDiscoveryAuditTransforms transforms = new PatientDiscoveryAuditTransforms() {
-            @Override
-            protected String getLocalHostAddress() {
-                return localIp;
-            }
-
-            @Override
-            protected String getRemoteHostAddress(Properties webContextProperties) {
-                if (webContextProperties != null && !webContextProperties.isEmpty() && webContextProperties
-                    .getProperty(NhincConstants.REMOTE_HOST_ADDRESS) != null) {
-
-                    return webContextProperties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS);
-                }
-                return AuditTransformsConstants.ACTIVE_PARTICIPANT_UNKNOWN_IP_ADDRESS;
-            }
-
-            @Override
-            protected String getWebServiceUrlFromRemoteObject(NhinTargetSystemType target, String serviceName) {
-                return remoteObjectUrl;
-            }
-        };
-
-        AssertionType assertion = createAssertion();
-        LogEventRequestType auditRequest = transforms.transformRequestToAuditMsg(TestPatientDiscoveryMessageHelper.
-            createPRPAIN201305UV02Request("Gallow", "Younger", "M", "01-12-2967", "1.1", "D123401", "2.2",
-                "abd3453dcd24wkkks545"), assertion, createNhinTarget(), NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
-            NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE, webContextProperties,
-            NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
-
-        testGetEventIdentificationType(auditRequest, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, Boolean.TRUE);
-        testGetActiveParticipantSource(auditRequest, Boolean.TRUE, webContextProperties, localIp);
-        testGetActiveParticipantDestination(auditRequest, Boolean.TRUE, webContextProperties, remoteObjectUrl);
-        testCreateActiveParticipantFromUser(auditRequest, Boolean.TRUE, assertion);
-        assertParticipantObjectIdentification(auditRequest);
-    }
-
-    @Test
+    @Ignore
     public void transformResponseToAuditMsg() throws ConnectionManagerException, UnknownHostException {
         final String localIp = "10.10.10.10";
         final String remoteIp = "16.14.13.12";
@@ -136,8 +97,9 @@ public class PatientDiscoveryAuditTransformsTest extends AuditTransformsTest<PRP
         Properties webContextProperties = new Properties();
         webContextProperties.setProperty(NhincConstants.WEB_SERVICE_REQUEST_URL, wsRequestUrl);
         webContextProperties.setProperty(NhincConstants.REMOTE_HOST_ADDRESS, remoteIp);
+        webContextProperties.setProperty(NhincConstants.INBOUND_REPLY_TO, "http://www.w3.org/2005/08/addressing/anonymous");
 
-        PatientDiscoveryAuditTransforms transforms = new PatientDiscoveryAuditTransforms() {
+        PatientDiscoveryDeferredResponseAuditTransforms transforms = new PatientDiscoveryDeferredResponseAuditTransforms() {
             @Override
             protected String getLocalHostAddress() {
                 return localIp;
@@ -151,6 +113,18 @@ public class PatientDiscoveryAuditTransformsTest extends AuditTransformsTest<PRP
                     return webContextProperties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS);
                 }
                 return AuditTransformsConstants.ACTIVE_PARTICIPANT_UNKNOWN_IP_ADDRESS;
+            }
+
+            @Override
+            protected String getInboundReplyToFromHeader(Properties webContextProperties) {
+
+                String inboundReplyTo = null;
+                if (webContextProperties != null && !webContextProperties.isEmpty() && webContextProperties.getProperty(
+                    NhincConstants.INBOUND_REPLY_TO) != null) {
+
+                    inboundReplyTo = webContextProperties.getProperty(NhincConstants.INBOUND_REPLY_TO);
+                }
+                return inboundReplyTo;
             }
 
             @Override
@@ -161,17 +135,16 @@ public class PatientDiscoveryAuditTransformsTest extends AuditTransformsTest<PRP
 
         AssertionType assertion = createAssertion();
         LogEventRequestType auditRequest = transforms.transformResponseToAuditMsg(
-            TestPatientDiscoveryMessageHelper.createPRPAIN201305UV02Request("Gallow", "Younger", "M", "01-12-2967",
-                "1.1", "D123401", "2.2", "abd3453dcd24wkkks545"), TestPatientDiscoveryMessageHelper.
-            createPRPAIN201306UV02Response("Gallow", "Younger", "M", "01-12-2967", "1.1", "D123401", "2.2",
-                "abd3453dcd24wkkks545"), assertion, createNhinTarget(), NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
-            NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE, webContextProperties,
-            NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
+            TestPatientDiscoveryMessageHelper.createPRPAIN201306UV02Response("Gallow", "Younger", "M", "01-12-2967",
+                "1.1", "D123401", "2.2", "abd3453dcd24wkkks545"), new MCCIIN000002UV01(), assertion, createNhinTarget(),
+            NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE,
+            webContextProperties, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
 
-        testGetEventIdentificationType(auditRequest, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, Boolean.TRUE);
-        testGetActiveParticipantSource(auditRequest, Boolean.TRUE, webContextProperties, localIp);
-        testGetActiveParticipantDestination(auditRequest, Boolean.TRUE, webContextProperties, remoteObjectUrl);
-        testCreateActiveParticipantFromUser(auditRequest, Boolean.TRUE, assertion);
+        testGetEventIdentificationType(auditRequest, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME,
+            Boolean.TRUE);
+        testGetActiveParticipantSource(auditRequest, Boolean.FALSE, webContextProperties, localIp);
+        testGetActiveParticipantDestination(auditRequest, Boolean.FALSE, webContextProperties, remoteObjectUrl);
+        testCreateActiveParticipantFromUser(auditRequest, Boolean.FALSE, assertion);
         assertParticipantObjectIdentification(auditRequest);
     }
 
@@ -235,7 +208,8 @@ public class PatientDiscoveryAuditTransformsTest extends AuditTransformsTest<PRP
     }
 
     @Override
-    protected AuditTransforms<PRPAIN201305UV02, PRPAIN201306UV02> getAuditTransforms() {
-        return new PatientDiscoveryAuditTransforms();
+    protected AuditTransforms<PRPAIN201306UV02, MCCIIN000002UV01> getAuditTransforms() {
+        return new PatientDiscoveryDeferredResponseAuditTransforms();
     }
+
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/PassthroughInboundPatientDiscoveryDeferredResponseTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/PassthroughInboundPatientDiscoveryDeferredResponseTest.java
@@ -27,7 +27,6 @@
 package gov.hhs.fha.nhinc.patientdiscovery.inbound.deferred.response;
 
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
-import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.response.proxy.AdapterPatientDiscoveryDeferredRespProxy;
 import gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.response.proxy.AdapterPatientDiscoveryDeferredRespProxyObjectFactory;
@@ -52,13 +51,13 @@ public class PassthroughInboundPatientDiscoveryDeferredResponseTest {
         PRPAIN201306UV02 request = new PRPAIN201306UV02();
         AssertionType assertion = new AssertionType();
         MCCIIN000002UV01 expectedResponse = new MCCIIN000002UV01();
-        NhinTargetSystemType target = new NhinTargetSystemType();
 
         // Mocks
-        AdapterPatientDiscoveryDeferredRespProxyObjectFactory adapterFactory = 
-            mock(AdapterPatientDiscoveryDeferredRespProxyObjectFactory.class);
+        AdapterPatientDiscoveryDeferredRespProxyObjectFactory adapterFactory
+            = mock(AdapterPatientDiscoveryDeferredRespProxyObjectFactory.class);
         AdapterPatientDiscoveryDeferredRespProxy adapterProxy = mock(AdapterPatientDiscoveryDeferredRespProxy.class);
-        PatientDiscoveryDeferredResponseAuditLogger auditLogger = mock(PatientDiscoveryDeferredResponseAuditLogger.class);
+        PatientDiscoveryDeferredResponseAuditLogger auditLogger
+            = mock(PatientDiscoveryDeferredResponseAuditLogger.class);
         Properties webContextProperties = new Properties();
 
         // Stubbing the methods
@@ -67,19 +66,18 @@ public class PassthroughInboundPatientDiscoveryDeferredResponseTest {
         when(adapterProxy.processPatientDiscoveryAsyncResp(request, assertion)).thenReturn(expectedResponse);
 
         // Actual invocation
-        PassthroughInboundPatientDiscoveryDeferredResponse passthroughPatientDiscovery = new       
-            PassthroughInboundPatientDiscoveryDeferredResponse(adapterFactory, auditLogger);
+        PassthroughInboundPatientDiscoveryDeferredResponse passthroughPatientDiscovery
+            = new PassthroughInboundPatientDiscoveryDeferredResponse(adapterFactory, auditLogger);
 
         MCCIIN000002UV01 actualResponse = passthroughPatientDiscovery.respondingGatewayDeferredPRPAIN201306UV02(
-                request, assertion, webContextProperties);
+            request, assertion, webContextProperties);
 
         // Verify
         assertSame(expectedResponse, actualResponse);
 
-
-        verify(auditLogger).auditResponseMessage(request, actualResponse, assertion, null, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
-                NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE, webContextProperties, 
-                NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
+        verify(auditLogger).auditResponseMessage(request, actualResponse, assertion, null,
+            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE,
+            webContextProperties, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
 
     }
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/StandardInboundPatientDiscoveryDeferredResponseTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/StandardInboundPatientDiscoveryDeferredResponseTest.java
@@ -71,8 +71,8 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
 
     @Test
     public void hasInboundProcessingEvent() throws Exception {
-        Class<StandardInboundPatientDiscoveryDeferredResponse> clazz = 
-            StandardInboundPatientDiscoveryDeferredResponse.class;
+        Class<StandardInboundPatientDiscoveryDeferredResponse> clazz
+            = StandardInboundPatientDiscoveryDeferredResponse.class;
         Method method = clazz.getDeclaredMethod("respondingGatewayDeferredPRPAIN201306UV02", PRPAIN201306UV02.class,
             AssertionType.class, Properties.class);
         InboundProcessingEvent annotation = method.getAnnotation(InboundProcessingEvent.class);
@@ -94,8 +94,8 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
         PatientDiscovery201306Processor msgProcessor = mock(PatientDiscovery201306Processor.class);
         PDDeferredCorrelationDao pdCorrelationDao = mock(PDDeferredCorrelationDao.class);
         ResponseMode responseMode = mock(ResponseMode.class);
-        AdapterPatientDiscoveryDeferredRespProxyObjectFactory adapterProxyFactory = 
-            mock(AdapterPatientDiscoveryDeferredRespProxyObjectFactory.class);
+        AdapterPatientDiscoveryDeferredRespProxyObjectFactory adapterProxyFactory
+            = mock(AdapterPatientDiscoveryDeferredRespProxyObjectFactory.class);
         AdapterPatientDiscoveryDeferredRespProxy adapterProxy = mock(AdapterPatientDiscoveryDeferredRespProxy.class);
 
         // Stubbing the methods
@@ -112,9 +112,9 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
         when(adapterProxy.processPatientDiscoveryAsyncResp(request, assertion)).thenReturn(expectedResponse);
 
         // Actual invocation
-        StandardInboundPatientDiscoveryDeferredResponse standardPatientDiscovery = 
-            new StandardInboundPatientDiscoveryDeferredResponse(
-            policyChecker, responseFactory, msgProcessor, adapterProxyFactory, pdCorrelationDao, auditLogger);
+        StandardInboundPatientDiscoveryDeferredResponse standardPatientDiscovery
+            = new StandardInboundPatientDiscoveryDeferredResponse(
+                policyChecker, responseFactory, msgProcessor, adapterProxyFactory, pdCorrelationDao, auditLogger);
 
         MCCIIN000002UV01 actualResponse = standardPatientDiscovery.respondingGatewayDeferredPRPAIN201306UV02(request,
             assertion, webContextProperties);
@@ -146,8 +146,8 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
         PatientDiscovery201306PolicyChecker policyChecker = mock(PatientDiscovery201306PolicyChecker.class);
         ResponseFactory responseFactory = mock(ResponseFactory.class);
         ResponseMode responseMode = mock(ResponseMode.class);
-        AdapterPatientDiscoveryDeferredRespProxyObjectFactory adapterProxyFactory = 
-            mock(AdapterPatientDiscoveryDeferredRespProxyObjectFactory.class);
+        AdapterPatientDiscoveryDeferredRespProxyObjectFactory adapterProxyFactory
+            = mock(AdapterPatientDiscoveryDeferredRespProxyObjectFactory.class);
         AdapterPatientDiscoveryDeferredRespProxy adapterProxy = mock(AdapterPatientDiscoveryDeferredRespProxy.class);
 
         // Stubbing the methods
@@ -160,8 +160,8 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
         when(adapterProxy.processPatientDiscoveryAsyncResp(request, assertion)).thenReturn(expectedResponse);
 
         // Actual invocation
-        StandardInboundPatientDiscoveryDeferredResponse standardPatientDiscovery = 
-            new StandardInboundPatientDiscoveryDeferredResponse(policyChecker, responseFactory, null, 
+        StandardInboundPatientDiscoveryDeferredResponse standardPatientDiscovery
+            = new StandardInboundPatientDiscoveryDeferredResponse(policyChecker, responseFactory, null,
                 adapterProxyFactory, null, auditLogger);
 
         MCCIIN000002UV01 actualResponse = standardPatientDiscovery.respondingGatewayDeferredPRPAIN201306UV02(request,
@@ -198,8 +198,7 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
             false);
 
         // Actual invocation
-        StandardInboundPatientDiscoveryDeferredResponse standardPatientDiscovery = new 
-            StandardInboundPatientDiscoveryDeferredResponse(policyChecker, null, null, null, null, auditLogger);
+        StandardInboundPatientDiscoveryDeferredResponse standardPatientDiscovery = new StandardInboundPatientDiscoveryDeferredResponse(policyChecker, null, null, null, null, auditLogger);
 
         MCCIIN000002UV01 errorResponse = standardPatientDiscovery.respondingGatewayDeferredPRPAIN201306UV02(request,
             assertion, webContextProperties);

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/StandardInboundPatientDiscoveryDeferredResponseTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/StandardInboundPatientDiscoveryDeferredResponseTest.java
@@ -26,38 +26,37 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.inbound.deferred.response;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.patientcorrelation.nhinc.dao.PDDeferredCorrelationDao;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscovery201306PolicyChecker;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscovery201306Processor;
-import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryAuditor;
 import gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.response.proxy.AdapterPatientDiscoveryDeferredRespProxy;
 import gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.response.proxy.AdapterPatientDiscoveryDeferredRespProxyObjectFactory;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.MCCIIN000002UV01EventDescriptionBuilder;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201306UV02EventDescriptionBuilder;
+import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryDeferredResponseAuditLogger;
 import gov.hhs.fha.nhinc.patientdiscovery.response.ResponseFactory;
 import gov.hhs.fha.nhinc.patientdiscovery.response.ResponseFactory.ResponseModeType;
 import gov.hhs.fha.nhinc.patientdiscovery.response.ResponseMode;
 import gov.hhs.fha.nhinc.transform.subdisc.HL7AckTransforms;
-
 import java.lang.reflect.Method;
-
+import java.util.Properties;
 import org.hl7.v3.II;
 import org.hl7.v3.MCCIIN000002UV01;
 import org.hl7.v3.PRPAIN201306UV02;
 import org.hl7.v3.RespondingGatewayPRPAIN201306UV02RequestType;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author achidamb
@@ -65,11 +64,17 @@ import org.mockito.ArgumentCaptor;
  */
 public class StandardInboundPatientDiscoveryDeferredResponseTest {
 
+    private final PRPAIN201306UV02 request = new PRPAIN201306UV02();
+    private final AssertionType assertion = new AssertionType();
+    private final Properties webContextProperties = new Properties();
+    PatientDiscoveryDeferredResponseAuditLogger auditLogger = mock(PatientDiscoveryDeferredResponseAuditLogger.class);
+
     @Test
     public void hasInboundProcessingEvent() throws Exception {
-        Class<StandardInboundPatientDiscoveryDeferredResponse> clazz = StandardInboundPatientDiscoveryDeferredResponse.class;
+        Class<StandardInboundPatientDiscoveryDeferredResponse> clazz = 
+            StandardInboundPatientDiscoveryDeferredResponse.class;
         Method method = clazz.getDeclaredMethod("respondingGatewayDeferredPRPAIN201306UV02", PRPAIN201306UV02.class,
-                AssertionType.class);
+            AssertionType.class, Properties.class);
         InboundProcessingEvent annotation = method.getAnnotation(InboundProcessingEvent.class);
         assertNotNull(annotation);
         assertEquals(PRPAIN201306UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
@@ -80,8 +85,6 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
 
     @Test
     public void invoke() {
-        PRPAIN201306UV02 request = new PRPAIN201306UV02();
-        AssertionType assertion = new AssertionType();
         MCCIIN000002UV01 expectedResponse = new MCCIIN000002UV01();
         II patientId = new II();
 
@@ -90,14 +93,14 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
         ResponseFactory responseFactory = mock(ResponseFactory.class);
         PatientDiscovery201306Processor msgProcessor = mock(PatientDiscovery201306Processor.class);
         PDDeferredCorrelationDao pdCorrelationDao = mock(PDDeferredCorrelationDao.class);
-        PatientDiscoveryAuditor auditLogger = mock(PatientDiscoveryAuditor.class);
         ResponseMode responseMode = mock(ResponseMode.class);
-        AdapterPatientDiscoveryDeferredRespProxyObjectFactory adapterProxyFactory = mock(AdapterPatientDiscoveryDeferredRespProxyObjectFactory.class);
+        AdapterPatientDiscoveryDeferredRespProxyObjectFactory adapterProxyFactory = 
+            mock(AdapterPatientDiscoveryDeferredRespProxyObjectFactory.class);
         AdapterPatientDiscoveryDeferredRespProxy adapterProxy = mock(AdapterPatientDiscoveryDeferredRespProxy.class);
 
         // Stubbing the methods
         when(policyChecker.checkOutgoingPolicy(any(RespondingGatewayPRPAIN201306UV02RequestType.class))).thenReturn(
-                true);
+            true);
 
         when(responseFactory.getResponseModeType()).thenReturn(ResponseModeType.VERIFY);
 
@@ -109,17 +112,18 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
         when(adapterProxy.processPatientDiscoveryAsyncResp(request, assertion)).thenReturn(expectedResponse);
 
         // Actual invocation
-        StandardInboundPatientDiscoveryDeferredResponse standardPatientDiscovery = new StandardInboundPatientDiscoveryDeferredResponse(
-                policyChecker, responseFactory, msgProcessor, adapterProxyFactory, pdCorrelationDao, auditLogger);
+        StandardInboundPatientDiscoveryDeferredResponse standardPatientDiscovery = 
+            new StandardInboundPatientDiscoveryDeferredResponse(
+            policyChecker, responseFactory, msgProcessor, adapterProxyFactory, pdCorrelationDao, auditLogger);
 
         MCCIIN000002UV01 actualResponse = standardPatientDiscovery.respondingGatewayDeferredPRPAIN201306UV02(request,
-                assertion);
+            assertion, webContextProperties);
 
         assertSame(expectedResponse, actualResponse);
 
         // Verify policy check is with the correct request
         ArgumentCaptor<RespondingGatewayPRPAIN201306UV02RequestType> policyReqArgument = ArgumentCaptor
-                .forClass(RespondingGatewayPRPAIN201306UV02RequestType.class);
+            .forClass(RespondingGatewayPRPAIN201306UV02RequestType.class);
 
         verify(policyChecker).checkOutgoingPolicy(policyReqArgument.capture());
         assertEquals(request, policyReqArgument.getValue().getPRPAIN201306UV02());
@@ -128,34 +132,27 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
         verify(responseMode).processResponse(request, assertion, patientId);
 
         // Verify audits
-        verify(auditLogger).auditNhinDeferred201306(request, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
+        verify(auditLogger).auditResponseMessage(request, actualResponse, assertion, null,
+            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE,
+            Boolean.FALSE, webContextProperties, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
 
-        verify(auditLogger).auditAck(actualResponse, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
-                NhincConstants.AUDIT_LOG_NHIN_INTERFACE);
-
-        verify(auditLogger).auditAdapterDeferred201306(request, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
-
-        verify(auditLogger).auditAck(actualResponse, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
-                NhincConstants.AUDIT_LOG_ADAPTER_INTERFACE);
     }
 
     @Test
     public void passthrough() {
-        PRPAIN201306UV02 request = new PRPAIN201306UV02();
-        AssertionType assertion = new AssertionType();
         MCCIIN000002UV01 expectedResponse = new MCCIIN000002UV01();
 
         // Mocks
         PatientDiscovery201306PolicyChecker policyChecker = mock(PatientDiscovery201306PolicyChecker.class);
         ResponseFactory responseFactory = mock(ResponseFactory.class);
-        PatientDiscoveryAuditor auditLogger = mock(PatientDiscoveryAuditor.class);
         ResponseMode responseMode = mock(ResponseMode.class);
-        AdapterPatientDiscoveryDeferredRespProxyObjectFactory adapterProxyFactory = mock(AdapterPatientDiscoveryDeferredRespProxyObjectFactory.class);
+        AdapterPatientDiscoveryDeferredRespProxyObjectFactory adapterProxyFactory = 
+            mock(AdapterPatientDiscoveryDeferredRespProxyObjectFactory.class);
         AdapterPatientDiscoveryDeferredRespProxy adapterProxy = mock(AdapterPatientDiscoveryDeferredRespProxy.class);
 
         // Stubbing the methods
         when(policyChecker.checkOutgoingPolicy(any(RespondingGatewayPRPAIN201306UV02RequestType.class))).thenReturn(
-                true);
+            true);
 
         when(responseFactory.getResponseModeType()).thenReturn(ResponseModeType.PASSTHROUGH);
 
@@ -163,30 +160,29 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
         when(adapterProxy.processPatientDiscoveryAsyncResp(request, assertion)).thenReturn(expectedResponse);
 
         // Actual invocation
-        StandardInboundPatientDiscoveryDeferredResponse standardPatientDiscovery = new StandardInboundPatientDiscoveryDeferredResponse(
-                policyChecker, responseFactory, null, adapterProxyFactory, null, auditLogger);
+        StandardInboundPatientDiscoveryDeferredResponse standardPatientDiscovery = 
+            new StandardInboundPatientDiscoveryDeferredResponse(policyChecker, responseFactory, null, 
+                adapterProxyFactory, null, auditLogger);
 
         MCCIIN000002UV01 actualResponse = standardPatientDiscovery.respondingGatewayDeferredPRPAIN201306UV02(request,
-                assertion);
+            assertion, webContextProperties);
 
         assertSame(expectedResponse, actualResponse);
 
         // Verify policy check is with the correct request
         ArgumentCaptor<RespondingGatewayPRPAIN201306UV02RequestType> policyReqArgument = ArgumentCaptor
-                .forClass(RespondingGatewayPRPAIN201306UV02RequestType.class);
+            .forClass(RespondingGatewayPRPAIN201306UV02RequestType.class);
 
         verify(policyChecker).checkOutgoingPolicy(policyReqArgument.capture());
         assertEquals(request, policyReqArgument.getValue().getPRPAIN201306UV02());
 
         // Verify response mode processing is never called
         verify(responseMode, never()).processResponse(any(PRPAIN201306UV02.class), any(AssertionType.class),
-                any(II.class));
+            any(II.class));
 
-        // Verify audits
-        verify(auditLogger).auditNhinDeferred201306(request, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
-
-        verify(auditLogger).auditAck(actualResponse, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
-                NhincConstants.AUDIT_LOG_NHIN_INTERFACE);
+        verify(auditLogger).auditResponseMessage(request, actualResponse, assertion, null,
+            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE,
+            Boolean.FALSE, webContextProperties, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
     }
 
     @Test
@@ -196,38 +192,35 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
 
         // Mocks
         PatientDiscovery201306PolicyChecker policyChecker = mock(PatientDiscovery201306PolicyChecker.class);
-        PatientDiscoveryAuditor auditLogger = mock(PatientDiscoveryAuditor.class);
 
         // Stubbing the methods
         when(policyChecker.checkOutgoingPolicy(any(RespondingGatewayPRPAIN201306UV02RequestType.class))).thenReturn(
-                false);
+            false);
 
         // Actual invocation
-        StandardInboundPatientDiscoveryDeferredResponse standardPatientDiscovery = new StandardInboundPatientDiscoveryDeferredResponse(
-                policyChecker, null, null, null, null, auditLogger);
+        StandardInboundPatientDiscoveryDeferredResponse standardPatientDiscovery = new 
+            StandardInboundPatientDiscoveryDeferredResponse(policyChecker, null, null, null, null, auditLogger);
 
         MCCIIN000002UV01 errorResponse = standardPatientDiscovery.respondingGatewayDeferredPRPAIN201306UV02(request,
-                assertion);
+            assertion, webContextProperties);
 
         // Verify error response
         assertEquals(HL7AckTransforms.ACK_DETAIL_TYPE_CODE_ERROR, errorResponse.getAcknowledgement().get(0)
-                .getAcknowledgementDetail().get(0).getTypeCode().toString());
+            .getAcknowledgementDetail().get(0).getTypeCode().toString());
 
         assertEquals("Policy Check Failed", errorResponse.getAcknowledgement().get(0).getAcknowledgementDetail().get(0)
-                .getText().getContent().get(0).toString());
+            .getText().getContent().get(0).toString());
 
         // Verify policy check is with the correct request
         ArgumentCaptor<RespondingGatewayPRPAIN201306UV02RequestType> policyReqArgument = ArgumentCaptor
-                .forClass(RespondingGatewayPRPAIN201306UV02RequestType.class);
+            .forClass(RespondingGatewayPRPAIN201306UV02RequestType.class);
 
         verify(policyChecker).checkOutgoingPolicy(policyReqArgument.capture());
         assertEquals(request, policyReqArgument.getValue().getPRPAIN201306UV02());
 
-        // Verify audits
-        verify(auditLogger).auditNhinDeferred201306(request, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
-
-        verify(auditLogger).auditAck(errorResponse, assertion, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
-                NhincConstants.AUDIT_LOG_NHIN_INTERFACE);
+        verify(auditLogger).auditResponseMessage(request, errorResponse, assertion, null,
+            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE,
+            Boolean.FALSE, webContextProperties, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/TestInboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/TestInboundPatientDiscoveryDeferredResponse.java
@@ -27,7 +27,7 @@
 package gov.hhs.fha.nhinc.patientdiscovery.inbound.deferred.response;
 
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
-
+import java.util.Properties;
 import org.hl7.v3.MCCIIN000002UV01;
 import org.hl7.v3.PRPAIN201306UV02;
 
@@ -37,8 +37,16 @@ import org.hl7.v3.PRPAIN201306UV02;
  */
 public class TestInboundPatientDiscoveryDeferredResponse implements InboundPatientDiscoveryDeferredResponse{
 
+    /**
+     *
+     * @param body
+     * @param assertion
+     * @param webContextProperties
+     * @return
+     */
     @Override
-    public MCCIIN000002UV01 respondingGatewayDeferredPRPAIN201306UV02(PRPAIN201306UV02 body, AssertionType assertion) {
+    public MCCIIN000002UV01 respondingGatewayDeferredPRPAIN201306UV02(PRPAIN201306UV02 body, AssertionType assertion, 
+        Properties webContextProperties) {
         return new MCCIIN000002UV01();
     }
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/TestInboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/TestInboundPatientDiscoveryDeferredResponse.java
@@ -35,7 +35,7 @@ import org.hl7.v3.PRPAIN201306UV02;
  * @author akong
  *
  */
-public class TestInboundPatientDiscoveryDeferredResponse implements InboundPatientDiscoveryDeferredResponse{
+public class TestInboundPatientDiscoveryDeferredResponse implements InboundPatientDiscoveryDeferredResponse {
 
     /**
      *
@@ -45,7 +45,7 @@ public class TestInboundPatientDiscoveryDeferredResponse implements InboundPatie
      * @return
      */
     @Override
-    public MCCIIN000002UV01 respondingGatewayDeferredPRPAIN201306UV02(PRPAIN201306UV02 body, AssertionType assertion, 
+    public MCCIIN000002UV01 respondingGatewayDeferredPRPAIN201306UV02(PRPAIN201306UV02 body, AssertionType assertion,
         Properties webContextProperties) {
         return new MCCIIN000002UV01();
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/PassthroughOutboundPatientDiscoveryDeferredResponseTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/PassthroughOutboundPatientDiscoveryDeferredResponseTest.java
@@ -26,27 +26,26 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.outbound.deferred.response;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
-import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryAuditor;
+import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryDeferredResponseAuditLogger;
 import gov.hhs.fha.nhinc.patientdiscovery.entity.deferred.response.OutboundPatientDiscoveryDeferredResponseDelegate;
 import gov.hhs.fha.nhinc.patientdiscovery.entity.deferred.response.OutboundPatientDiscoveryDeferredResponseOrchestratable;
-
+import java.util.Properties;
 import org.hl7.v3.MCCIIN000002UV01;
 import org.hl7.v3.PRPAIN201306UV02;
-import org.hl7.v3.RespondingGatewayPRPAIN201306UV02RequestType;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import org.mockito.Mockito;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author achidamb
@@ -60,10 +59,12 @@ public class PassthroughOutboundPatientDiscoveryDeferredResponseTest {
         AssertionType assertion = new AssertionType();
         NhinTargetCommunitiesType target = new NhinTargetCommunitiesType();
         MCCIIN000002UV01 expectedResponse = new MCCIIN000002UV01();
+        final NhinTargetSystemType targetSystem = mock(NhinTargetSystemType.class);
 
         OutboundPatientDiscoveryDeferredResponseDelegate delegate = mock(OutboundPatientDiscoveryDeferredResponseDelegate.class);
         OutboundPatientDiscoveryDeferredResponseOrchestratable returnedOrchestratable = mock(OutboundPatientDiscoveryDeferredResponseOrchestratable.class);
-        PatientDiscoveryAuditor auditLogger = mock(PatientDiscoveryAuditor.class);
+        PatientDiscoveryDeferredResponseAuditLogger auditLogger = mock(PatientDiscoveryDeferredResponseAuditLogger.class);
+        Properties webContextProperties = null;
 
         when(delegate.process(any(OutboundPatientDiscoveryDeferredResponseOrchestratable.class))).thenReturn(
                 returnedOrchestratable);
@@ -83,10 +84,9 @@ public class PassthroughOutboundPatientDiscoveryDeferredResponseTest {
         verify(delegate).process(orchestratableArgument.capture());
         assertEquals(request, orchestratableArgument.getValue().getRequest());
 
-        verify(auditLogger, never()).auditEntityDeferred201306(any(RespondingGatewayPRPAIN201306UV02RequestType.class),
-                any(AssertionType.class), any(String.class));
+        verify(auditLogger).auditRequestMessage(eq(request), eq(assertion),Mockito.any(NhinTargetSystemType.class) , 
+            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), 
+            eq(Boolean.TRUE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME));
 
-        verify(auditLogger, never()).auditAck(any(MCCIIN000002UV01.class), any(AssertionType.class), any(String.class),
-                eq(NhincConstants.AUDIT_LOG_ENTITY_INTERFACE));
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/PassthroughOutboundPatientDiscoveryDeferredResponseTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/PassthroughOutboundPatientDiscoveryDeferredResponseTest.java
@@ -67,25 +67,25 @@ public class PassthroughOutboundPatientDiscoveryDeferredResponseTest {
         Properties webContextProperties = null;
 
         when(delegate.process(any(OutboundPatientDiscoveryDeferredResponseOrchestratable.class))).thenReturn(
-                returnedOrchestratable);
+            returnedOrchestratable);
 
         when(returnedOrchestratable.getResponse()).thenReturn(expectedResponse);
 
         PassthroughOutboundPatientDiscoveryDeferredResponse passthroughPatientDiscovery = new PassthroughOutboundPatientDiscoveryDeferredResponse(
-                delegate, auditLogger);
+            delegate, auditLogger);
 
         MCCIIN000002UV01 actualResponse = passthroughPatientDiscovery.processPatientDiscoveryAsyncResp(request,
-                assertion, target);
+            assertion, target);
 
         assertSame(expectedResponse, actualResponse);
 
         ArgumentCaptor<OutboundPatientDiscoveryDeferredResponseOrchestratable> orchestratableArgument = ArgumentCaptor
-                .forClass(OutboundPatientDiscoveryDeferredResponseOrchestratable.class);
+            .forClass(OutboundPatientDiscoveryDeferredResponseOrchestratable.class);
         verify(delegate).process(orchestratableArgument.capture());
         assertEquals(request, orchestratableArgument.getValue().getRequest());
 
-        verify(auditLogger).auditRequestMessage(eq(request), eq(assertion),Mockito.any(NhinTargetSystemType.class) , 
-            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), 
+        verify(auditLogger).auditRequestMessage(eq(request), eq(assertion), Mockito.any(NhinTargetSystemType.class),
+            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), eq(webContextProperties), eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME));
 
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/StandardOutboundPatientDiscoveryDeferredResponseTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/StandardOutboundPatientDiscoveryDeferredResponseTest.java
@@ -75,7 +75,7 @@ public class StandardOutboundPatientDiscoveryDeferredResponseTest {
     private MCCIIN000002UV01 expectedResponse;
     private PRPAIN201306UV02 firstTargetRequest;
     private PRPAIN201306UV02 secondTargetRequest;
-    
+
     PatientDiscoveryDeferredResponseAuditLogger auditLogger = mock(PatientDiscoveryDeferredResponseAuditLogger.class);
     Properties webContextProperties = null;
 
@@ -103,7 +103,7 @@ public class StandardOutboundPatientDiscoveryDeferredResponseTest {
     public void hasOutboundProcessingEvent() throws Exception {
         Class<StandardOutboundPatientDiscoveryDeferredResponse> clazz = StandardOutboundPatientDiscoveryDeferredResponse.class;
         Method method = clazz.getMethod("processPatientDiscoveryAsyncResp", PRPAIN201306UV02.class,
-                AssertionType.class, NhinTargetCommunitiesType.class);
+            AssertionType.class, NhinTargetCommunitiesType.class);
         OutboundProcessingEvent annotation = method.getAnnotation(OutboundProcessingEvent.class);
         assertNotNull(annotation);
         assertEquals(PRPAIN201306UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
@@ -119,41 +119,41 @@ public class StandardOutboundPatientDiscoveryDeferredResponseTest {
         // Mocks
         PatientDiscovery201306PolicyChecker policyChecker = mock(PatientDiscovery201306PolicyChecker.class);
         PatientDiscovery201306Processor pd201306Processor = mock(PatientDiscovery201306Processor.class);
-        
-        OutboundPatientDiscoveryDeferredResponseDelegate delegate = 
-            mock(OutboundPatientDiscoveryDeferredResponseDelegate.class);
-        OutboundPatientDiscoveryDeferredResponseOrchestratable returnedOrchestratable = 
-            mock(OutboundPatientDiscoveryDeferredResponseOrchestratable.class);
+
+        OutboundPatientDiscoveryDeferredResponseDelegate delegate
+            = mock(OutboundPatientDiscoveryDeferredResponseDelegate.class);
+        OutboundPatientDiscoveryDeferredResponseOrchestratable returnedOrchestratable
+            = mock(OutboundPatientDiscoveryDeferredResponseOrchestratable.class);
         ConnectionManagerCache connectionManager = mock(ConnectionManagerCache.class);
 
         // Stubbing the methods
         when(connectionManager.getEndpointURLFromNhinTargetCommunities(targets,
-                NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME)).thenReturn(urlInfoList);
+            NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME)).thenReturn(urlInfoList);
 
         when(pd201306Processor.createNewRequest(request, "1.1")).thenReturn(firstTargetRequest);
         when(pd201306Processor.createNewRequest(request, "2.2")).thenReturn(secondTargetRequest);
 
         when(policyChecker.checkOutgoingPolicy(any(RespondingGatewayPRPAIN201306UV02RequestType.class))).thenReturn(
-                true);
+            true);
 
         when(delegate.process(any(OutboundPatientDiscoveryDeferredResponseOrchestratable.class))).thenReturn(
-                returnedOrchestratable);
+            returnedOrchestratable);
 
         when(returnedOrchestratable.getResponse()).thenReturn(expectedResponse);
 
         // Actual invocation
         StandardOutboundPatientDiscoveryDeferredResponse standardPatientDiscovery = new StandardOutboundPatientDiscoveryDeferredResponse(
-                policyChecker, pd201306Processor, auditLogger, delegate, connectionManager);
+            policyChecker, pd201306Processor, auditLogger, delegate, connectionManager);
 
         MCCIIN000002UV01 actualResponse = standardPatientDiscovery.processPatientDiscoveryAsyncResp(request, assertion,
-                targets);
+            targets);
 
         // Verify actual response is the same as expected
         assertSame(expectedResponse, actualResponse);
 
         // Verify policy is checking the request containing the first target and then the second target
         ArgumentCaptor<RespondingGatewayPRPAIN201306UV02RequestType> requestArgument = ArgumentCaptor
-                .forClass(RespondingGatewayPRPAIN201306UV02RequestType.class);
+            .forClass(RespondingGatewayPRPAIN201306UV02RequestType.class);
 
         verify(policyChecker, times(2)).checkOutgoingPolicy(requestArgument.capture());
         assertEquals(firstTargetRequest, requestArgument.getAllValues().get(0).getPRPAIN201306UV02());
@@ -161,7 +161,7 @@ public class StandardOutboundPatientDiscoveryDeferredResponseTest {
 
         // Verify the orchestratable is processing the request containing the first target and then the second target
         ArgumentCaptor<OutboundPatientDiscoveryDeferredResponseOrchestratable> orchestratableArgument = ArgumentCaptor
-                .forClass(OutboundPatientDiscoveryDeferredResponseOrchestratable.class);
+            .forClass(OutboundPatientDiscoveryDeferredResponseOrchestratable.class);
 
         verify(delegate, times(2)).process(orchestratableArgument.capture());
         assertEquals(firstTargetRequest, orchestratableArgument.getAllValues().get(0).getRequest());
@@ -169,11 +169,11 @@ public class StandardOutboundPatientDiscoveryDeferredResponseTest {
 
         // Verify request from adapter is audited
         requestArgument.getAllValues().clear();
-        verify(auditLogger).auditRequestMessage(eq(request), eq(assertion), 
+        verify(auditLogger).auditRequestMessage(eq(request), eq(assertion),
             Mockito.any(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
-            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE),eq(webContextProperties),
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE), eq(webContextProperties),
             eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME));
-       
+
     }
 
     @Test
@@ -184,30 +184,30 @@ public class StandardOutboundPatientDiscoveryDeferredResponseTest {
 
         // Stubbing the methods
         when(connectionManager.getEndpointURLFromNhinTargetCommunities(eq(targets),
-                eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME))).thenThrow(new ConnectionManagerException());
+            eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME))).thenThrow(new ConnectionManagerException());
 
         // Actual invocation
         StandardOutboundPatientDiscoveryDeferredResponse standardPatientDiscovery = new StandardOutboundPatientDiscoveryDeferredResponse(
-                null, null, auditLogger, null, connectionManager);
+            null, null, auditLogger, null, connectionManager);
 
         MCCIIN000002UV01 errorResponse = standardPatientDiscovery.processPatientDiscoveryAsyncResp(request, assertion,
-                targets);
+            targets);
 
         // Verify error response
         assertEquals(HL7AckTransforms.ACK_DETAIL_TYPE_CODE_ERROR, errorResponse.getAcknowledgement().get(0)
-                .getAcknowledgementDetail().get(0).getTypeCode().toString());
+            .getAcknowledgementDetail().get(0).getTypeCode().toString());
 
         assertEquals("No Targets Found", errorResponse.getAcknowledgement().get(0).getAcknowledgementDetail().get(0)
-                .getText().getContent().get(0).toString());
+            .getText().getContent().get(0).toString());
 
         // Verify request from adapter is audited
         ArgumentCaptor<RespondingGatewayPRPAIN201306UV02RequestType> requestArgument = ArgumentCaptor
-                .forClass(RespondingGatewayPRPAIN201306UV02RequestType.class);
-        verify(auditLogger).auditRequestMessage(eq(request), eq(assertion), 
+            .forClass(RespondingGatewayPRPAIN201306UV02RequestType.class);
+        verify(auditLogger).auditRequestMessage(eq(request), eq(assertion),
             Mockito.any(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
-            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE),eq(webContextProperties),
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE), eq(webContextProperties),
             eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME));
-        
+
     }
 
     @Test
@@ -222,33 +222,33 @@ public class StandardOutboundPatientDiscoveryDeferredResponseTest {
 
         // Stubbing the methods
         when(connectionManager.getEndpointURLFromNhinTargetCommunities(targets,
-                NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME)).thenReturn(urlInfoList);
+            NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME)).thenReturn(urlInfoList);
 
         when(pd201306Processor.createNewRequest(request, "1.1")).thenReturn(firstTargetRequest);
 
         when(policyChecker.checkOutgoingPolicy(any(RespondingGatewayPRPAIN201306UV02RequestType.class))).thenReturn(
-                false);
+            false);
 
         // Actual invocation
         StandardOutboundPatientDiscoveryDeferredResponse standardPatientDiscovery = new StandardOutboundPatientDiscoveryDeferredResponse(
-                policyChecker, pd201306Processor, auditLogger, delegate, connectionManager);
+            policyChecker, pd201306Processor, auditLogger, delegate, connectionManager);
 
         MCCIIN000002UV01 errorResponse = standardPatientDiscovery.processPatientDiscoveryAsyncResp(request, assertion,
-                targets);
+            targets);
 
         // Verify error response
         assertEquals(HL7AckTransforms.ACK_DETAIL_TYPE_CODE_ERROR, errorResponse.getAcknowledgement().get(0)
-                .getAcknowledgementDetail().get(0).getTypeCode().toString());
+            .getAcknowledgementDetail().get(0).getTypeCode().toString());
 
         assertEquals("Policy Check Failed", errorResponse.getAcknowledgement().get(0).getAcknowledgementDetail().get(0)
-                .getText().getContent().get(0).toString());
+            .getText().getContent().get(0).toString());
 
         // Verify request from adapter is audited
         ArgumentCaptor<RespondingGatewayPRPAIN201306UV02RequestType> requestArgument = ArgumentCaptor
-                .forClass(RespondingGatewayPRPAIN201306UV02RequestType.class);
-        verify(auditLogger).auditRequestMessage(eq(request), eq(assertion), 
+            .forClass(RespondingGatewayPRPAIN201306UV02RequestType.class);
+        verify(auditLogger).auditRequestMessage(eq(request), eq(assertion),
             Mockito.any(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
-            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE),eq(webContextProperties),
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE), eq(webContextProperties),
             eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME));
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/TestOutboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/TestOutboundPatientDiscoveryDeferredResponse.java
@@ -40,7 +40,7 @@ public class TestOutboundPatientDiscoveryDeferredResponse implements OutboundPat
 
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncResp(PRPAIN201306UV02 body, AssertionType assertion,
-            NhinTargetCommunitiesType target) {
+        NhinTargetCommunitiesType target) {
         return new MCCIIN000002UV01();
     }
 

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/AuditLogging-Passthrough-soapui-project.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/AuditLogging-Passthrough-soapui-project.xml
@@ -3444,11 +3444,11 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
                   <urn:parameterList>
                      <urn:livingSubjectAdministrativeGender>
                         <urn:value code="M"/>
-                        <urn:semanticsText representation="TXT"/>
+                        <urn:semanticsText representation="TXT">LivingSubject.administrativeGender</urn:semanticsText>
                      </urn:livingSubjectAdministrativeGender>
                      <urn:livingSubjectBirthTime>
                         <urn:value value="19630804"/>
-                        <urn:semanticsText representation="TXT"/>
+                        <urn:semanticsText representation="TXT">LivingSubject.birthTime</urn:semanticsText>
                      </urn:livingSubjectBirthTime>
                      <urn:livingSubjectId>
                         <urn:value extension="D123401" root="1.1"/>
@@ -3459,7 +3459,7 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
                            <urn:family partType="FAM">Younger</urn:family>
                            <urn:given partType="GIV">Gallow</urn:given>
                         </urn:value>
-                        <urn:semanticsText representation="TXT"/>
+                        <urn:semanticsText representation="TXT">LivingSubject.name</urn:semanticsText>
                      </urn:livingSubjectName>
                   </urn:parameterList>
                </urn:queryByParameter>
@@ -3483,7 +3483,7 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
             <urn1:haveWitnessSignature>true</urn1:haveWitnessSignature>
             <urn1:homeCommunity>
                <urn1:description>Test HCID1</urn1:description>
-               <urn1:homeCommunityId>2.16.840.1.113883.3.337</urn1:homeCommunityId>
+               <urn1:homeCommunityId>1.1</urn1:homeCommunityId>
                <urn1:name>HCID1</urn1:name>
             </urn1:homeCommunity>
             <urn1:personName>
@@ -3684,21 +3684,21 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:testStep type="delay" name="Wait for Audit table to populate">
         <con:settings/>
         <con:config>
-          <delay>10000</delay>
+          <delay>50000</delay>
         </con:config>
       </con:testStep>
-      <con:testStep type="groovy" name="Verify Audit Logs" id="82f1d25c-add6-4cf8-8851-9522bf94bc4b" disabled="true">
+      <con:testStep type="groovy" name="Verify Audit Logs" id="82f1d25c-add6-4cf8-8851-9522bf94bc4b">
         <con:settings/>
         <con:config>
           <script>context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
-	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where id = 1 and messageType="Nhin Outbound" and communityId="1.1"')[0]
-	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where id = 2 and messageType="Nhin Outbound" and communityId="2.2"')[0]
+	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where  messageType="Nhin Outbound" and communityId="1.1"')[0]
+	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where  messageType="Nhin Outbound" and communityId="2.2"')[0]
 	
 }</script>
         </con:config>
       </con:testStep>
-      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-RespondingGateway(2.2)" disabled="true">
+      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-RespondingGateway(2.2)">
         <con:settings/>
         <con:config>
           <script><![CDATA[context.withSql('AuditRepoDB') {sql ->
@@ -3858,7 +3858,7 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeC
 }]]></script>
         </con:config>
       </con:testStep>
-      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-InitiatingGateway(1.1) - ACK" disabled="true">
+      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-InitiatingGateway(1.1) - ACK">
         <con:settings/>
         <con:config>
           <script><![CDATA[context.withSql('AuditRepoDB') {sql ->
@@ -4022,7 +4022,7 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
-def propertiesFilename = projectPath + "/PatientDiscoveryDeferredAuditLog.properties"
+def propertiesFilename = projectPath + "/PatientDiscoveryDeferredResponseAuditLog.properties"
 def propertiesFile = new File(propertiesFilename)
 if (propertiesFile.exists()) {
  def props = new Properties()
@@ -4032,8 +4032,8 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
-context.setGatewayStandard(true);
-log.info ("Setting the gateway to Standard");</con:tearDownScript>
+//context.setGatewayStandard(true);
+//log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>LocalHCID</con:name>
@@ -4301,19 +4301,19 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
         </con:property>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-10-14T15:16:09Z</con:value>
+          <con:value>2015-10-17T05:09:40Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-10-14T15:26:09Z</con:value>
+          <con:value>2015-10-17T05:19:40Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>10/14/2015 15:16:09</con:value>
+          <con:value>10/17/2015 05:09:40</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-11-13T00:00:00Z</con:value>
+          <con:value>2015-11-16T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.EventID.@code</con:name>
@@ -4381,7 +4381,7 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>1111^^^&amp;1.1&amp;ISO</con:value>
+          <con:value>D123402^^^&amp;2.2&amp;ISO</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.@EventDateTime</con:name>
@@ -4457,7 +4457,7 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectId.value.@extension</con:name>
-          <con:value>1111</con:value>
+          <con:value>D123401</con:value>
         </con:property>
         <con:property>
           <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
@@ -4493,7 +4493,7 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscovery</con:value>
+          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncResp</con:value>
         </con:property>
         <con:property>
           <con:name>&lt;!--Destination--></con:name>
@@ -4577,7 +4577,7 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
         </con:property>
         <con:property>
           <con:name>queryId.@root</con:name>
-          <con:value>1.1</con:value>
+          <con:value>2.2</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
@@ -4613,7 +4613,7 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
-          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
+          <con:value>D123402^^^&amp;2.2&amp;ISO</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@UserName</con:name>
@@ -11520,11 +11520,11 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
                   <urn:parameterList>
                      <urn:livingSubjectAdministrativeGender>
                         <urn:value code="M"/>
-                        <urn:semanticsText representation="TXT"/>
+                        <urn:semanticsText representation="TXT">LivingSubject.administrativeGender</urn:semanticsText>
                      </urn:livingSubjectAdministrativeGender>
                      <urn:livingSubjectBirthTime>
                         <urn:value value="19630804"/>
-                        <urn:semanticsText representation="TXT"/>
+                        <urn:semanticsText representation="TXT">LivingSubject.birthTime</urn:semanticsText>
                      </urn:livingSubjectBirthTime>
                      <urn:livingSubjectId>
                         <urn:value extension="D123401" root="1.1"/>
@@ -11535,7 +11535,7 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
                            <urn:family partType="FAM">Younger</urn:family>
                            <urn:given partType="GIV">Gallow</urn:given>
                         </urn:value>
-                        <urn:semanticsText representation="TXT"/>
+                        <urn:semanticsText representation="TXT">LivingSubject.name</urn:semanticsText>
                      </urn:livingSubjectName>
                   </urn:parameterList>
                </urn:queryByParameter>
@@ -11559,7 +11559,7 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
             <urn1:haveWitnessSignature>true</urn1:haveWitnessSignature>
             <urn1:homeCommunity>
                <urn1:description>Test HCID1</urn1:description>
-               <urn1:homeCommunityId>2.16.840.1.113883.3.337</urn1:homeCommunityId>
+               <urn1:homeCommunityId>1.1</urn1:homeCommunityId>
                <urn1:name>HCID1</urn1:name>
             </urn1:homeCommunity>
             <urn1:personName>
@@ -11760,21 +11760,21 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:testStep type="delay" name="Wait for Audit table to populate">
         <con:settings/>
         <con:config>
-          <delay>10000</delay>
+          <delay>30000</delay>
         </con:config>
       </con:testStep>
-      <con:testStep type="groovy" name="Verify Audit Logs" id="51e31a14-520c-4ebe-9d91-1614db33b08d" disabled="true">
+      <con:testStep type="groovy" name="Verify Audit Logs" id="51e31a14-520c-4ebe-9d91-1614db33b08d">
         <con:settings/>
         <con:config>
           <script>context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
-	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where id = 1 and messageType="Nhin Outbound" and communityId="1.1"')[0]
-	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where id = 2 and messageType="Nhin Outbound" and communityId="2.2"')[0]
+	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where messageType="Nhin Outbound" and communityId="1.1"')[0]
+	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where messageType="Nhin Outbound" and communityId="2.2"')[0]
 	
 }</script>
         </con:config>
       </con:testStep>
-      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-RespondingGateway(2.2)" disabled="true">
+      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-RespondingGateway(2.2)">
         <con:settings/>
         <con:config>
           <script><![CDATA[context.withSql('AuditRepoDB') {sql ->
@@ -11934,7 +11934,7 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeC
 }]]></script>
         </con:config>
       </con:testStep>
-      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-InitiatingGateway(1.1) - ACK" disabled="true">
+      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-InitiatingGateway(1.1) - ACK">
         <con:settings/>
         <con:config>
           <script><![CDATA[context.withSql('AuditRepoDB') {sql ->
@@ -12098,7 +12098,7 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
-def propertiesFilename = projectPath + "/PatientDiscoveryDeferredAuditLog.properties"
+def propertiesFilename = projectPath + "/PatientDiscoveryDeferredResponseAuditLog.properties"
 def propertiesFile = new File(propertiesFilename)
 if (propertiesFile.exists()) {
  def props = new Properties()
@@ -12108,7 +12108,7 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
-context.setGatewayStandard(true);
+//context.setGatewayStandard(true);
 log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
         <con:property>
@@ -12377,19 +12377,19 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-10-14T15:22:46Z</con:value>
+          <con:value>2015-10-17T05:25:32Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>10/14/2015 15:12:46</con:value>
+          <con:value>10/17/2015 05:15:32</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-11-13T00:00:00Z</con:value>
+          <con:value>2015-11-16T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-10-14T15:12:46Z</con:value>
+          <con:value>2015-10-17T05:15:32Z</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.EventID.@code</con:name>
@@ -12457,7 +12457,7 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>1111^^^&amp;1.1&amp;ISO</con:value>
+          <con:value>D123402^^^&amp;2.2&amp;ISO</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.@EventDateTime</con:name>
@@ -12533,7 +12533,7 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectId.value.@extension</con:name>
-          <con:value>1111</con:value>
+          <con:value>D123401</con:value>
         </con:property>
         <con:property>
           <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
@@ -12569,7 +12569,7 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscovery</con:value>
+          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncResp</con:value>
         </con:property>
         <con:property>
           <con:name>&lt;!--Destination--></con:name>
@@ -12653,7 +12653,7 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
         </con:property>
         <con:property>
           <con:name>queryId.@root</con:name>
-          <con:value>1.1</con:value>
+          <con:value>2.2</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
@@ -12689,7 +12689,7 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
-          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
+          <con:value>D123402^^^&amp;2.2&amp;ISO</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@UserName</con:name>
@@ -18749,7 +18749,7 @@ if (propertiesFile.exists()) {
     </con:property>
     <con:property>
       <con:name>GatewayPropDir</con:name>
-      <con:value/>
+      <con:value>C:\app\wildfly-8.2.1.Final\wildfly-8.2.1.Final\modules\system\layers\base\org\connectopensource\configuration\main</con:value>
     </con:property>
     <con:property>
       <con:name>Gender</con:name>

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/AuditLogging-Passthrough-soapui-project.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/AuditLogging-Passthrough-soapui-project.xml
@@ -4301,19 +4301,19 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-10-17T05:09:40Z</con:value>
+          <con:value>2015-10-20T17:26:27Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-10-17T05:19:40Z</con:value>
+          <con:value>2015-10-20T17:36:27Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>10/17/2015 05:09:40</con:value>
+          <con:value>10/20/2015 17:26:27</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-11-16T00:00:00Z</con:value>
+          <con:value>2015-11-19T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.EventID.@code</con:name>

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/AuditLogging-Passthrough-soapui-project.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/AuditLogging-Passthrough-soapui-project.xml
@@ -3483,7 +3483,7 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
             <urn1:haveWitnessSignature>true</urn1:haveWitnessSignature>
             <urn1:homeCommunity>
                <urn1:description>Test HCID1</urn1:description>
-               <urn1:homeCommunityId>1.1</urn1:homeCommunityId>
+               <urn1:homeCommunityId>${#Project#LocalHCID}</urn1:homeCommunityId>
                <urn1:name>HCID1</urn1:name>
             </urn1:homeCommunity>
             <urn1:personName>
@@ -11559,7 +11559,7 @@ log.info ("Setting the gateway to Standard");</con:tearDownScript>
             <urn1:haveWitnessSignature>true</urn1:haveWitnessSignature>
             <urn1:homeCommunity>
                <urn1:description>Test HCID1</urn1:description>
-               <urn1:homeCommunityId>1.1</urn1:homeCommunityId>
+               <urn1:homeCommunityId>${#Project#LocalHCID}</urn1:homeCommunityId>
                <urn1:name>HCID1</urn1:name>
             </urn1:homeCommunity>
             <urn1:personName>

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/AuditLogging-Passthrough-soapui-project.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/AuditLogging-Passthrough-soapui-project.xml
@@ -18749,7 +18749,7 @@ if (propertiesFile.exists()) {
     </con:property>
     <con:property>
       <con:name>GatewayPropDir</con:name>
-      <con:value>C:\app\wildfly-8.2.1.Final\wildfly-8.2.1.Final\modules\system\layers\base\org\connectopensource\configuration\main</con:value>
+      <con:value></con:value>
     </con:property>
     <con:property>
       <con:name>Gender</con:name>

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/PatientDiscoveryDeferredResponseAuditLog.properties
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/PatientDiscoveryDeferredResponseAuditLog.properties
@@ -56,7 +56,6 @@ AuditSourceIdentification.@AuditSourceID=1.1
 AuditSourceIdentification.@AuditSourceTypeCode=1010
 
 ParticipantObjectIdentification.@ParticipantObjectID=D123402^^^&2.2&ISO
-ParticipantObjectIdentification_Responder.@ParticipantObjectID=D123402^^^&2.2&ISO
 ParticipantObjectIdentification.@ParticipantObjectTypeCode=1
 ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole=1
 

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/PatientDiscoveryDeferredResponseAuditLog.properties
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/PatientDiscoveryDeferredResponseAuditLog.properties
@@ -1,0 +1,100 @@
+AuditMessage.xmlns=http://nhinc.services.com/schema/auditmessage
+EventIdentification.@EventActionCode=E
+EventIdentification.@EventDateTime=2015-04-02T13:47:30.199Z
+EventIdentification.@EventOutcomeIndicator=0
+
+EventIdentification.EventID.@code=110112
+EventIdentification.EventID.@codeSystemName=DCM
+EventIdentification.EventID.@displayName=Query
+
+EventIdentification.EventTypeCode.@code=ITI-55
+EventIdentification.EventTypeCode.@codeSystemName=IHE Transactions
+EventIdentification.EventTypeCode.@displayName=Cross Gateway Patient Discovery
+
+ <!--Human Requestor-->
+
+ActiveParticipant.@UserID=kskagerb
+ActiveParticipant.@AlternativeUserID=19233@192.168.1.1
+ActiveParticipant.@UserName=Karl Skagerberg
+ActiveParticipant.@UserIsRequestor=true
+
+ActiveParticipant.RoleIDCode.@code=307969004
+ActiveParticipant.RoleIDCode.@codeSystemName=SNOMED_CT
+ActiveParticipant.RoleIDCode.@displayName=Human Requestor
+
+<!--Source-->
+	
+ActiveParticipant_Source.@UserID=http://www.w3.org/2005/08/addressing/anonymous
+ActiveParticipant_Source.@AlternativeUserID=19233@192.168.1.2
+ActiveParticipant_Source.@UserName=Karl Skagerberg
+ActiveParticipant_Source.@UserIsRequestor=true
+ActiveParticipant_Source.@UserIsRequestor.inbound=false
+ActiveParticipant_Source.@NetworkAccessPointID=192.168.1.2
+ActiveParticipant_Source.@NetworkAccessPointTypeCode=2
+
+ActiveParticipant_Source.RoleIDCode.@code=110153
+ActiveParticipant_Source.RoleIDCode.@codeSystemName=DCM
+ActiveParticipant_Source.RoleIDCode.@displayName=Source
+
+ <!--Destination-->  
+	
+ActiveParticipant_Dest.@UserID=https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncResp
+ActiveParticipant_Dest.@UserIsRequestor=false
+ActiveParticipant_Dest.@UserName=Karl Skagerberg
+ActiveParticipant_Dest.@AlternativeUserID=19233@192.168.1.2
+ActiveParticipant_Dest.@NetworkAccessPointID=localhost
+ActiveParticipant_Dest.@NetworkAccessPointTypeCode=1
+ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode=2
+
+
+ActiveParticipant_Dest.RoleIDCode.@code=110152
+ActiveParticipant_Dest.RoleIDCode.@codeSystemName=DCM
+ActiveParticipant_Dest.RoleIDCode.@displayName=Destination
+
+AuditSourceIdentification.@AuditEnterpriseSiteID=Gateway 1
+AuditSourceIdentification.@AuditSourceID=1.1
+AuditSourceIdentification.@AuditSourceTypeCode=1010
+
+ParticipantObjectIdentification.@ParticipantObjectID=D123402^^^&2.2&ISO
+ParticipantObjectIdentification_Responder.@ParticipantObjectID=D123402^^^&2.2&ISO
+ParticipantObjectIdentification.@ParticipantObjectTypeCode=1
+ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole=1
+
+ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code=2
+ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName=RFC-3881
+ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName=Patient Number
+
+ParticipantObjectIdentification_Query.@ParticipantObjectID=a797fa28-45fd-4a29-867d-32f3301e73fe
+ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode=2
+ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole=24
+
+ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code=ITI-55
+ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName=IHE Transactions
+ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName=Cross Gateway Patient Discovery
+ParticipantObjectIdentification_Query.ParticipantObjectName=1.1
+
+<--ParticipantObjectIdentification_Query.ParticipantObjectQuery checks -->
+
+queryId.@root=2.2
+queryId.@extension=-abd3453dcd24wkkks545
+statusCode.@code=new
+responseModalityCode.@code=R
+responsePriorityCode.@code=I
+parameterList.livingSubjectAdministrativeGender.value.@code=M
+parameterList.livingSubjectAdministrativeGender.semanticsText.@representation=TXT
+parameterList.livingSubjectAdministrativeGender.semanticsText=LivingSubject.administrativeGender
+
+parameterList.livingSubjectBirthTime.value.@value=19630804
+parameterList.livingSubjectBirthTime.semanticsText.@representation=TXT
+parameterList.livingSubjectBirthTime.semanticsText=LivingSubject.birthTime
+
+parameterList.livingSubjectId.value.@root=1.1
+parameterList.livingSubjectId.value.@extension=D123401
+parameterList.livingSubjectId.semanticsText.@representation=TXT
+
+parameterList.livingSubjectName.value.family.@partType=FAM
+parameterList.livingSubjectName.value.family=Younger
+parameterList.livingSubjectName.value.given.@partType=GIV
+parameterList.livingSubjectName.value.given=Gallow
+parameterList.livingSubjectName.semanticsText.@representation=TXT
+parameterList.livingSubjectName.semanticsText=LivingSubject.name

--- a/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/AuditLogging-Standard-soapui-project.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/AuditLogging-Standard-soapui-project.xml
@@ -3414,11 +3414,11 @@ if (propertiesFile.exists()) {
                   <urn:parameterList>
                      <urn:livingSubjectAdministrativeGender>
                         <urn:value code="M"/>
-                        <urn:semanticsText representation="TXT"/>
+                       <urn:semanticsText representation="TXT">LivingSubject.administrativeGender</urn:semanticsText>
                      </urn:livingSubjectAdministrativeGender>
                      <urn:livingSubjectBirthTime>
                         <urn:value value="19630804"/>
-                        <urn:semanticsText representation="TXT"/>
+                        <urn:semanticsText representation="TXT">LivingSubject.birthTime</urn:semanticsText>
                      </urn:livingSubjectBirthTime>
                      <urn:livingSubjectId>
                         <urn:value extension="D123401" root="1.1"/>
@@ -3429,7 +3429,7 @@ if (propertiesFile.exists()) {
                            <urn:family partType="FAM">Younger</urn:family>
                            <urn:given partType="GIV">Gallow</urn:given>
                         </urn:value>
-                        <urn:semanticsText representation="TXT"/>
+                        <urn:semanticsText representation="TXT">LivingSubject.name</urn:semanticsText>
                      </urn:livingSubjectName>
                   </urn:parameterList>
                </urn:queryByParameter>
@@ -3454,7 +3454,7 @@ if (propertiesFile.exists()) {
             <urn1:haveWitnessSignature>true</urn1:haveWitnessSignature>
             <urn1:homeCommunity>
                <urn1:description>Test HCID1</urn1:description>
-               <urn1:homeCommunityId>2.16.840.1.113883.3.337</urn1:homeCommunityId>
+               <urn1:homeCommunityId>1.1</urn1:homeCommunityId>
                <urn1:name>HCID1</urn1:name>
             </urn1:homeCommunity>
             <urn1:personName>
@@ -3660,18 +3660,24 @@ if (propertiesFile.exists()) {
           </con:request>
         </con:config>
       </con:testStep>
-      <con:testStep type="groovy" name="Verify Audit Logs" id="e87c68a1-d465-4a76-8ca4-b06010e140bd" disabled="true">
+      <con:testStep type="delay" name="Delay">
+        <con:settings/>
+        <con:config>
+          <delay>50000</delay>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="groovy" name="Verify Audit Logs" id="e87c68a1-d465-4a76-8ca4-b06010e140bd">
         <con:settings/>
         <con:config>
           <script>context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
-	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where id = 1 and messageType="Nhin Outbound" and communityId="1.1"')[0]
-	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where id = 2 and messageType="Nhin Outbound" and communityId="2.2"')[0]
+	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where messageType="Nhin Outbound" and communityId="1.1"')[0]
+	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where messageType="Nhin Outbound" and communityId="2.2"')[0]
 	
 }</script>
         </con:config>
       </con:testStep>
-      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-RespondingGateway(2.2)" disabled="true">
+      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-RespondingGateway(2.2)">
         <con:settings/>
         <con:config>
           <script><![CDATA[context.withSql('AuditRepoDB') {sql ->
@@ -3831,7 +3837,7 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeC
 }]]></script>
         </con:config>
       </con:testStep>
-      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-InitiatingGateway(1.1) - ACK" disabled="true">
+      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-InitiatingGateway(1.1) - ACK">
         <con:settings/>
         <con:config>
           <script><![CDATA[context.withSql('AuditRepoDB') {sql ->
@@ -3994,7 +4000,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
-def propertiesFilename = projectPath + "/PatientDiscoveryDeferredAuditLog.properties"
+def propertiesFilename = projectPath + "/PatientDiscoveryDeferredResponseAuditLog.properties"
 def propertiesFile = new File(propertiesFilename)
 if (propertiesFile.exists()) {
  def props = new Properties()
@@ -4271,19 +4277,19 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-10-14T15:30:29Z</con:value>
+          <con:value>2015-10-17T04:30:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-10-14T15:40:29Z</con:value>
+          <con:value>2015-10-17T04:40:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>10/14/2015 15:30:29</con:value>
+          <con:value>10/17/2015 04:30:00</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-11-13T00:00:00Z</con:value>
+          <con:value>2015-11-16T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.EventID.@code</con:name>
@@ -4351,7 +4357,7 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>1111^^^&amp;1.1&amp;ISO</con:value>
+          <con:value>D123402^^^&amp;2.2&amp;ISO</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.@EventDateTime</con:name>
@@ -4427,7 +4433,7 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectId.value.@extension</con:name>
-          <con:value>1111</con:value>
+          <con:value>D123401</con:value>
         </con:property>
         <con:property>
           <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
@@ -4463,7 +4469,7 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscovery</con:value>
+          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncResp</con:value>
         </con:property>
         <con:property>
           <con:name>&lt;!--Destination--></con:name>
@@ -4547,7 +4553,7 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>queryId.@root</con:name>
-          <con:value>1.1</con:value>
+          <con:value>2.2</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
@@ -4583,7 +4589,7 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
-          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
+          <con:value>D123402^^^&amp;2.2&amp;ISO</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@UserName</con:name>
@@ -11327,11 +11333,11 @@ if (propertiesFile.exists()) {
                   <urn:parameterList>
                      <urn:livingSubjectAdministrativeGender>
                         <urn:value code="M"/>
-                        <urn:semanticsText representation="TXT"/>
+                        <urn:semanticsText representation="TXT">LivingSubject.administrativeGender</urn:semanticsText>
                      </urn:livingSubjectAdministrativeGender>
                      <urn:livingSubjectBirthTime>
                         <urn:value value="19630804"/>
-                        <urn:semanticsText representation="TXT"/>
+                        <urn:semanticsText representation="TXT">LivingSubject.birthTime</urn:semanticsText>
                      </urn:livingSubjectBirthTime>
                      <urn:livingSubjectId>
                         <urn:value extension="D123401" root="1.1"/>
@@ -11342,14 +11348,14 @@ if (propertiesFile.exists()) {
                            <urn:family partType="FAM">Younger</urn:family>
                            <urn:given partType="GIV">Gallow</urn:given>
                         </urn:value>
-                        <urn:semanticsText representation="TXT"/>
+                        <urn:semanticsText representation="TXT">LivingSubject.name</urn:semanticsText>
                      </urn:livingSubjectName>
                   </urn:parameterList>
                </urn:queryByParameter>
             </urn:controlActProcess>
          </urn:PRPA_IN201306UV02>
          <urn:assertion>
-            <urn1:nationalProviderId>1234567890</urn1:nationalProviderId>         
+            <urn1:nationalProviderId>1234567890</urn1:nationalProviderId>
             <urn1:address>
                <urn1:addressType>
                   <urn1:code>W</urn1:code>
@@ -11367,7 +11373,7 @@ if (propertiesFile.exists()) {
             <urn1:haveWitnessSignature>true</urn1:haveWitnessSignature>
             <urn1:homeCommunity>
                <urn1:description>Test HCID1</urn1:description>
-               <urn1:homeCommunityId>2.16.840.1.113883.3.337</urn1:homeCommunityId>
+               <urn1:homeCommunityId>1.1</urn1:homeCommunityId>
                <urn1:name>HCID1</urn1:name>
             </urn1:homeCommunity>
             <urn1:personName>
@@ -11464,7 +11470,7 @@ if (propertiesFile.exists()) {
                <urn1:userName>wanderson</urn1:userName>
                <urn1:org>
                   <urn1:description>Test HCID1</urn1:description>
-                  <urn1:homeCommunityId>2.16.840.1.113883.3.337</urn1:homeCommunityId>
+                  <urn1:homeCommunityId>1.1</urn1:homeCommunityId>
                   <urn1:name>HCID1</urn1:name>
                </urn1:org>
                <!--Optional:-->
@@ -11573,18 +11579,24 @@ if (propertiesFile.exists()) {
           </con:request>
         </con:config>
       </con:testStep>
-      <con:testStep type="groovy" name="Verify Audit Logs" id="75840f83-2ae6-4898-8c2e-6c61104588a2" disabled="true">
+      <con:testStep type="delay" name="Delay">
+        <con:settings/>
+        <con:config>
+          <delay>50000</delay>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="groovy" name="Verify Audit Logs" id="75840f83-2ae6-4898-8c2e-6c61104588a2">
         <con:settings/>
         <con:config>
           <script>context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
-	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where id = 1 and messageType="Nhin Outbound" and communityId="1.1"')[0]
-	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where id = 2 and messageType="Nhin Outbound" and communityId="2.2"')[0]
+	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where messageType="Nhin Outbound" and communityId="1.1"')[0]
+	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where messageType="Nhin Outbound" and communityId="2.2"')[0]
 	
 }</script>
         </con:config>
       </con:testStep>
-      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-RespondingGateway(2.2)" disabled="true">
+      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-RespondingGateway(2.2)">
         <con:settings/>
         <con:config>
           <script><![CDATA[context.withSql('AuditRepoDB') {sql ->
@@ -11744,7 +11756,7 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeC
 }]]></script>
         </con:config>
       </con:testStep>
-      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-InitiatingGateway(1.1) - ACK" disabled="true">
+      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-InitiatingGateway(1.1) - ACK">
         <con:settings/>
         <con:config>
           <script><![CDATA[context.withSql('AuditRepoDB') {sql ->
@@ -11907,7 +11919,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
-def propertiesFilename = projectPath + "/PatientDiscoveryDeferredAuditLog.properties"
+def propertiesFilename = projectPath + "/PatientDiscoveryDeferredResponseAuditLog.properties"
 def propertiesFile = new File(propertiesFilename)
 if (propertiesFile.exists()) {
  def props = new Properties()
@@ -12184,19 +12196,19 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-10-14T15:37:41Z</con:value>
+          <con:value>2015-10-17T05:03:24Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>10/14/2015 15:27:41</con:value>
+          <con:value>10/17/2015 04:53:24</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-11-13T00:00:00Z</con:value>
+          <con:value>2015-11-16T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-10-14T15:27:41Z</con:value>
+          <con:value>2015-10-17T04:53:24Z</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.EventID.@code</con:name>
@@ -12264,7 +12276,7 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>1111^^^&amp;1.1&amp;ISO</con:value>
+          <con:value>D123402^^^&amp;2.2&amp;ISO</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.@EventDateTime</con:name>
@@ -12340,7 +12352,7 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectId.value.@extension</con:name>
-          <con:value>1111</con:value>
+          <con:value>D123401</con:value>
         </con:property>
         <con:property>
           <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
@@ -12376,7 +12388,7 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscovery</con:value>
+          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncResp</con:value>
         </con:property>
         <con:property>
           <con:name>&lt;!--Destination--></con:name>
@@ -12460,7 +12472,7 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>queryId.@root</con:name>
-          <con:value>1.1</con:value>
+          <con:value>2.2</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
@@ -12496,7 +12508,7 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
-          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
+          <con:value>D123402^^^&amp;2.2&amp;ISO</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@UserName</con:name>
@@ -16056,7 +16068,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
     </con:property>
     <con:property>
       <con:name>GatewayPropDir</con:name>
-      <con:value/>
+      <con:value>C:\app\wildfly-8.2.1.Final\wildfly-8.2.1.Final\modules\system\layers\base\org\connectopensource\configuration\main</con:value>
     </con:property>
     <con:property>
       <con:name>Gender</con:name>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/AuditLogging-Standard-soapui-project.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/AuditLogging-Standard-soapui-project.xml
@@ -3454,7 +3454,7 @@ if (propertiesFile.exists()) {
             <urn1:haveWitnessSignature>true</urn1:haveWitnessSignature>
             <urn1:homeCommunity>
                <urn1:description>Test HCID1</urn1:description>
-               <urn1:homeCommunityId>1.1</urn1:homeCommunityId>
+               <urn1:homeCommunityId>${#Project#LocalHCID}</urn1:homeCommunityId>
                <urn1:name>HCID1</urn1:name>
             </urn1:homeCommunity>
             <urn1:personName>
@@ -11373,7 +11373,7 @@ if (propertiesFile.exists()) {
             <urn1:haveWitnessSignature>true</urn1:haveWitnessSignature>
             <urn1:homeCommunity>
                <urn1:description>Test HCID1</urn1:description>
-               <urn1:homeCommunityId>1.1</urn1:homeCommunityId>
+               <urn1:homeCommunityId>${#Project#LocalHCID}</urn1:homeCommunityId>
                <urn1:name>HCID1</urn1:name>
             </urn1:homeCommunity>
             <urn1:personName>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/AuditLogging-Standard-soapui-project.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/AuditLogging-Standard-soapui-project.xml
@@ -16068,7 +16068,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
     </con:property>
     <con:property>
       <con:name>GatewayPropDir</con:name>
-      <con:value>C:\app\wildfly-8.2.1.Final\wildfly-8.2.1.Final\modules\system\layers\base\org\connectopensource\configuration\main</con:value>
+      <con:value/>
     </con:property>
     <con:property>
       <con:name>Gender</con:name>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/PatientDiscoveryDeferredResponseAuditLog.properties
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/PatientDiscoveryDeferredResponseAuditLog.properties
@@ -56,7 +56,6 @@ AuditSourceIdentification.@AuditSourceID=1.1
 AuditSourceIdentification.@AuditSourceTypeCode=1010
 
 ParticipantObjectIdentification.@ParticipantObjectID=D123402^^^&2.2&ISO
-ParticipantObjectIdentification_Responder.@ParticipantObjectID=D123402^^^&2.2&ISO
 ParticipantObjectIdentification.@ParticipantObjectTypeCode=1
 ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole=1
 

--- a/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/PatientDiscoveryDeferredResponseAuditLog.properties
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/PatientDiscoveryDeferredResponseAuditLog.properties
@@ -1,0 +1,100 @@
+AuditMessage.xmlns=http://nhinc.services.com/schema/auditmessage
+EventIdentification.@EventActionCode=E
+EventIdentification.@EventDateTime=2015-04-02T13:47:30.199Z
+EventIdentification.@EventOutcomeIndicator=0
+
+EventIdentification.EventID.@code=110112
+EventIdentification.EventID.@codeSystemName=DCM
+EventIdentification.EventID.@displayName=Query
+
+EventIdentification.EventTypeCode.@code=ITI-55
+EventIdentification.EventTypeCode.@codeSystemName=IHE Transactions
+EventIdentification.EventTypeCode.@displayName=Cross Gateway Patient Discovery
+
+ <!--Human Requestor-->
+
+ActiveParticipant.@UserID=kskagerb
+ActiveParticipant.@AlternativeUserID=19233@192.168.1.1
+ActiveParticipant.@UserName=Karl Skagerberg
+ActiveParticipant.@UserIsRequestor=true
+
+ActiveParticipant.RoleIDCode.@code=307969004
+ActiveParticipant.RoleIDCode.@codeSystemName=SNOMED_CT
+ActiveParticipant.RoleIDCode.@displayName=Human Requestor
+
+<!--Source-->
+	
+ActiveParticipant_Source.@UserID=http://www.w3.org/2005/08/addressing/anonymous
+ActiveParticipant_Source.@AlternativeUserID=19233@192.168.1.2
+ActiveParticipant_Source.@UserName=Karl Skagerberg
+ActiveParticipant_Source.@UserIsRequestor=true
+ActiveParticipant_Source.@UserIsRequestor.inbound=false
+ActiveParticipant_Source.@NetworkAccessPointID=192.168.1.2
+ActiveParticipant_Source.@NetworkAccessPointTypeCode=2
+
+ActiveParticipant_Source.RoleIDCode.@code=110153
+ActiveParticipant_Source.RoleIDCode.@codeSystemName=DCM
+ActiveParticipant_Source.RoleIDCode.@displayName=Source
+
+ <!--Destination-->  
+	
+ActiveParticipant_Dest.@UserID=https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncResp
+ActiveParticipant_Dest.@UserIsRequestor=false
+ActiveParticipant_Dest.@UserName=Karl Skagerberg
+ActiveParticipant_Dest.@AlternativeUserID=19233@192.168.1.2
+ActiveParticipant_Dest.@NetworkAccessPointID=localhost
+ActiveParticipant_Dest.@NetworkAccessPointTypeCode=1
+ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode=2
+
+
+ActiveParticipant_Dest.RoleIDCode.@code=110152
+ActiveParticipant_Dest.RoleIDCode.@codeSystemName=DCM
+ActiveParticipant_Dest.RoleIDCode.@displayName=Destination
+
+AuditSourceIdentification.@AuditEnterpriseSiteID=Gateway 1
+AuditSourceIdentification.@AuditSourceID=1.1
+AuditSourceIdentification.@AuditSourceTypeCode=1010
+
+ParticipantObjectIdentification.@ParticipantObjectID=D123402^^^&2.2&ISO
+ParticipantObjectIdentification_Responder.@ParticipantObjectID=D123402^^^&2.2&ISO
+ParticipantObjectIdentification.@ParticipantObjectTypeCode=1
+ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole=1
+
+ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code=2
+ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName=RFC-3881
+ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName=Patient Number
+
+ParticipantObjectIdentification_Query.@ParticipantObjectID=a797fa28-45fd-4a29-867d-32f3301e73fe
+ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode=2
+ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole=24
+
+ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code=ITI-55
+ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName=IHE Transactions
+ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName=Cross Gateway Patient Discovery
+ParticipantObjectIdentification_Query.ParticipantObjectName=1.1
+
+<--ParticipantObjectIdentification_Query.ParticipantObjectQuery checks -->
+
+queryId.@root=2.2
+queryId.@extension=-abd3453dcd24wkkks545
+statusCode.@code=new
+responseModalityCode.@code=R
+responsePriorityCode.@code=I
+parameterList.livingSubjectAdministrativeGender.value.@code=M
+parameterList.livingSubjectAdministrativeGender.semanticsText.@representation=TXT
+parameterList.livingSubjectAdministrativeGender.semanticsText=LivingSubject.administrativeGender
+
+parameterList.livingSubjectBirthTime.value.@value=19630804
+parameterList.livingSubjectBirthTime.semanticsText.@representation=TXT
+parameterList.livingSubjectBirthTime.semanticsText=LivingSubject.birthTime
+
+parameterList.livingSubjectId.value.@root=1.1
+parameterList.livingSubjectId.value.@extension=D123401
+parameterList.livingSubjectId.semanticsText.@representation=TXT
+
+parameterList.livingSubjectName.value.family.@partType=FAM
+parameterList.livingSubjectName.value.family=Younger
+parameterList.livingSubjectName.value.given.@partType=GIV
+parameterList.livingSubjectName.value.given=Gallow
+parameterList.livingSubjectName.semanticsText.@representation=TXT
+parameterList.livingSubjectName.semanticsText=LivingSubject.name


### PR DESCRIPTION
1. Create AuditTransformer to build ATNA complaint message for PatientDiscovery Deferred Response         audit.
2. Regressionsuite PatientDiscoveryDeferredResponse required assertion homecommunityId
3. SoapUI test case required QueryByParameters semanticsText representation
4. Required PatientDiscoveryDeferredResponse properties file for both Standard and Passthrough
