### PR TITLE
FHAC-587 ConnectAdminGUI pom update

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/pom.xml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/pom.xml
@@ -293,6 +293,12 @@
             <groupId>me.fhir</groupId>
             <artifactId>fhir-0.12</artifactId>
             <version>0.3</version>
+			<exclusions>
+				<exclusion>
+					<groupId>net.sf.saxon</groupId>
+					<artifactId>Saxon-HE</artifactId>
+				</exclusion>
+			</exclusions>
         </dependency>
     </dependencies>
 

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/pom.xml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/pom.xml
@@ -10,7 +10,7 @@
     <name>CONNECT Administration GUI</name>
     <packaging>war</packaging>
     <modelVersion>4.0.0</modelVersion>
-    
+
     <properties>
         <cxf.version>2.7.8</cxf.version>
     </properties>
@@ -21,7 +21,7 @@
             <groupId>javax</groupId>
             <artifactId>javaee-api</artifactId>
         </dependency>
-        
+
         <!-- CXF -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
@@ -287,18 +287,18 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
         </dependency>
-        
+
         <!-- FHIR -->
         <dependency>
             <groupId>me.fhir</groupId>
             <artifactId>fhir-0.12</artifactId>
             <version>0.3</version>
-			<exclusions>
-				<exclusion>
-					<groupId>net.sf.saxon</groupId>
-					<artifactId>Saxon-HE</artifactId>
-				</exclusion>
-			</exclusions>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.sf.saxon</groupId>
+                    <artifactId>Saxon-HE</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
1. Update ConnectadminGUI pom to exclude the Saxon-He jar which was pulling the xercesImpl  and xml-apis.
