### PR TITLE
FHAC-561: AuditLogging turned On and Off.

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
@@ -77,7 +77,7 @@ public class NhincConstants {
 
         PATIENT_DISCOVERY(PATIENT_DISCOVERY_SERVICE_NAME), PATIENT_DISCOVERY_DEFERRED_REQUEST(
             PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME), PATIENT_DISCOVERY_DEFERRED_RESPONSE(
-                PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
+            PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
         DOCUMENT_QUERY(DOC_QUERY_SERVICE_NAME),
         DOCUMENT_RETRIEVE(DOC_RETRIEVE_SERVICE_NAME),
         DOCUMENT_SUBMISSION(NHINC_XDR_SERVICE_NAME), DOCUMENT_SUBMISSION_DEFERRED_REQUEST(
@@ -473,6 +473,9 @@ public class NhincConstants {
     public static final String INBOUND_REPLY_TO = "ReplyTo";
     //ReplyTo Header to be retrieved from cxf Inbound messages
     public static final String INBOUND_REPLY_TO_HEADER = "javax.xml.ws.addressing.context.inbound";
+
+    // audit logging properties file name
+    public static final String AUDIT_LOGGING_PROPERTY_FILE = "audit";
 
     private NhincConstants() {
     }

--- a/Product/Production/Common/Properties/src/main/resources/audit.properties
+++ b/Product/Production/Common/Properties/src/main/resources/audit.properties
@@ -1,0 +1,22 @@
+# This file contains properties to turn on/off ATNA auditlogging through out CONNECT services
+
+#Patient Discovery
+PatientDiscovery=true
+PatientDiscoveryDeferredReq=true
+PatientDiscoveryDeferredResp=true
+
+#Document Query
+QueryForDocuments=true
+
+#Retrieve Documents
+RetrieveDocuments=true
+
+#Document Submission
+DocSubmission=true
+DocSubmissionDeferredReq=true
+DocSubmissionDeferredResp=true
+
+#X12
+CORE_X12DSGenericBatchRequest=true
+CORE_X12DSGenericBatchResponse=true
+CORE_X12DSRealTime=true

--- a/Product/Production/Common/Properties/src/main/resources/audit.properties
+++ b/Product/Production/Common/Properties/src/main/resources/audit.properties
@@ -1,4 +1,5 @@
-# This file contains properties to turn on/off ATNA auditlogging through out CONNECT services
+# This file contains properties to turn on/off ATNA auditlogging through out CONNECT services. A value of true means
+# Audit logging is turned on for that service. 
 
 #Patient Discovery
 PatientDiscovery=true

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/AuditLogger.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/AuditLogger.java
@@ -67,7 +67,7 @@ public abstract class AuditLogger<T, K> {
     public void auditRequestMessage(T request, AssertionType assertion, NhinTargetSystemType target, String direction,
         String _interface, Boolean isRequesting, Properties webContextProperties, String serviceName) {
         LOG.trace("--- Before auditing of request message ---");
-        if (getAuditLogger() != null && isAuditLoggingOn(serviceName)) {
+        if (isAuditLoggingOn(serviceName) && getAuditLogger() != null) {
             getAuditLogger().auditRequestMessage(request, assertion, target, direction, _interface, isRequesting,
                 webContextProperties, serviceName, getAuditTransforms());
         }
@@ -94,7 +94,7 @@ public abstract class AuditLogger<T, K> {
         String serviceName) {
 
         LOG.trace("--- Before auditing of response message ---");
-        if (getAuditLogger() != null && isAuditLoggingOn(serviceName)) {
+        if (isAuditLoggingOn(serviceName) && getAuditLogger() != null) {
             getAuditLogger().auditResponseMessage(request, response, assertion, target, direction, _interface,
                 isRequesting, webContextProperties, serviceName, getAuditTransforms());
         }

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/request/outbound/PassthroughOutboundCORE_X12DSGenericBatchRequest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/request/outbound/PassthroughOutboundCORE_X12DSGenericBatchRequest.java
@@ -46,13 +46,14 @@ public class PassthroughOutboundCORE_X12DSGenericBatchRequest implements Outboun
 
     private OutboundCORE_X12DSGenericBatchRequestDelegate dsDelegate
         = new OutboundCORE_X12DSGenericBatchRequestDelegate();
-    private CORE_X12BatchSubmissionAuditLogger auditLogger = new CORE_X12BatchSubmissionAuditLogger();
+    private CORE_X12BatchSubmissionAuditLogger auditLogger = null;
 
     /**
      * Constructor..
      */
     public PassthroughOutboundCORE_X12DSGenericBatchRequest() {
         super();
+        this.auditLogger = new CORE_X12BatchSubmissionAuditLogger();
     }
 
     /**
@@ -62,6 +63,7 @@ public class PassthroughOutboundCORE_X12DSGenericBatchRequest implements Outboun
      */
     public PassthroughOutboundCORE_X12DSGenericBatchRequest(OutboundCORE_X12DSGenericBatchRequestDelegate dsDelegate) {
         this.dsDelegate = dsDelegate;
+        this.auditLogger = new CORE_X12BatchSubmissionAuditLogger();
     }
 
     /**
@@ -106,9 +108,12 @@ public class PassthroughOutboundCORE_X12DSGenericBatchRequest implements Outboun
 
     private void auditRequestToNhin(COREEnvelopeBatchSubmission body, AssertionType assertion,
         NhinTargetSystemType targetSystem) {
-        auditLogger.auditRequestMessage(body, assertion, targetSystem,
+        getAuditLogger().auditRequestMessage(body, assertion, targetSystem,
             NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE,
             Boolean.TRUE, null, NhincConstants.CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME);
     }
 
+    protected CORE_X12BatchSubmissionAuditLogger getAuditLogger() {
+        return this.auditLogger;
+    }
 }

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/inbound/AbstractInboundCORE_X12DSGenericBatchResponse.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/inbound/AbstractInboundCORE_X12DSGenericBatchResponse.java
@@ -106,9 +106,9 @@ public abstract class AbstractInboundCORE_X12DSGenericBatchResponse implements I
         return oResponse;
     }
 
-    protected void auditResponseToNhin(COREEnvelopeBatchSubmission request, COREEnvelopeBatchSubmissionResponse oResponsse,
-        AssertionType assertion, Properties webContextProperties) {
-        getAuditLogger().auditResponseMessage(request, oResponsse, assertion, null,
+    protected void auditResponseToNhin(COREEnvelopeBatchSubmission request,
+        COREEnvelopeBatchSubmissionResponse oResponse, AssertionType assertion, Properties webContextProperties) {
+        getAuditLogger().auditResponseMessage(request, oResponse, assertion, null,
             NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE,
             webContextProperties, NhincConstants.CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME);
     }

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/inbound/AbstractInboundCORE_X12DSGenericBatchResponse.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/inbound/AbstractInboundCORE_X12DSGenericBatchResponse.java
@@ -53,8 +53,9 @@ public abstract class AbstractInboundCORE_X12DSGenericBatchResponse implements I
      * @param adapterFactory
      * @param auditLogger
      */
-    public AbstractInboundCORE_X12DSGenericBatchResponse(AdapterCORE_X12DSGenericBatchResponseProxyObjectFactory 
-        adapterFactory, CORE_X12BatchSubmissionAuditLogger auditLogger) {
+    public AbstractInboundCORE_X12DSGenericBatchResponse(
+        AdapterCORE_X12DSGenericBatchResponseProxyObjectFactory adapterFactory,
+        CORE_X12BatchSubmissionAuditLogger auditLogger) {
         oAdapterFactory = adapterFactory;
         this.auditLogger = auditLogger;
     }
@@ -95,7 +96,8 @@ public abstract class AbstractInboundCORE_X12DSGenericBatchResponse implements I
         COREEnvelopeBatchSubmissionResponse oResponse = null;
         try {
             CORE_X12DSLargePayloadUtils.convertDataToFileLocationIfEnabled(msg);
-            AdapterCORE_X12DGenericBatchResponseProxy oProxy = oAdapterFactory.getAdapterCORE_X12DocSubmissionProxy();
+            AdapterCORE_X12DGenericBatchResponseProxy oProxy
+                = getProxyObjectFactory().getAdapterCORE_X12DocSubmissionProxy();
             oResponse = oProxy.batchSubmitTransaction(msg, assertion);
             CORE_X12DSLargePayloadUtils.convertFileLocationToDataIfEnabled(oResponse);
         } catch (LargePayloadException e) {
@@ -104,10 +106,24 @@ public abstract class AbstractInboundCORE_X12DSGenericBatchResponse implements I
         return oResponse;
     }
 
-    protected void auditResponseToNhin(COREEnvelopeBatchSubmission request, COREEnvelopeBatchSubmissionResponse 
-        oResponsse, AssertionType assertion, Properties webContextProperties) {
-        auditLogger.auditResponseMessage(request, oResponsse, assertion, null,
+    protected void auditResponseToNhin(COREEnvelopeBatchSubmission request, COREEnvelopeBatchSubmissionResponse oResponsse,
+        AssertionType assertion, Properties webContextProperties) {
+        getAuditLogger().auditResponseMessage(request, oResponsse, assertion, null,
             NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE,
             webContextProperties, NhincConstants.CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME);
+    }
+
+    protected CORE_X12BatchSubmissionAuditLogger getAuditLogger() {
+        if (auditLogger == null) {
+            auditLogger = new CORE_X12BatchSubmissionAuditLogger();
+        }
+        return auditLogger;
+    }
+
+    protected AdapterCORE_X12DSGenericBatchResponseProxyObjectFactory getProxyObjectFactory() {
+        if (oAdapterFactory == null) {
+            oAdapterFactory = new AdapterCORE_X12DSGenericBatchResponseProxyObjectFactory();
+        }
+        return oAdapterFactory;
     }
 }

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/outbound/PassthroughOutboundCORE_X12DSGenericBatchResponse.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/outbound/PassthroughOutboundCORE_X12DSGenericBatchResponse.java
@@ -44,9 +44,11 @@ import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeBatchSubmissionResponse;
  */
 public class PassthroughOutboundCORE_X12DSGenericBatchResponse implements OutboundCORE_X12DSGenericBatchResponse {
 
-    private final OutboundCORE_X12DSGenericBatchResponseDelegate dsDelegate = 
-        new OutboundCORE_X12DSGenericBatchResponseDelegate();
-    private final CORE_X12BatchSubmissionAuditLogger auditLogger = new CORE_X12BatchSubmissionAuditLogger();
+    private OutboundCORE_X12DSGenericBatchResponseDelegate dsDelegate = null;
+    private CORE_X12BatchSubmissionAuditLogger auditLogger = null;
+
+    public PassthroughOutboundCORE_X12DSGenericBatchResponse() {
+    }
 
     /**
      *
@@ -63,10 +65,12 @@ public class PassthroughOutboundCORE_X12DSGenericBatchResponse implements Outbou
             convertFirstToNhinTargetSystemType(targets);
         this.auditRequestToNhin(msg, assertion, targetSystem);
         COREEnvelopeBatchSubmissionResponse oResponse;
-        OutboundCORE_X12DSGenericBatchResponseOrchestratable dsOrchestratable = createOrchestratable(dsDelegate, msg,
+        OutboundCORE_X12DSGenericBatchResponseDelegate localDelegate = getDelegate();
+        OutboundCORE_X12DSGenericBatchResponseOrchestratable dsOrchestratable = createOrchestratable(localDelegate, msg,
             targetSystem, assertion);
-        oResponse = ((OutboundCORE_X12DSGenericBatchResponseOrchestratable) 
-            dsDelegate.process(dsOrchestratable)).getResponse();
+        OutboundCORE_X12DSGenericBatchResponseOrchestratable orchResponse
+            = (OutboundCORE_X12DSGenericBatchResponseOrchestratable) localDelegate.process(dsOrchestratable);
+        oResponse = orchResponse.getResponse();
         return oResponse;
     }
 
@@ -78,12 +82,12 @@ public class PassthroughOutboundCORE_X12DSGenericBatchResponse implements Outbou
      * @param assertion
      * @return OutboundCORE_X12DSGenericBatchRequestOrchestratable
      */
-    public OutboundCORE_X12DSGenericBatchResponseOrchestratable createOrchestratable(
+    protected OutboundCORE_X12DSGenericBatchResponseOrchestratable createOrchestratable(
         OutboundCORE_X12DSGenericBatchResponseDelegate delegate, COREEnvelopeBatchSubmission request,
         NhinTargetSystemType targetSystem, AssertionType assertion) {
 
-        OutboundCORE_X12DSGenericBatchResponseOrchestratable core_x12dsOrchestratable = 
-            new OutboundCORE_X12DSGenericBatchResponseOrchestratable(delegate);
+        OutboundCORE_X12DSGenericBatchResponseOrchestratable core_x12dsOrchestratable
+            = new OutboundCORE_X12DSGenericBatchResponseOrchestratable(delegate);
         core_x12dsOrchestratable.setAssertion(assertion);
         core_x12dsOrchestratable.setRequest(request);
         core_x12dsOrchestratable.setTarget(targetSystem);
@@ -92,9 +96,22 @@ public class PassthroughOutboundCORE_X12DSGenericBatchResponse implements Outbou
 
     private void auditRequestToNhin(COREEnvelopeBatchSubmission body, AssertionType assertion,
         NhinTargetSystemType targetSystem) {
-        auditLogger.auditRequestMessage(body, assertion, targetSystem,
+        getAuditLogger().auditRequestMessage(body, assertion, targetSystem,
             NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE,
             Boolean.TRUE, null, NhincConstants.CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME);
     }
 
+    protected CORE_X12BatchSubmissionAuditLogger getAuditLogger() {
+        if (auditLogger == null) {
+            auditLogger = new CORE_X12BatchSubmissionAuditLogger();
+        }
+        return auditLogger;
+    }
+
+    protected OutboundCORE_X12DSGenericBatchResponseDelegate getDelegate() {
+        if (dsDelegate == null) {
+            dsDelegate = new OutboundCORE_X12DSGenericBatchResponseDelegate();
+        }
+        return dsDelegate;
+    }
 }

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/realtime/inbound/AbstractInboundCORE_X12DSRealTime.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/realtime/inbound/AbstractInboundCORE_X12DSRealTime.java
@@ -41,15 +41,15 @@ import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeRealTimeResponse;
  */
 public abstract class AbstractInboundCORE_X12DSRealTime implements InboundCORE_X12DSRealTime {
 
-    private AdapterCORE_X12DSRealTimeProxyObjectFactory adapterFactory;
-    private CORE_X12AuditLogger auditLogger;
+    private AdapterCORE_X12DSRealTimeProxyObjectFactory adapterFactory = null;
+    private CORE_X12AuditLogger auditLogger = null;
 
     /**
      *
      * @param adapterFactory
      * @param auditLogger
      */
-    public AbstractInboundCORE_X12DSRealTime(AdapterCORE_X12DSRealTimeProxyObjectFactory adapterFactory, 
+    public AbstractInboundCORE_X12DSRealTime(AdapterCORE_X12DSRealTimeProxyObjectFactory adapterFactory,
         CORE_X12AuditLogger auditLogger) {
         this.adapterFactory = adapterFactory;
         this.auditLogger = auditLogger;
@@ -72,7 +72,7 @@ public abstract class AbstractInboundCORE_X12DSRealTime implements InboundCORE_X
      * @return
      */
     @Override
-    public COREEnvelopeRealTimeResponse realTimeTransaction(COREEnvelopeRealTimeRequest msg, AssertionType assertion, 
+    public COREEnvelopeRealTimeResponse realTimeTransaction(COREEnvelopeRealTimeRequest msg, AssertionType assertion,
         Properties webContextProperties) {
         COREEnvelopeRealTimeResponse oResponsse = processCORE_X12DocSubmission(msg, assertion);
         auditResponseToNhin(msg, oResponsse, assertion, webContextProperties);
@@ -92,11 +92,17 @@ public abstract class AbstractInboundCORE_X12DSRealTime implements InboundCORE_X
         return proxy.realTimeTransaction(request, assertion);
     }
 
-    protected void auditResponseToNhin(COREEnvelopeRealTimeRequest request, COREEnvelopeRealTimeResponse oResponsse, 
+    protected void auditResponseToNhin(COREEnvelopeRealTimeRequest request, COREEnvelopeRealTimeResponse oResponsse,
         AssertionType assertion, Properties webContextProperties) {
-        auditLogger.auditResponseMessage(request, oResponsse, assertion, null, 
-            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE, 
+        getAuditLogger().auditResponseMessage(request, oResponsse, assertion, null,
+            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE,
             webContextProperties, NhincConstants.CORE_X12DS_REALTIME_SERVICE_NAME);
     }
 
+    protected CORE_X12AuditLogger getAuditLogger() {
+        if (auditLogger == null) {
+            auditLogger = new CORE_X12AuditLogger();
+        }
+        return auditLogger;
+    }
 }

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/realtime/outbound/PassthroughOutboundCORE_X12DSRealTime.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/realtime/outbound/PassthroughOutboundCORE_X12DSRealTime.java
@@ -76,8 +76,8 @@ public class PassthroughOutboundCORE_X12DSRealTime implements OutboundCORE_X12DS
         NhinTargetSystemType targetSystem = MessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(
             targets);
         this.auditRequestToNhin(body, assertion, targetSystem);
-        OutboundCORE_X12DSRealTimeOrchestratable dsOrchestratable = createOrchestratable(getDelegate(), body, targetSystem,
-            assertion);
+        OutboundCORE_X12DSRealTimeOrchestratable dsOrchestratable = createOrchestratable(getDelegate(), body,
+            targetSystem, assertion);
         COREEnvelopeRealTimeResponse response = ((OutboundCORE_X12DSRealTimeOrchestratable) getDelegate().process(
             dsOrchestratable)).getResponse();
         return response;

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/realtime/outbound/PassthroughOutboundCORE_X12DSRealTime.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/realtime/outbound/PassthroughOutboundCORE_X12DSRealTime.java
@@ -44,8 +44,8 @@ import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeRealTimeResponse;
  */
 public class PassthroughOutboundCORE_X12DSRealTime implements OutboundCORE_X12DSRealTime {
 
-    private OutboundCORE_X12DSRealTimeDelegate dsDelegate = new OutboundCORE_X12DSRealTimeDelegate();
-    private CORE_X12AuditLogger auditLogger = new CORE_X12AuditLogger();
+    private OutboundCORE_X12DSRealTimeDelegate dsDelegate = null;
+    private CORE_X12AuditLogger auditLogger = null;
 
     public PassthroughOutboundCORE_X12DSRealTime() {
         super();
@@ -56,7 +56,7 @@ public class PassthroughOutboundCORE_X12DSRealTime implements OutboundCORE_X12DS
      * @param dsDelegate
      * @param auditLogger
      */
-    public PassthroughOutboundCORE_X12DSRealTime(OutboundCORE_X12DSRealTimeDelegate dsDelegate, 
+    public PassthroughOutboundCORE_X12DSRealTime(OutboundCORE_X12DSRealTimeDelegate dsDelegate,
         CORE_X12AuditLogger auditLogger) {
         this.dsDelegate = dsDelegate;
         this.auditLogger = auditLogger;
@@ -76,18 +76,18 @@ public class PassthroughOutboundCORE_X12DSRealTime implements OutboundCORE_X12DS
         NhinTargetSystemType targetSystem = MessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(
             targets);
         this.auditRequestToNhin(body, assertion, targetSystem);
-        OutboundCORE_X12DSRealTimeOrchestratable dsOrchestratable = createOrchestratable(dsDelegate, body, targetSystem, 
+        OutboundCORE_X12DSRealTimeOrchestratable dsOrchestratable = createOrchestratable(getDelegate(), body, targetSystem,
             assertion);
-        COREEnvelopeRealTimeResponse response = ((OutboundCORE_X12DSRealTimeOrchestratable) 
-            dsDelegate.process(dsOrchestratable)).getResponse();
+        COREEnvelopeRealTimeResponse response = ((OutboundCORE_X12DSRealTimeOrchestratable) getDelegate().process(
+            dsOrchestratable)).getResponse();
         return response;
     }
 
     private OutboundCORE_X12DSRealTimeOrchestratable createOrchestratable(OutboundCORE_X12DSRealTimeDelegate delegate,
         COREEnvelopeRealTimeRequest request, NhinTargetSystemType targetSystem, AssertionType assertion) {
 
-        OutboundCORE_X12DSRealTimeOrchestratable core_x12dsOrchestratable = 
-            new OutboundCORE_X12DSRealTimeOrchestratable(delegate);
+        OutboundCORE_X12DSRealTimeOrchestratable core_x12dsOrchestratable
+            = new OutboundCORE_X12DSRealTimeOrchestratable(delegate);
         core_x12dsOrchestratable.setAssertion(assertion);
         core_x12dsOrchestratable.setRequest(request);
         core_x12dsOrchestratable.setTarget(targetSystem);
@@ -97,8 +97,21 @@ public class PassthroughOutboundCORE_X12DSRealTime implements OutboundCORE_X12DS
 
     private void auditRequestToNhin(COREEnvelopeRealTimeRequest body, AssertionType assertion,
         NhinTargetSystemType targetSystem) {
-        auditLogger.auditRequestMessage(body, assertion, targetSystem, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, 
-            NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE, null, 
-            NhincConstants.CORE_X12DS_REALTIME_SERVICE_NAME);
+        getAuditLogger().auditRequestMessage(body, assertion, targetSystem, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
+            NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE, null, NhincConstants.CORE_X12DS_REALTIME_SERVICE_NAME);
+    }
+
+    protected CORE_X12AuditLogger getAuditLogger() {
+        if (auditLogger == null) {
+            auditLogger = new CORE_X12AuditLogger();
+        }
+        return auditLogger;
+    }
+
+    protected OutboundCORE_X12DSRealTimeDelegate getDelegate() {
+        if (dsDelegate == null) {
+            dsDelegate = new OutboundCORE_X12DSRealTimeDelegate();
+        }
+        return dsDelegate;
     }
 }

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/request/inbound/PassthroughInboundCORE_X12DSGenericBatchReqTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/request/inbound/PassthroughInboundCORE_X12DSGenericBatchReqTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.corex12.docsubmission.genericbatch.request.inbound;
+
+import gov.hhs.fha.nhinc.audit.ejb.AuditEJBLogger;
+import gov.hhs.fha.nhinc.audit.ejb.impl.AuditEJBLoggerImpl;
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.corex12.docsubmission.audit.CORE_X12BatchSubmissionAuditLogger;
+import gov.hhs.fha.nhinc.corex12.docsubmission.audit.transform.COREX12BatchSubmissionAuditTransforms;
+import gov.hhs.fha.nhinc.corex12.docsubmission.genericbatch.request.adapter.proxy.AdapterCORE_X12DGenericBatchRequestProxy;
+import gov.hhs.fha.nhinc.corex12.docsubmission.genericbatch.request.adapter.proxy.AdapterCORE_X12DSGenericBatchRequestProxyObjectFactory;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import java.util.Properties;
+import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeBatchSubmission;
+import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeBatchSubmissionResponse;
+import org.junit.Test;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ *
+ * @author tjafri
+ */
+public class PassthroughInboundCORE_X12DSGenericBatchReqTest {
+
+    private final AuditEJBLoggerImpl mockEJBLogger = mock(AuditEJBLoggerImpl.class);
+    private final COREEnvelopeBatchSubmission request = new COREEnvelopeBatchSubmission();
+    private final AssertionType assertion = new AssertionType();
+    private final Properties webContextProperties = new Properties();
+    private final AdapterCORE_X12DSGenericBatchRequestProxyObjectFactory adpFactory
+        = mock(AdapterCORE_X12DSGenericBatchRequestProxyObjectFactory.class);
+    private final AdapterCORE_X12DGenericBatchRequestProxy reqProxy
+        = mock(AdapterCORE_X12DGenericBatchRequestProxy.class);
+
+    @Test
+    public void auditLoggingOnForInboundX12BatchRequest() {
+        final CORE_X12BatchSubmissionAuditLogger auditLogger = getAuditLogger(true);
+        COREEnvelopeBatchSubmissionResponse expectedResponse = new COREEnvelopeBatchSubmissionResponse();
+        when(adpFactory.getAdapterCORE_X12DocSubmissionProxy()).thenReturn(reqProxy);
+        when(reqProxy.batchSubmitTransaction(request, assertion)).thenReturn(expectedResponse);
+        PassthroughInboundCORE_X12DSGenericBatchRequest batchReq
+            = new PassthroughInboundCORE_X12DSGenericBatchRequest(adpFactory, auditLogger);
+        COREEnvelopeBatchSubmissionResponse actualResposne = batchReq.batchSubmitTransaction(
+            request, assertion, webContextProperties);
+        verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResposne),
+            eq(assertion), isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
+            eq(NhincConstants.CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME),
+            any(COREX12BatchSubmissionAuditTransforms.class));
+    }
+
+    @Test
+    public void auditLoggingOffForInboundX12BatchRequest() {
+        final CORE_X12BatchSubmissionAuditLogger auditLogger = getAuditLogger(false);
+        COREEnvelopeBatchSubmissionResponse expectedResponse = new COREEnvelopeBatchSubmissionResponse();
+        when(adpFactory.getAdapterCORE_X12DocSubmissionProxy()).thenReturn(reqProxy);
+        when(reqProxy.batchSubmitTransaction(request, assertion)).thenReturn(expectedResponse);
+
+        PassthroughInboundCORE_X12DSGenericBatchRequest batchReq
+            = new PassthroughInboundCORE_X12DSGenericBatchRequest(adpFactory, auditLogger);
+        COREEnvelopeBatchSubmissionResponse actualResposne = batchReq.batchSubmitTransaction(
+            request, assertion, webContextProperties);
+        verify(mockEJBLogger, never()).auditResponseMessage(eq(request), eq(actualResposne),
+            eq(assertion), isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
+            eq(NhincConstants.CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME),
+            any(COREX12BatchSubmissionAuditTransforms.class));
+    }
+
+    private CORE_X12BatchSubmissionAuditLogger getAuditLogger(final boolean isLoggingOn) {
+        return new CORE_X12BatchSubmissionAuditLogger() {
+            @Override
+            protected AuditEJBLogger getAuditLogger() {
+                return mockEJBLogger;
+            }
+
+            @Override
+            protected boolean isAuditLoggingOn(String serviceName) {
+                return isLoggingOn;
+            }
+        };
+    }
+}

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/request/inbound/PassthroughInboundCORE_X12DSGenericBatchReqTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/request/inbound/PassthroughInboundCORE_X12DSGenericBatchReqTest.java
@@ -61,17 +61,16 @@ public class PassthroughInboundCORE_X12DSGenericBatchReqTest {
         = mock(AdapterCORE_X12DSGenericBatchRequestProxyObjectFactory.class);
     private final AdapterCORE_X12DGenericBatchRequestProxy reqProxy
         = mock(AdapterCORE_X12DGenericBatchRequestProxy.class);
+    private final COREEnvelopeBatchSubmissionResponse expectedResponse = new COREEnvelopeBatchSubmissionResponse();
+    private COREEnvelopeBatchSubmissionResponse actualResposne = null;
+    private PassthroughInboundCORE_X12DSGenericBatchRequest batchReq = null;
 
     @Test
     public void auditLoggingOnForInboundX12BatchRequest() {
-        final CORE_X12BatchSubmissionAuditLogger auditLogger = getAuditLogger(true);
-        COREEnvelopeBatchSubmissionResponse expectedResponse = new COREEnvelopeBatchSubmissionResponse();
         when(adpFactory.getAdapterCORE_X12DocSubmissionProxy()).thenReturn(reqProxy);
         when(reqProxy.batchSubmitTransaction(request, assertion)).thenReturn(expectedResponse);
-        PassthroughInboundCORE_X12DSGenericBatchRequest batchReq
-            = new PassthroughInboundCORE_X12DSGenericBatchRequest(adpFactory, auditLogger);
-        COREEnvelopeBatchSubmissionResponse actualResposne = batchReq.batchSubmitTransaction(
-            request, assertion, webContextProperties);
+        batchReq = new PassthroughInboundCORE_X12DSGenericBatchRequest(adpFactory, getAuditLogger(true));
+        actualResposne = batchReq.batchSubmitTransaction(request, assertion, webContextProperties);
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResposne),
             eq(assertion), isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
@@ -81,15 +80,10 @@ public class PassthroughInboundCORE_X12DSGenericBatchReqTest {
 
     @Test
     public void auditLoggingOffForInboundX12BatchRequest() {
-        final CORE_X12BatchSubmissionAuditLogger auditLogger = getAuditLogger(false);
-        COREEnvelopeBatchSubmissionResponse expectedResponse = new COREEnvelopeBatchSubmissionResponse();
         when(adpFactory.getAdapterCORE_X12DocSubmissionProxy()).thenReturn(reqProxy);
         when(reqProxy.batchSubmitTransaction(request, assertion)).thenReturn(expectedResponse);
-
-        PassthroughInboundCORE_X12DSGenericBatchRequest batchReq
-            = new PassthroughInboundCORE_X12DSGenericBatchRequest(adpFactory, auditLogger);
-        COREEnvelopeBatchSubmissionResponse actualResposne = batchReq.batchSubmitTransaction(
-            request, assertion, webContextProperties);
+        batchReq = new PassthroughInboundCORE_X12DSGenericBatchRequest(adpFactory, getAuditLogger(false));
+        actualResposne = batchReq.batchSubmitTransaction(request, assertion, webContextProperties);
         verify(mockEJBLogger, never()).auditResponseMessage(eq(request), eq(actualResposne),
             eq(assertion), isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/request/outbound/PassthroughOutboundCORE_X12DSGenericBatchRequestTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/request/outbound/PassthroughOutboundCORE_X12DSGenericBatchRequestTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.corex12.docsubmission.genericbatch.request.outbound;
+
+import gov.hhs.fha.nhinc.audit.ejb.AuditEJBLogger;
+import gov.hhs.fha.nhinc.audit.ejb.impl.AuditEJBLoggerImpl;
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.common.nhinccommon.UrlInfoType;
+import gov.hhs.fha.nhinc.corex12.docsubmission.audit.CORE_X12BatchSubmissionAuditLogger;
+import gov.hhs.fha.nhinc.corex12.docsubmission.audit.transform.COREX12BatchSubmissionAuditTransforms;
+import gov.hhs.fha.nhinc.corex12.docsubmission.genericbatch.request.entity.OutboundCORE_X12DSGenericBatchRequestDelegate;
+import gov.hhs.fha.nhinc.corex12.docsubmission.genericbatch.request.entity.OutboundCORE_X12DSGenericBatchRequestOrchestratable;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import java.util.Properties;
+import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeBatchSubmission;
+import org.junit.Test;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+
+/**
+ *
+ * @author tjafri
+ */
+public class PassthroughOutboundCORE_X12DSGenericBatchRequestTest {
+
+    private final AuditEJBLoggerImpl mockEJBLogger = mock(AuditEJBLoggerImpl.class);
+    private final COREEnvelopeBatchSubmission msg = new COREEnvelopeBatchSubmission();
+    private final AssertionType assertion = new AssertionType();
+    private final NhinTargetCommunitiesType targets = new NhinTargetCommunitiesType();
+    private final UrlInfoType urlInfo = new UrlInfoType();
+    private final OutboundCORE_X12DSGenericBatchRequestDelegate mockDelegate
+        = mock(OutboundCORE_X12DSGenericBatchRequestDelegate.class);
+    private final OutboundCORE_X12DSGenericBatchRequestOrchestratable mockOrch
+        = mock(OutboundCORE_X12DSGenericBatchRequestOrchestratable.class);
+
+    @Test
+    public void auditLoggingOnForOutboundX12BatchRequest() {
+        final CORE_X12BatchSubmissionAuditLogger auditLogger = getAuditLogger(true);
+        PassthroughOutboundCORE_X12DSGenericBatchRequest x12BatchReq
+            = new PassthroughOutboundCORE_X12DSGenericBatchRequest(mockDelegate) {
+            @Override
+            protected CORE_X12BatchSubmissionAuditLogger getAuditLogger() {
+                return auditLogger;
+            }
+        };
+
+        when(mockDelegate.process(any(OutboundCORE_X12DSGenericBatchRequestOrchestratable.class))).thenReturn(mockOrch);
+        x12BatchReq.batchSubmitTransaction(msg, assertion, targets, urlInfo);
+        verify(mockEJBLogger).auditRequestMessage(eq(msg), eq(assertion), any(NhinTargetSystemType.class),
+            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
+            eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME),
+            any(COREX12BatchSubmissionAuditTransforms.class));
+    }
+
+    @Test
+    public void auditLoggingOffForOutboundX12BatchRequest() {
+        final CORE_X12BatchSubmissionAuditLogger auditLogger = getAuditLogger(false);
+        PassthroughOutboundCORE_X12DSGenericBatchRequest x12BatchReq
+            = new PassthroughOutboundCORE_X12DSGenericBatchRequest(mockDelegate) {
+            @Override
+            protected CORE_X12BatchSubmissionAuditLogger getAuditLogger() {
+                return auditLogger;
+            }
+        };
+
+        when(mockDelegate.process(any(OutboundCORE_X12DSGenericBatchRequestOrchestratable.class))).thenReturn(mockOrch);
+        x12BatchReq.batchSubmitTransaction(msg, assertion, targets, urlInfo);
+        verify(mockEJBLogger, never()).auditRequestMessage(eq(msg), eq(assertion), any(NhinTargetSystemType.class),
+            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
+            eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME),
+            any(COREX12BatchSubmissionAuditTransforms.class));
+    }
+
+    private CORE_X12BatchSubmissionAuditLogger getAuditLogger(final boolean isLoggingOn) {
+        return new CORE_X12BatchSubmissionAuditLogger() {
+            @Override
+            protected AuditEJBLogger getAuditLogger() {
+                return mockEJBLogger;
+            }
+
+            @Override
+            protected boolean isAuditLoggingOn(String serviceName) {
+                return isLoggingOn;
+            }
+        };
+    }
+}

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/request/outbound/PassthroughOutboundCORE_X12DSGenericBatchRequestTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/request/outbound/PassthroughOutboundCORE_X12DSGenericBatchRequestTest.java
@@ -66,15 +66,7 @@ public class PassthroughOutboundCORE_X12DSGenericBatchRequestTest {
 
     @Test
     public void auditLoggingOnForOutboundX12BatchRequest() {
-        final CORE_X12BatchSubmissionAuditLogger auditLogger = getAuditLogger(true);
-        PassthroughOutboundCORE_X12DSGenericBatchRequest x12BatchReq
-            = new PassthroughOutboundCORE_X12DSGenericBatchRequest(mockDelegate) {
-            @Override
-            protected CORE_X12BatchSubmissionAuditLogger getAuditLogger() {
-                return auditLogger;
-            }
-        };
-
+        PassthroughOutboundCORE_X12DSGenericBatchRequest x12BatchReq = createGenericBatchRequest(getAuditLogger(true));
         when(mockDelegate.process(any(OutboundCORE_X12DSGenericBatchRequestOrchestratable.class))).thenReturn(mockOrch);
         x12BatchReq.batchSubmitTransaction(msg, assertion, targets, urlInfo);
         verify(mockEJBLogger).auditRequestMessage(eq(msg), eq(assertion), any(NhinTargetSystemType.class),
@@ -85,15 +77,7 @@ public class PassthroughOutboundCORE_X12DSGenericBatchRequestTest {
 
     @Test
     public void auditLoggingOffForOutboundX12BatchRequest() {
-        final CORE_X12BatchSubmissionAuditLogger auditLogger = getAuditLogger(false);
-        PassthroughOutboundCORE_X12DSGenericBatchRequest x12BatchReq
-            = new PassthroughOutboundCORE_X12DSGenericBatchRequest(mockDelegate) {
-            @Override
-            protected CORE_X12BatchSubmissionAuditLogger getAuditLogger() {
-                return auditLogger;
-            }
-        };
-
+        PassthroughOutboundCORE_X12DSGenericBatchRequest x12BatchReq = createGenericBatchRequest(getAuditLogger(false));
         when(mockDelegate.process(any(OutboundCORE_X12DSGenericBatchRequestOrchestratable.class))).thenReturn(mockOrch);
         x12BatchReq.batchSubmitTransaction(msg, assertion, targets, urlInfo);
         verify(mockEJBLogger, never()).auditRequestMessage(eq(msg), eq(assertion), any(NhinTargetSystemType.class),
@@ -114,5 +98,16 @@ public class PassthroughOutboundCORE_X12DSGenericBatchRequestTest {
                 return isLoggingOn;
             }
         };
+    }
+
+    private PassthroughOutboundCORE_X12DSGenericBatchRequest createGenericBatchRequest(
+        final CORE_X12BatchSubmissionAuditLogger auditLogger) {
+        return new PassthroughOutboundCORE_X12DSGenericBatchRequest(mockDelegate) {
+            @Override
+            protected CORE_X12BatchSubmissionAuditLogger getAuditLogger() {
+                return auditLogger;
+            }
+        };
+
     }
 }

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/inbound/PassthroughInboundCORE_X12DSGenericBatchResponseTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/inbound/PassthroughInboundCORE_X12DSGenericBatchResponseTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.corex12.docsubmission.genericbatch.response.inbound;
+
+import gov.hhs.fha.nhinc.audit.ejb.AuditEJBLogger;
+import gov.hhs.fha.nhinc.audit.ejb.impl.AuditEJBLoggerImpl;
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.corex12.docsubmission.audit.CORE_X12BatchSubmissionAuditLogger;
+import gov.hhs.fha.nhinc.corex12.docsubmission.audit.transform.COREX12BatchSubmissionAuditTransforms;
+import gov.hhs.fha.nhinc.corex12.docsubmission.genericbatch.response.adapter.proxy.AdapterCORE_X12DGenericBatchResponseProxy;
+import gov.hhs.fha.nhinc.corex12.docsubmission.genericbatch.response.adapter.proxy.AdapterCORE_X12DSGenericBatchResponseProxyObjectFactory;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import java.util.Properties;
+import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeBatchSubmission;
+import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeBatchSubmissionResponse;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ *
+ * @author tjafri
+ */
+public class PassthroughInboundCORE_X12DSGenericBatchResponseTest {
+
+    private final AuditEJBLoggerImpl mockEJBLogger = mock(AuditEJBLoggerImpl.class);
+
+    @Test
+    public void auditLoggingOnForInboundX12BatchResponseTest() {
+        AdapterCORE_X12DSGenericBatchResponseProxyObjectFactory mockFactory
+            = mock(AdapterCORE_X12DSGenericBatchResponseProxyObjectFactory.class);
+        PassthroughInboundCORE_X12DSGenericBatchResponse inboundResp
+            = new PassthroughInboundCORE_X12DSGenericBatchResponse(mockFactory, getAuditLogger(true));
+        AdapterCORE_X12DGenericBatchResponseProxy mockResponseProxy
+            = mock(AdapterCORE_X12DGenericBatchResponseProxy.class);
+        COREEnvelopeBatchSubmission request = new COREEnvelopeBatchSubmission();
+        COREEnvelopeBatchSubmissionResponse expectedResponse = new COREEnvelopeBatchSubmissionResponse();
+        AssertionType assertion = new AssertionType();
+        Properties webContextProperties = new Properties();
+        when(mockFactory.getAdapterCORE_X12DocSubmissionProxy()).thenReturn(mockResponseProxy);
+        when(mockResponseProxy.batchSubmitTransaction(eq(request), eq(assertion))).thenReturn(expectedResponse);
+
+        COREEnvelopeBatchSubmissionResponse actualResponse = inboundResp.batchSubmitTransaction(request, assertion,
+            webContextProperties);
+
+        assertEquals("Actual and Expected response differ", actualResponse, expectedResponse);
+        verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
+            eq(NhincConstants.CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME), any(COREX12BatchSubmissionAuditTransforms.class));
+    }
+
+    @Test
+    public void auditLoggingOffForInboundX12BatchResponseTest() {
+        AdapterCORE_X12DSGenericBatchResponseProxyObjectFactory mockFactory
+            = mock(AdapterCORE_X12DSGenericBatchResponseProxyObjectFactory.class);
+        PassthroughInboundCORE_X12DSGenericBatchResponse inboundResp
+            = new PassthroughInboundCORE_X12DSGenericBatchResponse(mockFactory, getAuditLogger(false));
+        AdapterCORE_X12DGenericBatchResponseProxy mockResponseProxy
+            = mock(AdapterCORE_X12DGenericBatchResponseProxy.class);
+        COREEnvelopeBatchSubmission request = new COREEnvelopeBatchSubmission();
+        COREEnvelopeBatchSubmissionResponse expectedResponse = new COREEnvelopeBatchSubmissionResponse();
+        AssertionType assertion = new AssertionType();
+        Properties webContextProperties = new Properties();
+        when(mockFactory.getAdapterCORE_X12DocSubmissionProxy()).thenReturn(mockResponseProxy);
+        when(mockResponseProxy.batchSubmitTransaction(eq(request), eq(assertion))).thenReturn(expectedResponse);
+
+        COREEnvelopeBatchSubmissionResponse actualResponse = inboundResp.batchSubmitTransaction(request, assertion,
+            webContextProperties);
+
+        assertEquals("Actual and Expected response differ", actualResponse, expectedResponse);
+        verify(mockEJBLogger, never()).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
+            eq(NhincConstants.CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME), any(COREX12BatchSubmissionAuditTransforms.class));
+    }
+
+    private CORE_X12BatchSubmissionAuditLogger getAuditLogger(final boolean isLoggingOn) {
+        return new CORE_X12BatchSubmissionAuditLogger() {
+            @Override
+            protected AuditEJBLogger getAuditLogger() {
+                return mockEJBLogger;
+            }
+
+            @Override
+            protected boolean isAuditLoggingOn(String serviceName) {
+                return isLoggingOn;
+            }
+        };
+    }
+}

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/inbound/PassthroughInboundCORE_X12DSGenericBatchResponseTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/inbound/PassthroughInboundCORE_X12DSGenericBatchResponseTest.java
@@ -55,19 +55,19 @@ import static org.mockito.Mockito.when;
 public class PassthroughInboundCORE_X12DSGenericBatchResponseTest {
 
     private final AuditEJBLoggerImpl mockEJBLogger = mock(AuditEJBLoggerImpl.class);
+    private final AdapterCORE_X12DSGenericBatchResponseProxyObjectFactory mockFactory
+        = mock(AdapterCORE_X12DSGenericBatchResponseProxyObjectFactory.class);
+    private final AdapterCORE_X12DGenericBatchResponseProxy mockResponseProxy
+        = mock(AdapterCORE_X12DGenericBatchResponseProxy.class);
+    private final COREEnvelopeBatchSubmission request = new COREEnvelopeBatchSubmission();
+    private final AssertionType assertion = new AssertionType();
+    private final Properties webContextProperties = new Properties();
 
     @Test
     public void auditLoggingOnForInboundX12BatchResponseTest() {
-        AdapterCORE_X12DSGenericBatchResponseProxyObjectFactory mockFactory
-            = mock(AdapterCORE_X12DSGenericBatchResponseProxyObjectFactory.class);
         PassthroughInboundCORE_X12DSGenericBatchResponse inboundResp
             = new PassthroughInboundCORE_X12DSGenericBatchResponse(mockFactory, getAuditLogger(true));
-        AdapterCORE_X12DGenericBatchResponseProxy mockResponseProxy
-            = mock(AdapterCORE_X12DGenericBatchResponseProxy.class);
-        COREEnvelopeBatchSubmission request = new COREEnvelopeBatchSubmission();
         COREEnvelopeBatchSubmissionResponse expectedResponse = new COREEnvelopeBatchSubmissionResponse();
-        AssertionType assertion = new AssertionType();
-        Properties webContextProperties = new Properties();
         when(mockFactory.getAdapterCORE_X12DocSubmissionProxy()).thenReturn(mockResponseProxy);
         when(mockResponseProxy.batchSubmitTransaction(eq(request), eq(assertion))).thenReturn(expectedResponse);
 
@@ -83,16 +83,9 @@ public class PassthroughInboundCORE_X12DSGenericBatchResponseTest {
 
     @Test
     public void auditLoggingOffForInboundX12BatchResponseTest() {
-        AdapterCORE_X12DSGenericBatchResponseProxyObjectFactory mockFactory
-            = mock(AdapterCORE_X12DSGenericBatchResponseProxyObjectFactory.class);
         PassthroughInboundCORE_X12DSGenericBatchResponse inboundResp
             = new PassthroughInboundCORE_X12DSGenericBatchResponse(mockFactory, getAuditLogger(false));
-        AdapterCORE_X12DGenericBatchResponseProxy mockResponseProxy
-            = mock(AdapterCORE_X12DGenericBatchResponseProxy.class);
-        COREEnvelopeBatchSubmission request = new COREEnvelopeBatchSubmission();
         COREEnvelopeBatchSubmissionResponse expectedResponse = new COREEnvelopeBatchSubmissionResponse();
-        AssertionType assertion = new AssertionType();
-        Properties webContextProperties = new Properties();
         when(mockFactory.getAdapterCORE_X12DocSubmissionProxy()).thenReturn(mockResponseProxy);
         when(mockResponseProxy.batchSubmitTransaction(eq(request), eq(assertion))).thenReturn(expectedResponse);
 

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/outbound/PassthroughOutboundCORE_X12DSGenericBatchResponseTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/outbound/PassthroughOutboundCORE_X12DSGenericBatchResponseTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.corex12.docsubmission.genericbatch.response.outbound;
+
+import gov.hhs.fha.nhinc.audit.ejb.AuditEJBLogger;
+import gov.hhs.fha.nhinc.audit.ejb.impl.AuditEJBLoggerImpl;
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.common.nhinccommon.UrlInfoType;
+import gov.hhs.fha.nhinc.corex12.docsubmission.audit.CORE_X12BatchSubmissionAuditLogger;
+import gov.hhs.fha.nhinc.corex12.docsubmission.audit.transform.COREX12BatchSubmissionAuditTransforms;
+import gov.hhs.fha.nhinc.corex12.docsubmission.genericbatch.response.entity.OutboundCORE_X12DSGenericBatchResponseDelegate;
+import gov.hhs.fha.nhinc.corex12.docsubmission.genericbatch.response.entity.OutboundCORE_X12DSGenericBatchResponseOrchestratable;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.orchestration.OutboundOrchestratable;
+import java.util.Properties;
+import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeBatchSubmission;
+import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeBatchSubmissionResponse;
+import org.junit.Test;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ *
+ * @author tjafri
+ */
+public class PassthroughOutboundCORE_X12DSGenericBatchResponseTest {
+
+    private final AuditEJBLoggerImpl mockEJBLogger = mock(AuditEJBLoggerImpl.class);
+    OutboundCORE_X12DSGenericBatchResponseOrchestratable mockOrchestratable
+        = mock(OutboundCORE_X12DSGenericBatchResponseOrchestratable.class);
+    OutboundCORE_X12DSGenericBatchResponseDelegate mockDelegate
+        = mock(OutboundCORE_X12DSGenericBatchResponseDelegate.class);
+
+    @Test
+    public void auditLoggingOffForOutboundX12BatchResponse() {
+        COREEnvelopeBatchSubmission request = new COREEnvelopeBatchSubmission();
+        AssertionType assertion = new AssertionType();
+        NhinTargetCommunitiesType targets = new NhinTargetCommunitiesType();
+        UrlInfoType urlInfo = new UrlInfoType();
+        COREEnvelopeBatchSubmissionResponse successResponse = new COREEnvelopeBatchSubmissionResponse();
+        PassthroughOutboundCORE_X12DSGenericBatchResponse batchResp = createPassthruOutboundBatchResponse(
+            getAuditLogger(false));
+        when(mockOrchestratable.getResponse()).thenReturn(successResponse);
+        when(mockDelegate.process(any(OutboundOrchestratable.class))).thenReturn(mockOrchestratable);
+        batchResp.batchSubmitTransaction(request, assertion, targets, urlInfo);
+        verify(mockEJBLogger, never()).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
+            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE),
+            isNull(Properties.class), eq(NhincConstants.CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME),
+            any(COREX12BatchSubmissionAuditTransforms.class));
+    }
+
+    @Test
+    public void auditLoggingOnForOutboundX12BatchResponse() {
+        COREEnvelopeBatchSubmission request = new COREEnvelopeBatchSubmission();
+        AssertionType assertion = new AssertionType();
+        NhinTargetCommunitiesType targets = new NhinTargetCommunitiesType();
+        UrlInfoType urlInfo = new UrlInfoType();
+        COREEnvelopeBatchSubmissionResponse successResponse = new COREEnvelopeBatchSubmissionResponse();
+        PassthroughOutboundCORE_X12DSGenericBatchResponse batchResp = createPassthruOutboundBatchResponse(
+            getAuditLogger(true));
+        when(mockOrchestratable.getResponse()).thenReturn(successResponse);
+        when(mockDelegate.process(any(OutboundOrchestratable.class))).thenReturn(mockOrchestratable);
+        batchResp.batchSubmitTransaction(request, assertion, targets, urlInfo);
+        verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
+            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE),
+            isNull(Properties.class), eq(NhincConstants.CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME),
+            any(COREX12BatchSubmissionAuditTransforms.class));
+    }
+
+    private CORE_X12BatchSubmissionAuditLogger getAuditLogger(final boolean isLoggingOn) {
+        return new CORE_X12BatchSubmissionAuditLogger() {
+            @Override
+            protected AuditEJBLogger getAuditLogger() {
+                return mockEJBLogger;
+            }
+
+            @Override
+            protected boolean isAuditLoggingOn(String serviceName) {
+                return isLoggingOn;
+            }
+        };
+    }
+
+    private PassthroughOutboundCORE_X12DSGenericBatchResponse createPassthruOutboundBatchResponse(
+        final CORE_X12BatchSubmissionAuditLogger auditLogger) {
+        return new PassthroughOutboundCORE_X12DSGenericBatchResponse() {
+            @Override
+            protected CORE_X12BatchSubmissionAuditLogger getAuditLogger() {
+                return auditLogger;
+            }
+
+            @Override
+            protected OutboundCORE_X12DSGenericBatchResponseDelegate getDelegate() {
+                return mockDelegate;
+            }
+
+            @Override
+            protected OutboundCORE_X12DSGenericBatchResponseOrchestratable createOrchestratable(
+                OutboundCORE_X12DSGenericBatchResponseDelegate delegate, COREEnvelopeBatchSubmission request,
+                NhinTargetSystemType targetSystem, AssertionType assertion) {
+                return mockOrchestratable;
+            }
+        };
+    }
+}

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/outbound/PassthroughOutboundCORE_X12DSGenericBatchResponseTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/outbound/PassthroughOutboundCORE_X12DSGenericBatchResponseTest.java
@@ -57,17 +57,17 @@ import static org.mockito.Mockito.when;
 public class PassthroughOutboundCORE_X12DSGenericBatchResponseTest {
 
     private final AuditEJBLoggerImpl mockEJBLogger = mock(AuditEJBLoggerImpl.class);
-    OutboundCORE_X12DSGenericBatchResponseOrchestratable mockOrchestratable
+    private final OutboundCORE_X12DSGenericBatchResponseOrchestratable mockOrchestratable
         = mock(OutboundCORE_X12DSGenericBatchResponseOrchestratable.class);
-    OutboundCORE_X12DSGenericBatchResponseDelegate mockDelegate
+    private final OutboundCORE_X12DSGenericBatchResponseDelegate mockDelegate
         = mock(OutboundCORE_X12DSGenericBatchResponseDelegate.class);
+    private final AssertionType assertion = new AssertionType();
+    private final NhinTargetCommunitiesType targets = new NhinTargetCommunitiesType();
+    private final UrlInfoType urlInfo = new UrlInfoType();
 
     @Test
     public void auditLoggingOffForOutboundX12BatchResponse() {
         COREEnvelopeBatchSubmission request = new COREEnvelopeBatchSubmission();
-        AssertionType assertion = new AssertionType();
-        NhinTargetCommunitiesType targets = new NhinTargetCommunitiesType();
-        UrlInfoType urlInfo = new UrlInfoType();
         COREEnvelopeBatchSubmissionResponse successResponse = new COREEnvelopeBatchSubmissionResponse();
         PassthroughOutboundCORE_X12DSGenericBatchResponse batchResp = createPassthruOutboundBatchResponse(
             getAuditLogger(false));
@@ -83,9 +83,6 @@ public class PassthroughOutboundCORE_X12DSGenericBatchResponseTest {
     @Test
     public void auditLoggingOnForOutboundX12BatchResponse() {
         COREEnvelopeBatchSubmission request = new COREEnvelopeBatchSubmission();
-        AssertionType assertion = new AssertionType();
-        NhinTargetCommunitiesType targets = new NhinTargetCommunitiesType();
-        UrlInfoType urlInfo = new UrlInfoType();
         COREEnvelopeBatchSubmissionResponse successResponse = new COREEnvelopeBatchSubmissionResponse();
         PassthroughOutboundCORE_X12DSGenericBatchResponse batchResp = createPassthruOutboundBatchResponse(
             getAuditLogger(true));

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/outbound/PassthroughOutboundCORE_X12DSGenericBatchResponseTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/outbound/PassthroughOutboundCORE_X12DSGenericBatchResponseTest.java
@@ -64,13 +64,13 @@ public class PassthroughOutboundCORE_X12DSGenericBatchResponseTest {
     private final AssertionType assertion = new AssertionType();
     private final NhinTargetCommunitiesType targets = new NhinTargetCommunitiesType();
     private final UrlInfoType urlInfo = new UrlInfoType();
+    private final COREEnvelopeBatchSubmission request = new COREEnvelopeBatchSubmission();
+    private final COREEnvelopeBatchSubmissionResponse successResponse = new COREEnvelopeBatchSubmissionResponse();
+    private PassthroughOutboundCORE_X12DSGenericBatchResponse batchResp = null;
 
     @Test
     public void auditLoggingOffForOutboundX12BatchResponse() {
-        COREEnvelopeBatchSubmission request = new COREEnvelopeBatchSubmission();
-        COREEnvelopeBatchSubmissionResponse successResponse = new COREEnvelopeBatchSubmissionResponse();
-        PassthroughOutboundCORE_X12DSGenericBatchResponse batchResp = createPassthruOutboundBatchResponse(
-            getAuditLogger(false));
+        batchResp = createPassthruOutboundBatchResponse(getAuditLogger(false));
         when(mockOrchestratable.getResponse()).thenReturn(successResponse);
         when(mockDelegate.process(any(OutboundOrchestratable.class))).thenReturn(mockOrchestratable);
         batchResp.batchSubmitTransaction(request, assertion, targets, urlInfo);
@@ -82,10 +82,7 @@ public class PassthroughOutboundCORE_X12DSGenericBatchResponseTest {
 
     @Test
     public void auditLoggingOnForOutboundX12BatchResponse() {
-        COREEnvelopeBatchSubmission request = new COREEnvelopeBatchSubmission();
-        COREEnvelopeBatchSubmissionResponse successResponse = new COREEnvelopeBatchSubmissionResponse();
-        PassthroughOutboundCORE_X12DSGenericBatchResponse batchResp = createPassthruOutboundBatchResponse(
-            getAuditLogger(true));
+        batchResp = createPassthruOutboundBatchResponse(getAuditLogger(true));
         when(mockOrchestratable.getResponse()).thenReturn(successResponse);
         when(mockDelegate.process(any(OutboundOrchestratable.class))).thenReturn(mockOrchestratable);
         batchResp.batchSubmitTransaction(request, assertion, targets, urlInfo);

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/realtime/inbound/PassthroughInboundCORE_X12DSRealTimeTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/realtime/inbound/PassthroughInboundCORE_X12DSRealTimeTest.java
@@ -54,16 +54,17 @@ import static org.mockito.Mockito.when;
 public class PassthroughInboundCORE_X12DSRealTimeTest {
 
     private final AuditEJBLoggerImpl mockEJBLogger = mock(AuditEJBLoggerImpl.class);
+    private final AdapterCORE_X12DSRealTimeProxyObjectFactory mockFactory
+        = mock(AdapterCORE_X12DSRealTimeProxyObjectFactory.class);
+    private final AdapterCORE_X12DSRealTimeProxy mockAdapterProxy = mock(AdapterCORE_X12DSRealTimeProxy.class);
+    private final COREEnvelopeRealTimeRequest request = new COREEnvelopeRealTimeRequest();
+    private final AssertionType assertion = new AssertionType();
+    private final Properties webContextProperties = new Properties();
 
     @Test
     public void auditLoggingOnForInboundRealTime() {
-        AdapterCORE_X12DSRealTimeProxyObjectFactory mockFactory = mock(AdapterCORE_X12DSRealTimeProxyObjectFactory.class);
         PassthroughInboundCORE_X12DSRealTime realTimeX12
             = new PassthroughInboundCORE_X12DSRealTime(mockFactory, getAuditLogger(true));
-        COREEnvelopeRealTimeRequest request = new COREEnvelopeRealTimeRequest();
-        AssertionType assertion = new AssertionType();
-        Properties webContextProperties = new Properties();
-        AdapterCORE_X12DSRealTimeProxy mockAdapterProxy = mock(AdapterCORE_X12DSRealTimeProxy.class);
         when(mockFactory.getAdapterCORE_X12DocSubmissionProxy()).thenReturn(mockAdapterProxy);
         COREEnvelopeRealTimeResponse expectedResponse = new COREEnvelopeRealTimeResponse();
         when(mockAdapterProxy.realTimeTransaction(request, assertion)).thenReturn(expectedResponse);
@@ -77,13 +78,9 @@ public class PassthroughInboundCORE_X12DSRealTimeTest {
 
     @Test
     public void auditLoggingOffForInboundRealTime() {
-        AdapterCORE_X12DSRealTimeProxyObjectFactory mockFactory = mock(AdapterCORE_X12DSRealTimeProxyObjectFactory.class);
         PassthroughInboundCORE_X12DSRealTime realTimeX12
             = new PassthroughInboundCORE_X12DSRealTime(mockFactory, getAuditLogger(false));
-        COREEnvelopeRealTimeRequest request = new COREEnvelopeRealTimeRequest();
-        AssertionType assertion = new AssertionType();
-        Properties webContextProperties = new Properties();
-        AdapterCORE_X12DSRealTimeProxy mockAdapterProxy = mock(AdapterCORE_X12DSRealTimeProxy.class);
+
         when(mockFactory.getAdapterCORE_X12DocSubmissionProxy()).thenReturn(mockAdapterProxy);
         COREEnvelopeRealTimeResponse expectedResponse = new COREEnvelopeRealTimeResponse();
         when(mockAdapterProxy.realTimeTransaction(request, assertion)).thenReturn(expectedResponse);

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/realtime/outbound/PassthroughOutboundCORE_X12DSRealTimeTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/realtime/outbound/PassthroughOutboundCORE_X12DSRealTimeTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.corex12.docsubmission.realtime.outbound;
+
+import gov.hhs.fha.nhinc.audit.ejb.AuditEJBLogger;
+import gov.hhs.fha.nhinc.audit.ejb.impl.AuditEJBLoggerImpl;
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunityType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.common.nhinccommon.UrlInfoType;
+import gov.hhs.fha.nhinc.corex12.docsubmission.audit.CORE_X12AuditLogger;
+import gov.hhs.fha.nhinc.corex12.docsubmission.audit.transform.COREX12RealTimeAuditTransforms;
+import gov.hhs.fha.nhinc.corex12.docsubmission.realtime.entity.OutboundCORE_X12DSRealTimeDelegate;
+import gov.hhs.fha.nhinc.corex12.docsubmission.realtime.entity.OutboundCORE_X12DSRealTimeOrchestratable;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.orchestration.OutboundOrchestratable;
+import java.util.Properties;
+import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeRealTimeRequest;
+import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeRealTimeResponse;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ *
+ * @author tjafri
+ */
+public class PassthroughOutboundCORE_X12DSRealTimeTest {
+
+    private final AuditEJBLoggerImpl mockEJBLogger = mock(AuditEJBLoggerImpl.class);
+
+    @Test
+    public void auditLoggingOnForOutboundRealTime() {
+        COREEnvelopeRealTimeRequest request = new COREEnvelopeRealTimeRequest();
+        AssertionType assertion = new AssertionType();
+        UrlInfoType urlInfo = new UrlInfoType();
+        OutboundCORE_X12DSRealTimeOrchestratable mockOrch = mock(OutboundCORE_X12DSRealTimeOrchestratable.class);
+        OutboundCORE_X12DSRealTimeDelegate mockDelegate = mock(OutboundCORE_X12DSRealTimeDelegate.class);
+        COREEnvelopeRealTimeResponse expectedResponse = new COREEnvelopeRealTimeResponse();
+        PassthroughOutboundCORE_X12DSRealTime realTime = new PassthroughOutboundCORE_X12DSRealTime(
+            mockDelegate, getAuditLogger(true));
+        when(mockDelegate.process(any(OutboundOrchestratable.class))).thenReturn(mockOrch);
+        when(mockOrch.getResponse()).thenReturn(expectedResponse);
+        COREEnvelopeRealTimeResponse actualResponse = realTime.realTimeTransaction(request, assertion,
+            createNhinTargetCommunities(), urlInfo);
+        assertEquals("Actual and Expected Response differ", expectedResponse, actualResponse);
+        verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
+            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
+            eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.CORE_X12DS_REALTIME_SERVICE_NAME),
+            any(COREX12RealTimeAuditTransforms.class));
+    }
+
+    @Test
+    public void auditLoggingOffForOutboundRealTime() {
+        COREEnvelopeRealTimeRequest request = new COREEnvelopeRealTimeRequest();
+        AssertionType assertion = new AssertionType();
+        UrlInfoType urlInfo = new UrlInfoType();
+        OutboundCORE_X12DSRealTimeOrchestratable mockOrch = mock(OutboundCORE_X12DSRealTimeOrchestratable.class);
+        OutboundCORE_X12DSRealTimeDelegate mockDelegate = mock(OutboundCORE_X12DSRealTimeDelegate.class);
+        COREEnvelopeRealTimeResponse expectedResponse = new COREEnvelopeRealTimeResponse();
+        PassthroughOutboundCORE_X12DSRealTime realTime = new PassthroughOutboundCORE_X12DSRealTime(
+            mockDelegate, getAuditLogger(false));
+        when(mockDelegate.process(any(OutboundOrchestratable.class))).thenReturn(mockOrch);
+        when(mockOrch.getResponse()).thenReturn(expectedResponse);
+        COREEnvelopeRealTimeResponse actualResponse = realTime.realTimeTransaction(request, assertion,
+            createNhinTargetCommunities(), urlInfo);
+        assertEquals("Actual and Expected Response differ", expectedResponse, actualResponse);
+        verify(mockEJBLogger, never()).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
+            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
+            eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.CORE_X12DS_REALTIME_SERVICE_NAME),
+            any(COREX12RealTimeAuditTransforms.class));
+    }
+
+    private CORE_X12AuditLogger getAuditLogger(final boolean isLoggingOn) {
+        return new CORE_X12AuditLogger() {
+            @Override
+            protected AuditEJBLogger getAuditLogger() {
+                return mockEJBLogger;
+            }
+
+            @Override
+            protected boolean isAuditLoggingOn(String serviceName) {
+                return isLoggingOn;
+            }
+        };
+    }
+
+    private NhinTargetCommunitiesType createNhinTargetCommunities() {
+        NhinTargetCommunitiesType targets = new NhinTargetCommunitiesType();
+        NhinTargetCommunityType target = new NhinTargetCommunityType();
+        HomeCommunityType home = new HomeCommunityType();
+        home.setHomeCommunityId("1.1");
+        target.setHomeCommunity(home);
+        targets.getNhinTargetCommunity().add(target);
+        return targets;
+    }
+
+}

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/realtime/outbound/PassthroughOutboundCORE_X12DSRealTimeTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/realtime/outbound/PassthroughOutboundCORE_X12DSRealTimeTest.java
@@ -60,14 +60,14 @@ import static org.mockito.Mockito.when;
 public class PassthroughOutboundCORE_X12DSRealTimeTest {
 
     private final AuditEJBLoggerImpl mockEJBLogger = mock(AuditEJBLoggerImpl.class);
+    private final COREEnvelopeRealTimeRequest request = new COREEnvelopeRealTimeRequest();
+    private final AssertionType assertion = new AssertionType();
+    private final UrlInfoType urlInfo = new UrlInfoType();
+    private final OutboundCORE_X12DSRealTimeOrchestratable mockOrch = mock(OutboundCORE_X12DSRealTimeOrchestratable.class);
+    private final OutboundCORE_X12DSRealTimeDelegate mockDelegate = mock(OutboundCORE_X12DSRealTimeDelegate.class);
 
     @Test
     public void auditLoggingOnForOutboundRealTime() {
-        COREEnvelopeRealTimeRequest request = new COREEnvelopeRealTimeRequest();
-        AssertionType assertion = new AssertionType();
-        UrlInfoType urlInfo = new UrlInfoType();
-        OutboundCORE_X12DSRealTimeOrchestratable mockOrch = mock(OutboundCORE_X12DSRealTimeOrchestratable.class);
-        OutboundCORE_X12DSRealTimeDelegate mockDelegate = mock(OutboundCORE_X12DSRealTimeDelegate.class);
         COREEnvelopeRealTimeResponse expectedResponse = new COREEnvelopeRealTimeResponse();
         PassthroughOutboundCORE_X12DSRealTime realTime = new PassthroughOutboundCORE_X12DSRealTime(
             mockDelegate, getAuditLogger(true));
@@ -84,11 +84,6 @@ public class PassthroughOutboundCORE_X12DSRealTimeTest {
 
     @Test
     public void auditLoggingOffForOutboundRealTime() {
-        COREEnvelopeRealTimeRequest request = new COREEnvelopeRealTimeRequest();
-        AssertionType assertion = new AssertionType();
-        UrlInfoType urlInfo = new UrlInfoType();
-        OutboundCORE_X12DSRealTimeOrchestratable mockOrch = mock(OutboundCORE_X12DSRealTimeOrchestratable.class);
-        OutboundCORE_X12DSRealTimeDelegate mockDelegate = mock(OutboundCORE_X12DSRealTimeDelegate.class);
         COREEnvelopeRealTimeResponse expectedResponse = new COREEnvelopeRealTimeResponse();
         PassthroughOutboundCORE_X12DSRealTime realTime = new PassthroughOutboundCORE_X12DSRealTime(
             mockDelegate, getAuditLogger(false));

--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/inbound/PassthroughInboundDocQueryTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/inbound/PassthroughInboundDocQueryTest.java
@@ -27,8 +27,18 @@
 package gov.hhs.fha.nhinc.docquery.inbound;
 
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.docquery.audit.transform.DocQueryAuditTransforms;
+import static gov.hhs.fha.nhinc.docquery.inbound.InboundDocQueryTest.request;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import java.util.Properties;
+import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryResponse;
 
 import org.junit.Test;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.verify;
 
 /**
  * @author akong
@@ -51,13 +61,11 @@ public class PassthroughInboundDocQueryTest extends InboundDocQueryTest {
     private void passthroughInboundDocQueryHomeHcid(String sendingHcid, String sendingHcidFormatted) {
 
         AssertionType mockAssertion = getMockAssertion(sendingHcid);
-
         PassthroughInboundDocQuery passthroughDocQuery = new PassthroughInboundDocQuery(
-                getMockAdapterFactory(mockAssertion), mockAuditLogger);
+            getMockAdapterFactory(mockAssertion), getAuditLogger(true));
 
         verifyInboundDocQuery(mockAssertion, sendingHcidFormatted, passthroughDocQuery,
-                NUM_TIMES_TO_INVOKE_ADAPTER_AUDIT);
-
+            NUM_TIMES_TO_INVOKE_ADAPTER_AUDIT);
     }
 
 }

--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/inbound/StandardInboundDocQueryTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/inbound/StandardInboundDocQueryTest.java
@@ -33,12 +33,14 @@ import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.docquery.adapter.proxy.AdapterDocQueryProxy;
 import gov.hhs.fha.nhinc.docquery.adapter.proxy.AdapterDocQueryProxyObjectFactory;
+import gov.hhs.fha.nhinc.docquery.audit.transform.DocQueryAuditTransforms;
 import gov.hhs.fha.nhinc.document.DocumentConstants;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import java.util.Properties;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryResponse;
 
 import org.junit.Test;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.verify;
@@ -71,7 +73,7 @@ public class StandardInboundDocQueryTest extends InboundDocQueryTest {
         AssertionType mockAssertion = getMockAssertion(sendingHcid);
 
         StandardInboundDocQuery standardDocQuery = new StandardInboundDocQuery(policyChecker,
-            getMockAdapterFactory(mockAssertion), mockAuditLogger) {
+            getMockAdapterFactory(mockAssertion), getAuditLogger(true)) {
             @Override
             protected String getLocalHomeCommunityId() {
                 return RESPONDING_HCID_FORMATTED;
@@ -95,7 +97,7 @@ public class StandardInboundDocQueryTest extends InboundDocQueryTest {
         when(policyChecker.checkIncomingPolicy(request, assertion)).thenReturn(false);
 
         StandardInboundDocQuery standardDocQuery = new StandardInboundDocQuery(policyChecker, mockAdapterFactory,
-            mockAuditLogger) {
+            getAuditLogger(true)) {
             @Override
             protected String getLocalHomeCommunityId() {
                 return RESPONDING_HCID_FORMATTED;
@@ -109,9 +111,9 @@ public class StandardInboundDocQueryTest extends InboundDocQueryTest {
             .getRegistryError().get(0).getErrorCode());
         assertEquals(NhincConstants.XDS_REGISTRY_ERROR_SEVERITY_ERROR, actualResponse.getRegistryErrorList()
             .getRegistryError().get(0).getSeverity());
-        verify(mockAuditLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
+        verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
             NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
-            eq(NhincConstants.DOC_QUERY_SERVICE_NAME));
+            eq(NhincConstants.DOC_QUERY_SERVICE_NAME), any(DocQueryAuditTransforms.class));
     }
 }

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/inbound/PassthroughInboundDocRetrieveTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/inbound/PassthroughInboundDocRetrieveTest.java
@@ -26,9 +26,8 @@
  */
 package gov.hhs.fha.nhinc.docretrieve.inbound;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import gov.hhs.fha.nhinc.audit.ejb.AuditEJBLogger;
+import gov.hhs.fha.nhinc.audit.ejb.impl.AuditEJBLoggerImpl;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 import java.util.Properties;
@@ -37,6 +36,7 @@ import org.mockito.ArgumentCaptor;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.docretrieve.audit.DocRetrieveAuditLogger;
+import gov.hhs.fha.nhinc.docretrieve.audit.transform.DocRetrieveAuditTransforms;
 import gov.hhs.fha.nhinc.docretrieve.nhin.InboundDocRetrieveDelegate;
 import gov.hhs.fha.nhinc.docretrieve.nhin.InboundDocRetrieveOrchestratable;
 import gov.hhs.fha.nhinc.docretrieve.nhin.InboundDocRetrievePolicyTransformer_g0;
@@ -44,10 +44,14 @@ import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.orchestration.CONNECTInboundOrchestrator;
 import ihe.iti.xds_b._2007.RetrieveDocumentSetRequestType;
 import ihe.iti.xds_b._2007.RetrieveDocumentSetResponseType;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import static org.mockito.Matchers.eq;
-import org.mockito.Mockito;
+import static org.mockito.Mockito.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -57,14 +61,14 @@ import static org.mockito.Mockito.verify;
 public class PassthroughInboundDocRetrieveTest {
 
     NhinTargetSystemType nhinTargetSystemType;
-    DocRetrieveAuditLogger logger;
     AssertionType assertionType;
     RetrieveDocumentSetRequestType retrieveDocumentSetRequestType;
     RetrieveDocumentSetResponseType retrieveDocumentSetResponseType;
+    AuditEJBLoggerImpl mockEJBLogger;
 
     @Before
     public void setup() {
-        logger = mock(DocRetrieveAuditLogger.class);
+        mockEJBLogger = mock(AuditEJBLoggerImpl.class);
     }
 
     @Test
@@ -88,18 +92,18 @@ public class PassthroughInboundDocRetrieveTest {
         when(orchestratable.getResponse()).thenReturn(expectedResponse);
 
         // Actual Invocation
-        PassthroughInboundDocRetrieve inboundDocRetrieve = new PassthroughInboundDocRetrieve(pt, ad, orch, logger);
+        PassthroughInboundDocRetrieve inboundDocRetrieve = new PassthroughInboundDocRetrieve(pt, ad, orch,
+            getAuditLogger(true));
         RetrieveDocumentSetResponseType actualResponse = inboundDocRetrieve.respondingGatewayCrossGatewayRetrieve(
             request, assertion, webContextProperties);
 
         // Verify response is expected
         assertSame(expectedResponse, actualResponse);
 
-        verify(logger).auditResponseMessage(eq(request),
-            eq(actualResponse), eq(assertion),
-            Mockito.any(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+        verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
-            eq(NhincConstants.DOC_RETRIEVE_SERVICE_NAME));
+            eq(NhincConstants.DOC_RETRIEVE_SERVICE_NAME), any(DocRetrieveAuditTransforms.class));
 
         // Verify that the orchestrator is processing the correct passthru orchestratable
         ArgumentCaptor<InboundDocRetrieveOrchestratable> orchArgument = ArgumentCaptor
@@ -111,4 +115,61 @@ public class PassthroughInboundDocRetrieveTest {
         assertTrue(orchArgument.getValue().isPassthru());
     }
 
+    @Test
+    public void auditLoggingOffForInboundDR() {
+        RetrieveDocumentSetRequestType request = new RetrieveDocumentSetRequestType();
+        AssertionType assertion = new AssertionType();
+        RetrieveDocumentSetResponseType expectedResponse = new RetrieveDocumentSetResponseType();
+        Properties webContextProperties = new Properties();
+
+        InboundDocRetrievePolicyTransformer_g0 pt = new InboundDocRetrievePolicyTransformer_g0();
+        InboundDocRetrieveDelegate ad = new InboundDocRetrieveDelegate();
+
+        // Mocks
+        CONNECTInboundOrchestrator orch = mock(CONNECTInboundOrchestrator.class);
+
+        InboundDocRetrieveOrchestratable orchestratable = mock(InboundDocRetrieveOrchestratable.class);
+
+        // Method Stubbing
+        when(orch.process(any(InboundDocRetrieveOrchestratable.class))).thenReturn(orchestratable);
+
+        when(orchestratable.getResponse()).thenReturn(expectedResponse);
+
+        // Actual Invocation
+        PassthroughInboundDocRetrieve inboundDocRetrieve = new PassthroughInboundDocRetrieve(pt, ad, orch,
+            getAuditLogger(false));
+        RetrieveDocumentSetResponseType actualResponse = inboundDocRetrieve.respondingGatewayCrossGatewayRetrieve(
+            request, assertion, webContextProperties);
+
+        // Verify response is expected
+        assertSame(expectedResponse, actualResponse);
+
+        verify(mockEJBLogger, never()).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
+            eq(NhincConstants.DOC_RETRIEVE_SERVICE_NAME), any(DocRetrieveAuditTransforms.class));
+
+        // Verify that the orchestrator is processing the correct passthru orchestratable
+        ArgumentCaptor<InboundDocRetrieveOrchestratable> orchArgument = ArgumentCaptor
+            .forClass(InboundDocRetrieveOrchestratable.class);
+
+        verify(orch).process(orchArgument.capture());
+        assertEquals(pt, orchArgument.getValue().getPolicyTransformer());
+        assertEquals(ad, orchArgument.getValue().getDelegate());
+        assertTrue(orchArgument.getValue().isPassthru());
+    }
+
+    private DocRetrieveAuditLogger getAuditLogger(final boolean isLoggingOn) {
+        return new DocRetrieveAuditLogger() {
+            @Override
+            protected AuditEJBLogger getAuditLogger() {
+                return mockEJBLogger;
+            }
+
+            @Override
+            protected boolean isAuditLoggingOn(String serviceName) {
+                return isLoggingOn;
+            }
+        };
+    }
 }

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/inbound/StandardInboundDocRetrieveTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/inbound/StandardInboundDocRetrieveTest.java
@@ -26,18 +26,19 @@
  */
 package gov.hhs.fha.nhinc.docretrieve.inbound;
 
-import static org.junit.Assert.assertEquals;
 import java.lang.reflect.Method;
 import java.util.Properties;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
+import gov.hhs.fha.nhinc.audit.ejb.AuditEJBLogger;
+import gov.hhs.fha.nhinc.audit.ejb.impl.AuditEJBLoggerImpl;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
-import gov.hhs.fha.nhinc.docretrieve.adapter.proxy.AdapterDocRetrieveProxy;
 import gov.hhs.fha.nhinc.docretrieve.aspect.RetrieveDocumentSetRequestTypeDescriptionBuilder;
 import gov.hhs.fha.nhinc.docretrieve.aspect.RetrieveDocumentSetResponseTypeDescriptionBuilder;
 import gov.hhs.fha.nhinc.docretrieve.audit.DocRetrieveAuditLogger;
+import gov.hhs.fha.nhinc.docretrieve.audit.transform.DocRetrieveAuditTransforms;
 import gov.hhs.fha.nhinc.docretrieve.nhin.InboundDocRetrieveDelegate;
 import gov.hhs.fha.nhinc.docretrieve.nhin.InboundDocRetrieveOrchestratable;
 import gov.hhs.fha.nhinc.docretrieve.nhin.InboundDocRetrievePolicyTransformer_g0;
@@ -45,16 +46,18 @@ import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.orchestration.CONNECTInboundOrchestrator;
 import ihe.iti.xds_b._2007.RetrieveDocumentSetRequestType;
 import ihe.iti.xds_b._2007.RetrieveDocumentSetResponseType;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import org.junit.Before;
-import org.mockito.Mockito;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.never;
 
 /**
  * @author akong
@@ -62,11 +65,11 @@ import org.mockito.Mockito;
  */
 public class StandardInboundDocRetrieveTest {
 
-    DocRetrieveAuditLogger logger;
+    private AuditEJBLoggerImpl mockEJBLogger;
 
     @Before
     public void setup() {
-        logger = mock(DocRetrieveAuditLogger.class);
+        mockEJBLogger = mock(AuditEJBLoggerImpl.class);
     }
 
     @Test
@@ -89,9 +92,50 @@ public class StandardInboundDocRetrieveTest {
         RetrieveDocumentSetResponseType expectedResponse = new RetrieveDocumentSetResponseType();
         Properties webContextProperties = new Properties();
 
-        // creating mocks for necessary arguments
-        InboundDocRetrieveOrchestratable message = mock(InboundDocRetrieveOrchestratable.class);
-        AdapterDocRetrieveProxy adapterProxy = mock(AdapterDocRetrieveProxy.class);
+        InboundDocRetrievePolicyTransformer_g0 pt = new InboundDocRetrievePolicyTransformer_g0();
+        InboundDocRetrieveDelegate ad = new InboundDocRetrieveDelegate();
+
+        // Mocks
+        CONNECTInboundOrchestrator orch = mock(CONNECTInboundOrchestrator.class);
+
+        InboundDocRetrieveOrchestratable orchestratable = mock(InboundDocRetrieveOrchestratable.class);
+
+        // Method Stubbing
+        when(orch.process(any(InboundDocRetrieveOrchestratable.class))).thenReturn(orchestratable);
+
+        when(orchestratable.getResponse()).thenReturn(expectedResponse);
+
+        // Actual Invocation
+        StandardInboundDocRetrieve inboundDocRetrieve = new StandardInboundDocRetrieve(pt, ad, orch,
+            getAuditLogger(true));
+
+        RetrieveDocumentSetResponseType actualResponse = inboundDocRetrieve.respondingGatewayCrossGatewayRetrieve(
+            request, assertion, webContextProperties);
+
+        // Verify response is expected
+        assertSame(expectedResponse, actualResponse);
+
+        verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
+            eq(NhincConstants.DOC_RETRIEVE_SERVICE_NAME), any(DocRetrieveAuditTransforms.class));
+
+        // Verify that the orchestrator is processing the correct orchestratable
+        ArgumentCaptor< InboundDocRetrieveOrchestratable> orchArgument = ArgumentCaptor
+            .forClass(InboundDocRetrieveOrchestratable.class);
+
+        verify(orch).process(orchArgument.capture());
+        assertEquals(pt, orchArgument.getValue().getPolicyTransformer());
+        assertEquals(ad, orchArgument.getValue().getDelegate());
+        assertFalse(orchArgument.getValue().isPassthru());
+    }
+
+    @Test
+    public void auditLoggingOffForInboundDR() {
+        RetrieveDocumentSetRequestType request = new RetrieveDocumentSetRequestType();
+        AssertionType assertion = new AssertionType();
+        RetrieveDocumentSetResponseType expectedResponse = new RetrieveDocumentSetResponseType();
+        Properties webContextProperties = new Properties();
 
         InboundDocRetrievePolicyTransformer_g0 pt = new InboundDocRetrievePolicyTransformer_g0();
         InboundDocRetrieveDelegate ad = new InboundDocRetrieveDelegate();
@@ -107,7 +151,8 @@ public class StandardInboundDocRetrieveTest {
         when(orchestratable.getResponse()).thenReturn(expectedResponse);
 
         // Actual Invocation
-        StandardInboundDocRetrieve inboundDocRetrieve = new StandardInboundDocRetrieve(pt, ad, orch, logger);
+        StandardInboundDocRetrieve inboundDocRetrieve = new StandardInboundDocRetrieve(pt, ad, orch,
+            getAuditLogger(false));
 
         RetrieveDocumentSetResponseType actualResponse = inboundDocRetrieve.respondingGatewayCrossGatewayRetrieve(
             request, assertion, webContextProperties);
@@ -115,20 +160,23 @@ public class StandardInboundDocRetrieveTest {
         // Verify response is expected
         assertSame(expectedResponse, actualResponse);
 
-        verify(logger).auditResponseMessage(eq(request),
-            eq(actualResponse), eq(assertion),
-            Mockito.any(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+        verify(mockEJBLogger, never()).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
-            eq(NhincConstants.DOC_RETRIEVE_SERVICE_NAME));
-
-        // Verify that the orchestrator is processing the correct orchestratable
-        ArgumentCaptor< InboundDocRetrieveOrchestratable> orchArgument = ArgumentCaptor
-            .forClass(InboundDocRetrieveOrchestratable.class);
-
-        verify(orch).process(orchArgument.capture());
-        assertEquals(pt, orchArgument.getValue().getPolicyTransformer());
-        assertEquals(ad, orchArgument.getValue().getDelegate());
-        assertFalse(orchArgument.getValue().isPassthru());
+            eq(NhincConstants.DOC_RETRIEVE_SERVICE_NAME), any(DocRetrieveAuditTransforms.class));
     }
 
+    private DocRetrieveAuditLogger getAuditLogger(final boolean isLoggingOn) {
+        return new DocRetrieveAuditLogger() {
+            @Override
+            protected AuditEJBLogger getAuditLogger() {
+                return mockEJBLogger;
+            }
+
+            @Override
+            protected boolean isAuditLoggingOn(String serviceName) {
+                return isLoggingOn;
+            }
+        };
+    }
 }

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/outbound/AbstractOutboundDocRetrieveTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/outbound/AbstractOutboundDocRetrieveTest.java
@@ -26,6 +26,8 @@
  */
 package gov.hhs.fha.nhinc.docretrieve.outbound;
 
+import gov.hhs.fha.nhinc.audit.ejb.AuditEJBLogger;
+import gov.hhs.fha.nhinc.audit.ejb.impl.AuditEJBLoggerImpl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
@@ -34,6 +36,7 @@ import static org.mockito.Mockito.when;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunityType;
+import gov.hhs.fha.nhinc.docretrieve.audit.DocRetrieveAuditLogger;
 import gov.hhs.fha.nhinc.docretrieve.entity.OutboundDocRetrieveOrchestratable;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants.ADAPTER_API_LEVEL;
@@ -56,11 +59,15 @@ import org.junit.Test;
  */
 public abstract class AbstractOutboundDocRetrieveTest {
 
+    protected AuditEJBLoggerImpl mockEJBLogger = mock(AuditEJBLoggerImpl.class);
+
     /**
      * @param orchestrator
+     * @param isAuditOn
      * @return
      */
-    protected abstract OutboundDocRetrieve getOutboundDocRetrieve(CONNECTOutboundOrchestrator orchestrator);
+    protected abstract OutboundDocRetrieve getOutboundDocRetrieve(CONNECTOutboundOrchestrator orchestrator,
+        boolean isAuditOn);
 
     @Test
     public void test30GuidanceOnA0Interface() {
@@ -68,7 +75,7 @@ public abstract class AbstractOutboundDocRetrieveTest {
 
         CONNECTOutboundOrchestrator orchestrator = mock(CONNECTOutboundOrchestrator.class);
         when(orchestrator.process(any(Orchestratable.class))).thenReturn(getSuccessOrchResult());
-        OutboundDocRetrieve instance = getOutboundDocRetrieve(orchestrator);
+        OutboundDocRetrieve instance = getOutboundDocRetrieve(orchestrator, true);
 
         RetrieveDocumentSetRequestType request = mock(RetrieveDocumentSetRequestType.class);
         AssertionType assertion = mock(AssertionType.class);
@@ -85,7 +92,7 @@ public abstract class AbstractOutboundDocRetrieveTest {
 
         CONNECTOutboundOrchestrator orchestrator = mock(CONNECTOutboundOrchestrator.class);
         when(orchestrator.process(any(Orchestratable.class))).thenReturn(getSuccessOrchResult());
-        OutboundDocRetrieve instance = getOutboundDocRetrieve(orchestrator);
+        OutboundDocRetrieve instance = getOutboundDocRetrieve(orchestrator, true);
 
         RetrieveDocumentSetRequestType request = mock(RetrieveDocumentSetRequestType.class);
         AssertionType assertion = mock(AssertionType.class);
@@ -102,7 +109,7 @@ public abstract class AbstractOutboundDocRetrieveTest {
 
         CONNECTOutboundOrchestrator orchestrator = mock(CONNECTOutboundOrchestrator.class);
         when(orchestrator.process(any(Orchestratable.class))).thenReturn(getSuccessOrchResult());
-        OutboundDocRetrieve instance = getOutboundDocRetrieve(orchestrator);
+        OutboundDocRetrieve instance = getOutboundDocRetrieve(orchestrator, true);
 
         RetrieveDocumentSetRequestType request = mock(RetrieveDocumentSetRequestType.class);
         AssertionType assertion = mock(AssertionType.class);
@@ -119,7 +126,7 @@ public abstract class AbstractOutboundDocRetrieveTest {
 
         CONNECTOutboundOrchestrator orchestrator = mock(CONNECTOutboundOrchestrator.class);
         when(orchestrator.process(any(Orchestratable.class))).thenReturn(getSuccessOrchResult());
-        OutboundDocRetrieve instance = getOutboundDocRetrieve(orchestrator);
+        OutboundDocRetrieve instance = getOutboundDocRetrieve(orchestrator, true);
 
         RetrieveDocumentSetRequestType request = mock(RetrieveDocumentSetRequestType.class);
         AssertionType assertion = mock(AssertionType.class);
@@ -136,7 +143,7 @@ public abstract class AbstractOutboundDocRetrieveTest {
 
         CONNECTOutboundOrchestrator orchestrator = mock(CONNECTOutboundOrchestrator.class);
         when(orchestrator.process(any(Orchestratable.class))).thenReturn(getSuccessOrchResult());
-        OutboundDocRetrieve instance = getOutboundDocRetrieve(orchestrator);
+        OutboundDocRetrieve instance = getOutboundDocRetrieve(orchestrator, true);
 
         RetrieveDocumentSetRequestType request = mock(RetrieveDocumentSetRequestType.class);
         AssertionType assertion = mock(AssertionType.class);
@@ -153,7 +160,7 @@ public abstract class AbstractOutboundDocRetrieveTest {
 
         CONNECTOutboundOrchestrator orchestrator = mock(CONNECTOutboundOrchestrator.class);
         when(orchestrator.process(any(Orchestratable.class))).thenReturn(getSuccessOrchResult());
-        OutboundDocRetrieve instance = getOutboundDocRetrieve(orchestrator);
+        OutboundDocRetrieve instance = getOutboundDocRetrieve(orchestrator, true);
 
         RetrieveDocumentSetRequestType request = mock(RetrieveDocumentSetRequestType.class);
         AssertionType assertion = mock(AssertionType.class);
@@ -244,5 +251,19 @@ public abstract class AbstractOutboundDocRetrieveTest {
         NhinTargetCommunityType targetCommunity = new NhinTargetCommunityType();
         target.getNhinTargetCommunity().add(targetCommunity);
         return target;
+    }
+
+    protected DocRetrieveAuditLogger getAuditLogger(final boolean isLoggingOn) {
+        return new DocRetrieveAuditLogger() {
+            @Override
+            protected AuditEJBLogger getAuditLogger() {
+                return mockEJBLogger;
+            }
+
+            @Override
+            protected boolean isAuditLoggingOn(String serviceName) {
+                return isLoggingOn;
+            }
+        };
     }
 }

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/outbound/PassthroughOutboundDocRetrieveTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/outbound/PassthroughOutboundDocRetrieveTest.java
@@ -41,6 +41,7 @@ import ihe.iti.xds_b._2007.RetrieveDocumentSetRequestType;
 import ihe.iti.xds_b._2007.RetrieveDocumentSetResponseType;
 
 import java.util.Properties;
+import org.junit.Before;
 
 import org.junit.Test;
 import static org.mockito.Matchers.eq;
@@ -55,21 +56,25 @@ import static org.mockito.Mockito.verify;
  */
 public class PassthroughOutboundDocRetrieveTest extends AbstractOutboundDocRetrieveTest {
 
-    NhinTargetSystemType nhinTargetSystemType;
-    AssertionType assertionType;
-    RetrieveDocumentSetRequestType retrieveDocumentSetRequestType;
-    RetrieveDocumentSetResponseType retrieveDocumentSetResponseType;
+    private RetrieveDocumentSetRequestType request;
+    private AssertionType assertion;
+    private NhinTargetCommunitiesType targets;
+    private CONNECTOutboundOrchestrator orchestrator;
+    private OutboundDocRetrieveOrchestratable orchResponse;
+
+    @Before
+    public void setup() {
+        request = new RetrieveDocumentSetRequestType();
+        assertion = new AssertionType();
+        targets = new NhinTargetCommunitiesType();
+        orchestrator = mock(CONNECTOutboundOrchestrator.class);
+        orchResponse = mock(OutboundDocRetrieveOrchestratable.class);
+    }
 
     @Test
     public void invoke() {
-        RetrieveDocumentSetRequestType request = new RetrieveDocumentSetRequestType();
-        AssertionType assertion = new AssertionType();
-        NhinTargetCommunitiesType targets = new NhinTargetCommunitiesType();
         targets.setUseSpecVersion("2.0");
         RetrieveDocumentSetResponseType expectedResponse = new RetrieveDocumentSetResponseType();
-
-        CONNECTOutboundOrchestrator orchestrator = mock(CONNECTOutboundOrchestrator.class);
-        OutboundDocRetrieveOrchestratable orchResponse = mock(OutboundDocRetrieveOrchestratable.class);
 
         when(orchestrator.process(any(OutboundDocRetrieveOrchestratable.class))).thenReturn(orchResponse);
 
@@ -91,14 +96,8 @@ public class PassthroughOutboundDocRetrieveTest extends AbstractOutboundDocRetri
 
     @Test
     public void auditLoggingOffForOutboundDR() {
-        RetrieveDocumentSetRequestType request = new RetrieveDocumentSetRequestType();
-        AssertionType assertion = new AssertionType();
-        NhinTargetCommunitiesType targets = new NhinTargetCommunitiesType();
         targets.setUseSpecVersion("2.0");
         RetrieveDocumentSetResponseType expectedResponse = new RetrieveDocumentSetResponseType();
-
-        CONNECTOutboundOrchestrator orchestrator = mock(CONNECTOutboundOrchestrator.class);
-        OutboundDocRetrieveOrchestratable orchResponse = mock(OutboundDocRetrieveOrchestratable.class);
 
         when(orchestrator.process(any(OutboundDocRetrieveOrchestratable.class))).thenReturn(orchResponse);
 

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/PassthroughInboundDocSubmissionDeferredRequestTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/PassthroughInboundDocSubmissionDeferredRequestTest.java
@@ -26,12 +26,10 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.inbound.deferred.request;
 
+import gov.hhs.fha.nhinc.audit.ejb.AuditEJBLogger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
@@ -40,14 +38,21 @@ import gov.hhs.fha.nhinc.docsubmission.DocSubmissionUtils;
 import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.request.proxy.AdapterDocSubmissionDeferredRequestProxy;
 import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.request.proxy.AdapterDocSubmissionDeferredRequestProxyObjectFactory;
 import gov.hhs.fha.nhinc.docsubmission.audit.DocSubmissionDeferredRequestAuditLogger;
+import gov.hhs.fha.nhinc.docsubmission.audit.transform.DocSubmissionDeferredRequestAuditTransforms;
 import gov.hhs.fha.nhinc.largefile.LargePayloadException;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.healthit.nhin.XDRAcknowledgementType;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 import java.util.Properties;
+import static org.junit.Assert.assertSame;
 
 import org.junit.Test;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 /**
  * @author akong
@@ -59,8 +64,7 @@ public class PassthroughInboundDocSubmissionDeferredRequestTest {
         = mock(AdapterDocSubmissionDeferredRequestProxyObjectFactory.class);
     private final AdapterDocSubmissionDeferredRequestProxy adapterProxy
         = mock(AdapterDocSubmissionDeferredRequestProxy.class);
-    private final DocSubmissionDeferredRequestAuditLogger auditLogger
-        = mock(DocSubmissionDeferredRequestAuditLogger.class);
+    private final AuditEJBLogger mockEJBLogger = mock(AuditEJBLogger.class);
     private final DocSubmissionUtils dsUtils = mock(DocSubmissionUtils.class);
 
     @Test
@@ -74,17 +78,17 @@ public class PassthroughInboundDocSubmissionDeferredRequestTest {
 
         when(adapterProxy.provideAndRegisterDocumentSetBRequest(request, assertion)).thenReturn(expectedResponse);
 
-        PassthroughInboundDocSubmissionDeferredRequest passthroughDocSubmission = new PassthroughInboundDocSubmissionDeferredRequest(
-            adapterFactory, auditLogger, dsUtils);
+        PassthroughInboundDocSubmissionDeferredRequest passthroughDocSubmission
+            = new PassthroughInboundDocSubmissionDeferredRequest(adapterFactory, getAuditLogger(true), dsUtils);
 
         XDRAcknowledgementType actualResponse = passthroughDocSubmission.provideAndRegisterDocumentSetBRequest(request,
             assertion, webContextProperties);
 
         assertSame(expectedResponse, actualResponse);
-        verify(auditLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
+        verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
             NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
-            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE),
-            eq(webContextProperties), eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME));
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
+            eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME), any(DocSubmissionDeferredRequestAuditTransforms.class));
     }
 
     @Test
@@ -96,19 +100,58 @@ public class PassthroughInboundDocSubmissionDeferredRequestTest {
         doThrow(new LargePayloadException()).when(dsUtils).convertDataToFileLocationIfEnabled(request);
 
         PassthroughInboundDocSubmissionDeferredRequest passthroughDocSubmission = new PassthroughInboundDocSubmissionDeferredRequest(
-            adapterFactory, auditLogger, dsUtils);
+            adapterFactory, getAuditLogger(true), dsUtils);
 
         XDRAcknowledgementType actualResponse = passthroughDocSubmission.provideAndRegisterDocumentSetBRequest(request,
             assertion, webContextProperties);
 
-        assertEquals("XDSRegistryError", actualResponse.getMessage().getRegistryErrorList().getRegistryError().get(0).getErrorCode());
+        assertEquals("XDSRegistryError", actualResponse.getMessage().getRegistryErrorList().getRegistryError().get(0
+        ).getErrorCode());
         assertEquals("urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Failure", actualResponse.getMessage().getStatus());
-        assertEquals("urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error", actualResponse.getMessage().getRegistryErrorList()
-            .getRegistryError().get(0).getSeverity());
+        assertEquals("urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error", actualResponse.getMessage().
+            getRegistryErrorList().getRegistryError().get(0).getSeverity());
 
-        verify(auditLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
+        verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
             NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
-            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE),
-            eq(webContextProperties), eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME));
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
+            eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME), any(DocSubmissionDeferredRequestAuditTransforms.class));
+    }
+
+    @Test
+    public void testAuditLoggingOffForDSDeferredRequest() {
+        ProvideAndRegisterDocumentSetRequestType request = new ProvideAndRegisterDocumentSetRequestType();
+        AssertionType assertion = new AssertionType();
+        XDRAcknowledgementType expectedResponse = new XDRAcknowledgementType();
+
+        Properties webContextProperties = new Properties();
+        when(adapterFactory.getAdapterDocSubmissionDeferredRequestProxy()).thenReturn(adapterProxy);
+
+        when(adapterProxy.provideAndRegisterDocumentSetBRequest(request, assertion)).thenReturn(expectedResponse);
+
+        PassthroughInboundDocSubmissionDeferredRequest passthroughDocSubmission
+            = new PassthroughInboundDocSubmissionDeferredRequest(adapterFactory, getAuditLogger(false), dsUtils);
+
+        XDRAcknowledgementType actualResponse = passthroughDocSubmission.provideAndRegisterDocumentSetBRequest(request,
+            assertion, webContextProperties);
+
+        assertSame(expectedResponse, actualResponse);
+        verify(mockEJBLogger, never()).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
+            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
+            eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME), any(DocSubmissionDeferredRequestAuditTransforms.class));
+    }
+
+    private DocSubmissionDeferredRequestAuditLogger getAuditLogger(final boolean isAuditOn) {
+        return new DocSubmissionDeferredRequestAuditLogger() {
+            @Override
+            protected AuditEJBLogger getAuditLogger() {
+                return mockEJBLogger;
+            }
+
+            @Override
+            protected boolean isAuditLoggingOn(String serviceName) {
+                return isAuditOn;
+            }
+        };
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/StandardInboundDocSubmissionDeferredRequestTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/StandardInboundDocSubmissionDeferredRequestTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
+import gov.hhs.fha.nhinc.audit.ejb.AuditEJBLogger;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
@@ -45,6 +46,7 @@ import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.request.proxy.AdapterDoc
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionArgTransformerBuilder;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionBaseEventDescriptionBuilder;
 import gov.hhs.fha.nhinc.docsubmission.audit.DocSubmissionDeferredRequestAuditLogger;
+import gov.hhs.fha.nhinc.docsubmission.audit.transform.DocSubmissionDeferredRequestAuditTransforms;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.properties.PropertyAccessException;
 import gov.hhs.fha.nhinc.properties.PropertyAccessor;
@@ -55,8 +57,10 @@ import java.lang.reflect.Method;
 import java.util.Properties;
 
 import org.junit.Test;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -69,8 +73,7 @@ public class StandardInboundDocSubmissionDeferredRequestTest {
         = mock(AdapterDocSubmissionDeferredRequestProxyObjectFactory.class);
     private final AdapterDocSubmissionDeferredRequestProxy adapterProxy
         = mock(AdapterDocSubmissionDeferredRequestProxy.class);
-    private final DocSubmissionDeferredRequestAuditLogger auditLogger
-        = mock(DocSubmissionDeferredRequestAuditLogger.class);
+    private final AuditEJBLogger mockEJBLogger = mock(AuditEJBLogger.class);
     private final PropertyAccessor propertyAccessor = mock(PropertyAccessor.class);
     private final XDRPolicyChecker policyChecker = mock(XDRPolicyChecker.class);
     private final AdapterDocSubmissionDeferredRequestErrorProxyObjectFactory errorAdapterFactory
@@ -102,7 +105,7 @@ public class StandardInboundDocSubmissionDeferredRequestTest {
         final DocSubmissionUtils mockDocSubmissionUtils = mock(DocSubmissionUtils.class);
 
         StandardInboundDocSubmissionDeferredRequest standardDocSubmission = new StandardInboundDocSubmissionDeferredRequest(
-            adapterFactory, policyChecker, propertyAccessor, auditLogger, errorAdapterFactory) {
+            adapterFactory, policyChecker, propertyAccessor, getAuditLogger(true), errorAdapterFactory) {
             @Override
             public DocSubmissionUtils getDocSubmissionUtils() {
                 return mockDocSubmissionUtils;
@@ -113,10 +116,10 @@ public class StandardInboundDocSubmissionDeferredRequestTest {
             assertion, webContextProperties);
 
         assertSame(expectedResponse, actualResponse);
-        verify(auditLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
+        verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
             NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
-            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE),
-            eq(webContextProperties), eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME));
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
+            eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME), any(DocSubmissionDeferredRequestAuditTransforms.class));
     }
 
     @Test
@@ -142,17 +145,17 @@ public class StandardInboundDocSubmissionDeferredRequestTest {
             .thenReturn(expectedResponse);
 
         StandardInboundDocSubmissionDeferredRequest standardDocSubmission = new StandardInboundDocSubmissionDeferredRequest(
-            adapterFactory, policyChecker, propertyAccessor, auditLogger, errorAdapterFactory);
+            adapterFactory, policyChecker, propertyAccessor, getAuditLogger(true), errorAdapterFactory);
 
         XDRAcknowledgementType actualResponse = standardDocSubmission.provideAndRegisterDocumentSetBRequest(request,
             assertion, webContextProperties);
 
         assertSame(expectedResponse, actualResponse);
 
-        verify(auditLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
+        verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
             NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
-            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE),
-            eq(webContextProperties), eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME));
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
+            eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME), any(DocSubmissionDeferredRequestAuditTransforms.class));
     }
 
     @Test
@@ -169,17 +172,17 @@ public class StandardInboundDocSubmissionDeferredRequestTest {
             .thenReturn(expectedResponse);
 
         StandardInboundDocSubmissionDeferredRequest standardDocSubmission = new StandardInboundDocSubmissionDeferredRequest(
-            adapterFactory, policyChecker, propertyAccessor, auditLogger, errorAdapterFactory);
+            adapterFactory, policyChecker, propertyAccessor, getAuditLogger(true), errorAdapterFactory);
 
         XDRAcknowledgementType actualResponse = standardDocSubmission.provideAndRegisterDocumentSetBRequest(request,
             assertion, webContextProperties);
 
         assertSame(expectedResponse, actualResponse);
 
-        verify(auditLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
+        verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
             NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
-            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE),
-            eq(webContextProperties), eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME));
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
+            eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME), any(DocSubmissionDeferredRequestAuditTransforms.class));
     }
 
     @Test
@@ -193,5 +196,60 @@ public class StandardInboundDocSubmissionDeferredRequestTest {
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Request", annotation.serviceType());
         assertEquals("", annotation.version());
+    }
+
+    @Test
+    public void testAuditLoggingOffForDSDeferredRequest() throws PropertyAccessException {
+        String localHCID = "1.1";
+        String senderHCID = "2.2";
+        ProvideAndRegisterDocumentSetRequestType request = new ProvideAndRegisterDocumentSetRequestType();
+        AssertionType assertion = new AssertionType();
+        assertion.setHomeCommunity(new HomeCommunityType());
+        assertion.getHomeCommunity().setHomeCommunityId(senderHCID);
+        XDRAcknowledgementType expectedResponse = new XDRAcknowledgementType();
+
+        Properties webContextProperties = new Properties();
+        when(adapterFactory.getAdapterDocSubmissionDeferredRequestProxy()).thenReturn(adapterProxy);
+
+        when(adapterProxy.provideAndRegisterDocumentSetBRequest(request, assertion)).thenReturn(expectedResponse);
+
+        when(propertyAccessor.getProperty(NhincConstants.GATEWAY_PROPERTY_FILE,
+            NhincConstants.HOME_COMMUNITY_ID_PROPERTY)).thenReturn(localHCID);
+
+        when(policyChecker.checkXDRRequestPolicy(request, assertion, senderHCID, localHCID,
+            NhincConstants.POLICYENGINE_INBOUND_DIRECTION)).thenReturn(true);
+
+        final DocSubmissionUtils mockDocSubmissionUtils = mock(DocSubmissionUtils.class);
+
+        StandardInboundDocSubmissionDeferredRequest standardDocSubmission = new StandardInboundDocSubmissionDeferredRequest(
+            adapterFactory, policyChecker, propertyAccessor, getAuditLogger(false), errorAdapterFactory) {
+            @Override
+            public DocSubmissionUtils getDocSubmissionUtils() {
+                return mockDocSubmissionUtils;
+            }
+        };
+
+        XDRAcknowledgementType actualResponse = standardDocSubmission.provideAndRegisterDocumentSetBRequest(request,
+            assertion, webContextProperties);
+
+        assertSame(expectedResponse, actualResponse);
+        verify(mockEJBLogger, never()).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
+            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
+            eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME), any(DocSubmissionDeferredRequestAuditTransforms.class));
+    }
+
+    private DocSubmissionDeferredRequestAuditLogger getAuditLogger(final boolean isAuditOn) {
+        return new DocSubmissionDeferredRequestAuditLogger() {
+            @Override
+            protected AuditEJBLogger getAuditLogger() {
+                return mockEJBLogger;
+            }
+
+            @Override
+            protected boolean isAuditLoggingOn(String serviceName) {
+                return isAuditOn;
+            }
+        };
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/StandardInboundDocSubmissionDeferredResponseTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/StandardInboundDocSubmissionDeferredResponseTest.java
@@ -27,6 +27,7 @@
 package gov.hhs.fha.nhinc.docsubmission.inbound.deferred.response;
 
 import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
+import gov.hhs.fha.nhinc.audit.ejb.AuditEJBLogger;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
@@ -36,6 +37,7 @@ import gov.hhs.fha.nhinc.docsubmission.adapter.deferred.response.proxy.AdapterDo
 import gov.hhs.fha.nhinc.docsubmission.aspect.DeferredResponseDescriptionBuilder;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionArgTransformerBuilder;
 import gov.hhs.fha.nhinc.docsubmission.audit.DSDeferredResponseAuditLogger;
+import gov.hhs.fha.nhinc.docsubmission.audit.transform.DSDeferredResponseAuditTransforms;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.properties.PropertyAccessException;
 import gov.hhs.fha.nhinc.properties.PropertyAccessor;
@@ -47,9 +49,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import org.junit.Test;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -60,7 +64,7 @@ import static org.mockito.Mockito.when;
 public class StandardInboundDocSubmissionDeferredResponseTest {
 
     private final Properties webContextProperties = new Properties();
-    private final DSDeferredResponseAuditLogger auditLogger = mock(DSDeferredResponseAuditLogger.class);
+    private final AuditEJBLogger mockEJBLogger = mock(AuditEJBLogger.class);
 
     private final AdapterDocSubmissionDeferredResponseProxyObjectFactory adapterFactory
         = mock(AdapterDocSubmissionDeferredResponseProxyObjectFactory.class);
@@ -92,17 +96,17 @@ public class StandardInboundDocSubmissionDeferredResponseTest {
 
         StandardInboundDocSubmissionDeferredResponse standardDocSubmission
             = new StandardInboundDocSubmissionDeferredResponse(adapterFactory, policyChecker, propertyAccessor,
-                auditLogger);
+                getAuditLogger(true));
 
         XDRAcknowledgementType actualResponse = standardDocSubmission.provideAndRegisterDocumentSetBResponse(
             regResponse, assertion, webContextProperties);
 
         assertSame(expectedResponse, actualResponse);
 
-        verify(auditLogger).auditResponseMessage(eq(regResponse), eq(actualResponse), eq(assertion),
+        verify(mockEJBLogger).auditResponseMessage(eq(regResponse), eq(actualResponse), eq(assertion),
             isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
-            eq(NhincConstants.NHINC_XDR_RESPONSE_SERVICE_NAME));
+            eq(NhincConstants.NHINC_XDR_RESPONSE_SERVICE_NAME), any(DSDeferredResponseAuditTransforms.class));
     }
 
     @Test
@@ -122,7 +126,7 @@ public class StandardInboundDocSubmissionDeferredResponseTest {
 
         StandardInboundDocSubmissionDeferredResponse standardDocSubmission
             = new StandardInboundDocSubmissionDeferredResponse(adapterFactory, policyChecker, propertyAccessor,
-                auditLogger);
+                getAuditLogger(true));
 
         XDRAcknowledgementType actualResponse = standardDocSubmission.provideAndRegisterDocumentSetBResponse(
             regResponse, assertion, webContextProperties);
@@ -134,10 +138,10 @@ public class StandardInboundDocSubmissionDeferredResponseTest {
         assertEquals("urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error", actualResponse.getMessage()
             .getRegistryErrorList().getRegistryError().get(0).getSeverity());
 
-        verify(auditLogger).auditResponseMessage(eq(regResponse), eq(actualResponse), eq(assertion),
+        verify(mockEJBLogger).auditResponseMessage(eq(regResponse), eq(actualResponse), eq(assertion),
             isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
-            eq(NhincConstants.NHINC_XDR_RESPONSE_SERVICE_NAME));
+            eq(NhincConstants.NHINC_XDR_RESPONSE_SERVICE_NAME), any(DSDeferredResponseAuditTransforms.class));
     }
 
     @Test
@@ -145,7 +149,7 @@ public class StandardInboundDocSubmissionDeferredResponseTest {
 
         StandardInboundDocSubmissionDeferredResponse standardDocSubmission
             = new StandardInboundDocSubmissionDeferredResponse(adapterFactory, policyChecker, propertyAccessor,
-                auditLogger);
+                getAuditLogger(true));
 
         XDRAcknowledgementType actualResponse = standardDocSubmission.provideAndRegisterDocumentSetBResponse(
             regResponse, assertion, webContextProperties);
@@ -157,10 +161,10 @@ public class StandardInboundDocSubmissionDeferredResponseTest {
         assertEquals("urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error", actualResponse.getMessage()
             .getRegistryErrorList().getRegistryError().get(0).getSeverity());
 
-        verify(auditLogger).auditResponseMessage(eq(regResponse), eq(actualResponse), eq(assertion),
+        verify(mockEJBLogger).auditResponseMessage(eq(regResponse), eq(actualResponse), eq(assertion),
             isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
-            eq(NhincConstants.NHINC_XDR_RESPONSE_SERVICE_NAME));
+            eq(NhincConstants.NHINC_XDR_RESPONSE_SERVICE_NAME), any(DSDeferredResponseAuditTransforms.class));
     }
 
     @Test
@@ -174,5 +178,54 @@ public class StandardInboundDocSubmissionDeferredResponseTest {
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Response", annotation.serviceType());
         assertEquals("", annotation.version());
+    }
+
+    @Test
+    public void testAuditLoggingOffForDSDeferredResponse() throws PropertyAccessException {
+        String localHCID = "1.1";
+        String senderHCID = "2.2";
+        assertion.setHomeCommunity(new HomeCommunityType());
+        assertion.getHomeCommunity().setHomeCommunityId(senderHCID);
+        XDRAcknowledgementType expectedResponse = new XDRAcknowledgementType();
+
+        when(adapterFactory.getAdapterDocSubmissionDeferredResponseProxy()).thenReturn(adapterProxy);
+
+        when(adapterProxy.provideAndRegisterDocumentSetBResponse(regResponse, assertion)).thenReturn(expectedResponse);
+
+        when(
+            propertyAccessor.getProperty(NhincConstants.GATEWAY_PROPERTY_FILE,
+                NhincConstants.HOME_COMMUNITY_ID_PROPERTY)).thenReturn(localHCID);
+
+        when(
+            policyChecker.checkXDRResponsePolicy(regResponse, assertion, senderHCID, localHCID,
+                NhincConstants.POLICYENGINE_INBOUND_DIRECTION)).thenReturn(true);
+
+        StandardInboundDocSubmissionDeferredResponse standardDocSubmission
+            = new StandardInboundDocSubmissionDeferredResponse(adapterFactory, policyChecker, propertyAccessor,
+                getAuditLogger(false));
+
+        XDRAcknowledgementType actualResponse = standardDocSubmission.provideAndRegisterDocumentSetBResponse(
+            regResponse, assertion, webContextProperties);
+
+        assertSame(expectedResponse, actualResponse);
+
+        verify(mockEJBLogger, never()).auditResponseMessage(eq(regResponse), eq(actualResponse), eq(assertion),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
+            eq(NhincConstants.NHINC_XDR_RESPONSE_SERVICE_NAME), any(DSDeferredResponseAuditTransforms.class));
+    }
+
+    private DSDeferredResponseAuditLogger getAuditLogger(final boolean isAuditOn) {
+        return new DSDeferredResponseAuditLogger() {
+            @Override
+            protected AuditEJBLogger getAuditLogger() {
+                return mockEJBLogger;
+            }
+
+            @Override
+            protected boolean isAuditLoggingOn(String serviceName) {
+                return isAuditOn;
+            }
+        };
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscovery.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscovery.java
@@ -78,7 +78,7 @@ public class StandardOutboundPatientDiscovery implements OutboundPatientDiscover
     private ExecutorService regularExecutor = null;
     private ExecutorService largejobExecutor = null;
     private final TransactionLogger transactionLogger = new TransactionLogger();
-    private final PatientDiscoveryAuditLogger patientDiscoveryAuditor = new PatientDiscoveryAuditLogger();
+    private PatientDiscoveryAuditLogger patientDiscoveryAuditor;
 
     /**
      * Add default constructor that is used by test cases Note that implementations should always use constructor that
@@ -207,7 +207,7 @@ public class StandardOutboundPatientDiscovery implements OutboundPatientDiscover
                     LOG.debug("Executing tasks to concurrently retrieve responses");
                     NhinTaskExecutor<OutboundPatientDiscoveryOrchestratable, OutboundPatientDiscoveryOrchestratable> pdExecutor = new NhinTaskExecutor<>(
                         ExecutorServiceHelper.getInstance().checkExecutorTaskIsLarge(callableList.size())
-                            ? largejobExecutor : regularExecutor, callableList, transactionId);
+                        ? largejobExecutor : regularExecutor, callableList, transactionId);
                     pdExecutor.executeTask();
                     LOG.debug("Aggregating all responses");
                     response = getCumulativeResponse(pdExecutor);
@@ -410,7 +410,7 @@ public class StandardOutboundPatientDiscovery implements OutboundPatientDiscover
     }
 
     private void auditRequest(PRPAIN201305UV02 request, AssertionType assertion, NhinTargetSystemType target) {
-        patientDiscoveryAuditor.auditRequestMessage(request, assertion, target,
+        getNewPatientDiscoveryAuditLogger().auditRequestMessage(request, assertion, target,
             NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE,
             null, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscovery.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscovery.java
@@ -405,12 +405,12 @@ public class StandardOutboundPatientDiscovery implements OutboundPatientDiscover
     /**
      * @return a new instance of PatientDiscoveryAuditLogger
      */
-    protected PatientDiscoveryAuditLogger getNewPatientDiscoveryAuditLogger() {
+    protected PatientDiscoveryAuditLogger getAuditLogger() {
         return new PatientDiscoveryAuditLogger();
     }
 
     private void auditRequest(PRPAIN201305UV02 request, AssertionType assertion, NhinTargetSystemType target) {
-        getNewPatientDiscoveryAuditLogger().auditRequestMessage(request, assertion, target,
+        getAuditLogger().auditRequestMessage(request, assertion, target,
             NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE,
             null, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/StandardInboundPatientDiscoveryDeferredResponseTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/StandardInboundPatientDiscoveryDeferredResponseTest.java
@@ -27,7 +27,10 @@
 package gov.hhs.fha.nhinc.patientdiscovery.inbound.deferred.response;
 
 import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
+import gov.hhs.fha.nhinc.audit.ejb.AuditEJBLogger;
+import gov.hhs.fha.nhinc.audit.ejb.impl.AuditEJBLoggerImpl;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.patientcorrelation.nhinc.dao.PDDeferredCorrelationDao;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscovery201306PolicyChecker;
@@ -37,6 +40,7 @@ import gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.response.proxy.Adapte
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.MCCIIN000002UV01EventDescriptionBuilder;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201306UV02EventDescriptionBuilder;
 import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryDeferredResponseAuditLogger;
+import gov.hhs.fha.nhinc.patientdiscovery.audit.transform.PatientDiscoveryDeferredResponseAuditTransforms;
 import gov.hhs.fha.nhinc.patientdiscovery.response.ResponseFactory;
 import gov.hhs.fha.nhinc.patientdiscovery.response.ResponseFactory.ResponseModeType;
 import gov.hhs.fha.nhinc.patientdiscovery.response.ResponseMode;
@@ -52,7 +56,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -67,7 +73,7 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
     private final PRPAIN201306UV02 request = new PRPAIN201306UV02();
     private final AssertionType assertion = new AssertionType();
     private final Properties webContextProperties = new Properties();
-    PatientDiscoveryDeferredResponseAuditLogger auditLogger = mock(PatientDiscoveryDeferredResponseAuditLogger.class);
+    private final AuditEJBLoggerImpl mockEJBLogger = mock(AuditEJBLoggerImpl.class);
 
     @Test
     public void hasInboundProcessingEvent() throws Exception {
@@ -97,7 +103,7 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
         AdapterPatientDiscoveryDeferredRespProxyObjectFactory adapterProxyFactory
             = mock(AdapterPatientDiscoveryDeferredRespProxyObjectFactory.class);
         AdapterPatientDiscoveryDeferredRespProxy adapterProxy = mock(AdapterPatientDiscoveryDeferredRespProxy.class);
-
+        PatientDiscoveryDeferredResponseAuditLogger auditLogger = getAuditLogger(true);
         // Stubbing the methods
         when(policyChecker.checkOutgoingPolicy(any(RespondingGatewayPRPAIN201306UV02RequestType.class))).thenReturn(
             true);
@@ -132,10 +138,11 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
         verify(responseMode).processResponse(request, assertion, patientId);
 
         // Verify audits
-        verify(auditLogger).auditResponseMessage(request, actualResponse, assertion, null,
-            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE,
-            Boolean.FALSE, webContextProperties, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
-
+        verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
+            eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
+            any(PatientDiscoveryDeferredResponseAuditTransforms.class));
     }
 
     @Test
@@ -149,7 +156,7 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
         AdapterPatientDiscoveryDeferredRespProxyObjectFactory adapterProxyFactory
             = mock(AdapterPatientDiscoveryDeferredRespProxyObjectFactory.class);
         AdapterPatientDiscoveryDeferredRespProxy adapterProxy = mock(AdapterPatientDiscoveryDeferredRespProxy.class);
-
+        PatientDiscoveryDeferredResponseAuditLogger auditLogger = getAuditLogger(true);
         // Stubbing the methods
         when(policyChecker.checkOutgoingPolicy(any(RespondingGatewayPRPAIN201306UV02RequestType.class))).thenReturn(
             true);
@@ -180,19 +187,18 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
         verify(responseMode, never()).processResponse(any(PRPAIN201306UV02.class), any(AssertionType.class),
             any(II.class));
 
-        verify(auditLogger).auditResponseMessage(request, actualResponse, assertion, null,
-            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE,
-            Boolean.FALSE, webContextProperties, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
+        verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
+            eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
+            any(PatientDiscoveryDeferredResponseAuditTransforms.class));
     }
 
     @Test
     public void policyFailed() {
-        PRPAIN201306UV02 request = new PRPAIN201306UV02();
-        AssertionType assertion = new AssertionType();
-
         // Mocks
         PatientDiscovery201306PolicyChecker policyChecker = mock(PatientDiscovery201306PolicyChecker.class);
-
+        PatientDiscoveryDeferredResponseAuditLogger auditLogger = getAuditLogger(true);
         // Stubbing the methods
         when(policyChecker.checkOutgoingPolicy(any(RespondingGatewayPRPAIN201306UV02RequestType.class))).thenReturn(
             false);
@@ -217,9 +223,81 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
         verify(policyChecker).checkOutgoingPolicy(policyReqArgument.capture());
         assertEquals(request, policyReqArgument.getValue().getPRPAIN201306UV02());
 
-        verify(auditLogger).auditResponseMessage(request, errorResponse, assertion, null,
-            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE,
-            Boolean.FALSE, webContextProperties, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
+        verify(mockEJBLogger).auditResponseMessage(eq(request), eq(errorResponse), eq(assertion),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
+            eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
+            any(PatientDiscoveryDeferredResponseAuditTransforms.class));
+    }
+
+    @Test
+    public void auditOffForInboundPDDeferredResp() {
+        MCCIIN000002UV01 expectedResponse = new MCCIIN000002UV01();
+        II patientId = new II();
+
+        // Mocks
+        PatientDiscovery201306PolicyChecker policyChecker = mock(PatientDiscovery201306PolicyChecker.class);
+        ResponseFactory responseFactory = mock(ResponseFactory.class);
+        PatientDiscovery201306Processor msgProcessor = mock(PatientDiscovery201306Processor.class);
+        PDDeferredCorrelationDao pdCorrelationDao = mock(PDDeferredCorrelationDao.class);
+        ResponseMode responseMode = mock(ResponseMode.class);
+        AdapterPatientDiscoveryDeferredRespProxyObjectFactory adapterProxyFactory
+            = mock(AdapterPatientDiscoveryDeferredRespProxyObjectFactory.class);
+        AdapterPatientDiscoveryDeferredRespProxy adapterProxy = mock(AdapterPatientDiscoveryDeferredRespProxy.class);
+        PatientDiscoveryDeferredResponseAuditLogger auditLogger = getAuditLogger(false);
+        // Stubbing the methods
+        when(policyChecker.checkOutgoingPolicy(any(RespondingGatewayPRPAIN201306UV02RequestType.class))).thenReturn(
+            true);
+
+        when(responseFactory.getResponseModeType()).thenReturn(ResponseModeType.VERIFY);
+
+        when(responseFactory.getResponseMode()).thenReturn(responseMode);
+
+        when(pdCorrelationDao.queryByMessageId(any(String.class))).thenReturn(patientId);
+
+        when(adapterProxyFactory.create()).thenReturn(adapterProxy);
+        when(adapterProxy.processPatientDiscoveryAsyncResp(request, assertion)).thenReturn(expectedResponse);
+
+        // Actual invocation
+        StandardInboundPatientDiscoveryDeferredResponse standardPatientDiscovery
+            = new StandardInboundPatientDiscoveryDeferredResponse(
+                policyChecker, responseFactory, msgProcessor, adapterProxyFactory, pdCorrelationDao, auditLogger);
+
+        MCCIIN000002UV01 actualResponse = standardPatientDiscovery.respondingGatewayDeferredPRPAIN201306UV02(request,
+            assertion, webContextProperties);
+
+        assertSame(expectedResponse, actualResponse);
+
+        // Verify policy check is with the correct request
+        ArgumentCaptor<RespondingGatewayPRPAIN201306UV02RequestType> policyReqArgument = ArgumentCaptor
+            .forClass(RespondingGatewayPRPAIN201306UV02RequestType.class);
+
+        verify(policyChecker).checkOutgoingPolicy(policyReqArgument.capture());
+        assertEquals(request, policyReqArgument.getValue().getPRPAIN201306UV02());
+
+        // Verify response mode is called
+        verify(responseMode).processResponse(request, assertion, patientId);
+
+        // Verify audits
+        verify(mockEJBLogger, never()).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
+            eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
+            any(PatientDiscoveryDeferredResponseAuditTransforms.class));
+    }
+
+    private PatientDiscoveryDeferredResponseAuditLogger getAuditLogger(final boolean isLoggingOn) {
+        return new PatientDiscoveryDeferredResponseAuditLogger() {
+            @Override
+            protected AuditEJBLogger getAuditLogger() {
+                return mockEJBLogger;
+            }
+
+            @Override
+            protected boolean isAuditLoggingOn(String serviceName) {
+                return isLoggingOn;
+            }
+        };
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscoveryTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscoveryTest.java
@@ -26,6 +26,7 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.outbound;
 
+import com.google.common.base.Optional;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import gov.hhs.fha.nhinc.aspect.OutboundProcessingEvent;
@@ -38,6 +39,7 @@ import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunityType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.connectmgr.UrlInfo;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.orchestration.OutboundResponseProcessor;
 import gov.hhs.fha.nhinc.patientdiscovery.MessageGeneratorUtils;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryPolicyChecker;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201305UV02ArgTransformer;
@@ -58,7 +60,6 @@ import org.hl7.v3.PRPAIN201306UV02;
 
 import org.hl7.v3.RespondingGatewayPRPAIN201305UV02RequestType;
 import org.hl7.v3.RespondingGatewayPRPAIN201306UV02ResponseType;
-import static org.junit.Assert.assertSame;
 import org.junit.Test;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -77,6 +78,10 @@ public class StandardOutboundPatientDiscoveryTest {
     private final AuditEJBLoggerImpl mockEJBLogger = mock(AuditEJBLoggerImpl.class);
     private final OutboundPatientDiscoveryDelegate delegate = mock(OutboundPatientDiscoveryDelegate.class);
     private final String TARGET_HCID = "1.1";
+    private final String PD_URL = "https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscovery";
+    private final OutboundPatientDiscoveryOrchestratable mockOrchestratable
+        = mock(OutboundPatientDiscoveryOrchestratable.class);
+    private final PatientDiscoveryPolicyChecker pdPolicyChecker = mock(PatientDiscoveryPolicyChecker.class);
 
     @Test
     public void hasOutboundProcessingEvent() throws Exception {
@@ -100,41 +105,14 @@ public class StandardOutboundPatientDiscoveryTest {
         NhinTargetSystemType target = MessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(targets);
         AssertionType assertion = createAssertion();
         request.setAssertion(assertion);
-        final OutboundPatientDiscoveryOrchestratable mockOrchestratable = mock(OutboundPatientDiscoveryOrchestratable.class);
-        //outOrchestratable.setResponse(new PRPAIN201306UV02());
-        final PatientDiscoveryAuditLogger auditLogger = getAuditLogger(true);
-        PatientDiscoveryPolicyChecker pdPolicyChecker = mock(PatientDiscoveryPolicyChecker.class);
 
         PolicyEngineProxyObjectFactory policyFactory = mock(PolicyEngineProxyObjectFactory.class);
         PolicyEngineProxy policyEngine = mock(PolicyEngineProxy.class);
 
-        //when(delegate.process(any(OutboundPatientDiscoveryOrchestratable.class))).thenReturn(outOrchestratable);
         when(pdPolicyChecker.checkOutgoingPolicy(any(RespondingGatewayPRPAIN201305UV02RequestType.class))).thenReturn(Boolean.TRUE);
         when(policyFactory.create()).thenReturn(policyEngine);
 
-        StandardOutboundPatientDiscovery standardPD = new StandardOutboundPatientDiscovery() {
-            @Override
-            protected PatientDiscoveryAuditLogger getNewPatientDiscoveryAuditLogger() {
-                return auditLogger;
-            }
-
-            @Override
-            protected List<UrlInfo> getEndpoints(NhinTargetCommunitiesType targetCommunities) {
-                return getEndPoints(MessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(
-                    targetCommunities));
-            }
-
-            @Override
-            protected boolean checkPolicy(RespondingGatewayPRPAIN201305UV02RequestType request) {
-                return true;
-            }
-
-            @Override
-            protected OutboundPatientDiscoveryOrchestratable createOrchestratable(PRPAIN201305UV02 message,
-                AssertionType assertion, NhinTargetSystemType target, NhincConstants.GATEWAY_API_LEVEL gatewayLevel) {
-                return mockOrchestratable;
-            }
-        };
+        StandardOutboundPatientDiscovery standardPD = createStandardPDObj(getAuditLogger(true));
         when(mockOrchestratable.getAssertion()).thenReturn(assertion);
         when(mockOrchestratable.getRequest()).thenReturn(request.getPRPAIN201305UV02());
         when(mockOrchestratable.getTarget()).thenReturn(target);
@@ -147,7 +125,7 @@ public class StandardOutboundPatientDiscoveryTest {
             eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME), any(PatientDiscoveryAuditTransforms.class));
     }
 
-    /*@Test
+    @Test
     public void auditLoggingTurnedOffForPD() {
         RespondingGatewayPRPAIN201305UV02RequestType request = new RespondingGatewayPRPAIN201305UV02RequestType();
         request.setPRPAIN201305UV02(new PRPAIN201305UV02());
@@ -155,24 +133,18 @@ public class StandardOutboundPatientDiscoveryTest {
         AssertionType assertion = new AssertionType();
         OutboundPatientDiscoveryOrchestratable outOrchestratable = new OutboundPatientDiscoveryOrchestratable();
         outOrchestratable.setResponse(new PRPAIN201306UV02());
-        final PatientDiscoveryAuditLogger auditLogger = getAuditLogger(false);
 
         when(delegate.process(any(OutboundPatientDiscoveryOrchestratable.class))).thenReturn(outOrchestratable);
-        StandardOutboundPatientDiscovery standardPatientDiscovery = new StandardOutboundPatientDiscovery() {
-            @Override
-            protected PatientDiscoveryAuditLogger getNewPatientDiscoveryAuditLogger() {
-                return auditLogger;
-            }
-        };
+        StandardOutboundPatientDiscovery standardPatientDiscovery = createStandardPDObj(getAuditLogger(false));
         RespondingGatewayPRPAIN201306UV02ResponseType actualMessage = standardPatientDiscovery
             .respondingGatewayPRPAIN201305UV02(request, assertion);
 
-        verify(mockEJbLogger, never()).auditRequestMessage(any(PRPAIN201305UV02.class), any(AssertionType.class),
+        verify(mockEJBLogger, never()).auditRequestMessage(any(PRPAIN201305UV02.class), any(AssertionType.class),
             any(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE), isNull(Properties.class),
             eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME), any(PatientDiscoveryAuditTransforms.class));
     }
-     */
+
     private NhinTargetCommunitiesType createNhinTargetCommunitiesType(String hcid) {
         NhinTargetCommunitiesType targetCommunities = new NhinTargetCommunitiesType();
         NhinTargetCommunityType targetCommunity = new NhinTargetCommunityType();
@@ -205,7 +177,7 @@ public class StandardOutboundPatientDiscoveryTest {
         List<UrlInfo> endpoints = new ArrayList<>();
         UrlInfo entry = new UrlInfo();
         entry.setHcid(target.getHomeCommunity().getHomeCommunityId());
-        entry.setUrl("https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscovery");
+        entry.setUrl(PD_URL);
         endpoints.add(entry);
         return endpoints;
     }
@@ -214,5 +186,32 @@ public class StandardOutboundPatientDiscoveryTest {
         AssertionType assertion = new AssertionType();
         assertion.setMessageId(TARGET_HCID);
         return assertion;
+    }
+
+    private StandardOutboundPatientDiscovery createStandardPDObj(final PatientDiscoveryAuditLogger auditLogger) {
+        return new StandardOutboundPatientDiscovery() {
+            @Override
+            protected PatientDiscoveryAuditLogger getAuditLogger() {
+                return auditLogger;
+            }
+
+            @Override
+            protected List<UrlInfo> getEndpoints(NhinTargetCommunitiesType targetCommunities) {
+                return getEndPoints(MessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(
+                    targetCommunities));
+            }
+
+            @Override
+            protected boolean checkPolicy(RespondingGatewayPRPAIN201305UV02RequestType request) {
+                return true;
+            }
+
+            @Override
+            protected OutboundPatientDiscoveryOrchestratable createOrchestratable(PRPAIN201305UV02 message,
+                AssertionType assertion, NhinTargetSystemType target, NhincConstants.GATEWAY_API_LEVEL gatewayLevel) {
+                return mockOrchestratable;
+            }
+        };
+
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscoveryTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscoveryTest.java
@@ -29,14 +29,44 @@ package gov.hhs.fha.nhinc.patientdiscovery.outbound;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import gov.hhs.fha.nhinc.aspect.OutboundProcessingEvent;
+import gov.hhs.fha.nhinc.audit.ejb.AuditEJBLogger;
+import gov.hhs.fha.nhinc.audit.ejb.impl.AuditEJBLoggerImpl;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunityType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.connectmgr.UrlInfo;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.patientdiscovery.MessageGeneratorUtils;
+import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryPolicyChecker;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201305UV02ArgTransformer;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.RespondingGatewayPRPAIN201306UV02Builder;
+import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryAuditLogger;
+import gov.hhs.fha.nhinc.patientdiscovery.audit.transform.PatientDiscoveryAuditTransforms;
+import gov.hhs.fha.nhinc.patientdiscovery.entity.OutboundPatientDiscoveryDelegate;
+import gov.hhs.fha.nhinc.patientdiscovery.entity.OutboundPatientDiscoveryOrchestratable;
+import gov.hhs.fha.nhinc.policyengine.adapter.proxy.PolicyEngineProxy;
+import gov.hhs.fha.nhinc.policyengine.adapter.proxy.PolicyEngineProxyObjectFactory;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import org.hl7.v3.PRPAIN201305UV02;
+import org.hl7.v3.PRPAIN201306UV02;
 
 import org.hl7.v3.RespondingGatewayPRPAIN201305UV02RequestType;
+import org.hl7.v3.RespondingGatewayPRPAIN201306UV02ResponseType;
+import static org.junit.Assert.assertSame;
 import org.junit.Test;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author akong
@@ -44,16 +74,145 @@ import org.junit.Test;
  */
 public class StandardOutboundPatientDiscoveryTest {
 
+    private final AuditEJBLoggerImpl mockEJBLogger = mock(AuditEJBLoggerImpl.class);
+    private final OutboundPatientDiscoveryDelegate delegate = mock(OutboundPatientDiscoveryDelegate.class);
+    private final String TARGET_HCID = "1.1";
+
     @Test
     public void hasOutboundProcessingEvent() throws Exception {
         Class<StandardOutboundPatientDiscovery> clazz = StandardOutboundPatientDiscovery.class;
-        Method method = clazz.getMethod("respondingGatewayPRPAIN201305UV02", RespondingGatewayPRPAIN201305UV02RequestType.class,
-                AssertionType.class);
+        Method method = clazz.getMethod("respondingGatewayPRPAIN201305UV02",
+            RespondingGatewayPRPAIN201305UV02RequestType.class, AssertionType.class);
         OutboundProcessingEvent annotation = method.getAnnotation(OutboundProcessingEvent.class);
         assertNotNull(annotation);
         assertEquals(PRPAIN201305UV02ArgTransformer.class, annotation.beforeBuilder());
         assertEquals(RespondingGatewayPRPAIN201306UV02Builder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery", annotation.serviceType());
         assertEquals("1.0", annotation.version());
+    }
+
+    @Test
+    public void auditLoggingTurnedOnForPD() {
+        RespondingGatewayPRPAIN201305UV02RequestType request = new RespondingGatewayPRPAIN201305UV02RequestType();
+        request.setPRPAIN201305UV02(new PRPAIN201305UV02());
+        NhinTargetCommunitiesType targets = createNhinTargetCommunitiesType(TARGET_HCID);
+        request.setNhinTargetCommunities(createNhinTargetCommunitiesType(TARGET_HCID));
+        NhinTargetSystemType target = MessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(targets);
+        AssertionType assertion = createAssertion();
+        request.setAssertion(assertion);
+        final OutboundPatientDiscoveryOrchestratable mockOrchestratable = mock(OutboundPatientDiscoveryOrchestratable.class);
+        //outOrchestratable.setResponse(new PRPAIN201306UV02());
+        final PatientDiscoveryAuditLogger auditLogger = getAuditLogger(true);
+        PatientDiscoveryPolicyChecker pdPolicyChecker = mock(PatientDiscoveryPolicyChecker.class);
+
+        PolicyEngineProxyObjectFactory policyFactory = mock(PolicyEngineProxyObjectFactory.class);
+        PolicyEngineProxy policyEngine = mock(PolicyEngineProxy.class);
+
+        //when(delegate.process(any(OutboundPatientDiscoveryOrchestratable.class))).thenReturn(outOrchestratable);
+        when(pdPolicyChecker.checkOutgoingPolicy(any(RespondingGatewayPRPAIN201305UV02RequestType.class))).thenReturn(Boolean.TRUE);
+        when(policyFactory.create()).thenReturn(policyEngine);
+
+        StandardOutboundPatientDiscovery standardPD = new StandardOutboundPatientDiscovery() {
+            @Override
+            protected PatientDiscoveryAuditLogger getNewPatientDiscoveryAuditLogger() {
+                return auditLogger;
+            }
+
+            @Override
+            protected List<UrlInfo> getEndpoints(NhinTargetCommunitiesType targetCommunities) {
+                return getEndPoints(MessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(
+                    targetCommunities));
+            }
+
+            @Override
+            protected boolean checkPolicy(RespondingGatewayPRPAIN201305UV02RequestType request) {
+                return true;
+            }
+
+            @Override
+            protected OutboundPatientDiscoveryOrchestratable createOrchestratable(PRPAIN201305UV02 message,
+                AssertionType assertion, NhinTargetSystemType target, NhincConstants.GATEWAY_API_LEVEL gatewayLevel) {
+                return mockOrchestratable;
+            }
+        };
+        when(mockOrchestratable.getAssertion()).thenReturn(assertion);
+        when(mockOrchestratable.getRequest()).thenReturn(request.getPRPAIN201305UV02());
+        when(mockOrchestratable.getTarget()).thenReturn(target);
+        RespondingGatewayPRPAIN201306UV02ResponseType actualMessage = standardPD.respondingGatewayPRPAIN201305UV02(
+            request, assertion);
+
+        verify(mockEJBLogger).auditRequestMessage(eq(request.getPRPAIN201305UV02()), any(AssertionType.class), any(
+            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE), isNull(Properties.class),
+            eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME), any(PatientDiscoveryAuditTransforms.class));
+    }
+
+    /*@Test
+    public void auditLoggingTurnedOffForPD() {
+        RespondingGatewayPRPAIN201305UV02RequestType request = new RespondingGatewayPRPAIN201305UV02RequestType();
+        request.setPRPAIN201305UV02(new PRPAIN201305UV02());
+        request.setNhinTargetCommunities(createNhinTargetCommunitiesType(TARGET_HCID));
+        AssertionType assertion = new AssertionType();
+        OutboundPatientDiscoveryOrchestratable outOrchestratable = new OutboundPatientDiscoveryOrchestratable();
+        outOrchestratable.setResponse(new PRPAIN201306UV02());
+        final PatientDiscoveryAuditLogger auditLogger = getAuditLogger(false);
+
+        when(delegate.process(any(OutboundPatientDiscoveryOrchestratable.class))).thenReturn(outOrchestratable);
+        StandardOutboundPatientDiscovery standardPatientDiscovery = new StandardOutboundPatientDiscovery() {
+            @Override
+            protected PatientDiscoveryAuditLogger getNewPatientDiscoveryAuditLogger() {
+                return auditLogger;
+            }
+        };
+        RespondingGatewayPRPAIN201306UV02ResponseType actualMessage = standardPatientDiscovery
+            .respondingGatewayPRPAIN201305UV02(request, assertion);
+
+        verify(mockEJbLogger, never()).auditRequestMessage(any(PRPAIN201305UV02.class), any(AssertionType.class),
+            any(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE), isNull(Properties.class),
+            eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME), any(PatientDiscoveryAuditTransforms.class));
+    }
+     */
+    private NhinTargetCommunitiesType createNhinTargetCommunitiesType(String hcid) {
+        NhinTargetCommunitiesType targetCommunities = new NhinTargetCommunitiesType();
+        NhinTargetCommunityType targetCommunity = new NhinTargetCommunityType();
+        targetCommunity.setHomeCommunity(createHomeCommunity(hcid));
+        targetCommunities.getNhinTargetCommunity().add(targetCommunity);
+        return targetCommunities;
+    }
+
+    private HomeCommunityType createHomeCommunity(String hcid) {
+        HomeCommunityType homeCommunity = new HomeCommunityType();
+        homeCommunity.setHomeCommunityId(hcid);
+        return homeCommunity;
+    }
+
+    private PatientDiscoveryAuditLogger getAuditLogger(final boolean isLoggingOn) {
+        return new PatientDiscoveryAuditLogger() {
+            @Override
+            protected AuditEJBLogger getAuditLogger() {
+                return mockEJBLogger;
+            }
+
+            @Override
+            protected boolean isAuditLoggingOn(String serviceName) {
+                return isLoggingOn;
+            }
+        };
+    }
+
+    private List<UrlInfo> getEndPoints(NhinTargetSystemType target) {
+        List<UrlInfo> endpoints = new ArrayList<>();
+        UrlInfo entry = new UrlInfo();
+        entry.setHcid(target.getHomeCommunity().getHomeCommunityId());
+        entry.setUrl("https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscovery");
+        endpoints.add(entry);
+        return endpoints;
+    }
+
+    private AssertionType createAssertion() {
+        AssertionType assertion = new AssertionType();
+        assertion.setMessageId(TARGET_HCID);
+        return assertion;
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/request/StandardOutboundPatientDiscoveryDeferredRequestTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/request/StandardOutboundPatientDiscoveryDeferredRequestTest.java
@@ -88,6 +88,14 @@ public class StandardOutboundPatientDiscoveryDeferredRequestTest {
     private II patientId;
     private AssertionType assertion;
     private final AuditEJBLoggerImpl mockEJBLogger = mock(AuditEJBLoggerImpl.class);
+    private final PatientDiscovery201305Processor pd201305Processor = mock(PatientDiscovery201305Processor.class);
+    private final AsyncMessageProcessHelper asyncProcessHelper = mock(AsyncMessageProcessHelper.class);
+    private final PatientDiscoveryPolicyChecker policyChecker = mock(PatientDiscoveryPolicyChecker.class);
+    private final OutboundPatientDiscoveryDeferredRequestDelegate delegate = mock(OutboundPatientDiscoveryDeferredRequestDelegate.class);
+    private final PDDeferredCorrelationDao correlationDao = mock(PDDeferredCorrelationDao.class);
+    private final ConnectionManagerCache connectionManager = mock(ConnectionManagerCache.class);
+    private final OutboundPatientDiscoveryDeferredRequestOrchestratable orchestratableResponse
+        = mock(OutboundPatientDiscoveryDeferredRequestOrchestratable.class);
 
     @Before
     public void initialize() {
@@ -139,16 +147,7 @@ public class StandardOutboundPatientDiscoveryDeferredRequestTest {
     public void invoke() throws ConnectionManagerException {
         List<UrlInfo> urlInfoList = createUrlInfoList("1.1", "2.2");
 
-        // Mocks
-        PatientDiscovery201305Processor pd201305Processor = mock(PatientDiscovery201305Processor.class);
-        AsyncMessageProcessHelper asyncProcessHelper = mock(AsyncMessageProcessHelper.class);
-        PatientDiscoveryPolicyChecker policyChecker = mock(PatientDiscoveryPolicyChecker.class);
-        OutboundPatientDiscoveryDeferredRequestDelegate delegate = mock(OutboundPatientDiscoveryDeferredRequestDelegate.class);
-        PDDeferredCorrelationDao correlationDao = mock(PDDeferredCorrelationDao.class);
-        ConnectionManagerCache connectionManager = mock(ConnectionManagerCache.class);
         PatientDiscoveryDeferredRequestAuditLogger auditLogger = getAuditLogger(true);
-        OutboundPatientDiscoveryDeferredRequestOrchestratable orchestratableResponse
-            = mock(OutboundPatientDiscoveryDeferredRequestOrchestratable.class);
         // Stubbing the methods
         when(
             connectionManager.getEndpointURLFromNhinTargetCommunities(eq(targets),
@@ -204,8 +203,6 @@ public class StandardOutboundPatientDiscoveryDeferredRequestTest {
     @Test
     public void noTargets() throws ConnectionManagerException {
         PatientDiscoveryDeferredRequestAuditLogger auditLogger = getAuditLogger(true);
-        // Mocks
-        ConnectionManagerCache connectionManager = mock(ConnectionManagerCache.class);
         // Stubbing the methods
         when(
             connectionManager.getEndpointURLFromNhinTargetCommunities(eq(targets),
@@ -240,14 +237,6 @@ public class StandardOutboundPatientDiscoveryDeferredRequestTest {
     public void policyFailed() throws ConnectionManagerException {
         List<UrlInfo> urlInfoList = createUrlInfoList("1.1");
         PatientDiscoveryDeferredRequestAuditLogger auditLogger = getAuditLogger(true);
-        // Mocks
-        PatientDiscovery201305Processor pd201305Processor = mock(PatientDiscovery201305Processor.class);
-        AsyncMessageProcessHelper asyncProcessHelper = mock(AsyncMessageProcessHelper.class);
-        PatientDiscoveryPolicyChecker policyChecker = mock(PatientDiscoveryPolicyChecker.class);
-        OutboundPatientDiscoveryDeferredRequestDelegate delegate
-            = mock(OutboundPatientDiscoveryDeferredRequestDelegate.class);
-        PDDeferredCorrelationDao correlationDao = mock(PDDeferredCorrelationDao.class);
-        ConnectionManagerCache connectionManager = mock(ConnectionManagerCache.class);
         // Stubbing the methods
         when(
             connectionManager.getEndpointURLFromNhinTargetCommunities(eq(targets),
@@ -300,16 +289,7 @@ public class StandardOutboundPatientDiscoveryDeferredRequestTest {
     public void auditOffForOutboundPDDeferredReq() throws ConnectionManagerException {
         List<UrlInfo> urlInfoList = createUrlInfoList("1.1", "2.2");
 
-        // Mocks
-        PatientDiscovery201305Processor pd201305Processor = mock(PatientDiscovery201305Processor.class);
-        AsyncMessageProcessHelper asyncProcessHelper = mock(AsyncMessageProcessHelper.class);
-        PatientDiscoveryPolicyChecker policyChecker = mock(PatientDiscoveryPolicyChecker.class);
-        OutboundPatientDiscoveryDeferredRequestDelegate delegate = mock(OutboundPatientDiscoveryDeferredRequestDelegate.class);
-        PDDeferredCorrelationDao correlationDao = mock(PDDeferredCorrelationDao.class);
-        ConnectionManagerCache connectionManager = mock(ConnectionManagerCache.class);
         PatientDiscoveryDeferredRequestAuditLogger auditLogger = getAuditLogger(false);
-        OutboundPatientDiscoveryDeferredRequestOrchestratable orchestratableResponse
-            = mock(OutboundPatientDiscoveryDeferredRequestOrchestratable.class);
         // Stubbing the methods
         when(
             connectionManager.getEndpointURLFromNhinTargetCommunities(eq(targets),

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/StandardOutboundPatientDiscoveryDeferredResponseTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/StandardOutboundPatientDiscoveryDeferredResponseTest.java
@@ -27,6 +27,8 @@
 package gov.hhs.fha.nhinc.patientdiscovery.outbound.deferred.response;
 
 import gov.hhs.fha.nhinc.aspect.OutboundProcessingEvent;
+import gov.hhs.fha.nhinc.audit.ejb.AuditEJBLogger;
+import gov.hhs.fha.nhinc.audit.ejb.impl.AuditEJBLoggerImpl;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
@@ -39,6 +41,7 @@ import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscovery201306Processor;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.MCCIIN000002UV01EventDescriptionBuilder;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201306UV02EventDescriptionBuilder;
 import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryDeferredResponseAuditLogger;
+import gov.hhs.fha.nhinc.patientdiscovery.audit.transform.PatientDiscoveryDeferredResponseAuditTransforms;
 import gov.hhs.fha.nhinc.patientdiscovery.entity.deferred.response.OutboundPatientDiscoveryDeferredResponseDelegate;
 import gov.hhs.fha.nhinc.patientdiscovery.entity.deferred.response.OutboundPatientDiscoveryDeferredResponseOrchestratable;
 import gov.hhs.fha.nhinc.transform.subdisc.HL7AckTransforms;
@@ -57,8 +60,9 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import org.mockito.Mockito;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -76,7 +80,7 @@ public class StandardOutboundPatientDiscoveryDeferredResponseTest {
     private PRPAIN201306UV02 firstTargetRequest;
     private PRPAIN201306UV02 secondTargetRequest;
 
-    PatientDiscoveryDeferredResponseAuditLogger auditLogger = mock(PatientDiscoveryDeferredResponseAuditLogger.class);
+    private final AuditEJBLoggerImpl mockEJBLogger = mock(AuditEJBLoggerImpl.class);
     Properties webContextProperties = null;
 
     @Before
@@ -119,7 +123,7 @@ public class StandardOutboundPatientDiscoveryDeferredResponseTest {
         // Mocks
         PatientDiscovery201306PolicyChecker policyChecker = mock(PatientDiscovery201306PolicyChecker.class);
         PatientDiscovery201306Processor pd201306Processor = mock(PatientDiscovery201306Processor.class);
-
+        PatientDiscoveryDeferredResponseAuditLogger auditLogger = getAuditLogger(true);
         OutboundPatientDiscoveryDeferredResponseDelegate delegate
             = mock(OutboundPatientDiscoveryDeferredResponseDelegate.class);
         OutboundPatientDiscoveryDeferredResponseOrchestratable returnedOrchestratable
@@ -169,11 +173,10 @@ public class StandardOutboundPatientDiscoveryDeferredResponseTest {
 
         // Verify request from adapter is audited
         requestArgument.getAllValues().clear();
-        verify(auditLogger).auditRequestMessage(eq(request), eq(assertion),
-            Mockito.any(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
-            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE), eq(webContextProperties),
-            eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME));
-
+        verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
+            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE),
+            isNull(Properties.class), eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
+            any(PatientDiscoveryDeferredResponseAuditTransforms.class));
     }
 
     @Test
@@ -181,7 +184,7 @@ public class StandardOutboundPatientDiscoveryDeferredResponseTest {
 
         // Mocks
         ConnectionManagerCache connectionManager = mock(ConnectionManagerCache.class);
-
+        PatientDiscoveryDeferredResponseAuditLogger auditLogger = getAuditLogger(true);
         // Stubbing the methods
         when(connectionManager.getEndpointURLFromNhinTargetCommunities(eq(targets),
             eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME))).thenThrow(new ConnectionManagerException());
@@ -203,11 +206,10 @@ public class StandardOutboundPatientDiscoveryDeferredResponseTest {
         // Verify request from adapter is audited
         ArgumentCaptor<RespondingGatewayPRPAIN201306UV02RequestType> requestArgument = ArgumentCaptor
             .forClass(RespondingGatewayPRPAIN201306UV02RequestType.class);
-        verify(auditLogger).auditRequestMessage(eq(request), eq(assertion),
-            Mockito.any(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
-            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE), eq(webContextProperties),
-            eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME));
-
+        verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
+            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE),
+            isNull(Properties.class), eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
+            any(PatientDiscoveryDeferredResponseAuditTransforms.class));
     }
 
     @Test
@@ -219,7 +221,7 @@ public class StandardOutboundPatientDiscoveryDeferredResponseTest {
         PatientDiscovery201306Processor pd201306Processor = mock(PatientDiscovery201306Processor.class);
         OutboundPatientDiscoveryDeferredResponseDelegate delegate = mock(OutboundPatientDiscoveryDeferredResponseDelegate.class);
         ConnectionManagerCache connectionManager = mock(ConnectionManagerCache.class);
-
+        PatientDiscoveryDeferredResponseAuditLogger auditLogger = getAuditLogger(true);
         // Stubbing the methods
         when(connectionManager.getEndpointURLFromNhinTargetCommunities(targets,
             NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME)).thenReturn(urlInfoList);
@@ -246,9 +248,87 @@ public class StandardOutboundPatientDiscoveryDeferredResponseTest {
         // Verify request from adapter is audited
         ArgumentCaptor<RespondingGatewayPRPAIN201306UV02RequestType> requestArgument = ArgumentCaptor
             .forClass(RespondingGatewayPRPAIN201306UV02RequestType.class);
-        verify(auditLogger).auditRequestMessage(eq(request), eq(assertion),
-            Mockito.any(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
-            eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE), eq(webContextProperties),
-            eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME));
+        verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
+            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE),
+            isNull(Properties.class), eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
+            any(PatientDiscoveryDeferredResponseAuditTransforms.class));
+    }
+
+    @Test
+    public void auditOffForOutboundPDDeferredResp() throws ConnectionManagerException {
+        List<UrlInfo> urlInfoList = createUrlInfoList("1.1", "2.2");
+
+        // Mocks
+        PatientDiscovery201306PolicyChecker policyChecker = mock(PatientDiscovery201306PolicyChecker.class);
+        PatientDiscovery201306Processor pd201306Processor = mock(PatientDiscovery201306Processor.class);
+        PatientDiscoveryDeferredResponseAuditLogger auditLogger = getAuditLogger(false);
+        OutboundPatientDiscoveryDeferredResponseDelegate delegate
+            = mock(OutboundPatientDiscoveryDeferredResponseDelegate.class);
+        OutboundPatientDiscoveryDeferredResponseOrchestratable returnedOrchestratable
+            = mock(OutboundPatientDiscoveryDeferredResponseOrchestratable.class);
+        ConnectionManagerCache connectionManager = mock(ConnectionManagerCache.class);
+
+        // Stubbing the methods
+        when(connectionManager.getEndpointURLFromNhinTargetCommunities(targets,
+            NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME)).thenReturn(urlInfoList);
+
+        when(pd201306Processor.createNewRequest(request, "1.1")).thenReturn(firstTargetRequest);
+        when(pd201306Processor.createNewRequest(request, "2.2")).thenReturn(secondTargetRequest);
+
+        when(policyChecker.checkOutgoingPolicy(any(RespondingGatewayPRPAIN201306UV02RequestType.class))).thenReturn(
+            true);
+
+        when(delegate.process(any(OutboundPatientDiscoveryDeferredResponseOrchestratable.class))).thenReturn(
+            returnedOrchestratable);
+
+        when(returnedOrchestratable.getResponse()).thenReturn(expectedResponse);
+
+        // Actual invocation
+        StandardOutboundPatientDiscoveryDeferredResponse standardPatientDiscovery
+            = new StandardOutboundPatientDiscoveryDeferredResponse(policyChecker, pd201306Processor, auditLogger,
+                delegate, connectionManager);
+
+        MCCIIN000002UV01 actualResponse = standardPatientDiscovery.processPatientDiscoveryAsyncResp(request, assertion,
+            targets);
+
+        // Verify actual response is the same as expected
+        assertSame(expectedResponse, actualResponse);
+
+        // Verify policy is checking the request containing the first target and then the second target
+        ArgumentCaptor<RespondingGatewayPRPAIN201306UV02RequestType> requestArgument = ArgumentCaptor
+            .forClass(RespondingGatewayPRPAIN201306UV02RequestType.class);
+
+        verify(policyChecker, times(2)).checkOutgoingPolicy(requestArgument.capture());
+        assertEquals(firstTargetRequest, requestArgument.getAllValues().get(0).getPRPAIN201306UV02());
+        assertEquals(secondTargetRequest, requestArgument.getAllValues().get(1).getPRPAIN201306UV02());
+
+        // Verify the orchestratable is processing the request containing the first target and then the second target
+        ArgumentCaptor<OutboundPatientDiscoveryDeferredResponseOrchestratable> orchestratableArgument = ArgumentCaptor
+            .forClass(OutboundPatientDiscoveryDeferredResponseOrchestratable.class);
+
+        verify(delegate, times(2)).process(orchestratableArgument.capture());
+        assertEquals(firstTargetRequest, orchestratableArgument.getAllValues().get(0).getRequest());
+        assertEquals(secondTargetRequest, orchestratableArgument.getAllValues().get(1).getRequest());
+
+        // Verify request from adapter is audited
+        requestArgument.getAllValues().clear();
+        verify(mockEJBLogger, never()).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
+            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE),
+            isNull(Properties.class), eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
+            any(PatientDiscoveryDeferredResponseAuditTransforms.class));
+    }
+
+    private PatientDiscoveryDeferredResponseAuditLogger getAuditLogger(final boolean isLoggingOn) {
+        return new PatientDiscoveryDeferredResponseAuditLogger() {
+            @Override
+            protected AuditEJBLogger getAuditLogger() {
+                return mockEJBLogger;
+            }
+
+            @Override
+            protected boolean isAuditLoggingOn(String serviceName) {
+                return isLoggingOn;
+            }
+        };
     }
 }


### PR DESCRIPTION
Auditlogging turn on/off feature for PD,DQ,DR,X12 services, PDDeferredRequest and PDDeferredResponse, DSDeferredRequest and DSDeferredResponse.
1. Source files that were changed: AuditLogger.java, NhincConstants.java
2. Properties file: added a new property file audit.properties.
3. Junit test cases were updated throughout CONNECT services 
