### PR TITLE
FHAC-596 HCID not populated with Prefix for AuditSourceIdentification-AuditSourceID

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/HomeCommunityMap.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/HomeCommunityMap.java
@@ -147,13 +147,12 @@ public class HomeCommunityMap {
      */
     public static String getHomeCommunityIdFromAssertion(AssertionType assertion) {
         String homeCommunity = null;
-        try {
-            if (NullChecker.isNotNullish(assertion.getHomeCommunity().getHomeCommunityId())) {
-                homeCommunity = assertion.getHomeCommunity().getHomeCommunityId();
-            }
-        } catch (NullPointerException ex) {
-            LOG.warn("Could not obtain HCID from HomeCommunity in assertion.", ex);
+
+        if (assertion != null && assertion.getHomeCommunity() != null
+            && NullChecker.isNotNullish(assertion.getHomeCommunity().getHomeCommunityId())) {
+            homeCommunity = assertion.getHomeCommunity().getHomeCommunityId();
         }
+
         return homeCommunity;
     }
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/HomeCommunityMap.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/HomeCommunityMap.java
@@ -57,7 +57,6 @@ public class HomeCommunityMap {
     private static ConnectionManagerCache connection = ConnectionManagerCache.getInstance();
     private static PropertyAccessor propertyAccessor = PropertyAccessor.getInstance();
 
-
     /**
      * This method retrieves the name of the home community baased on the home community Id.
      *
@@ -71,7 +70,7 @@ public class HomeCommunityMap {
 
             BusinessEntity oEntity = connection.getBusinessEntity(sHomeCommunityId);
             if ((oEntity != null) && (oEntity.getName() != null) && (oEntity.getName().size() > 0)
-                    && (oEntity.getName().get(0) != null) && (oEntity.getName().get(0).getValue().length() > 0)) {
+                && (oEntity.getName().get(0) != null) && (oEntity.getName().get(0).getValue().length() > 0)) {
                 sHomeCommunityName = oEntity.getName().get(0).getValue();
             }
         } catch (Exception e) {
@@ -90,7 +89,7 @@ public class HomeCommunityMap {
     public static String getCommunityIdFromTargetCommunities(NhinTargetCommunitiesType target) {
         String responseCommunityId = null;
         if (target != null && NullChecker.isNotNullish(target.getNhinTargetCommunity())
-                && target.getNhinTargetCommunity().get(0) != null) {
+            && target.getNhinTargetCommunity().get(0) != null) {
             responseCommunityId = target.getNhinTargetCommunity().get(0).getHomeCommunity().getHomeCommunityId();
         }
         LOG.debug("=====>>>>> responseCommunityId is " + responseCommunityId);
@@ -106,7 +105,7 @@ public class HomeCommunityMap {
     public static String getCommunityIdFromTargetSystem(NhinTargetSystemType target) {
         String responseCommunityId = null;
         if (target != null && target.getHomeCommunity() != null
-                && target.getHomeCommunity().getHomeCommunityId() != null) {
+            && target.getHomeCommunity().getHomeCommunityId() != null) {
             responseCommunityId = target.getHomeCommunity().getHomeCommunityId();
         }
         LOG.debug("=====>>>>> responseCommunityId is " + responseCommunityId);
@@ -128,7 +127,7 @@ public class HomeCommunityMap {
 
             if (userInfo != null && userInfo.getOrg() != null) {
                 if (userInfo.getOrg().getHomeCommunityId() != null
-                        && userInfo.getOrg().getHomeCommunityId().length() > 0) {
+                    && userInfo.getOrg().getHomeCommunityId().length() > 0) {
                     communityId = userInfo.getOrg().getHomeCommunityId();
                 }
             }
@@ -149,8 +148,9 @@ public class HomeCommunityMap {
     public static String getHomeCommunityIdFromAssertion(AssertionType assertion) {
         String homeCommunity = null;
         try {
-            if (NullChecker.isNotNullish(assertion.getHomeCommunity().getHomeCommunityId()))
+            if (NullChecker.isNotNullish(assertion.getHomeCommunity().getHomeCommunityId())) {
                 homeCommunity = assertion.getHomeCommunity().getHomeCommunityId();
+            }
         } catch (NullPointerException ex) {
             LOG.warn("Could not obtain HCID from HomeCommunity in assertion.", ex);
         }
@@ -180,9 +180,9 @@ public class HomeCommunityMap {
     public static String getCommunityIdForDeferredQDResponse(AdhocQueryResponse body) {
         String responseCommunityID = null;
         if (body != null && body.getRegistryObjectList() != null
-                && body.getRegistryObjectList().getIdentifiable() != null
-                && body.getRegistryObjectList().getIdentifiable().size() > 0
-                && body.getRegistryObjectList().getIdentifiable().get(0) != null) {
+            && body.getRegistryObjectList().getIdentifiable() != null
+            && body.getRegistryObjectList().getIdentifiable().size() > 0
+            && body.getRegistryObjectList().getIdentifiable().get(0) != null) {
             responseCommunityID = body.getRegistryObjectList().getIdentifiable().get(0).getValue().getHome();
         }
         return formatHomeCommunityId(responseCommunityID);
@@ -197,7 +197,7 @@ public class HomeCommunityMap {
     public static String getCommunityIdForRDRequest(RetrieveDocumentSetRequestType body) {
         String responseCommunityID = null;
         if (body != null && NullChecker.isNotNullish(body.getDocumentRequest())
-                && body.getDocumentRequest().get(0) != null) {
+            && body.getDocumentRequest().get(0) != null) {
             responseCommunityID = body.getDocumentRequest().get(0).getHomeCommunityId();
         }
         return getHomeCommunityIdWithPrefix(responseCommunityID);
@@ -212,7 +212,7 @@ public class HomeCommunityMap {
     public static String getCommunityIdForDeferredRDResponse(RetrieveDocumentSetResponseType body) {
         String responseCommunityID = null;
         if (body != null && NullChecker.isNotNullish(body.getDocumentResponse())
-                && body.getDocumentResponse().get(0) != null) {
+            && body.getDocumentResponse().get(0) != null) {
             responseCommunityID = body.getDocumentResponse().get(0).getHomeCommunityId();
         }
         return formatHomeCommunityId(responseCommunityID);
@@ -251,7 +251,7 @@ public class HomeCommunityMap {
         String sHomeCommunity = null;
         try {
             sHomeCommunity = propertyAccessor.getProperty(NhincConstants.GATEWAY_PROPERTY_FILE,
-                    NhincConstants.HOME_COMMUNITY_ID_PROPERTY);
+                NhincConstants.HOME_COMMUNITY_ID_PROPERTY);
         } catch (PropertyAccessException ex) {
             LOG.error(ex.getMessage());
         }
@@ -266,9 +266,9 @@ public class HomeCommunityMap {
      */
     public static String getHomeCommunityIdWithPrefix(String communityId) {
         if (communityId != null) {
-            if (!communityId.startsWith("urn:oid:")) {
+            if (!communityId.startsWith(NhincConstants.HCID_PREFIX)) {
                 LOG.trace("Prefixing communityId with urn:oid");
-                communityId = "urn:oid:" + communityId;
+                communityId = NhincConstants.HCID_PREFIX + communityId;
             }
         }
         return communityId;

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/AuditTransformsConstants.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/AuditTransformsConstants.java
@@ -24,7 +24,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package gov.hhs.fha.nhinc.audit;
 
 /**
@@ -33,6 +32,7 @@ package gov.hhs.fha.nhinc.audit;
  * @author achidamb
  */
 public class AuditTransformsConstants {
+
     public static final Integer EVENT_OUTCOME_INDICATOR_SUCCESS = 0;
     public static final String ACTIVE_PARTICIPANT_USER_ID_SOURCE = "anonymous";
     public static final String ACTIVE_PARTICIPANT_ROLE_CODE_SOURCE_DISPLAY_NAME = "Source";
@@ -43,4 +43,6 @@ public class AuditTransformsConstants {
     public static final String ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME = "DCM";
     public static final Short NETWORK_ACCESSOR_PT_TYPE_CODE_NAME = 1;
     public static final Short NETWORK_ACCESSOR_PT_TYPE_CODE_IP = 2;
+    public static final String HOME_COMMUNITY_ID_PREFIX = "urn:oid:";
+
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/AuditTransformsConstants.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/AuditTransformsConstants.java
@@ -43,6 +43,5 @@ public class AuditTransformsConstants {
     public static final String ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME = "DCM";
     public static final Short NETWORK_ACCESSOR_PT_TYPE_CODE_NAME = 1;
     public static final Short NETWORK_ACCESSOR_PT_TYPE_CODE_IP = 2;
-    public static final String HOME_COMMUNITY_ID_PREFIX = "urn:oid:";
 
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
@@ -480,10 +480,12 @@ public abstract class AuditTransforms<T, K> {
 
         // Set the Audit Source Id (community id)
         if (communityId != null) {
-            if (communityId.startsWith("urn:oid:")) {
-                auditSrcId.setAuditSourceID(communityId.substring(8));
-            } else {
+            if (communityId.startsWith(AuditTransformsConstants.HOME_COMMUNITY_ID_PREFIX)) {
                 auditSrcId.setAuditSourceID(communityId);
+
+            } else {
+                auditSrcId.setAuditSourceID(AuditTransformsConstants.HOME_COMMUNITY_ID_PREFIX + communityId);
+
             }
         }
 

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
@@ -480,11 +480,11 @@ public abstract class AuditTransforms<T, K> {
 
         // Set the Audit Source Id (community id)
         if (communityId != null) {
-            if (communityId.startsWith(AuditTransformsConstants.HOME_COMMUNITY_ID_PREFIX)) {
+            if (communityId.startsWith(NhincConstants.HCID_PREFIX)) {
                 auditSrcId.setAuditSourceID(communityId);
 
             } else {
-                auditSrcId.setAuditSourceID(AuditTransformsConstants.HOME_COMMUNITY_ID_PREFIX + communityId);
+                auditSrcId.setAuditSourceID(HomeCommunityMap.getHomeCommunityIdWithPrefix(communityId));
 
             }
         }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
@@ -480,13 +480,9 @@ public abstract class AuditTransforms<T, K> {
 
         // Set the Audit Source Id (community id)
         if (communityId != null) {
-            if (communityId.startsWith(NhincConstants.HCID_PREFIX)) {
-                auditSrcId.setAuditSourceID(communityId);
-
-            } else {
-                auditSrcId.setAuditSourceID(HomeCommunityMap.getHomeCommunityIdWithPrefix(communityId));
-
-            }
+            /* HomeCommunityMap.getHomeCommunityIdWithPrefix(communityId) mehtod
+             checks & takes care of prefix if not populated*/
+            auditSrcId.setAuditSourceID(HomeCommunityMap.getHomeCommunityIdWithPrefix(communityId));
         }
 
         // If specified, set the Audit Enterprise Site Id (community name)

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformsTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformsTest.java
@@ -27,6 +27,7 @@
 package gov.hhs.fha.nhinc.audit.transform;
 
 import com.services.nhinc.schema.auditmessage.AuditMessageType.ActiveParticipant;
+import com.services.nhinc.schema.auditmessage.AuditSourceIdentificationType;
 import com.services.nhinc.schema.auditmessage.EventIdentificationType;
 import gov.hhs.fha.nhinc.audit.AuditTransformsConstants;
 import gov.hhs.fha.nhinc.common.auditlog.LogEventRequestType;
@@ -217,6 +218,17 @@ public abstract class AuditTransformsTest<T, K> {
 
         testGetActiveParticipantDestination(request, isRequesting, webContextProperties, remoteObjectUrl,
             webContextProperties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS));
+    }
+
+    protected void testAuditSourceIdentification(List<AuditSourceIdentificationType> auditSourceIdentification, AssertionType assertion) {
+        if (assertion != null && assertion.getUserInfo() != null && assertion.getUserInfo().getOrg() != null
+            && assertion.getUserInfo().getOrg().getHomeCommunityId() != null
+            && auditSourceIdentification != null && !auditSourceIdentification.isEmpty()
+            && auditSourceIdentification.size() > 0) {
+            for (AuditSourceIdentificationType auditSourceId : auditSourceIdentification) {
+                assertEquals(AuditTransformsConstants.HOME_COMMUNITY_ID_PREFIX + assertion.getUserInfo().getOrg().getHomeCommunityId(), auditSourceId.getAuditSourceID());
+            }
+        }
     }
 
     /**

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformsTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformsTest.java
@@ -38,6 +38,7 @@ import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.common.nhinccommon.PersonNameType;
 import gov.hhs.fha.nhinc.common.nhinccommon.UserType;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.util.HomeCommunityMap;
 import java.lang.management.ManagementFactory;
 import java.net.UnknownHostException;
 import java.util.List;
@@ -220,13 +221,14 @@ public abstract class AuditTransformsTest<T, K> {
             webContextProperties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS));
     }
 
-    protected void testAuditSourceIdentification(List<AuditSourceIdentificationType> auditSourceIdentification, AssertionType assertion) {
+    protected void testAuditSourceIdentification(List<AuditSourceIdentificationType> auditSourceIdentification,
+        AssertionType assertion) {
         if (assertion != null && assertion.getUserInfo() != null && assertion.getUserInfo().getOrg() != null
             && assertion.getUserInfo().getOrg().getHomeCommunityId() != null
-            && auditSourceIdentification != null && !auditSourceIdentification.isEmpty()
-            && auditSourceIdentification.size() > 0) {
+            && auditSourceIdentification != null) {
             for (AuditSourceIdentificationType auditSourceId : auditSourceIdentification) {
-                assertEquals(AuditTransformsConstants.HOME_COMMUNITY_ID_PREFIX + assertion.getUserInfo().getOrg().getHomeCommunityId(), auditSourceId.getAuditSourceID());
+                assertEquals(HomeCommunityMap.getHomeCommunityIdWithPrefix(
+                    assertion.getUserInfo().getOrg().getHomeCommunityId()), auditSourceId.getAuditSourceID());
             }
         }
     }

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/audit/transform/COREX12BatchSubmissionAuditTransformsTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/audit/transform/COREX12BatchSubmissionAuditTransformsTest.java
@@ -50,7 +50,8 @@ import org.junit.Test;
  *
  * @author achidamb
  */
-public class COREX12BatchSubmissionAuditTransformsTest extends AuditTransformsTest<COREEnvelopeBatchSubmission, COREEnvelopeBatchSubmissionResponse> {
+public class COREX12BatchSubmissionAuditTransformsTest extends
+    AuditTransformsTest<COREEnvelopeBatchSubmission, COREEnvelopeBatchSubmissionResponse> {
 
     @Test
     public void transformRequestToAuditMsg() throws ConnectionManagerException, UnknownHostException {

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/audit/transform/COREX12BatchSubmissionAuditTransformsTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/audit/transform/COREX12BatchSubmissionAuditTransformsTest.java
@@ -24,7 +24,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package gov.hhs.fha.nhinc.corex12.docsubmission.audit.transform;
 
 import com.services.nhinc.schema.auditmessage.ParticipantObjectIdentificationType;
@@ -51,8 +50,7 @@ import org.junit.Test;
  *
  * @author achidamb
  */
-public class COREX12BatchSubmissionAuditTransformsTest extends AuditTransformsTest<COREEnvelopeBatchSubmission,
-    COREEnvelopeBatchSubmissionResponse> {
+public class COREX12BatchSubmissionAuditTransformsTest extends AuditTransformsTest<COREEnvelopeBatchSubmission, COREEnvelopeBatchSubmissionResponse> {
 
     @Test
     public void transformRequestToAuditMsg() throws ConnectionManagerException, UnknownHostException {
@@ -96,6 +94,7 @@ public class COREX12BatchSubmissionAuditTransformsTest extends AuditTransformsTe
         testGetEventIdentificationType(auditRequest, NhincConstants.CORE_X12DS_REALTIME_SERVICE_NAME, Boolean.TRUE);
         testGetActiveParticipantSource(auditRequest, Boolean.TRUE, webContextProperties, localIp);
         testGetActiveParticipantDestination(auditRequest, Boolean.TRUE, webContextProperties, remoteObjectUrl);
+        testAuditSourceIdentification(auditRequest.getAuditMessage().getAuditSourceIdentification(), assertion);
         testCreateActiveParticipantFromUser(auditRequest, Boolean.TRUE, assertion);
         assertParticipantObjectIdentification(auditRequest);
     }
@@ -142,6 +141,7 @@ public class COREX12BatchSubmissionAuditTransformsTest extends AuditTransformsTe
         testGetEventIdentificationType(auditRequest, NhincConstants.CORE_X12DS_REALTIME_SERVICE_NAME, Boolean.TRUE);
         testGetActiveParticipantSource(auditRequest, Boolean.TRUE, webContextProperties, localIp);
         testGetActiveParticipantDestination(auditRequest, Boolean.TRUE, webContextProperties, remoteObjectUrl);
+        testAuditSourceIdentification(auditRequest.getAuditMessage().getAuditSourceIdentification(), assertion);
         testCreateActiveParticipantFromUser(auditRequest, Boolean.TRUE, assertion);
         assertParticipantObjectIdentification(auditRequest);
     }

--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/audit/transform/DocQueryAuditTransformsTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/audit/transform/DocQueryAuditTransformsTest.java
@@ -114,6 +114,7 @@ public class DocQueryAuditTransformsTest extends AuditTransformsTest<AdhocQueryR
         testGetEventIdentificationType(auditRequest, NhincConstants.DOC_QUERY_SERVICE_NAME, Boolean.TRUE);
         testGetActiveParticipantSource(auditRequest, Boolean.TRUE, webContextProperties, localIp);
         testGetActiveParticipantDestination(auditRequest, Boolean.TRUE, webContextProperties, remoteObjectUrl);
+        testAuditSourceIdentification(auditRequest.getAuditMessage().getAuditSourceIdentification(), assertion);
         testCreateActiveParticipantFromUser(auditRequest, Boolean.TRUE, assertion);
         assertParticipantObjectIdentification(auditRequest);
     }
@@ -160,6 +161,7 @@ public class DocQueryAuditTransformsTest extends AuditTransformsTest<AdhocQueryR
         testGetEventIdentificationType(auditRequest, NhincConstants.DOC_QUERY_SERVICE_NAME, Boolean.TRUE);
         testGetActiveParticipantSource(auditRequest, Boolean.TRUE, webContextProperties, localIp);
         testGetActiveParticipantDestination(auditRequest, Boolean.TRUE, webContextProperties, remoteObjectUrl);
+        testAuditSourceIdentification(auditRequest.getAuditMessage().getAuditSourceIdentification(), assertion);
         testCreateActiveParticipantFromUser(auditRequest, Boolean.TRUE, assertion);
         assertParticipantObjectIdentification(auditRequest);
     }

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/audit/transform/DocRetrieveAuditTransformsTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/audit/transform/DocRetrieveAuditTransformsTest.java
@@ -114,6 +114,7 @@ public class DocRetrieveAuditTransformsTest
         testGetEventIdentificationType(auditRequest, NhincConstants.DOC_RETRIEVE_SERVICE_NAME, Boolean.TRUE);
         testGetActiveParticipantSource(auditRequest, Boolean.FALSE, webContextProperties, remoteObjectUrl);
         testGetActiveParticipantDestination(auditRequest, Boolean.FALSE, webContextProperties, localIp);
+        testAuditSourceIdentification(auditRequest.getAuditMessage().getAuditSourceIdentification(), assertion);
         testCreateActiveParticipantFromUser(auditRequest, Boolean.TRUE, assertion);
         assertParticipantObjectIdentification(auditRequest, assertion);
     }
@@ -160,6 +161,7 @@ public class DocRetrieveAuditTransformsTest
         testGetEventIdentificationType(auditResponse, NhincConstants.DOC_RETRIEVE_SERVICE_NAME, Boolean.TRUE);
         testGetActiveParticipantSource(auditResponse, Boolean.FALSE, webContextProperties, remoteObjectUrl);
         testGetActiveParticipantDestination(auditResponse, Boolean.FALSE, webContextProperties, localIp);
+        testAuditSourceIdentification(auditResponse.getAuditMessage().getAuditSourceIdentification(), assertion);
         testCreateActiveParticipantFromUser(auditResponse, Boolean.TRUE, assertion);
         assertParticipantObjectIdentification(auditResponse, assertion);
     }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/audit/transform/DocSubmissionAuditTransformsTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/audit/transform/DocSubmissionAuditTransformsTest.java
@@ -103,6 +103,7 @@ public class DocSubmissionAuditTransformsTest extends AuditTransformsTest<
         testGetEventIdentificationType(auditRequest, NhincConstants.NHINC_XDR_SERVICE_NAME, Boolean.TRUE);
         testCreateActiveParticipantFromUser(auditRequest, Boolean.TRUE, assertion);
         testGetActiveParticipantDestination(auditRequest, Boolean.TRUE, webContextProperties, soapUIEndpoint);
+        testAuditSourceIdentification(auditRequest.getAuditMessage().getAuditSourceIdentification(), assertion);
         testGetActiveParticipantSource(auditRequest, Boolean.TRUE, webContextProperties, localIP);
         assertParticipantObjectIdentification(auditRequest.getAuditMessage());
     }
@@ -146,6 +147,7 @@ public class DocSubmissionAuditTransformsTest extends AuditTransformsTest<
             Boolean.FALSE, webContextProperties, NhincConstants.NHINC_XDR_SERVICE_NAME);
         testGetEventIdentificationType(auditResponse, NhincConstants.NHINC_XDR_SERVICE_NAME, Boolean.FALSE);
         testGetActiveParticipantDestination(auditResponse, Boolean.TRUE, webContextProperties, soapUIEndpoint);
+        testAuditSourceIdentification(auditResponse.getAuditMessage().getAuditSourceIdentification(), assertion);
         testGetActiveParticipantSource(auditResponse, Boolean.TRUE, webContextProperties, destinationIP);
         assertParticipantObjectIdentification(auditResponse.getAuditMessage());
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransformsTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransformsTest.java
@@ -122,6 +122,7 @@ public class PatientDiscoveryAuditTransformsTest extends AuditTransformsTest<PRP
         testGetEventIdentificationType(auditRequest, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, Boolean.TRUE);
         testGetActiveParticipantSource(auditRequest, Boolean.TRUE, webContextProperties, localIp);
         testGetActiveParticipantDestination(auditRequest, Boolean.TRUE, webContextProperties, remoteObjectUrl);
+        testAuditSourceIdentification(auditRequest.getAuditMessage().getAuditSourceIdentification(), assertion);
         testCreateActiveParticipantFromUser(auditRequest, Boolean.TRUE, assertion);
         assertParticipantObjectIdentification(auditRequest);
     }
@@ -172,6 +173,7 @@ public class PatientDiscoveryAuditTransformsTest extends AuditTransformsTest<PRP
         testGetActiveParticipantSource(auditRequest, Boolean.FALSE, webContextProperties, localIp);
         testGetActiveParticipantDestination(auditRequest, Boolean.FALSE, webContextProperties, remoteObjectUrl);
         testCreateActiveParticipantFromUser(auditRequest, Boolean.FALSE, assertion);
+        testAuditSourceIdentification(auditRequest.getAuditMessage().getAuditSourceIdentification(), assertion);
         assertParticipantObjectIdentification(auditRequest);
     }
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredResponseAuditTransformsTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredResponseAuditTransformsTest.java
@@ -104,6 +104,7 @@ public class PatientDiscoveryDeferredResponseAuditTransformsTest extends AuditTr
             Boolean.TRUE);
         testGetActiveParticipantSource(auditRequest, Boolean.TRUE, webContextProperties, localIp);
         testGetActiveParticipantDestination(auditRequest, Boolean.TRUE, webContextProperties, remoteObjectUrl);
+        testAuditSourceIdentification(auditRequest.getAuditMessage().getAuditSourceIdentification(), assertion);
         assertParticipantObjectIdentification(auditRequest);
     }
 
@@ -177,6 +178,7 @@ public class PatientDiscoveryDeferredResponseAuditTransformsTest extends AuditTr
             Boolean.FALSE);
         testGetActiveParticipantSource(auditRequest, Boolean.FALSE, webContextProperties, localIp);
         testGetActiveParticipantDestination(auditRequest, Boolean.FALSE, webContextProperties, remoteObjectUrl);
+        testAuditSourceIdentification(auditRequest.getAuditMessage().getAuditSourceIdentification(), assertion);
         testCreateActiveParticipantFromUser(auditRequest, Boolean.FALSE, assertion);
         assertParticipantObjectIdentification(auditRequest);
     }

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/COREX12BatchSubmitRequest.properties
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/COREX12BatchSubmitRequest.properties
@@ -52,7 +52,7 @@ ActiveParticipant_Dest.RoleIDCode.@codeSystemName=DCM
 ActiveParticipant_Dest.RoleIDCode.@displayName=Destination
 
 AuditSourceIdentification.@AuditEnterpriseSiteID=Gateway 1
-AuditSourceIdentification.@AuditSourceID=1.1
+AuditSourceIdentification.@AuditSourceID=urn:oid:1.1
 AuditSourceIdentification.@AuditSourceTypeCode=1010
 
 ParticipantObjectIdentification.@ParticipantObjectID=f81d4fae-7dec-11d0-a765-00a0c91e6bf6

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/COREX12BatchSubmitResponse.properties
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/COREX12BatchSubmitResponse.properties
@@ -52,7 +52,7 @@ ActiveParticipant_Dest.RoleIDCode.@codeSystemName=DCM
 ActiveParticipant_Dest.RoleIDCode.@displayName=Destination
 
 AuditSourceIdentification.@AuditEnterpriseSiteID=Gateway 1
-AuditSourceIdentification.@AuditSourceID=1.1
+AuditSourceIdentification.@AuditSourceID=urn:oid:1.1
 AuditSourceIdentification.@AuditSourceTypeCode=1010
 
 ParticipantObjectIdentification.@ParticipantObjectID=f81d4fae-7dec-11d0-a765-00a0c91e6bf6

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/COREX12RealTimeTransaction.properties
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/COREX12RealTimeTransaction.properties
@@ -51,7 +51,7 @@ ActiveParticipant_Dest.RoleIDCode.@codeSystemName=DCM
 ActiveParticipant_Dest.RoleIDCode.@displayName=Destination
 
 AuditSourceIdentification.@AuditEnterpriseSiteID=Gateway 1
-AuditSourceIdentification.@AuditSourceID=1.1
+AuditSourceIdentification.@AuditSourceID=urn:oid:1.1
 AuditSourceIdentification.@AuditSourceTypeCode=1010
 
 ParticipantObjectIdentification.@ParticipantObjectID=f81d4fae-7dec-11d0-a765-00a0c91e6bf6

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/DocumentSubmissionAuditLog.properties
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/DocumentSubmissionAuditLog.properties
@@ -52,7 +52,7 @@ ActiveParticipant_Dest.RoleIDCode.@codeSystemName=DCM
 ActiveParticipant_Dest.RoleIDCode.@displayName=Destination
 
 AuditSourceIdentification.@AuditEnterpriseSiteID=Gateway 1
-AuditSourceIdentification.@AuditSourceID=1.1
+AuditSourceIdentification.@AuditSourceID=urn:oid:1.1
 AuditSourceIdentification.@AuditSourceTypeCode=1010
 
 <--Patient-->

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/PatientDiscoveryAuditLog.properties
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/PatientDiscoveryAuditLog.properties
@@ -52,7 +52,7 @@ ActiveParticipant_Dest.RoleIDCode.@codeSystemName=DCM
 ActiveParticipant_Dest.RoleIDCode.@displayName=Destination
 
 AuditSourceIdentification.@AuditEnterpriseSiteID=Gateway 1
-AuditSourceIdentification.@AuditSourceID=1.1
+AuditSourceIdentification.@AuditSourceID=urn:oid:1.1
 AuditSourceIdentification.@AuditSourceTypeCode=1010
 
 ParticipantObjectIdentification.@ParticipantObjectID=1111^^^&1.1&ISO

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/PatientDiscoveryDeferredAuditLog.properties
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/PatientDiscoveryDeferredAuditLog.properties
@@ -52,7 +52,7 @@ ActiveParticipant_Dest.RoleIDCode.@codeSystemName=DCM
 ActiveParticipant_Dest.RoleIDCode.@displayName=Destination
 
 AuditSourceIdentification.@AuditEnterpriseSiteID=Gateway 1
-AuditSourceIdentification.@AuditSourceID=1.1
+AuditSourceIdentification.@AuditSourceID=urn:oid:1.1
 AuditSourceIdentification.@AuditSourceTypeCode=1010
 
 ParticipantObjectIdentification.@ParticipantObjectID=D123401^^^&1.1&ISO

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/PatientDiscoveryDeferredResponseAuditLog.properties
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/PatientDiscoveryDeferredResponseAuditLog.properties
@@ -52,7 +52,7 @@ ActiveParticipant_Dest.RoleIDCode.@codeSystemName=DCM
 ActiveParticipant_Dest.RoleIDCode.@displayName=Destination
 
 AuditSourceIdentification.@AuditEnterpriseSiteID=Gateway 1
-AuditSourceIdentification.@AuditSourceID=1.1
+AuditSourceIdentification.@AuditSourceID=urn:oid:1.1
 AuditSourceIdentification.@AuditSourceTypeCode=1010
 
 ParticipantObjectIdentification.@ParticipantObjectID=D123402^^^&2.2&ISO

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/QueryDocumentAuditLog.properties
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/QueryDocumentAuditLog.properties
@@ -53,7 +53,7 @@ ActiveParticipant_Dest.RoleIDCode.@codeSystemName=DCM
 ActiveParticipant_Dest.RoleIDCode.@displayName=Destination
 
 AuditSourceIdentification.@AuditEnterpriseSiteID=Gateway 1
-AuditSourceIdentification.@AuditSourceID=1.1
+AuditSourceIdentification.@AuditSourceID=urn:oid:1.1
 AuditSourceIdentification.@AuditSourceTypeCode=1010
 
 <--Patient-->

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/RetrieveDocumentAuditLog.properties
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/RetrieveDocumentAuditLog.properties
@@ -54,7 +54,7 @@ ActiveParticipant_Dest.RoleIDCode.@codeSystemName=DCM
 ActiveParticipant_Dest.RoleIDCode.@displayName=Destination
 
 AuditSourceIdentification.@AuditEnterpriseSiteID=Gateway 1
-AuditSourceIdentification.@AuditSourceID=1.1
+AuditSourceIdentification.@AuditSourceID=urn:oid:1.1
 AuditSourceIdentification.@AuditSourceTypeCode=1010
 
 <--Patient-->

--- a/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/DocumentSubmissionAuditLog.properties
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/DocumentSubmissionAuditLog.properties
@@ -52,7 +52,7 @@ ActiveParticipant_Dest.RoleIDCode.@codeSystemName=DCM
 ActiveParticipant_Dest.RoleIDCode.@displayName=Destination
 
 AuditSourceIdentification.@AuditEnterpriseSiteID=Gateway 1
-AuditSourceIdentification.@AuditSourceID=1.1
+AuditSourceIdentification.@AuditSourceID=urn:oid:1.1
 AuditSourceIdentification.@AuditSourceTypeCode=1010
 
 <--Patient-->

--- a/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/PatientDiscoveryAuditLog.properties
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/PatientDiscoveryAuditLog.properties
@@ -52,7 +52,7 @@ ActiveParticipant_Dest.RoleIDCode.@codeSystemName=DCM
 ActiveParticipant_Dest.RoleIDCode.@displayName=Destination
 
 AuditSourceIdentification.@AuditEnterpriseSiteID=Gateway 1
-AuditSourceIdentification.@AuditSourceID=1.1
+AuditSourceIdentification.@AuditSourceID=urn:oid:1.1
 AuditSourceIdentification.@AuditSourceTypeCode=1010
 
 ParticipantObjectIdentification.@ParticipantObjectID=1111^^^&1.1&ISO

--- a/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/PatientDiscoveryDeferredAuditLog.properties
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/PatientDiscoveryDeferredAuditLog.properties
@@ -52,7 +52,7 @@ ActiveParticipant_Dest.RoleIDCode.@codeSystemName=DCM
 ActiveParticipant_Dest.RoleIDCode.@displayName=Destination
 
 AuditSourceIdentification.@AuditEnterpriseSiteID=Gateway 1
-AuditSourceIdentification.@AuditSourceID=1.1
+AuditSourceIdentification.@AuditSourceID=urn:oid:1.1
 AuditSourceIdentification.@AuditSourceTypeCode=1010
 
 ParticipantObjectIdentification.@ParticipantObjectID=D123401^^^&1.1&ISO

--- a/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/PatientDiscoveryDeferredResponseAuditLog.properties
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/PatientDiscoveryDeferredResponseAuditLog.properties
@@ -52,7 +52,7 @@ ActiveParticipant_Dest.RoleIDCode.@codeSystemName=DCM
 ActiveParticipant_Dest.RoleIDCode.@displayName=Destination
 
 AuditSourceIdentification.@AuditEnterpriseSiteID=Gateway 1
-AuditSourceIdentification.@AuditSourceID=1.1
+AuditSourceIdentification.@AuditSourceID=urn:oid:1.1
 AuditSourceIdentification.@AuditSourceTypeCode=1010
 
 ParticipantObjectIdentification.@ParticipantObjectID=D123402^^^&2.2&ISO

--- a/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/QueryDocumentAuditLog.properties
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/QueryDocumentAuditLog.properties
@@ -53,7 +53,7 @@ ActiveParticipant_Dest.RoleIDCode.@codeSystemName=DCM
 ActiveParticipant_Dest.RoleIDCode.@displayName=Destination
 
 AuditSourceIdentification.@AuditEnterpriseSiteID=Gateway 1
-AuditSourceIdentification.@AuditSourceID=1.1
+AuditSourceIdentification.@AuditSourceID=urn:oid:1.1
 AuditSourceIdentification.@AuditSourceTypeCode=1010
 
 <--Patient-->

--- a/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/RetrieveDocumentAuditLog.properties
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/RetrieveDocumentAuditLog.properties
@@ -53,7 +53,7 @@ ActiveParticipant_Dest.RoleIDCode.@codeSystemName=DCM
 ActiveParticipant_Dest.RoleIDCode.@displayName=Destination
 
 AuditSourceIdentification.@AuditEnterpriseSiteID=Gateway 1
-AuditSourceIdentification.@AuditSourceID=1.1
+AuditSourceIdentification.@AuditSourceID=urn:oid:1.1
 AuditSourceIdentification.@AuditSourceTypeCode=1010
 
 <--Patient-->


### PR DESCRIPTION
HCID is now populated with prefix AuditSourceIdentification->AuditSourceID field across all services.
