### PR TITLE
FHAC-621 Fix Source ActiveParticipant for AlternateUserID and Username

### DIFF
--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
@@ -525,14 +525,12 @@ public abstract class AuditTransforms<T, K> {
     protected String getUserName(UserType userInfo) {
         String userName = null;
         if (userInfo != null && userInfo.getPersonName() != null) {
-            if (userInfo.getPersonName().getGivenName() != null && userInfo.getPersonName().getGivenName().
-                length() > 0) {
+            if (NullChecker.isNotNullish(userInfo.getPersonName().getGivenName())) {
 
                 userName = userInfo.getPersonName().getGivenName();
             }
 
-            if (userInfo.getPersonName().getFamilyName() != null
-                && userInfo.getPersonName().getFamilyName().length() > 0) {
+            if (NullChecker.isNotNullish(userInfo.getPersonName().getFamilyName())) {
 
                 if (userName != null) {
                     userName += (" " + userInfo.getPersonName().getFamilyName());

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
@@ -204,26 +204,9 @@ public abstract class AuditTransforms<T, K> {
         }
 
         // If specified, set the User Name
-        String userName = null;
-        if (userInfo != null && userInfo.getPersonName() != null) {
-            if (userInfo.getPersonName().getGivenName() != null && userInfo.getPersonName().getGivenName().
-                length() > 0) {
-
-                userName = userInfo.getPersonName().getGivenName();
-            }
-
-            if (userInfo.getPersonName().getFamilyName() != null
-                && userInfo.getPersonName().getFamilyName().length() > 0) {
-
-                if (userName != null) {
-                    userName += (" " + userInfo.getPersonName().getFamilyName());
-                } else {
-                    userName = userInfo.getPersonName().getFamilyName();
-                }
-            }
-            if (userName != null) {
-                participant.setUserName(userName);
-            }
+        String userName = getUserName(userInfo);
+        if (userName != null) {
+            participant.setUserName(userName);
         }
 
         participant.setUserIsRequestor(Boolean.TRUE);
@@ -269,17 +252,17 @@ public abstract class AuditTransforms<T, K> {
      * @param serviceName
      * @param isRequesting
      * @param webContextProperties
+     * @param oUserInfo
      * @return
      */
     protected ActiveParticipant getActiveParticipantSource(NhinTargetSystemType target, String serviceName,
-        boolean isRequesting, Properties webContextProperties) {
+        boolean isRequesting, Properties webContextProperties, UserType oUserInfo) {
 
         String ipOrHost = isRequesting ? getLocalHostAddress() : getRemoteHostAddress(webContextProperties);
 
         AuditMessageType.ActiveParticipant participant = new AuditMessageType.ActiveParticipant();
         participant.setUserID(isRequesting ? NhincConstants.WSA_REPLY_TO
             : getInboundReplyToFromHeader(webContextProperties));
-        participant.setAlternativeUserID(ManagementFactory.getRuntimeMXBean().getName());
         participant.setNetworkAccessPointID(ipOrHost);
         participant.setNetworkAccessPointTypeCode(getNetworkAccessPointTypeCode(ipOrHost));
         participant.getRoleIDCode().add(AuditDataTransformHelper.createCodeValueType(
@@ -287,6 +270,15 @@ public abstract class AuditTransforms<T, K> {
             AuditTransformsConstants.ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME,
             AuditTransformsConstants.ACTIVE_PARTICIPANT_ROLE_CODE_SOURCE_DISPLAY_NAME));
         participant.setUserIsRequestor(Boolean.TRUE);
+
+        if (isRequesting) {
+            participant.setAlternativeUserID(ManagementFactory.getRuntimeMXBean().getName());
+        }
+
+        String userName = getUserName(oUserInfo);
+        if (userName != null) {
+            participant.setUserName(userName);
+        }
         return participant;
 
     }
@@ -514,7 +506,7 @@ public abstract class AuditTransforms<T, K> {
             }
         }
         ActiveParticipant participantSource = getActiveParticipantSource(target, serviceName, isRequesting,
-            webContextProperties);
+            webContextProperties, assertion.getUserInfo());
         ActiveParticipant participantDestination = getActiveParticipantDestination(target,
             isRequesting, webContextProperties, serviceName);
         auditMsg.getActiveParticipant().add(participantSource);
@@ -528,6 +520,29 @@ public abstract class AuditTransforms<T, K> {
         // ******************************Construct Audit Source Identification**********************
         auditMsg.getAuditSourceIdentification().add(auditSource);
         return auditMsg;
+    }
+
+    protected String getUserName(UserType userInfo) {
+        String userName = null;
+        if (userInfo != null && userInfo.getPersonName() != null) {
+            if (userInfo.getPersonName().getGivenName() != null && userInfo.getPersonName().getGivenName().
+                length() > 0) {
+
+                userName = userInfo.getPersonName().getGivenName();
+            }
+
+            if (userInfo.getPersonName().getFamilyName() != null
+                && userInfo.getPersonName().getFamilyName().length() > 0) {
+
+                if (userName != null) {
+                    userName += (" " + userInfo.getPersonName().getFamilyName());
+                } else {
+                    userName = userInfo.getPersonName().getFamilyName();
+                }
+            }
+
+        }
+        return userName;
     }
 
     private LogEventRequestType buildLogEventRequestType(AuditMessageType auditMsg, String direction,

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
@@ -533,7 +533,7 @@ public abstract class AuditTransforms<T, K> {
             if (NullChecker.isNotNullish(userInfo.getPersonName().getFamilyName())) {
 
                 if (userName != null) {
-                    userName += (" " + userInfo.getPersonName().getFamilyName());
+                    userName += " " + userInfo.getPersonName().getFamilyName();
                 } else {
                     userName = userInfo.getPersonName().getFamilyName();
                 }

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformsTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformsTest.java
@@ -183,14 +183,12 @@ public abstract class AuditTransformsTest<T, K> {
 
         if (isRequesting) {
             assertEquals("UserId mismatch", NhincConstants.WSA_REPLY_TO, sourceActiveParticipant.getUserID());
-            assertEquals("AlternativeUserId mismatch", ManagementFactory.getRuntimeMXBean().getName(),
-                sourceActiveParticipant.getAlternativeUserID());
-
             ipOrHost = localIp;
         } else {
             ipOrHost = webContextProperties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS);
         }
 
+        checkAlternativeUserId(sourceActiveParticipant.getAlternativeUserID(), isRequesting);
         assertEquals("NetworkAccessPointID mismatch", ipOrHost, sourceActiveParticipant.getNetworkAccessPointID());
         assertEquals("SourceActiveParticipant requestor flag mismatch", Boolean.TRUE,
             sourceActiveParticipant.isUserIsRequestor());
@@ -230,6 +228,19 @@ public abstract class AuditTransformsTest<T, K> {
                 assertEquals(HomeCommunityMap.getHomeCommunityIdWithPrefix(
                     assertion.getUserInfo().getOrg().getHomeCommunityId()), auditSourceId.getAuditSourceID());
             }
+        }
+    }
+
+    /**
+     * Tests for alternativeUserID
+     *
+     * @param alternativeUserID
+     * @param isRequesting
+     */
+    protected void checkAlternativeUserId(String alternativeUserID, Boolean isRequesting) {
+        if (isRequesting) {
+            assertEquals("AlternativeUserId mismatch", ManagementFactory.getRuntimeMXBean().getName(),
+                alternativeUserID);
         }
     }
 

--- a/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/audit/transform/DocRetrieveAuditTransforms.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/audit/transform/DocRetrieveAuditTransforms.java
@@ -44,6 +44,7 @@ import gov.hhs.fha.nhinc.transform.audit.AuditDataTransformHelper;
 import com.services.nhinc.schema.auditmessage.AuditMessageType.ActiveParticipant;
 import java.net.MalformedURLException;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.common.nhinccommon.UserType;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.util.HomeCommunityMap;
 
@@ -316,7 +317,7 @@ public class DocRetrieveAuditTransforms
      */
     @Override
     protected ActiveParticipant getActiveParticipantSource(NhinTargetSystemType target, String serviceName,
-        boolean isRequesting, Properties webContextProperties) {
+        boolean isRequesting, Properties webContextProperties, UserType oUserInfo) {
 
         ActiveParticipant participant = new ActiveParticipant();
 
@@ -356,11 +357,16 @@ public class DocRetrieveAuditTransforms
             participant.setAlternativeUserID(ManagementFactory.getRuntimeMXBean().getName());
         }
 
+        String userName = getUserName(oUserInfo);
+        if (userName != null) {
+            participant.setUserName(userName);
+        }
+
         participant.getRoleIDCode()
             .add(AuditDataTransformHelper.createCodeValueType(
-                AuditTransformsConstants.ACTIVE_PARTICIPANT_ROLE_CODE_SOURCE, null,
-                AuditTransformsConstants.ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME,
-                AuditTransformsConstants.ACTIVE_PARTICIPANT_ROLE_CODE_SOURCE_DISPLAY_NAME));
+                    AuditTransformsConstants.ACTIVE_PARTICIPANT_ROLE_CODE_SOURCE, null,
+                    AuditTransformsConstants.ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME,
+                    AuditTransformsConstants.ACTIVE_PARTICIPANT_ROLE_CODE_SOURCE_DISPLAY_NAME));
 
         participant.setUserIsRequestor(Boolean.FALSE);
 
@@ -404,9 +410,9 @@ public class DocRetrieveAuditTransforms
 
         participant.getRoleIDCode()
             .add(AuditDataTransformHelper.createCodeValueType(
-                AuditTransformsConstants.ACTIVE_PARTICIPANT_ROLE_CODE_DEST, null,
-                AuditTransformsConstants.ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME,
-                AuditTransformsConstants.ACTIVE_PARTICIPANT_ROLE_CODE_DESTINATION_DISPLAY_NAME));
+                    AuditTransformsConstants.ACTIVE_PARTICIPANT_ROLE_CODE_DEST, null,
+                    AuditTransformsConstants.ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME,
+                    AuditTransformsConstants.ACTIVE_PARTICIPANT_ROLE_CODE_DESTINATION_DISPLAY_NAME));
         return participant;
     }
 

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/audit/transform/DocRetrieveAuditTransformsTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/audit/transform/DocRetrieveAuditTransformsTest.java
@@ -136,8 +136,8 @@ public class DocRetrieveAuditTransformsTest
             null, NhincConstants.DOC_RETRIEVE_SERVICE_NAME);
 
         testGetEventIdentificationType(auditRequest, NhincConstants.DOC_RETRIEVE_SERVICE_NAME, Boolean.TRUE);
-        testGetActiveParticipantSource(auditRequest, Boolean.FALSE, webContextProperties, REMOTE_OBJECT_URL);
-        testGetActiveParticipantDestination(auditRequest, Boolean.FALSE, webContextProperties, LOCAL_IP);
+        testGetActiveParticipantSource(auditRequest, Boolean.TRUE, webContextProperties, REMOTE_OBJECT_URL);
+        testGetActiveParticipantDestination(auditRequest, Boolean.TRUE, webContextProperties, LOCAL_IP);
         testAuditSourceIdentification(auditRequest.getAuditMessage().getAuditSourceIdentification(), assertion);
         testCreateActiveParticipantFromUser(auditRequest, Boolean.TRUE, assertion);
         assertParticipantObjectIdentification(auditRequest, assertion);
@@ -303,7 +303,7 @@ public class DocRetrieveAuditTransformsTest
 
         assertNotNull("sourceActiveParticipant is null", sourceActiveParticipant);
 
-        if (isRequesting) {
+        if (!isRequesting) {
             assertEquals("AlternativeUserId mismatch", ManagementFactory.getRuntimeMXBean().getName(),
                 sourceActiveParticipant.getAlternativeUserID());
         }
@@ -312,8 +312,15 @@ public class DocRetrieveAuditTransformsTest
 
         assertEquals("UserId mismatch", remoteObjectUrl, sourceActiveParticipant.getUserID());
         assertEquals("NetworkAccessPointID mismatch", ipOrHost, sourceActiveParticipant.getNetworkAccessPointID());
-        assertEquals("SourceActiveParticipant requestor flag mismatch", isRequesting,
-            sourceActiveParticipant.isUserIsRequestor());
+
+        if (isRequesting) {
+            assertEquals("SourceActiveParticipant requestor flag mismatch", !isRequesting,
+                sourceActiveParticipant.isUserIsRequestor());
+        } else {
+            assertEquals("SourceActiveParticipant requestor flag mismatch", isRequesting,
+                sourceActiveParticipant.isUserIsRequestor());
+        }
+
         assertEquals("NetworkAccessPointTypeCode mismatch",
             AuditTransformsConstants.NETWORK_ACCESSOR_PT_TYPE_CODE_IP,
             sourceActiveParticipant.getNetworkAccessPointTypeCode());
@@ -353,9 +360,21 @@ public class DocRetrieveAuditTransformsTest
 
         userId = NhincConstants.WSA_REPLY_TO;
 
+        if (isRequesting) {
+            assertEquals("AlternativeUserId mismatch", ManagementFactory.getRuntimeMXBean().getName(),
+                destinationActiveParticipant.getAlternativeUserID());
+        }
+
         assertEquals("UserID mismatch", userId, destinationActiveParticipant.getUserID());
-        assertEquals("DestinationActiveParticipant requestor flag mismatch", !isRequesting,
-            destinationActiveParticipant.isUserIsRequestor());
+
+        if (isRequesting) {
+            assertEquals("DestinationActiveParticipant requestor flag mismatch", isRequesting,
+                destinationActiveParticipant.isUserIsRequestor());
+        } else {
+            assertEquals("DestinationActiveParticipant requestor flag mismatch", !isRequesting,
+                destinationActiveParticipant.isUserIsRequestor());
+        }
+
         assertEquals("NetworkAccessPointID mismatch", localIp, destinationActiveParticipant.getNetworkAccessPointID());
         assertEquals("NetworkAccessPointTypeCode mismatch", AuditTransformsConstants.NETWORK_ACCESSOR_PT_TYPE_CODE_IP,
             destinationActiveParticipant.getNetworkAccessPointTypeCode());

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/audit/transform/DocRetrieveAuditTransformsTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/audit/transform/DocRetrieveAuditTransformsTest.java
@@ -317,7 +317,7 @@ public class DocRetrieveAuditTransformsTest
             assertEquals("SourceActiveParticipant requestor flag mismatch", !isRequesting,
                 sourceActiveParticipant.isUserIsRequestor());
         } else {
-            assertEquals("SourceActiveParticipant requestor flag mismatch", isRequesting,
+            assertEquals("SourceActiveParticipant responder flag mismatch", isRequesting,
                 sourceActiveParticipant.isUserIsRequestor());
         }
 
@@ -371,7 +371,7 @@ public class DocRetrieveAuditTransformsTest
             assertEquals("DestinationActiveParticipant requestor flag mismatch", isRequesting,
                 destinationActiveParticipant.isUserIsRequestor());
         } else {
-            assertEquals("DestinationActiveParticipant requestor flag mismatch", !isRequesting,
+            assertEquals("DestinationActiveParticipant responder flag mismatch", !isRequesting,
                 destinationActiveParticipant.isUserIsRequestor());
         }
 

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/audit/transform/DSDeferredResponseAuditTransforms.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/audit/transform/DSDeferredResponseAuditTransforms.java
@@ -126,14 +126,14 @@ public class DSDeferredResponseAuditTransforms extends
 
     @Override
     protected AuditMessageType.ActiveParticipant getActiveParticipantSource(NhinTargetSystemType target,
-        String serviceName, boolean isRequesting, Properties webContextProperties) {
+        String serviceName, boolean isRequesting, Properties webContextProperties, UserType oUserInfo) {
 
         String ipOrHost = isRequesting ? getDSDeferredRequestInitiatorAddress(target) : getLocalHostAddress();
 
         AuditMessageType.ActiveParticipant participant = new AuditMessageType.ActiveParticipant();
         participant.setUserID(isRequesting ? NhincConstants.WSA_REPLY_TO
             : getInboundReplyToFromHeader(webContextProperties));
-        if (isRequesting) {
+        if (!isRequesting) {
             participant.setAlternativeUserID(ManagementFactory.getRuntimeMXBean().getName());
         }
         participant.setNetworkAccessPointID(ipOrHost);
@@ -143,6 +143,11 @@ public class DSDeferredResponseAuditTransforms extends
             AuditTransformsConstants.ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME,
             AuditTransformsConstants.ACTIVE_PARTICIPANT_ROLE_CODE_SOURCE_DISPLAY_NAME));
         participant.setUserIsRequestor(Boolean.TRUE);
+
+        String userName = getUserName(oUserInfo);
+        if (userName != null) {
+            participant.setUserName(userName);
+        }
         return participant;
 
     }
@@ -171,7 +176,7 @@ public class DSDeferredResponseAuditTransforms extends
             participant.setNetworkAccessPointTypeCode(AuditTransformsConstants.NETWORK_ACCESSOR_PT_TYPE_CODE_NAME);
             participant.setNetworkAccessPointID(AuditTransformsConstants.ACTIVE_PARTICIPANT_UNKNOWN_IP_ADDRESS);
         }
-        if (!isRequesting) {
+        if (isRequesting) {
             participant.setAlternativeUserID(ManagementFactory.getRuntimeMXBean().getName());
         }
         participant.setUserIsRequestor(Boolean.FALSE);

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/audit/transform/DSDeferredResponseAuditTransformsTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/audit/transform/DSDeferredResponseAuditTransformsTest.java
@@ -38,12 +38,14 @@ import gov.hhs.fha.nhinc.connectmgr.ConnectionManagerException;
 import gov.hhs.fha.nhinc.docsubmission.audit.DocSubmissionAuditTransformsConstants;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.healthit.nhin.XDRAcknowledgementType;
+import java.lang.management.ManagementFactory;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Properties;
 import javax.xml.bind.JAXBException;
 import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import org.junit.Test;
 
@@ -201,6 +203,14 @@ public class DSDeferredResponseAuditTransformsTest extends
         assertEquals("EventTypeCode.DisplayName mismatch",
             DocSubmissionAuditTransformsConstants.EVENT_TYPE_CODE_DISPLAY_NAME,
             eventIdentificationType.getEventTypeCode().get(0).getDisplayName());
+    }
+
+    @Override
+    protected void checkAlternativeUserId(String alternativeUserID, Boolean isRequesting) {
+        if (!isRequesting) {
+            assertEquals("AlternativeUserId mismatch", ManagementFactory.getRuntimeMXBean().getName(),
+                alternativeUserID);
+        }
     }
 
     @Override

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredResponseAuditTransforms.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredResponseAuditTransforms.java
@@ -98,14 +98,16 @@ public class PatientDiscoveryDeferredResponseAuditTransforms extends
 
     @Override
     protected AuditMessageType.ActiveParticipant getActiveParticipantSource(NhinTargetSystemType target,
-        String serviceName, boolean isRequesting, Properties webContextProperties) {
+        String serviceName, boolean isRequesting, Properties webContextProperties, UserType oUserInfo) {
 
         String ipOrHost = isRequesting ? getPDDeferredRequestInitiatorAddress() : getLocalHostAddress();
 
         AuditMessageType.ActiveParticipant participant = new AuditMessageType.ActiveParticipant();
         participant.setUserID(isRequesting ? NhincConstants.WSA_REPLY_TO
             : getInboundReplyToFromHeader(webContextProperties));
-        participant.setAlternativeUserID(ManagementFactory.getRuntimeMXBean().getName());
+        if (!isRequesting) {
+            participant.setAlternativeUserID(ManagementFactory.getRuntimeMXBean().getName());
+        }
         participant.setNetworkAccessPointID(ipOrHost);
         participant.setNetworkAccessPointTypeCode(getNetworkAccessPointTypeCode(ipOrHost));
         participant.getRoleIDCode().add(AuditDataTransformHelper.createCodeValueType(
@@ -113,6 +115,11 @@ public class PatientDiscoveryDeferredResponseAuditTransforms extends
             AuditTransformsConstants.ACTIVE_PARTICIPANT_CODE_SYSTEM_NAME,
             AuditTransformsConstants.ACTIVE_PARTICIPANT_ROLE_CODE_SOURCE_DISPLAY_NAME));
         participant.setUserIsRequestor(Boolean.TRUE);
+
+        String userName = getUserName(oUserInfo);
+        if (userName != null) {
+            participant.setUserName(userName);
+        }
         return participant;
 
     }
@@ -145,7 +152,7 @@ public class PatientDiscoveryDeferredResponseAuditTransforms extends
                 participant.setNetworkAccessPointID(AuditTransformsConstants.ACTIVE_PARTICIPANT_UNKNOWN_IP_ADDRESS);
             }
         }
-        if (!isRequesting) {
+        if (isRequesting) {
             participant.setAlternativeUserID(ManagementFactory.getRuntimeMXBean().getName());
         }
         participant.setUserIsRequestor(Boolean.FALSE);

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredResponseAuditTransformsTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredResponseAuditTransformsTest.java
@@ -26,6 +26,7 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.audit.transform;
 
+import com.services.nhinc.schema.auditmessage.AuditMessageType;
 import com.services.nhinc.schema.auditmessage.ParticipantObjectIdentificationType;
 import gov.hhs.fha.nhinc.audit.AuditTransformsConstants;
 import gov.hhs.fha.nhinc.audit.transform.AuditTransforms;
@@ -37,6 +38,7 @@ import gov.hhs.fha.nhinc.connectmgr.ConnectionManagerException;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryAuditTransformsConstants;
 import gov.hhs.fha.nhinc.patientdiscovery.parser.TestPatientDiscoveryMessageHelper;
+import java.lang.management.ManagementFactory;
 import java.net.UnknownHostException;
 import java.util.Properties;
 import org.hl7.v3.MCCIIN000002UV01;
@@ -240,6 +242,14 @@ public class PatientDiscoveryDeferredResponseAuditTransformsTest extends AuditTr
             participantQuery.getParticipantObjectName());
         assertNotNull("ParticipantQuery.ParticipantObjectQuery is null",
             participantQuery.getParticipantObjectQuery());
+    }
+
+    @Override
+    protected void checkAlternativeUserId(String alternativeUserID, Boolean isRequesting) {
+        if (!isRequesting) {
+            assertEquals("AlternativeUserId mismatch", ManagementFactory.getRuntimeMXBean().getName(),
+                alternativeUserID);
+        }
     }
 
     @Override


### PR DESCRIPTION
1. Initiating side blob message will have Source->ActiveParticipant AlternativeUserID for all services except RD, PD Deferred Response ACK and DS Deferred Response ACK. 
2.  Initiating side blob message will have Source->ActiveParticipant username for all services 
3. Junit Test case for all services are updated for testing AlternativeUserID and username
4. RD Junit Test case for initiating gateway for passing incorrect values for testing initiating gateway that is also fixed as a part of this ticket 
5. Regression suites are not updated and will be fixed in other sub-task ticket
