### PR TITLE
FHAC-568 Create AuditLog off suite for testing auditlogging is turned off

### DIFF
--- a/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/AuditLogging-Passthrough-soapui-project.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/AuditLogging-Passthrough-soapui-project.xml
@@ -646,6 +646,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -979,7 +980,12 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -989,6 +995,7 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -1002,188 +1009,245 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq','true', log);
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
         <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-12T18:23:56Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-12T18:33:56Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/12/2015 18:23:56</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>submission set classificationNode</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
-          <con:value>C</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-41</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@code</con:name>
-          <con:value>110107</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Patient--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Submission</con:name>
-          <con:value>Set --></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
         </con:property>
         <con:property>
           <con:name>&lt;!--Human</con:name>
           <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
+          <con:name>&lt;--Patient--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>R</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
-          <con:value>110152</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Export</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
+          <con:name>&lt;--Submission</con:name>
+          <con:value>Set --></con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.@AlternativeUserID</con:name>
           <con:value>19233@192.168.1.1</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Provide and Register Document Set-b</con:value>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110106</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
           <con:value>307969004</con:value>
         </con:property>
         <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID_g0</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/1_1/NhinService/XDRRequest_Service</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID_g1</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/NhinService/XDRRequest_Service</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
+          <con:value>110152</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
+        </con:property>
+        <con:property>
+          <con:name>auditLogStatus</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-13T08:31:27Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
           <con:name>EventIdentification.@EventDateTime</con:name>
           <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110106</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Export</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-41</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Provide and Register Document Set-b</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
+          <con:value>C</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@code</con:name>
+          <con:value>110107</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
+          <con:value>Import</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-13T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>SELF-5^^^&amp;1.3.6.1.4.1.21367.2005.3.7&amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectID</con:name>
+          <con:value>1.3.6.1.4.1.21367.2005.3.9999.33</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCodeRole</con:name>
@@ -1194,75 +1258,23 @@ if (propertiesFile.exists()) {
           <con:value>urn:uuid:a54d6aa5-d40d-43f9-88c5-b4633d873bdd</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
           <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
           <con:value>IHE XDS Metadata</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>2</con:value>
+          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>submission set classificationNode</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
+          <con:name>sigDate</con:name>
+          <con:value>11/13/2015 08:21:27</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>SELF-5^^^&amp;1.3.6.1.4.1.21367.2005.3.7&amp;ISO</con:value>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-13T08:21:27Z</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
-          <con:value>Import</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectID</con:name>
-          <con:value>1.3.6.1.4.1.21367.2005.3.9999.33</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID_g1</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/NhinService/XDRRequest_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID_g0</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/1_1/NhinService/XDRRequest_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>auditLogStatus</con:name>
+          <con:name>AuditOff</con:name>
           <con:value>true</con:value>
         </con:property>
       </con:properties>
@@ -1645,6 +1657,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -1843,7 +1856,12 @@ parsedXmlMessage.AuditSourceIdentification.find{
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
@@ -1851,6 +1869,7 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -1864,24 +1883,25 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp','true', log);
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-12T18:24:09Z</con:value>
+          <con:value>2015-11-13T08:11:26Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-12T18:34:09Z</con:value>
+          <con:value>2015-11-13T08:21:26Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/12/2015 18:24:09</con:value>
+          <con:value>11/13/2015 08:11:26</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
@@ -2037,6 +2057,10 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>auditLogStatus</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
           <con:value>true</con:value>
         </con:property>
       </con:properties>
@@ -2553,6 +2577,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -2794,7 +2819,12 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeC
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -2805,6 +2835,7 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -2818,24 +2849,25 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission','true', log);
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-12T18:24:17Z</con:value>
+          <con:value>2015-11-13T08:11:45Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-12T18:34:17Z</con:value>
+          <con:value>2015-11-13T08:21:45Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/12/2015 18:24:17</con:value>
+          <con:value>11/13/2015 08:11:45</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
@@ -3079,6 +3111,10 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>auditLogStatus</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
           <con:value>true</con:value>
         </con:property>
       </con:properties>
@@ -3434,6 +3470,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+		testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -3754,7 +3791,12 @@ if (parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCo
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -3764,6 +3806,7 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -3777,6 +3820,7 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq','true', log);
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
@@ -3858,7 +3902,7 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-12T18:34:41Z</con:value>
+          <con:value>2015-11-13T08:22:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>Endpoint-AuditLogQuery</con:name>
@@ -3902,7 +3946,7 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>FamilyName</con:name>
@@ -4002,7 +4046,7 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/12/2015 18:24:41</con:value>
+          <con:value>11/13/2015 08:12:00</con:value>
         </con:property>
         <con:property>
           <con:name>SSN</con:name>
@@ -4010,7 +4054,7 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-12T18:24:41Z</con:value>
+          <con:value>2015-11-13T08:12:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>State</con:name>
@@ -4370,6 +4414,10 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>auditLogStatus</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
           <con:value>true</con:value>
         </con:property>
       </con:properties>
@@ -4751,6 +4799,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -5071,7 +5120,12 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeC
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -5081,6 +5135,8 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
+
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -5094,6 +5150,7 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp','true', log);
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
@@ -5363,19 +5420,19 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-12T18:24:59Z</con:value>
+          <con:value>2015-11-13T08:12:29Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-12T18:34:59Z</con:value>
+          <con:value>2015-11-13T08:22:29Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/12/2015 18:24:59</con:value>
+          <con:value>11/13/2015 08:12:29</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.EventID.@code</con:name>
@@ -5691,6 +5748,10 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>auditLogStatus</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
           <con:value>true</con:value>
         </con:property>
       </con:properties>
@@ -6193,6 +6254,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -6508,7 +6570,12 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -6518,6 +6585,7 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -6531,24 +6599,25 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery','true', log);
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-12T18:25:17Z</con:value>
+          <con:value>2015-11-13T08:13:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-12T18:35:17Z</con:value>
+          <con:value>2015-11-13T08:23:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/12/2015 18:25:17</con:value>
+          <con:value>11/13/2015 08:13:00</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
@@ -6952,6 +7021,10 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>auditLogStatus</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
           <con:value>true</con:value>
         </con:property>
       </con:properties>
@@ -7319,6 +7392,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -7606,7 +7680,12 @@ if(!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCo
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
@@ -7614,6 +7693,7 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -7627,24 +7707,25 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments','true', log);
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-12T18:25:49Z</con:value>
+          <con:value>2015-11-13T08:14:05Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-12T18:35:49Z</con:value>
+          <con:value>2015-11-13T08:24:05Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/12/2015 18:25:49</con:value>
+          <con:value>11/13/2015 08:14:05</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>FullPatientID</con:name>
@@ -7948,6 +8029,10 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>auditLogStatus</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
           <con:value>true</con:value>
         </con:property>
       </con:properties>
@@ -8276,6 +8361,7 @@ context.withSql(context.findProperty('AuditRepoDB')) {sql ->
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 }
+testRunner.testCase.setPropertyValue('AuditOff', 'true')
 testRunner.gotoStepByName( "Success")
  }
  else
@@ -8548,7 +8634,12 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -8558,6 +8649,7 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -8571,6 +8663,7 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments','true', log);
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
@@ -8580,19 +8673,19 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-12T18:26:01Z</con:value>
+          <con:value>2015-11-13T08:14:21Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-12T18:36:01Z</con:value>
+          <con:value>2015-11-13T08:24:21Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/12/2015 18:26:01</con:value>
+          <con:value>11/13/2015 08:14:21</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@value</con:name>
@@ -8912,6 +9005,10 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>auditLogStatus</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
           <con:value>true</con:value>
         </con:property>
       </con:properties>
@@ -9312,19 +9409,19 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-12T18:26:29Z</con:value>
+          <con:value>2015-11-13T08:14:49Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-12T18:36:29Z</con:value>
+          <con:value>2015-11-13T08:24:49Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/12/2015 18:26:29</con:value>
+          <con:value>11/13/2015 08:14:49</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
       </con:properties>
     </con:testCase>
@@ -9873,7 +9970,8 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
       <con:testStep type="groovy" name="Verify Audit Logs" id="f48a57a8-e26c-40a0-9de4-1245b744f953">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>log.info " ### Verify Audit Logs auditLogStatus " + testRunner.testCase.getPropertyValue("auditLogStatus")
+if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
@@ -9887,6 +9985,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -10220,7 +10319,12 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -10230,7 +10334,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -10244,188 +10348,249 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq','true', log);
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
         <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-12T18:26:43Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-12T18:36:43Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/12/2015 18:26:43</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>submission set classificationNode</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
-          <con:value>C</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-41</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@code</con:name>
-          <con:value>110107</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Patient--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Submission</con:name>
-          <con:value>Set --></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
         </con:property>
         <con:property>
           <con:name>&lt;!--Human</con:name>
           <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
+          <con:name>&lt;--Patient--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>R</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
-          <con:value>110152</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Export</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
+          <con:name>&lt;--Submission</con:name>
+          <con:value>Set --></con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.@AlternativeUserID</con:name>
           <con:value>19233@192.168.1.1</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Provide and Register Document Set-b</con:value>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110106</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
           <con:value>307969004</con:value>
         </con:property>
         <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID_g0</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/1_1/NhinService/XDRRequest_Service</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID_g1</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/NhinService/XDRRequest_Service</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
+          <con:value>110152</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
+        </con:property>
+        <con:property>
+          <con:name>auditLogStatus</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-13T08:33:16Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
           <con:name>EventIdentification.@EventDateTime</con:name>
           <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110106</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Export</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-41</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Provide and Register Document Set-b</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
+          <con:value>C</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@code</con:name>
+          <con:value>110107</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
+          <con:value>Import</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-13T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>SELF-5^^^&amp;1.3.6.1.4.1.21367.2005.3.7&amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectID</con:name>
+          <con:value>1.3.6.1.4.1.21367.2005.3.9999.33</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCodeRole</con:name>
@@ -10436,76 +10601,20 @@ if (propertiesFile.exists()) {
           <con:value>urn:uuid:a54d6aa5-d40d-43f9-88c5-b4633d873bdd</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
           <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
           <con:value>IHE XDS Metadata</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>2</con:value>
+          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>submission set classificationNode</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
+          <con:name>sigDate</con:name>
+          <con:value>11/13/2015 08:23:16</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>SELF-5^^^&amp;1.3.6.1.4.1.21367.2005.3.7&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
-          <con:value>Import</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectID</con:name>
-          <con:value>1.3.6.1.4.1.21367.2005.3.9999.33</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID_g1</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/NhinService/XDRRequest_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID_g0</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/1_1/NhinService/XDRRequest_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>true</con:value>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-13T08:23:16Z</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -10887,6 +10996,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -11086,7 +11196,12 @@ parsedXmlMessage.AuditSourceIdentification.find{
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
@@ -11096,6 +11211,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -11109,24 +11225,25 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp','true', log);
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-12T18:26:53Z</con:value>
+          <con:value>2015-11-13T08:23:32Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-12T18:36:53Z</con:value>
+          <con:value>2015-11-13T08:33:32Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/12/2015 18:26:53</con:value>
+          <con:value>11/13/2015 08:23:32</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
@@ -11282,6 +11399,10 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>auditLogStatus</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
           <con:value>true</con:value>
         </con:property>
       </con:properties>
@@ -11798,6 +11919,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -12039,7 +12161,12 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeC
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -12049,6 +12176,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -12062,24 +12190,25 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission','true', log);
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-12T18:27:00Z</con:value>
+          <con:value>2015-11-13T08:23:47Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-12T18:37:00Z</con:value>
+          <con:value>2015-11-13T08:33:47Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/12/2015 18:27:00</con:value>
+          <con:value>11/13/2015 08:23:47</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
@@ -12323,6 +12452,10 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>auditLogStatus</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
           <con:value>true</con:value>
         </con:property>
       </con:properties>
@@ -12678,6 +12811,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -12998,17 +13132,23 @@ if (parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCo
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
 nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
+
 //context.setGatewayStandard(false);
 //log.info ("Setting the gateway to Passthrough");
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -13022,6 +13162,7 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq','true', log);
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
@@ -13103,7 +13244,7 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-12T18:37:10Z</con:value>
+          <con:value>2015-11-13T08:34:04Z</con:value>
         </con:property>
         <con:property>
           <con:name>Endpoint-AuditLogQuery</con:name>
@@ -13147,7 +13288,7 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>FamilyName</con:name>
@@ -13247,7 +13388,7 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/12/2015 18:27:10</con:value>
+          <con:value>11/13/2015 08:24:04</con:value>
         </con:property>
         <con:property>
           <con:name>SSN</con:name>
@@ -13255,7 +13396,7 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-12T18:27:10Z</con:value>
+          <con:value>2015-11-13T08:24:04Z</con:value>
         </con:property>
         <con:property>
           <con:name>State</con:name>
@@ -13615,6 +13756,10 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>auditLogStatus</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
           <con:value>true</con:value>
         </con:property>
       </con:properties>
@@ -13996,6 +14141,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -14316,7 +14462,12 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeC
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -14326,6 +14477,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -14339,6 +14491,7 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp','true', log);
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
@@ -14608,19 +14761,19 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-11T23:37:45Z</con:value>
+          <con:value>2015-11-13T08:34:32Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/11/2015 23:27:45</con:value>
+          <con:value>11/13/2015 08:24:32</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-11T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-11T23:27:45Z</con:value>
+          <con:value>2015-11-13T08:24:32Z</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.EventID.@code</con:name>
@@ -14937,6 +15090,10 @@ if (propertiesFile.exists()) {
         <con:property>
           <con:name>auditLogStatus</con:name>
           <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
+          <con:value>true</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -15438,6 +15595,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -15628,6 +15786,7 @@ if (!parsedXmlMessage.ActiveParticipant[0].RoleIDCode.@displayName.isEmpty() && 
 	     	assert node.@UserID == context.findProperty( "ActiveParticipant_Source.@UserID" )
 	     }
      	assert node.@UserIsRequestor == context.findProperty( "ActiveParticipant_Source.@UserIsRequestor" )
+     	assert node.@UserName == context.findProperty( "ActiveParticipant_Source.@UserName" )
      	assert(!node.@NetworkAccessPointTypeCode.isEmpty())
    	 	def NetworkAccessPointTypeCode = node.@NetworkAccessPointTypeCode
    	 	assert NetworkAccessPointTypeCode == 1 || NetworkAccessPointTypeCode == 2
@@ -15652,8 +15811,7 @@ if (!parsedXmlMessage.ActiveParticipant[0].RoleIDCode.@displayName.isEmpty() && 
 if (!parsedXmlMessage.ActiveParticipant[1].RoleIDCode.@displayName.isEmpty() && parsedXmlMessage.ActiveParticipant[1].RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@displayName" )){
 	parsedXmlMessage.ActiveParticipant[1].each{ node ->
 	    	assert node.@UserID == context.findProperty( "ActiveParticipant_Dest.@UserID" )	    
-   	    assert node.@UserName == context.findProperty( "ActiveParticipant_Source.@UserName" )
-	     assert(!node.@AlternativeUserID.isEmpty())	    
+   	     assert(!node.@AlternativeUserID.isEmpty())	    
      	assert node.@UserIsRequestor == context.findProperty( "ActiveParticipant_Dest.@UserIsRequestor" )
      	assert(!node.@NetworkAccessPointTypeCode.isEmpty())
    	 	def NetworkAccessPointTypeCode = node.@NetworkAccessPointTypeCode
@@ -15754,7 +15912,12 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -15764,6 +15927,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -15777,24 +15941,25 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp','true', log);
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-11T23:28:00Z</con:value>
+          <con:value>2015-11-13T08:25:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-11T23:38:00Z</con:value>
+          <con:value>2015-11-13T08:35:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/11/2015 23:28:00</con:value>
+          <con:value>11/13/2015 08:25:00</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-11T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
@@ -16188,6 +16353,10 @@ if (propertiesFile.exists()) {
           <con:name>auditLogStatus</con:name>
           <con:value>false</con:value>
         </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
+          <con:value>true</con:value>
+        </con:property>
       </con:properties>
       <con:reportParameters/>
     </con:testCase>
@@ -16553,6 +16722,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -16841,7 +17011,12 @@ if(!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCo
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -16852,6 +17027,8 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
+
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -16865,24 +17042,25 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments','true', log);
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-11T23:28:31Z</con:value>
+          <con:value>2015-11-13T08:26:08Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-11T23:38:31Z</con:value>
+          <con:value>2015-11-13T08:36:08Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/11/2015 23:28:31</con:value>
+          <con:value>11/13/2015 08:26:08</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-11T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>FullPatientID</con:name>
@@ -17195,6 +17373,10 @@ if (propertiesFile.exists()) {
         <con:property>
           <con:name>auditLogStatus</con:name>
           <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
+          <con:value>true</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -17522,6 +17704,7 @@ context.withSql(context.findProperty('AuditRepoDB')) {sql ->
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 }
+testRunner.testCase.setPropertyValue('AuditOff', 'true')
 testRunner.gotoStepByName( "Success")
  }
  else
@@ -17796,7 +17979,12 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -17806,7 +17994,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -17820,6 +18008,7 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments','true', log);
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
@@ -17977,7 +18166,7 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-11T23:38:41Z</con:value>
+          <con:value>2015-11-13T08:36:23Z</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.@EventActionCode</con:name>
@@ -18029,7 +18218,7 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-11T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
@@ -18145,15 +18334,19 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/11/2015 23:28:41</con:value>
+          <con:value>11/13/2015 08:26:23</con:value>
         </con:property>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-11T23:28:41Z</con:value>
+          <con:value>2015-11-13T08:26:23Z</con:value>
         </con:property>
         <con:property>
           <con:name>auditLogStatus</con:name>
           <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
+          <con:value>true</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -18548,19 +18741,19 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-11T23:28:58Z</con:value>
+          <con:value>2015-11-13T08:26:51Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-11T23:38:58Z</con:value>
+          <con:value>2015-11-13T08:36:51Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/11/2015 23:28:58</con:value>
+          <con:value>11/13/2015 08:26:51</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-11T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -18864,6 +19057,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -19097,7 +19291,12 @@ parsedXmlMessage.ParticipantObjectIdentification.find{
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSRealTime',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -19105,6 +19304,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSRealTime', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -19117,23 +19317,24 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSRealTime','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-11T23:29:04Z</con:value>
+          <con:value>2015-11-13T08:29:34Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-11T23:39:04Z</con:value>
+          <con:value>2015-11-13T08:39:34Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/11/2015 23:29:04</con:value>
+          <con:value>11/13/2015 08:29:34</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-11T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.@UserIsRequestor</con:name>
@@ -19390,6 +19591,10 @@ if (propertiesFile.exists()) {
         <con:property>
           <con:name>auditLogStatus</con:name>
           <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
+          <con:value>true</con:value>
         </con:property>
       </con:properties>
     </con:testCase>
@@ -19694,6 +19899,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -19922,7 +20128,12 @@ parsedXmlMessage.ParticipantObjectIdentification.find{
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSGenericBatchRequest',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -19930,6 +20141,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSGenericBatchRequest', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -19942,23 +20154,24 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSGenericBatchRequest','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-11T23:29:11Z</con:value>
+          <con:value>2015-11-13T08:27:07Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-11T23:39:11Z</con:value>
+          <con:value>2015-11-13T08:37:07Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/11/2015 23:29:11</con:value>
+          <con:value>11/13/2015 08:27:07</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-11T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
@@ -20194,6 +20407,10 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>auditLogStatus</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
           <con:value>false</con:value>
         </con:property>
       </con:properties>
@@ -20503,6 +20720,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -20734,7 +20952,12 @@ parsedXmlMessage.ParticipantObjectIdentification.find{
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSGenericBatchResponse',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -20742,6 +20965,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSGenericBatchResponse', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -20754,23 +20978,24 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSGenericBatchResponse','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-11T23:29:18Z</con:value>
+          <con:value>2015-11-13T08:27:23Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-11T23:39:18Z</con:value>
+          <con:value>2015-11-13T08:37:23Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/11/2015 23:29:18</con:value>
+          <con:value>11/13/2015 08:27:23</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-11T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
@@ -21000,6 +21225,10 @@ if (propertiesFile.exists()) {
           <con:name>auditLogStatus</con:name>
           <con:value>false</con:value>
         </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
+          <con:value>true</con:value>
+        </con:property>
       </con:properties>
     </con:testCase>
     <con:properties>
@@ -21155,7 +21384,7 @@ if (propertiesFile.exists()) {
     </con:property>
     <con:property>
       <con:name>GatewayPropDir</con:name>
-      <con:value/>
+      <con:value>C:\jboss-as-7.1.1.Final\modules\org\connectopensource\configuration\main</con:value>
     </con:property>
     <con:property>
       <con:name>Gender</con:name>

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/AuditLogging-Passthrough-soapui-project.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/AuditLogging-Passthrough-soapui-project.xml
@@ -146,6 +146,12 @@
 			}</script>
         </con:config>
       </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
+        </con:config>
+      </con:testStep>
       <con:testStep name="Doc Submission Deferred Req" type="request" id="bb127108-2de3-48c0-8524-4be0016f3b41">
         <con:settings/>
         <con:config xsi:type="con:RequestStep" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -626,13 +632,13 @@
       <con:testStep type="delay" name="Wait for Audit table to populate">
         <con:settings/>
         <con:config>
-          <delay>2000</delay>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Verify Audit Logs" id="92119199-812d-4282-9182-b3f3e4ebac54">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if ( nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
@@ -641,12 +647,11 @@ context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	}
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if ( nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -974,28 +979,22 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
 	 	}
 	}
   }
-}]]></script>
+}
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
 nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
 //context.setGatewayStandard(false);
 //log.info ("Setting the gateway to Passthrough");
-
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -1009,7 +1008,7 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq','true', log);
+
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
@@ -1142,10 +1141,6 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>Source</con:value>
         </con:property>
         <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
           <con:name>AuditMessage.xmlns</con:name>
           <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
         </con:property>
@@ -1163,7 +1158,7 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-13T08:31:27Z</con:value>
+          <con:value>2015-11-14T01:50:35Z</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.@EventActionCode</con:name>
@@ -1215,7 +1210,7 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
+          <con:value>2015-12-14T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
@@ -1267,15 +1262,11 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/13/2015 08:21:27</con:value>
+          <con:value>11/14/2015 01:40:35</con:value>
         </con:property>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-13T08:21:27Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditOff</con:name>
-          <con:value>true</con:value>
+          <con:value>2015-11-14T01:40:35Z</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -1289,6 +1280,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 			}</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Doc Submission Deferred Resp" type="request" id="2849140e-e4a5-48ff-8d87-093fef199d05">
@@ -1636,28 +1633,26 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="delay" name="Wait for Audit table to populate">
         <con:settings/>
         <con:config>
-          <delay>2000</delay>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Verify Audit Logs" id="8d894511-06da-4f8c-b281-7637f7fe3c56">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
-	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where  direction="Nhin Outbound" and remoteHcid="2.2"')[0]
-	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where  direction="Nhin Outbound" and remoteHcid="1.1"')[0]
-	
-}
+	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
+	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
+	}
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -1850,26 +1845,22 @@ parsedXmlMessage.AuditSourceIdentification.find{
 			assert it.@AuditSourceID == context.findProperty( "AuditSourceIdentification.@AuditSourceID" )	
 		}
   }
-}</script>
+}
+
+
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")</script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
 nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
-
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -1883,133 +1874,121 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp','true', log);
+
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
-        <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-13T08:11:26Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-13T08:21:26Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/13/2015 08:11:26</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
         <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
         </con:property>
         <con:property>
-          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
-          <con:value>R</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
           <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-41</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@code</con:name>
-          <con:value>110106</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
           <con:value>localhost</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>C</con:value>
+          <con:name>ActiveParticipant_Dest.@UserID_g0</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/1_1/NhinService/XDRResponse_Service</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID_g1</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/NhinService/XDRResponse_Service</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
           <con:value>110152</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Import</con:value>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Provide and Register Document Set-b</con:value>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110107</con:value>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:50:50Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>C</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.@EventDateTime</con:name>
@@ -2020,48 +1999,52 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>0</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110107</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Import</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-41</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Provide and Register Document Set-b</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@code</con:name>
+          <con:value>110106</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
           <con:value>Export</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:40:50</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID_g1</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/NhinService/XDRResponse_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID_g0</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/1_1/NhinService/XDRResponse_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditOff</con:name>
-          <con:value>true</con:value>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:40:50Z</con:value>
         </con:property>
       </con:properties>
     </con:testCase>
@@ -2074,6 +2057,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Doc Submission" type="request" id="efed7670-fb06-4951-958e-4af171f6007f">
@@ -2562,22 +2551,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="d9e498c1-9552-498c-baa1-0ff26cf9d1ff">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
-}
-
+	}
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -2813,18 +2800,16 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeC
      	assert node.ParticipantObjectIDTypeCode.@displayName == context.findProperty( "ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@displayName" )
   	}
  }
-}]]></script>
+}
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -2833,9 +2818,6 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
 //log.info ("Setting the gateway to Passthrough");
 
 
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -2849,49 +2831,69 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission','true', log);
+
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
-        <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-13T08:11:45Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-13T08:21:45Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/13/2015 08:11:45</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
         <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>submission set classificationNode</con:value>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
-          <con:value>C</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>&lt;--Patient--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>&lt;--Submission</con:name>
+          <con:value>Set --></con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@UserID</con:name>
@@ -2902,204 +2904,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>false</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-41</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@code</con:name>
-          <con:value>110107</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Patient--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Submission</con:name>
-          <con:value>Set --></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>R</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
           <con:value>110152</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Export</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.1</con:value>
-        </con:property>
-        <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Provide and Register Document Set-b</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110106</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventDateTime</con:name>
-          <con:value>2015-04-02T13:47:30.199Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>20</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>urn:uuid:a54d6aa5-d40d-43f9-88c5-b4633d873bdd</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>IHE XDS Metadata</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>SELF-5^^^&amp;1.3.6.1.4.1.21367.2005.3.7&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
-          <con:value>Import</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectID</con:name>
-          <con:value>SubSetID_UniqueID01</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest_g0.@UserID</con:name>
@@ -3110,12 +2928,168 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</con:value>
         </con:property>
         <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditOff</con:name>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
           <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:51:06Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventDateTime</con:name>
+          <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110106</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Export</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-41</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Provide and Register Document Set-b</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
+          <con:value>C</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@code</con:name>
+          <con:value>110107</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
+          <con:value>Import</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>SELF-5^^^&amp;1.3.6.1.4.1.21367.2005.3.7&amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectID</con:name>
+          <con:value>SubSetID_UniqueID01</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>20</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>urn:uuid:a54d6aa5-d40d-43f9-88c5-b4633d873bdd</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>IHE XDS Metadata</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>submission set classificationNode</con:value>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:41:06</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:41:06Z</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -3129,6 +3103,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait for Clear Audit Logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Patient Discovery Deferred Req" type="request" id="0c821937-6034-4309-8285-07b913f76725">
@@ -3455,22 +3435,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="a581ace1-eeb4-477c-8344-bd95926a0eaf">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
-	
-}
+	}
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-		testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -3785,18 +3763,15 @@ if (parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCo
 	 	}
 	}
   }
-}]]></script>
+}
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -3804,9 +3779,6 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
 //context.setGatewayStandard(false);
 //log.info ("Setting the gateway to Passthrough");
 
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -3820,10 +3792,26 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq','true', log);
+
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
+        <con:property>
+          <con:name>&lt;!--Destination--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
+        </con:property>
+        <con:property>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
+          <con:value>checks --></con:value>
+        </con:property>
         <con:property>
           <con:name>AAMappingDB</con:name>
           <con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
@@ -3831,6 +3819,114 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
         <con:property>
           <con:name>AAMappingTable</con:name>
           <con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncReq</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
+          <con:value>110152</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
         </con:property>
         <con:property>
           <con:name>AQPatientID</con:name>
@@ -3847,6 +3943,22 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
         <con:property>
           <con:name>AsyncMsgTable</con:name>
           <con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+        </con:property>
+        <con:property>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
         </con:property>
         <con:property>
           <con:name>BirthTime</con:name>
@@ -3902,7 +4014,7 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-13T08:22:00Z</con:value>
+          <con:value>2015-11-14T01:51:20Z</con:value>
         </con:property>
         <con:property>
           <con:name>Endpoint-AuditLogQuery</con:name>
@@ -3941,12 +4053,48 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
         </con:property>
         <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>E</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventDateTime</con:name>
+          <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110112</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Query</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
+        </con:property>
+        <con:property>
           <con:name>ExpirationDate</con:name>
           <con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
+          <con:value>2015-12-14T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>FamilyName</con:name>
@@ -4001,6 +4149,122 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
         </con:property>
         <con:property>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
+          <con:value>LivingSubject.administrativeGender</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
+          <con:value>M</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectBirthTime.semanticsText</con:name>
+          <con:value>LivingSubject.birthTime</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectBirthTime.value.@value</con:name>
+          <con:value>19630804</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectId.value.@root</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.semanticsText</con:name>
+          <con:value>LivingSubject.name</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.value.family</con:name>
+          <con:value>Younger</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
+          <con:value>FAM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.value.given</con:name>
+          <con:value>Gallow</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
+          <con:value>GIV</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
+          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>24</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
+          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
+        </con:property>
+        <con:property>
           <con:name>PatientCorrelationDB</con:name>
           <con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
         </con:property>
@@ -4019,6 +4283,14 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
         <con:property>
           <con:name>PurposeOfDisclosure</con:name>
           <con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+        </con:property>
+        <con:property>
+          <con:name>queryId.@extension</con:name>
+          <con:value>-abd3453dcd24wkkks545</con:value>
+        </con:property>
+        <con:property>
+          <con:name>queryId.@root</con:name>
+          <con:value>2.2</con:value>
         </con:property>
         <con:property>
           <con:name>RealAA</con:name>
@@ -4045,8 +4317,16 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
         </con:property>
         <con:property>
+          <con:name>responseModalityCode.@code</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responsePriorityCode.@code</con:name>
+          <con:value>I</con:value>
+        </con:property>
+        <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/13/2015 08:12:00</con:value>
+          <con:value>11/14/2015 01:41:20</con:value>
         </con:property>
         <con:property>
           <con:name>SSN</con:name>
@@ -4054,11 +4334,15 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
         </con:property>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-13T08:12:00Z</con:value>
+          <con:value>2015-11-14T01:41:20Z</con:value>
         </con:property>
         <con:property>
           <con:name>State</con:name>
           <con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+        </con:property>
+        <con:property>
+          <con:name>statusCode.@code</con:name>
+          <con:value>new</con:value>
         </con:property>
         <con:property>
           <con:name>StreetAddress</con:name>
@@ -4100,326 +4384,6 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:name>ZipCode</con:name>
           <con:value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
         </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110112</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>24</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectBirthTime.semanticsText</con:name>
-          <con:value>LivingSubject.birthTime</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
-          <con:value>GIV</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventDateTime</con:name>
-          <con:value>2015-04-02T13:47:30.199Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
-          <con:value>FAM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responseModalityCode.@code</con:name>
-          <con:value>R</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectBirthTime.value.@value</con:name>
-          <con:value>19630804</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
-          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
-          <con:value>checks --></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectId.value.@root</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.semanticsText</con:name>
-          <con:value>LivingSubject.name</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responsePriorityCode.@code</con:name>
-          <con:value>I</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncReq</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Destination--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.value.family</con:name>
-          <con:value>Younger</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.value.given</con:name>
-          <con:value>Gallow</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
-          <con:value>LivingSubject.administrativeGender</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
-          <con:value>110152</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>E</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>queryId.@root</con:name>
-          <con:value>2.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
-          <con:value>M</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>queryId.@extension</con:name>
-          <con:value>-abd3453dcd24wkkks545</con:value>
-        </con:property>
-        <con:property>
-          <con:name>statusCode.@code</con:name>
-          <con:value>new</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
-          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
-        </con:property>
-        <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditOff</con:name>
-          <con:value>true</con:value>
-        </con:property>
       </con:properties>
       <con:reportParameters/>
     </con:testCase>
@@ -4432,6 +4396,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait for Clear Audit Logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Patient Discovery Deferred Resp" type="request" id="2c897726-977c-47f6-be07-e3ce1977cd53">
@@ -4784,28 +4754,178 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="82f1d25c-add6-4cf8-8851-9522bf94bc4b">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
-	
 }
-	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
+	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1) - ACK")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
 {
  	testRunner.fail( "Incorrect AuditLogging property found for this service testcase" )
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-InitiatingGateway(1.1) - ACK">
+        <con:settings/>
+        <con:config>
+          <script><![CDATA[context.withSql('AuditRepoDB') {sql ->
+def nhinAuditMessage_22_Outbound = sql.firstRow('SELECT CONVERT(message USING utf8) FROM ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
+def parsedXmlMessage = new XmlSlurper().parseText(nhinAuditMessage_22_Outbound)
+
+parsedXmlMessage.EventIdentification.find{
+	assert it.@EventActionCode == context.findProperty( "EventIdentification.@EventActionCode" )
+	//assert it.@EventDateTime == context.findProperty( "EventIdentification.@EventDateTime" )
+     assert it.@EventOutcomeIndicator == context.findProperty( "EventIdentification.@EventOutcomeIndicator" )
+	assert it.EventID.@code == context.findProperty( "EventIdentification.EventID.@code" )
+	assert it.EventID.@codeSystemName == context.findProperty( "EventIdentification.EventID.@codeSystemName" )
+	assert it.EventID.@displayName == context.findProperty( "EventIdentification.EventID.@displayName" )
+	assert it.EventTypeCode.@code == context.findProperty( "EventIdentification.EventTypeCode.@code" )
+	assert it.EventTypeCode.@codeSystemName == context.findProperty( "EventIdentification.EventTypeCode.@codeSystemName" )
+	assert it.EventTypeCode.@displayName == context.findProperty( "EventIdentification.EventTypeCode.@displayName" )	
+}
+
+//check for ActiveParticipant Source details
+if (!parsedXmlMessage.ActiveParticipant[0].RoleIDCode.@displayName.isEmpty() && parsedXmlMessage.ActiveParticipant[0].RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@displayName" )){
+	parsedXmlMessage.ActiveParticipant[0].each{ node ->
+	     assert node.@UserID == context.findProperty( "ActiveParticipant_Source.@UserID" )	     
+     	assert node.@UserName == context.findProperty( "ActiveParticipant_Source.@UserName" )
+	     assert(!node.@AlternativeUserID.isEmpty())
+     	assert node.@UserIsRequestor == context.findProperty( "ActiveParticipant_Source.@UserIsRequestor" )
+     	assert(!node.@NetworkAccessPointTypeCode.isEmpty())
+   	 	def NetworkAccessPointTypeCode = node.@NetworkAccessPointTypeCode
+   	 	assert NetworkAccessPointTypeCode == 1 || NetworkAccessPointTypeCode == 2
+     	assert(!node.@NetworkAccessPointID.isEmpty())
+     	def NetworkAccessPointID = node.@NetworkAccessPointID
+     	if (NetworkAccessPointTypeCode == 1) {
+
+     		assert node.@NetworkAccessPointID == context.findProperty( "ActiveParticipant_Source.@NetworkAccessPointID" )
+     		
+     	} else {
+
+     		def x = ~/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
+     		def matcher = (NetworkAccessPointID =~ x)  
+			assert matcher.matches()
+     		
+     	}
+          assert node.RoleIDCode.@code == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@code" )
+     	assert node.RoleIDCode.@codeSystemName == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@codeSystemName" )
+     	assert node.RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@displayName" )	     
+	}
+}
+
+//check for ActiveParticipant Destination details
+if (!parsedXmlMessage.ActiveParticipant[1].RoleIDCode.@displayName.isEmpty() && parsedXmlMessage.ActiveParticipant[1].RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@displayName" )){
+	parsedXmlMessage.ActiveParticipant[1].each{ node ->
+	     assert node.@UserID == context.findProperty( "ActiveParticipant_Dest.@UserID" )	     
+   	     if(!node.@UserName.isEmpty()){
+	     	assert node.@UserName == context.findProperty( "ActiveParticipant_Dest.@UserNamee" )
+	     }
+     	assert node.@UserIsRequestor == context.findProperty( "ActiveParticipant_Dest.@UserIsRequestor" )
+     	assert(!node.@NetworkAccessPointTypeCode.isEmpty())
+   	 	def NetworkAccessPointTypeCode = node.@NetworkAccessPointTypeCode
+   	 	assert NetworkAccessPointTypeCode == 1 || NetworkAccessPointTypeCode == 2
+     	assert(!node.@NetworkAccessPointID.isEmpty())
+     	def NetworkAccessPointID = node.@NetworkAccessPointID
+     	if (NetworkAccessPointTypeCode == 1) {
+
+     		assert node.@NetworkAccessPointID == context.findProperty( "ActiveParticipant_Dest.@NetworkAccessPointID" )
+     		
+     	} else {
+
+     		def x = ~/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
+     		def matcher = (NetworkAccessPointID =~ x)  
+			assert matcher.matches()
+     		
+     	}
+          assert node.RoleIDCode.@code == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@code" )
+     	assert node.RoleIDCode.@codeSystemName == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@codeSystemName" )
+     	assert node.RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@displayName" )	     
+	}
+}
+parsedXmlMessage.AuditSourceIdentification.find{
+		if(!it.@AuditEnterpriseSiteID.isEmpty()){
+			assert it.@AuditEnterpriseSiteID == context.findProperty( "AuditSourceIdentification.@AuditEnterpriseSiteID" )
+		}
+		if(!it.@AuditSourceTypeCode.isEmpty()){			
+			assert it.@AuditSourceTypeCode == context.findProperty( "AuditSourceIdentification.@AuditSourceTypeCode" )
+		}
+		if(!it.@AuditSourceID.isEmpty()){
+			assert it.@AuditSourceID == context.findProperty( "AuditSourceIdentification.@AuditSourceID" )	
+		}
+}
+
+//check for Patient ParticipantObjectIdentification
+if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCode.isEmpty() && parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectTypeCode" )){
+	parsedXmlMessage.ParticipantObjectIdentification[0].each{ node ->
+	     assert node.@ParticipantObjectID == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectID" )
+	     assert node.@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectTypeCode" )     
+   	    	assert node.@ParticipantObjectTypeCodeRole == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole" )	     
+    		assert node.ParticipantObjectIDTypeCode.@code == context.findProperty( "ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code" )
+    		assert node.ParticipantObjectIDTypeCode.@codeSystemName == context.findProperty( "ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName" )
+    		assert node.ParticipantObjectIDTypeCode.@displayName == context.findProperty( "ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName" )
+	}
+ }
+ 
+//check for Query Parameters ParticipantObjectIdentification
+if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeCode.isEmpty() && parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode" )){
+	parsedXmlMessage.ParticipantObjectIdentification[1].each{ node ->
+		if (!node.@ParticipantObjectID.isEmpty()){
+			assert node.@ParticipantObjectID == context.findProperty ( "queryId.@extension" )
+		}	
+	     assert node.@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode" )     
+   	     assert node.@ParticipantObjectTypeCodeRole == context.findProperty( "ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole" )	     
+    		assert node.ParticipantObjectIDTypeCode.@code == context.findProperty( "ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code" )
+    		assert node.ParticipantObjectIDTypeCode.@codeSystemName == context.findProperty( "ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName" )
+    		assert node.ParticipantObjectIDTypeCode.@displayName == context.findProperty( "ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName" )
+
+	 	if(!node.ParticipantObjectQuery.text().isEmpty()){	 		
+	 		byte[] participantobjectQueryDecoded = node.ParticipantObjectQuery.text().decodeBase64()			
+			def parsedParticipantObjectQuery = new XmlSlurper().parseText(new String(participantobjectQueryDecoded))			
+			parsedParticipantObjectQuery.queryId.find{				
+				assert it.@root == context.findProperty( "queryId.@root" )
+				assert it.@extension == context.findProperty ( "queryId.@extension" )
+			}
+			assert parsedParticipantObjectQuery.statusCode.@code == context.findProperty( "statusCode.@code" )
+			assert parsedParticipantObjectQuery.responseModalityCode.@code == context.findProperty( "responseModalityCode.@code" )
+			assert parsedParticipantObjectQuery.responsePriorityCode.@code == context.findProperty( "responsePriorityCode.@code" )
+			parsedParticipantObjectQuery.parameterList.livingSubjectAdministrativeGender.find{
+				assert it.value.@code == context.findProperty ( "parameterList.livingSubjectAdministrativeGender.value.@code" )
+				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectAdministrativeGender.semanticsText.@representation" )
+				assert it.semanticsText.text() == context.findProperty ( "parameterList.livingSubjectAdministrativeGender.semanticsText" )
+			}
+			parsedParticipantObjectQuery.parameterList.livingSubjectBirthTime.find{
+				assert it.value.@value == context.findProperty ( "parameterList.livingSubjectBirthTime.value.@value" )
+				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectBirthTime.semanticsText.@representation" )
+				assert it.semanticsText.text() == context.findProperty ( "parameterList.livingSubjectBirthTime.semanticsText" )
+			}
+			parsedParticipantObjectQuery.parameterList.livingSubjectId.find{
+				assert it.value.@root == context.findProperty ( "parameterList.livingSubjectId.value.@root" )
+				assert it.value.@extension == context.findProperty ( "parameterList.livingSubjectId.value.@extension" )
+				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectId.semanticsText.@representation" )				
+			}
+			parsedParticipantObjectQuery.parameterList.livingSubjectName.find{
+				assert it.value.family.@partType == context.findProperty ( "parameterList.livingSubjectName.value.family.@partType" )
+				assert it.value.family.text() == context.findProperty ( "parameterList.livingSubjectName.value.family" )
+				assert it.value.given.@partType == context.findProperty ( "parameterList.livingSubjectName.value.given.@partType" )
+				assert it.value.given.text() == context.findProperty ( "parameterList.livingSubjectName.value.given" )
+				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectName.semanticsText.@representation" )
+				assert it.semanticsText.text() == context.findProperty ( "parameterList.livingSubjectName.semanticsText" )
+			}			
+	 	}
+	}
+  }
+}]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-RespondingGateway(2.2)">
@@ -4962,181 +5082,21 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeC
 	 	}
 	}
   }
-}]]></script>
-        </con:config>
-      </con:testStep>
-      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-InitiatingGateway(1.1) - ACK">
-        <con:settings/>
-        <con:config>
-          <script><![CDATA[context.withSql('AuditRepoDB') {sql ->
-def nhinAuditMessage_22_Outbound = sql.firstRow('SELECT CONVERT(message USING utf8) FROM ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
-def parsedXmlMessage = new XmlSlurper().parseText(nhinAuditMessage_22_Outbound)
-
-parsedXmlMessage.EventIdentification.find{
-	assert it.@EventActionCode == context.findProperty( "EventIdentification.@EventActionCode" )
-	//assert it.@EventDateTime == context.findProperty( "EventIdentification.@EventDateTime" )
-     assert it.@EventOutcomeIndicator == context.findProperty( "EventIdentification.@EventOutcomeIndicator" )
-	assert it.EventID.@code == context.findProperty( "EventIdentification.EventID.@code" )
-	assert it.EventID.@codeSystemName == context.findProperty( "EventIdentification.EventID.@codeSystemName" )
-	assert it.EventID.@displayName == context.findProperty( "EventIdentification.EventID.@displayName" )
-	assert it.EventTypeCode.@code == context.findProperty( "EventIdentification.EventTypeCode.@code" )
-	assert it.EventTypeCode.@codeSystemName == context.findProperty( "EventIdentification.EventTypeCode.@codeSystemName" )
-	assert it.EventTypeCode.@displayName == context.findProperty( "EventIdentification.EventTypeCode.@displayName" )	
 }
-
-//check for ActiveParticipant Source details
-if (!parsedXmlMessage.ActiveParticipant[0].RoleIDCode.@displayName.isEmpty() && parsedXmlMessage.ActiveParticipant[0].RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@displayName" )){
-	parsedXmlMessage.ActiveParticipant[0].each{ node ->
-	     assert node.@UserID == context.findProperty( "ActiveParticipant_Source.@UserID" )	     
-     	assert node.@UserName == context.findProperty( "ActiveParticipant_Source.@UserName" )
-	     assert(!node.@AlternativeUserID.isEmpty())
-     	assert node.@UserIsRequestor == context.findProperty( "ActiveParticipant_Source.@UserIsRequestor" )
-     	assert(!node.@NetworkAccessPointTypeCode.isEmpty())
-   	 	def NetworkAccessPointTypeCode = node.@NetworkAccessPointTypeCode
-   	 	assert NetworkAccessPointTypeCode == 1 || NetworkAccessPointTypeCode == 2
-     	assert(!node.@NetworkAccessPointID.isEmpty())
-     	def NetworkAccessPointID = node.@NetworkAccessPointID
-     	if (NetworkAccessPointTypeCode == 1) {
-
-     		assert node.@NetworkAccessPointID == context.findProperty( "ActiveParticipant_Source.@NetworkAccessPointID" )
-     		
-     	} else {
-
-     		def x = ~/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
-     		def matcher = (NetworkAccessPointID =~ x)  
-			assert matcher.matches()
-     		
-     	}
-          assert node.RoleIDCode.@code == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@code" )
-     	assert node.RoleIDCode.@codeSystemName == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@codeSystemName" )
-     	assert node.RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@displayName" )	     
-	}
-}
-
-//check for ActiveParticipant Destination details
-if (!parsedXmlMessage.ActiveParticipant[1].RoleIDCode.@displayName.isEmpty() && parsedXmlMessage.ActiveParticipant[1].RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@displayName" )){
-	parsedXmlMessage.ActiveParticipant[1].each{ node ->
-	     assert node.@UserID == context.findProperty( "ActiveParticipant_Dest.@UserID" )	     
-   	     if(!node.@UserName.isEmpty()){
-	     	assert node.@UserName == context.findProperty( "ActiveParticipant_Dest.@UserNamee" )
-	     }
-     	assert node.@UserIsRequestor == context.findProperty( "ActiveParticipant_Dest.@UserIsRequestor" )
-     	assert(!node.@NetworkAccessPointTypeCode.isEmpty())
-   	 	def NetworkAccessPointTypeCode = node.@NetworkAccessPointTypeCode
-   	 	assert NetworkAccessPointTypeCode == 1 || NetworkAccessPointTypeCode == 2
-     	assert(!node.@NetworkAccessPointID.isEmpty())
-     	def NetworkAccessPointID = node.@NetworkAccessPointID
-     	if (NetworkAccessPointTypeCode == 1) {
-
-     		assert node.@NetworkAccessPointID == context.findProperty( "ActiveParticipant_Dest.@NetworkAccessPointID" )
-     		
-     	} else {
-
-     		def x = ~/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
-     		def matcher = (NetworkAccessPointID =~ x)  
-			assert matcher.matches()
-     		
-     	}
-          assert node.RoleIDCode.@code == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@code" )
-     	assert node.RoleIDCode.@codeSystemName == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@codeSystemName" )
-     	assert node.RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@displayName" )	     
-	}
-}
-parsedXmlMessage.AuditSourceIdentification.find{
-		if(!it.@AuditEnterpriseSiteID.isEmpty()){
-			assert it.@AuditEnterpriseSiteID == context.findProperty( "AuditSourceIdentification.@AuditEnterpriseSiteID" )
-		}
-		if(!it.@AuditSourceTypeCode.isEmpty()){			
-			assert it.@AuditSourceTypeCode == context.findProperty( "AuditSourceIdentification.@AuditSourceTypeCode" )
-		}
-		if(!it.@AuditSourceID.isEmpty()){
-			assert it.@AuditSourceID == context.findProperty( "AuditSourceIdentification.@AuditSourceID" )	
-		}
-}
-
-//check for Patient ParticipantObjectIdentification
-if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCode.isEmpty() && parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectTypeCode" )){
-	parsedXmlMessage.ParticipantObjectIdentification[0].each{ node ->
-	     assert node.@ParticipantObjectID == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectID" )
-	     assert node.@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectTypeCode" )     
-   	    	assert node.@ParticipantObjectTypeCodeRole == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole" )	     
-    		assert node.ParticipantObjectIDTypeCode.@code == context.findProperty( "ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code" )
-    		assert node.ParticipantObjectIDTypeCode.@codeSystemName == context.findProperty( "ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName" )
-    		assert node.ParticipantObjectIDTypeCode.@displayName == context.findProperty( "ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName" )
-	}
- }
- 
-//check for Query Parameters ParticipantObjectIdentification
-if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeCode.isEmpty() && parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode" )){
-	parsedXmlMessage.ParticipantObjectIdentification[1].each{ node ->
-		if (!node.@ParticipantObjectID.isEmpty()){
-			assert node.@ParticipantObjectID == context.findProperty ( "queryId.@extension" )
-		}	
-	     assert node.@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode" )     
-   	     assert node.@ParticipantObjectTypeCodeRole == context.findProperty( "ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole" )	     
-    		assert node.ParticipantObjectIDTypeCode.@code == context.findProperty( "ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code" )
-    		assert node.ParticipantObjectIDTypeCode.@codeSystemName == context.findProperty( "ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName" )
-    		assert node.ParticipantObjectIDTypeCode.@displayName == context.findProperty( "ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName" )
-
-	 	if(!node.ParticipantObjectQuery.text().isEmpty()){	 		
-	 		byte[] participantobjectQueryDecoded = node.ParticipantObjectQuery.text().decodeBase64()			
-			def parsedParticipantObjectQuery = new XmlSlurper().parseText(new String(participantobjectQueryDecoded))			
-			parsedParticipantObjectQuery.queryId.find{				
-				assert it.@root == context.findProperty( "queryId.@root" )
-				assert it.@extension == context.findProperty ( "queryId.@extension" )
-			}
-			assert parsedParticipantObjectQuery.statusCode.@code == context.findProperty( "statusCode.@code" )
-			assert parsedParticipantObjectQuery.responseModalityCode.@code == context.findProperty( "responseModalityCode.@code" )
-			assert parsedParticipantObjectQuery.responsePriorityCode.@code == context.findProperty( "responsePriorityCode.@code" )
-			parsedParticipantObjectQuery.parameterList.livingSubjectAdministrativeGender.find{
-				assert it.value.@code == context.findProperty ( "parameterList.livingSubjectAdministrativeGender.value.@code" )
-				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectAdministrativeGender.semanticsText.@representation" )
-				assert it.semanticsText.text() == context.findProperty ( "parameterList.livingSubjectAdministrativeGender.semanticsText" )
-			}
-			parsedParticipantObjectQuery.parameterList.livingSubjectBirthTime.find{
-				assert it.value.@value == context.findProperty ( "parameterList.livingSubjectBirthTime.value.@value" )
-				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectBirthTime.semanticsText.@representation" )
-				assert it.semanticsText.text() == context.findProperty ( "parameterList.livingSubjectBirthTime.semanticsText" )
-			}
-			parsedParticipantObjectQuery.parameterList.livingSubjectId.find{
-				assert it.value.@root == context.findProperty ( "parameterList.livingSubjectId.value.@root" )
-				assert it.value.@extension == context.findProperty ( "parameterList.livingSubjectId.value.@extension" )
-				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectId.semanticsText.@representation" )				
-			}
-			parsedParticipantObjectQuery.parameterList.livingSubjectName.find{
-				assert it.value.family.@partType == context.findProperty ( "parameterList.livingSubjectName.value.family.@partType" )
-				assert it.value.family.text() == context.findProperty ( "parameterList.livingSubjectName.value.family" )
-				assert it.value.given.@partType == context.findProperty ( "parameterList.livingSubjectName.value.given.@partType" )
-				assert it.value.given.text() == context.findProperty ( "parameterList.livingSubjectName.value.given" )
-				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectName.semanticsText.@representation" )
-				assert it.semanticsText.text() == context.findProperty ( "parameterList.livingSubjectName.semanticsText" )
-			}			
-	 	}
-	}
-  }
-}]]></script>
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
 nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
 //context.setGatewayStandard(false);
 //log.info ("Setting the gateway to Passthrough");
-
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
-
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -5150,121 +5110,25 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp','true', log);
+
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
         <con:property>
-          <con:name>LocalHCID</con:name>
-          <con:value>1.1</con:value>
+          <con:name>&lt;!--Destination--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>LocalAA</con:name>
-          <con:value>1.1</con:value>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>LocalHCDescription</con:name>
-          <con:value>InternalTest1</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>LocalPatientID</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemoteHCID</con:name>
-          <con:value>2.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemoteAA</con:name>
-          <con:value>2.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemoteHCDescription</con:name>
-          <con:value>InternalTest2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemotePatientID</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>NHINGatewayConfigDir</con:name>
-          <con:value>C:/Sun/AppServer/domains/domain1/config/nhin</con:value>
-        </con:property>
-        <con:property>
-          <con:name>MPIDir</con:name>
-          <con:value>C:/Sun/AppServer/domains/domain1/config</con:value>
-        </con:property>
-        <con:property>
-          <con:name>LocalConfigDir</con:name>
-          <con:value>C:/SelfTest/EndToEndSelfTest</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-DocQuery</con:name>
-          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityDocQueryUnsecured</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-DocRetrieve</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityDocRetrieve</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Reidentification</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubjectDiscovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Subscribe</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationProducer</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Notify</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationConsumer</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Unsubscribe</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubscriptionManager</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-AuditLogQuery</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityAuditQuery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-PatientDiscoveryAsyncReq</con:name>
-          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityPatientDiscoveryDeferredRequestUnsecured</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-PatientDiscoveryAsyncResp</con:name>
-          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityPatientDiscoveryDeferredResponseUnsecured</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBHost</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBPort</con:name>
-          <con:value>3306</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBUser</con:name>
-          <con:value>nhincuser</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBPass</con:name>
-          <con:value>nhincpass</con:value>
-        </con:property>
-        <con:property>
-          <con:name>PatientCorrelationDB</con:name>
-          <con:value>patientcorrelationdb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>PatientCorrelationTable</con:name>
-          <con:value>correlatedidentifiers</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubscriptionDB</con:name>
-          <con:value>subscriptionrepository</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubscriptionTable</con:name>
-          <con:value>subscription</con:value>
+          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
+          <con:value>checks --></con:value>
         </con:property>
         <con:property>
           <con:name>AAMappingDB</con:name>
@@ -5275,6 +5139,122 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>aa_to_home_community_mapping</con:value>
         </con:property>
         <con:property>
+          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncResp</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
+          <con:value>110152</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AQPatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AQUserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
           <con:name>AsyncMsgDB</con:name>
           <con:value>asyncmsgs</con:value>
         </con:property>
@@ -5283,20 +5263,52 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>asyncmsgrepo</con:value>
         </con:property>
         <con:property>
-          <con:name>PseudonymAA</con:name>
-          <con:value>ABC</con:value>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
         </con:property>
         <con:property>
-          <con:name>PseudonymPatientID</con:name>
-          <con:value>PSEUDO001</con:value>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
         </con:property>
         <con:property>
-          <con:name>RealAA</con:name>
-          <con:value>1.1.1</con:value>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
         </con:property>
         <con:property>
-          <con:name>RealPatientID</con:name>
-          <con:value>D1234010050</con:value>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>BirthTime</con:name>
+          <con:value>19630804</con:value>
+        </con:property>
+        <con:property>
+          <con:name>City</con:name>
+          <con:value>Melbourne</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Country</con:name>
+          <con:value>US</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DBHost</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DBPass</con:name>
+          <con:value>nhincpass</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DBPort</con:name>
+          <con:value>3306</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DBUser</con:name>
+          <con:value>nhincuser</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DOB</con:name>
+          <con:value>19800516</con:value>
         </con:property>
         <con:property>
           <con:name>DQDocID</con:name>
@@ -5307,10 +5319,6 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>D123401</con:value>
         </con:property>
         <con:property>
-          <con:name>DynamicDQDocID</con:name>
-          <con:value>103.8.9284320.020.3590.75^1266324032288</con:value>
-        </con:property>
-        <con:property>
           <con:name>DRDocID</con:name>
           <con:value>1.123407.777777</con:value>
         </con:property>
@@ -5319,16 +5327,140 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>1</con:value>
         </con:property>
         <con:property>
+          <con:name>DynamicDQDocID</con:name>
+          <con:value>103.8.9284320.020.3590.75^1266324032288</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:51:50Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-AuditLogQuery</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityAuditQuery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-DocQuery</con:name>
+          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityDocQueryUnsecured</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-DocRetrieve</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityDocRetrieve</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-EntityXDRRequest</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityProxyService/EntityXDRRequest</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Notify</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationConsumer</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-PatientDiscoveryAsyncReq</con:name>
+          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityPatientDiscoveryDeferredRequestUnsecured</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-PatientDiscoveryAsyncResp</con:name>
+          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityPatientDiscoveryDeferredResponseUnsecured</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Reidentification</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubjectDiscovery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Subscribe</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationProducer</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Unsubscribe</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubscriptionManager</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>E</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventDateTime</con:name>
+          <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110112</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Query</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ExpirationDate</con:name>
+          <con:value>20100520</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>FamilyName</con:name>
+          <con:value>Younger</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Gender</con:name>
+          <con:value>M</con:value>
+        </con:property>
+        <con:property>
+          <con:name>GivenName</con:name>
+          <con:value>Gallow</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalAA</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalConfigDir</con:name>
+          <con:value>C:/SelfTest/EndToEndSelfTest</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalHCDescription</con:name>
+          <con:value>InternalTest1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalHCID</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalPatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>MPIDir</con:name>
+          <con:value>C:/Sun/AppServer/domains/domain1/config</con:value>
+        </con:property>
+        <con:property>
+          <con:name>NHINGatewayConfigDir</con:name>
+          <con:value>C:/Sun/AppServer/domains/domain1/config/nhin</con:value>
+        </con:property>
+        <con:property>
           <con:name>NotificationEndpoint</con:name>
           <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/NotificationConsumerService/HiemNotify</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubscriptionEndpoint</con:name>
-          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/NotificationProducerService/HiemSubscription</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubscribePatientID</con:name>
-          <con:value>D123401</con:value>
         </con:property>
         <con:property>
           <con:name>NotifySubscriptionID</con:name>
@@ -5339,232 +5471,40 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
         </con:property>
         <con:property>
-          <con:name>UnSubscriptionID</con:name>
-          <con:value>3e74139f-5271-4db1-98c0-88748fa3e4e3</con:value>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
+          <con:value>LivingSubject.administrativeGender</con:value>
         </con:property>
         <con:property>
-          <con:name>SubscriptionManagerEndpointAddress</con:name>
-          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
         </con:property>
         <con:property>
-          <con:name>AQUserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AQPatientID</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-EntityXDRRequest</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityProxyService/EntityXDRRequest</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Gender</con:name>
+          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
           <con:value>M</con:value>
-        </con:property>
-        <con:property>
-          <con:name>BirthTime</con:name>
-          <con:value>19630804</con:value>
-        </con:property>
-        <con:property>
-          <con:name>FamilyName</con:name>
-          <con:value>Younger</con:value>
-        </con:property>
-        <con:property>
-          <con:name>GivenName</con:name>
-          <con:value>Gallow</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubjectID</con:name>
-          <con:value>1111</con:value>
-        </con:property>
-        <con:property>
-          <con:name>UniquePatientId</con:name>
-          <con:value>1111^^^&amp;amp;1.1&amp;amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>StreetAddress</con:name>
-          <con:value>123 Johnson Rd</con:value>
-        </con:property>
-        <con:property>
-          <con:name>City</con:name>
-          <con:value>Melbourne</con:value>
-        </con:property>
-        <con:property>
-          <con:name>State</con:name>
-          <con:value>FL</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ZipCode</con:name>
-          <con:value>12345</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Country</con:name>
-          <con:value>US</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SSN</con:name>
-          <con:value>123456789</con:value>
-        </con:property>
-        <con:property>
-          <con:name>PurposeOfDisclosure</con:name>
-          <con:value>Mental</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ExpirationDate</con:name>
-          <con:value>20100520</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DOB</con:name>
-          <con:value>19800516</con:value>
-        </con:property>
-        <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-13T08:12:29Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-13T08:22:29Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/13/2015 08:12:29</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110112</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>24</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectBirthTime.semanticsText</con:name>
           <con:value>LivingSubject.birthTime</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
-          <con:value>GIV</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>D123402^^^&amp;2.2&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventDateTime</con:name>
-          <con:value>2015-04-02T13:47:30.199Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
-          <con:value>FAM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responseModalityCode.@code</con:name>
-          <con:value>R</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
+          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectBirthTime.value.@value</con:name>
           <con:value>19630804</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
-          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
+          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
-          <con:value>checks --></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
+          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
+          <con:value>D123401</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectId.value.@root</con:name>
           <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectName.semanticsText</con:name>
@@ -5575,184 +5515,196 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>TXT</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responsePriorityCode.@code</con:name>
-          <con:value>I</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncResp</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Destination--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
           <con:name>parameterList.livingSubjectName.value.family</con:name>
           <con:value>Younger</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
+          <con:value>FAM</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectName.value.given</con:name>
           <con:value>Gallow</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
+          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
+          <con:value>GIV</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>D123402^^^&amp;2.2&amp;ISO</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
-          <con:value>LivingSubject.administrativeGender</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
-          <con:value>110152</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>E</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
           <con:value>2</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
         </con:property>
         <con:property>
-          <con:name>queryId.@root</con:name>
-          <con:value>2.2</con:value>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
+          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
           <con:value>2</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>24</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
           <con:value>IHE Transactions</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
-          <con:value>M</con:value>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>queryId.@extension</con:name>
-          <con:value>-abd3453dcd24wkkks545</con:value>
-        </con:property>
-        <con:property>
-          <con:name>statusCode.@code</con:name>
-          <con:value>new</con:value>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
           <con:value>D123402^^^&amp;2.2&amp;ISO</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
+          <con:name>PatientCorrelationDB</con:name>
+          <con:value>patientcorrelationdb</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
+          <con:name>PatientCorrelationTable</con:name>
+          <con:value>correlatedidentifiers</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
+          <con:name>PseudonymAA</con:name>
+          <con:value>ABC</con:value>
         </con:property>
         <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
+          <con:name>PseudonymPatientID</con:name>
+          <con:value>PSEUDO001</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditOff</con:name>
-          <con:value>true</con:value>
+          <con:name>PurposeOfDisclosure</con:name>
+          <con:value>Mental</con:value>
+        </con:property>
+        <con:property>
+          <con:name>queryId.@extension</con:name>
+          <con:value>-abd3453dcd24wkkks545</con:value>
+        </con:property>
+        <con:property>
+          <con:name>queryId.@root</con:name>
+          <con:value>2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RealAA</con:name>
+          <con:value>1.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RealPatientID</con:name>
+          <con:value>D1234010050</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemoteAA</con:name>
+          <con:value>2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemoteHCDescription</con:name>
+          <con:value>InternalTest2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemoteHCID</con:name>
+          <con:value>2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemotePatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responseModalityCode.@code</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responsePriorityCode.@code</con:name>
+          <con:value>I</con:value>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:41:50</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SSN</con:name>
+          <con:value>123456789</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:41:50Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>State</con:name>
+          <con:value>FL</con:value>
+        </con:property>
+        <con:property>
+          <con:name>statusCode.@code</con:name>
+          <con:value>new</con:value>
+        </con:property>
+        <con:property>
+          <con:name>StreetAddress</con:name>
+          <con:value>123 Johnson Rd</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubjectID</con:name>
+          <con:value>1111</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscribePatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionDB</con:name>
+          <con:value>subscriptionrepository</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionEndpoint</con:name>
+          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/NotificationProducerService/HiemSubscription</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionManagerEndpointAddress</con:name>
+          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionTable</con:name>
+          <con:value>subscription</con:value>
+        </con:property>
+        <con:property>
+          <con:name>UniquePatientId</con:name>
+          <con:value>1111^^^&amp;amp;1.1&amp;amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>UnSubscriptionID</con:name>
+          <con:value>3e74139f-5271-4db1-98c0-88748fa3e4e3</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ZipCode</con:name>
+          <con:value>12345</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -5766,6 +5718,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait for Clear Audit Logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Set Up PassThru" id="22829d23-344f-4e67-add1-519774f6d335">
@@ -6240,7 +6198,7 @@ nhinc.FileUtils.createOrUpdateConnection("internalConnectionInfo.xml", dir, "1.1
       <con:testStep type="groovy" name="Verify Audit Logs" id="91fb646d-64ae-45b2-83a0-8190c122bfe6">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
@@ -6249,12 +6207,11 @@ context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 }
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -6564,18 +6521,17 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
 	 	}
 	}
   }
-}]]></script>
+}
+
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -6583,9 +6539,6 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
 //context.setGatewayStandard(false);
 //log.info ("Setting the gateway to Passthrough");
 
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -6599,45 +6552,65 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery','true', log);
+
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
-        <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-13T08:13:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-13T08:23:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/13/2015 08:13:00</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
         <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
-          <con:value>anonymus</con:value>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
+        </con:property>
+        <con:property>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
+          <con:value>checks --></con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@UserID</con:name>
@@ -6648,132 +6621,88 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>false</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>E</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
           <con:value>110152</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
+          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Query</con:value>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
+          <con:value>false</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110112</con:value>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectSensitivity</con:name>
-          <con:value/>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:52:20Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>E</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.@EventDateTime</con:name>
@@ -6784,180 +6713,64 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>0</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110112</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Query</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>1111^^^&amp;1.1&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@value</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxuczM6Q09SRUVudmVsb3BlUmVhbFRpbWVSZXF1ZXN0IHhtbG5zOm5zMj0iaHR0cDovL3d3dy5jYXFoLm9yZy9TT0FQL1dTREwvQ09SRVJ1bGUyLjIuMC54c2QiIHhtbG5zOm5zMz0idXJuOm9yZzpjYXFoOnNvYXA6d3NkbDpjb3JlcnVsZTJfMl8wIj48UGF5bG9hZFR5cGU+WDEyXzI3MF9SZXF1ZXN0XzAwNTAxMFgyNzlBMTwvUGF5bG9hZFR5cGU+PFByb2Nlc3NpbmdNb2RlPlJlYWxUaW1lPC9Qcm9jZXNzaW5nTW9kZT48UGF5bG9hZElEPmY4MWQ0ZmFlLTdkZWMtMTFkMC1hNzY1LTAwYTBjOTFlNmJmNjwvUGF5bG9hZElEPjxUaW1lU3RhbXA+MjAwNy0wOC0zMFQxMDoyMDozNFo8L1RpbWVTdGFtcD48U2VuZGVySUQ+SG9zcGl0YWxBPC9TZW5kZXJJRD48UmVjZWl2ZXJJRD5QYXllckI8L1JlY2VpdmVySUQ+PENPUkVSdWxlVmVyc2lvbj4yLjIuMDwvQ09SRVJ1bGVWZXJzaW9uPjxQYXlsb2FkPjwvUGF5bG9hZD48L25zMzpDT1JFRW52ZWxvcGVSZWFsVGltZVJlcXVlc3Q+</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0idXJuOmdvdjpoaHM6ZmhhOm5oaW5jOmNvbW1vbjpwYXRpZW50Y29ycmVsYXRpb25mYWNhZGUiIHhtbG5zOm5zNT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmFkbWluaXN0cmF0aXZlR2VuZGVyPC9zZW1hbnRpY3NUZXh0PjwvbGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPjxsaXZpbmdTdWJqZWN0QmlydGhUaW1lPjx2YWx1ZSB2YWx1ZT0iMTk2MzA4MDQiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmJpcnRoVGltZTwvc2VtYW50aWNzVGV4dD48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgPC92YWx1ZT48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0Lm5hbWU8L3NlbWFudGljc1RleHQ+PC9saXZpbmdTdWJqZWN0TmFtZT48L3BhcmFtZXRlckxpc3Q+PC9xdWVyeUJ5UGFyYW1ldGVyPg==</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIiB4bWxuczpuczU9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246cGF0aWVudGNvcnJlbGF0aW9uZmFjYWRlIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmFkbWluaXN0cmF0aXZlR2VuZGVyPC9zZW1hbnRpY3NUZXh0PjwvbGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPjxsaXZpbmdTdWJqZWN0QmlydGhUaW1lPjx2YWx1ZSB2YWx1ZT0iMTk2MzA4MDQiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmJpcnRoVGltZTwvc2VtYW50aWNzVGV4dD48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgPC92YWx1ZT48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0Lm5hbWU8L3NlbWFudGljc1RleHQ+PC9saXZpbmdTdWJqZWN0TmFtZT48L3BhcmFtZXRlckxpc3Q+PC9xdWVyeUJ5UGFyYW1ldGVyPg==</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
           <con:value>ITI-55</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
-          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>24</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
           <con:value>IHE Transactions</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDetail.@value</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxuczM6Q09SRUVudmVsb3BlUmVhbFRpbWVSZXF1ZXN0IHhtbG5zOm5zMj0iaHR0cDovL3d3dy5jYXFoLm9yZy9TT0FQL1dTREwvQ09SRVJ1bGUyLjIuMC54c2QiIHhtbG5zOm5zMz0idXJuOm9yZzpjYXFoOnNvYXA6d3NkbDpjb3JlcnVsZTJfMl8wIj48UGF5bG9hZFR5cGU+WDEyXzI3MF9SZXF1ZXN0XzAwNTAxMFgyNzlBMTwvUGF5bG9hZFR5cGU+PFByb2Nlc3NpbmdNb2RlPlJlYWxUaW1lPC9Qcm9jZXNzaW5nTW9kZT48UGF5bG9hZElEPmY4MWQ0ZmFlLTdkZWMtMTFkMC1hNzY1LTAwYTBjOTFlNmJmNjwvUGF5bG9hZElEPjxUaW1lU3RhbXA+MjAwNy0wOC0zMFQxMDoyMDozNFo8L1RpbWVTdGFtcD48U2VuZGVySUQ+SG9zcGl0YWxBPC9TZW5kZXJJRD48UmVjZWl2ZXJJRD5QYXllckI8L1JlY2VpdmVySUQ+PENPUkVSdWxlVmVyc2lvbj4yLjIuMDwvQ09SRVJ1bGVWZXJzaW9uPjxQYXlsb2FkPjwvUGF5bG9hZD48L25zMzpDT1JFRW52ZWxvcGVSZWFsVGltZVJlcXVlc3Q+</con:value>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
+          <con:value>LivingSubject.administrativeGender</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectName.@value</con:name>
-          <con:value>anonymus</con:value>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName.@value</con:name>
-          <con:value>anonymus</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery.@value</con:name>
-          <con:value>test</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectQuery.@value</con:name>
-          <con:value>test</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail</con:name>
-          <con:value>test</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDetail</con:name>
-          <con:value>test</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
-          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query_Response.ParticipantObjectQuery</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIiB4bWxuczpuczU9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246cGF0aWVudGNvcnJlbGF0aW9uZmFjYWRlIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PGxpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PHZhbHVlIHZhbHVlPSIxOTYzMDgwNCIvPjxzZW1hbnRpY3NUZXh0IHJlcHJlc2VudGF0aW9uPSJUWFQiLz48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgCQk8L3ZhbHVlPjxzZW1hbnRpY3NUZXh0IHJlcHJlc2VudGF0aW9uPSJUWFQiLz48L2xpdmluZ1N1YmplY3ROYW1lPjwvcGFyYW1ldGVyTGlzdD48L3F1ZXJ5QnlQYXJhbWV0ZXI+</con:value>
+          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
+          <con:value>M</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectBirthTime.semanticsText</con:name>
           <con:value>LivingSubject.birthTime</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
-          <con:value>GIV</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
-          <con:value>FAM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responseModalityCode.@code</con:name>
-          <con:value>R</con:value>
+          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectBirthTime.value.@value</con:name>
           <con:value>19630804</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
-          <con:value>checks --></con:value>
+          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
+          <con:value>1111</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectId.value.@root</con:name>
@@ -6972,60 +6785,192 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>TXT</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
-          <con:value>1111</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responsePriorityCode.@code</con:name>
-          <con:value>I</con:value>
-        </con:property>
-        <con:property>
           <con:name>parameterList.livingSubjectName.value.family</con:name>
           <con:value>Younger</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
+          <con:value>FAM</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectName.value.given</con:name>
           <con:value>Gallow</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
+          <con:value>GIV</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
-          <con:value>LivingSubject.administrativeGender</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>1111^^^&amp;1.1&amp;ISO</con:value>
         </con:property>
         <con:property>
-          <con:name>queryId.@root</con:name>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectName</con:name>
           <con:value>1.1</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
-          <con:value>M</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail</con:name>
+          <con:value>test</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@value</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxuczM6Q09SRUVudmVsb3BlUmVhbFRpbWVSZXF1ZXN0IHhtbG5zOm5zMj0iaHR0cDovL3d3dy5jYXFoLm9yZy9TT0FQL1dTREwvQ09SRVJ1bGUyLjIuMC54c2QiIHhtbG5zOm5zMz0idXJuOm9yZzpjYXFoOnNvYXA6d3NkbDpjb3JlcnVsZTJfMl8wIj48UGF5bG9hZFR5cGU+WDEyXzI3MF9SZXF1ZXN0XzAwNTAxMFgyNzlBMTwvUGF5bG9hZFR5cGU+PFByb2Nlc3NpbmdNb2RlPlJlYWxUaW1lPC9Qcm9jZXNzaW5nTW9kZT48UGF5bG9hZElEPmY4MWQ0ZmFlLTdkZWMtMTFkMC1hNzY1LTAwYTBjOTFlNmJmNjwvUGF5bG9hZElEPjxUaW1lU3RhbXA+MjAwNy0wOC0zMFQxMDoyMDozNFo8L1RpbWVTdGFtcD48U2VuZGVySUQ+SG9zcGl0YWxBPC9TZW5kZXJJRD48UmVjZWl2ZXJJRD5QYXllckI8L1JlY2VpdmVySUQ+PENPUkVSdWxlVmVyc2lvbj4yLjIuMDwvQ09SRVJ1bGVWZXJzaW9uPjxQYXlsb2FkPjwvUGF5bG9hZD48L25zMzpDT1JFRW52ZWxvcGVSZWFsVGltZVJlcXVlc3Q+</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
+          <con:value>anonymus</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectName.@value</con:name>
+          <con:value>anonymus</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0idXJuOmdvdjpoaHM6ZmhhOm5oaW5jOmNvbW1vbjpwYXRpZW50Y29ycmVsYXRpb25mYWNhZGUiIHhtbG5zOm5zNT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmFkbWluaXN0cmF0aXZlR2VuZGVyPC9zZW1hbnRpY3NUZXh0PjwvbGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPjxsaXZpbmdTdWJqZWN0QmlydGhUaW1lPjx2YWx1ZSB2YWx1ZT0iMTk2MzA4MDQiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmJpcnRoVGltZTwvc2VtYW50aWNzVGV4dD48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgPC92YWx1ZT48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0Lm5hbWU8L3NlbWFudGljc1RleHQ+PC9saXZpbmdTdWJqZWN0TmFtZT48L3BhcmFtZXRlckxpc3Q+PC9xdWVyeUJ5UGFyYW1ldGVyPg==</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery.@value</con:name>
+          <con:value>test</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
+          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>24</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDetail</con:name>
+          <con:value>test</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDetail.@value</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxuczM6Q09SRUVudmVsb3BlUmVhbFRpbWVSZXF1ZXN0IHhtbG5zOm5zMj0iaHR0cDovL3d3dy5jYXFoLm9yZy9TT0FQL1dTREwvQ09SRVJ1bGUyLjIuMC54c2QiIHhtbG5zOm5zMz0idXJuOm9yZzpjYXFoOnNvYXA6d3NkbDpjb3JlcnVsZTJfMl8wIj48UGF5bG9hZFR5cGU+WDEyXzI3MF9SZXF1ZXN0XzAwNTAxMFgyNzlBMTwvUGF5bG9hZFR5cGU+PFByb2Nlc3NpbmdNb2RlPlJlYWxUaW1lPC9Qcm9jZXNzaW5nTW9kZT48UGF5bG9hZElEPmY4MWQ0ZmFlLTdkZWMtMTFkMC1hNzY1LTAwYTBjOTFlNmJmNjwvUGF5bG9hZElEPjxUaW1lU3RhbXA+MjAwNy0wOC0zMFQxMDoyMDozNFo8L1RpbWVTdGFtcD48U2VuZGVySUQ+SG9zcGl0YWxBPC9TZW5kZXJJRD48UmVjZWl2ZXJJRD5QYXllckI8L1JlY2VpdmVySUQ+PENPUkVSdWxlVmVyc2lvbj4yLjIuMDwvQ09SRVJ1bGVWZXJzaW9uPjxQYXlsb2FkPjwvUGF5bG9hZD48L25zMzpDT1JFRW52ZWxvcGVSZWFsVGltZVJlcXVlc3Q+</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName.@value</con:name>
+          <con:value>anonymus</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIiB4bWxuczpuczU9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246cGF0aWVudGNvcnJlbGF0aW9uZmFjYWRlIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmFkbWluaXN0cmF0aXZlR2VuZGVyPC9zZW1hbnRpY3NUZXh0PjwvbGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPjxsaXZpbmdTdWJqZWN0QmlydGhUaW1lPjx2YWx1ZSB2YWx1ZT0iMTk2MzA4MDQiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmJpcnRoVGltZTwvc2VtYW50aWNzVGV4dD48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgPC92YWx1ZT48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0Lm5hbWU8L3NlbWFudGljc1RleHQ+PC9saXZpbmdTdWJqZWN0TmFtZT48L3BhcmFtZXRlckxpc3Q+PC9xdWVyeUJ5UGFyYW1ldGVyPg==</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectQuery.@value</con:name>
+          <con:value>test</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query_Response.ParticipantObjectQuery</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIiB4bWxuczpuczU9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246cGF0aWVudGNvcnJlbGF0aW9uZmFjYWRlIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PGxpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PHZhbHVlIHZhbHVlPSIxOTYzMDgwNCIvPjxzZW1hbnRpY3NUZXh0IHJlcHJlc2VudGF0aW9uPSJUWFQiLz48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgCQk8L3ZhbHVlPjxzZW1hbnRpY3NUZXh0IHJlcHJlc2VudGF0aW9uPSJUWFQiLz48L2xpdmluZ1N1YmplY3ROYW1lPjwvcGFyYW1ldGVyTGlzdD48L3F1ZXJ5QnlQYXJhbWV0ZXI+</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
+          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
         </con:property>
         <con:property>
           <con:name>queryId.@extension</con:name>
           <con:value>-abd3453dcd24wkkks545</con:value>
         </con:property>
         <con:property>
+          <con:name>queryId.@root</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responseModalityCode.@code</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responsePriorityCode.@code</con:name>
+          <con:value>I</con:value>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:42:20</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:42:20Z</con:value>
+        </con:property>
+        <con:property>
           <con:name>statusCode.@code</con:name>
           <con:value>new</con:value>
-        </con:property>
-        <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditOff</con:name>
-          <con:value>true</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -7079,6 +7024,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 		"values (1, ?, ?)"
 		sql.executeUpdate(insertSql, [remoteAA, remoteHCID])
 		}</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait for Clear Audit Logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Document Query" type="request" id="bef3b45f-7008-4720-8945-372ae9c2c487">
@@ -7378,7 +7329,7 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="6f291114-5eef-4421-8d37-d77a36023952">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
@@ -7387,12 +7338,11 @@ context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 }
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -7674,26 +7624,20 @@ if(!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCo
 	 	} 
   	}
   }
-}]]></script>
+}
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
 nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
-
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -7707,53 +7651,73 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments','true', log);
+
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
-        <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-13T08:14:05Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-13T08:24:05Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/13/2015 08:14:05</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>FullPatientID</con:name>
-          <con:value>'D123401^^^&amp;amp;1.1&amp;amp;ISO'</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
         <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>24</con:value>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@type</con:name>
-          <con:value>QueryEncoding</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
-          <con:value>anonymus</con:value>
+          <con:name>&lt;--Document</con:name>
+          <con:value>--></con:value>
+        </con:property>
+        <con:property>
+          <con:name>&lt;--Patient--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>&lt;--RESPONDER--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@UserID</con:name>
@@ -7764,260 +7728,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>false</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-38</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>ITI-38</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Patient--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Document</con:name>
-          <con:value>--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@value</con:name>
-          <con:value>UTF-8</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>E</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
           <con:value>110152</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.1</con:value>
-        </con:property>
-        <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110112</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventDateTime</con:name>
-          <con:value>2015-04-02T13:47:30.199Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectID</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@value</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@type</con:name>
-          <con:value>urn:ihe:iti:xca:2010:homeCommunityId</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
-          <con:value>Export</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
-          <con:value>unknown</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectQuery</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxBZGhvY1F1ZXJ5UmVxdWVzdCB4bWx....</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--RESPONDER--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ResponderActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentQuery/2_0/NhinService/RespondingGateway_Query_Service/DocQuery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parsedParticipantObjectQuery.AdhocQuery.Slot.ValueList.Value.PatientID</con:name>
-          <con:value>D123401</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest_g0.@UserID</con:name>
@@ -8028,12 +7752,224 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>https://localhost:8181/Gateway/DocumentQuery/3_0/NhinService/RespondingGateway_Query_Service/DocQuery</con:value>
         </con:property>
         <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
+          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditOff</con:name>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
           <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:53:20Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>E</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventDateTime</con:name>
+          <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110112</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Query</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-38</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Query</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
+          <con:value>Export</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>FullPatientID</con:name>
+          <con:value>'D123401^^^&amp;amp;1.1&amp;amp;ISO'</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parsedParticipantObjectQuery.AdhocQuery.Slot.ValueList.Value.PatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
+          <con:value>anonymus</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
+          <con:value>unknown</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>24</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@type</con:name>
+          <con:value>QueryEncoding</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@value</con:name>
+          <con:value>UTF-8</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@type</con:name>
+          <con:value>urn:ihe:iti:xca:2010:homeCommunityId</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@value</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>ITI-38</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Query</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectQuery</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxBZGhvY1F1ZXJ5UmVxdWVzdCB4bWx....</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ResponderActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentQuery/2_0/NhinService/RespondingGateway_Query_Service/DocQuery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:43:20</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:43:20Z</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -8047,6 +7983,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait for Clear Audit Logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Document Retrieve" type="request" id="224217e3-1d69-4bd2-8a34-4a6832fd39cb">
@@ -8347,27 +8289,26 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="96c4a100-2609-4b9a-a62c-d38f44ff3a2d">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
- {
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments', log) == "true")
+{
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
 }
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
- }
- else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
- {
+}
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments', log) == "false")
+{
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
+	}
+	testRunner.gotoStepByName( "Success")
 }
-testRunner.testCase.setPropertyValue('AuditOff', 'true')
-testRunner.gotoStepByName( "Success")
- }
- else
- {
+else
+{
  	testRunner.fail( "Incorrect AuditLogging property found for this service testcase" )
- }</script>
+}</script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-InitiatingGateway(1.1)">
@@ -8628,28 +8569,21 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
 	 	}	  
 	}
  }
-}]]></script>
+}
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
 nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
 //context.setGatewayStandard(false);
 //log.info ("Setting the gateway to Passthrough");
-
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -8663,56 +8597,20 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments','true', log);
+
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
         <con:property>
-          <con:name>CorrectedRemoteHCID</con:name>
-          <con:value>urn:oid:2.2</con:value>
+          <con:name>&lt;!--Destination--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-13T08:14:21Z</con:value>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-13T08:24:21Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/13/2015 08:14:21</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@value</con:name>
-          <con:value>urn:oid:2.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110107</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
-          <con:value>anonymus</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
+          <con:name>&lt;!--Source--></con:name>
           <con:value/>
         </con:property>
         <con:property>
@@ -8720,280 +8618,112 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>--></con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Retrieve</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectDataLifeCycle</con:name>
+          <con:name>&lt;--Patient--></con:name>
           <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>500000000^^^&amp;1.1&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventDateTime</con:name>
-          <con:value>2015-04-02T13:47:30.199Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.@AlternativeUserID</con:name>
           <con:value>19233@192.168.1.1</con:value>
         </con:property>
         <con:property>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
           <con:name>ActiveParticipant.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@code</con:name>
-          <con:value>110106</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
-          <con:value>unknown</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@value</con:name>
-          <con:value>ihe:RepositoryUniqueId</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-39</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Destination--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Patient--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectQuery</con:name>
-          <con:value>unknown</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>9</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>3</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail_1.@type</con:name>
-          <con:value>ihe:homeCommunityID</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Import</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
-          <con:value>110152</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>C</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@type</con:name>
-          <con:value>ihe:homeCommunityID</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
-          <con:value>Export</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectID</con:name>
-          <con:value>1.123407.777777</con:value>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
           <con:value>SNOMED_CT</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentRetrieve/3_0/NhinService/RespondingGateway_Retrieve_Service/DocRetrieve</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail_1.@value</con:name>
-          <con:value>homeCommunityID</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
-          <con:value>R</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Report Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@value</con:name>
-          <con:value>1</con:value>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
           <con:value>19233@192.168.1.2</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@type</con:name>
-          <con:value>Repository Unique Id</con:value>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@type</con:name>
-          <con:value>Repository Unique Id</con:value>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail_one.@value</con:name>
-          <con:value>homeCommunityID</con:value>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail_one.@type</con:name>
-          <con:value>ihe:homeCommunityID</con:value>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
+          <con:value>110152</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentRetrieve/3_0/NhinService/RespondingGateway_Retrieve_Service/DocRetrieve</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source_g0.@UserID</con:name>
@@ -9004,12 +8734,216 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>https://localhost:8181/Gateway/DocumentRetrieve/3_0/NhinService/RespondingGateway_Retrieve_Service/DocRetrieve</con:value>
         </con:property>
         <con:property>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>CorrectedRemoteHCID</con:name>
+          <con:value>urn:oid:2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:53:35Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>C</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventDateTime</con:name>
+          <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110107</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Import</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-39</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Retrieve</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@code</con:name>
+          <con:value>110106</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
+          <con:value>Export</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>500000000^^^&amp;1.1&amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@type</con:name>
+          <con:value>Repository Unique Id</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@value</con:name>
+          <con:value>ihe:RepositoryUniqueId</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail_1.@type</con:name>
+          <con:value>ihe:homeCommunityID</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail_1.@value</con:name>
+          <con:value>homeCommunityID</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail_one.@type</con:name>
+          <con:value>ihe:homeCommunityID</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail_one.@value</con:name>
+          <con:value>homeCommunityID</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
+          <con:value>anonymus</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
+          <con:value>unknown</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectID</con:name>
+          <con:value>1.123407.777777</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>3</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@type</con:name>
+          <con:value>Repository Unique Id</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@value</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@type</con:name>
+          <con:value>ihe:homeCommunityID</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@value</con:name>
+          <con:value>urn:oid:2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>9</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Report Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectQuery</con:name>
+          <con:value>unknown</con:value>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:43:35</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:43:35Z</con:value>
+        </con:property>
+        <con:property>
           <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
+          <con:value>true</con:value>
         </con:property>
         <con:property>
           <con:name>AuditOff</con:name>
-          <con:value>true</con:value>
+          <con:value>false</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -9409,19 +9343,19 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-13T08:14:49Z</con:value>
+          <con:value>2015-11-14T01:43:49Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-13T08:24:49Z</con:value>
+          <con:value>2015-11-14T01:53:49Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/13/2015 08:14:49</con:value>
+          <con:value>11/14/2015 01:43:49</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
+          <con:value>2015-12-14T00:00:00Z</con:value>
         </con:property>
       </con:properties>
     </con:testCase>
@@ -9479,6 +9413,12 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Doc Submission Deferred Req" type="request" id="2cf077da-15d5-42a3-a5d7-3ab233476557">
@@ -9970,8 +9910,7 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
       <con:testStep type="groovy" name="Verify Audit Logs" id="f48a57a8-e26c-40a0-9de4-1245b744f953">
         <con:settings/>
         <con:config>
-          <script>log.info " ### Verify Audit Logs auditLogStatus " + testRunner.testCase.getPropertyValue("auditLogStatus")
-if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if ( nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
@@ -9980,12 +9919,11 @@ context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	}
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if ( nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -10313,18 +10251,16 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
 	 	}
 	}
   }
-}]]></script>
+}
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -10332,9 +10268,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 //context.setGatewayStandard(false);
 //log.info ("Setting the gateway to Passthrough");
 
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
+
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -10348,7 +10282,7 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq','true', log);
+
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
@@ -10481,16 +10415,8 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>Source</con:value>
         </con:property>
         <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
           <con:name>AuditMessage.xmlns</con:name>
           <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditOff</con:name>
-          <con:value>true</con:value>
         </con:property>
         <con:property>
           <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
@@ -10506,7 +10432,7 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-13T08:33:16Z</con:value>
+          <con:value>2015-11-14T01:43:39Z</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.@EventActionCode</con:name>
@@ -10558,7 +10484,7 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
+          <con:value>2015-12-14T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
@@ -10610,11 +10536,11 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/13/2015 08:23:16</con:value>
+          <con:value>11/14/2015 01:33:39</con:value>
         </con:property>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-13T08:23:16Z</con:value>
+          <con:value>2015-11-14T01:33:39Z</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -10628,6 +10554,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Doc Submission Deferred Resp" type="request" id="dc79d4f4-99b4-4ea6-bccc-c9d269226f61">
@@ -10981,22 +10913,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="55485d23-b657-4913-8606-4bc6d4b94c67">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
-	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where  direction="Nhin Outbound" and remoteHcid="2.2"')[0]
-	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where  direction="Nhin Outbound" and remoteHcid="1.1"')[0]
-	
-}
+	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
+	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
+	}
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -11190,28 +11120,22 @@ parsedXmlMessage.AuditSourceIdentification.find{
 			assert it.@AuditSourceID == context.findProperty( "AuditSourceIdentification.@AuditSourceID" )	
 		}
   }
-}</script>
+}
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")</script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
 nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
 //context.setGatewayStandard(false);
 //log.info ("Setting the gateway to Passthrough");
-
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -11225,133 +11149,121 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp','true', log);
+
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
-        <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-13T08:23:32Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-13T08:33:32Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/13/2015 08:23:32</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
         <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
         </con:property>
         <con:property>
-          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
-          <con:value>R</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
           <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-41</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@code</con:name>
-          <con:value>110106</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
           <con:value>localhost</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>C</con:value>
+          <con:name>ActiveParticipant_Dest.@UserID_g0</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/1_1/NhinService/XDRResponse_Service</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID_g1</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/NhinService/XDRResponse_Service</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
           <con:value>110152</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Import</con:value>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Provide and Register Document Set-b</con:value>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110107</con:value>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:43:53Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>C</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.@EventDateTime</con:name>
@@ -11362,48 +11274,52 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>0</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110107</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Import</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-41</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Provide and Register Document Set-b</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@code</con:name>
+          <con:value>110106</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
           <con:value>Export</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:33:53</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID_g1</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/NhinService/XDRResponse_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID_g0</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/1_1/NhinService/XDRResponse_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditOff</con:name>
-          <con:value>true</con:value>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:33:53Z</con:value>
         </con:property>
       </con:properties>
     </con:testCase>
@@ -11416,6 +11332,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Doc Submission" type="request" id="20b3c101-a2f1-4c1f-88dd-56fe0e5c480a">
@@ -11904,22 +11826,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="6846903e-4c2f-4c34-8b95-8c7f7804f568">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
-}
-
+	}
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -12155,28 +12075,22 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeC
      	assert node.ParticipantObjectIDTypeCode.@displayName == context.findProperty( "ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@displayName" )
   	}
  }
-}]]></script>
+}
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
 nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
 //context.setGatewayStandard(false);
 //log.info ("Setting the gateway to Passthrough");
-
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -12195,44 +12109,64 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
         <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-13T08:23:47Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-13T08:33:47Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/13/2015 08:23:47</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>submission set classificationNode</con:value>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
-          <con:value>C</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>&lt;--Patient--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>&lt;--Submission</con:name>
+          <con:value>Set --></con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@UserID</con:name>
@@ -12243,204 +12177,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>false</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-41</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@code</con:name>
-          <con:value>110107</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Patient--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Submission</con:name>
-          <con:value>Set --></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>R</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
           <con:value>110152</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Export</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.1</con:value>
-        </con:property>
-        <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Provide and Register Document Set-b</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110106</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventDateTime</con:name>
-          <con:value>2015-04-02T13:47:30.199Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>20</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>urn:uuid:a54d6aa5-d40d-43f9-88c5-b4633d873bdd</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>IHE XDS Metadata</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>SELF-5^^^&amp;1.3.6.1.4.1.21367.2005.3.7&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
-          <con:value>Import</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectID</con:name>
-          <con:value>SubSetID_UniqueID01</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest_g0.@UserID</con:name>
@@ -12451,12 +12201,168 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</con:value>
         </con:property>
         <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditOff</con:name>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
           <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:44:08Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventDateTime</con:name>
+          <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110106</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Export</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-41</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Provide and Register Document Set-b</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
+          <con:value>C</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@code</con:name>
+          <con:value>110107</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
+          <con:value>Import</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>SELF-5^^^&amp;1.3.6.1.4.1.21367.2005.3.7&amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectID</con:name>
+          <con:value>SubSetID_UniqueID01</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>20</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>urn:uuid:a54d6aa5-d40d-43f9-88c5-b4633d873bdd</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>IHE XDS Metadata</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>submission set classificationNode</con:value>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:34:08</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:34:08Z</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -12470,6 +12376,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Patient Discovery Deferred Req" type="request" id="39c72b7c-1cb3-4668-9929-d767963ea8e2">
@@ -12796,22 +12708,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="bdb61b25-6dfb-4d39-b46b-b612e3894c49">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
-	
-}
+	}
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -13126,18 +13036,15 @@ if (parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCo
 	 	}
 	}
   }
-}]]></script>
+}
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -13167,12 +13074,136 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
         <con:property>
+          <con:name>&lt;!--Destination--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
+        </con:property>
+        <con:property>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
+          <con:value>checks --></con:value>
+        </con:property>
+        <con:property>
           <con:name>AAMappingDB</con:name>
           <con:value>assigningauthoritydb</con:value>
         </con:property>
         <con:property>
           <con:name>AAMappingTable</con:name>
           <con:value>aa_to_home_community_mapping</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncReq</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
+          <con:value>110152</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
         </con:property>
         <con:property>
           <con:name>AQPatientID</con:name>
@@ -13189,6 +13220,22 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
         <con:property>
           <con:name>AsyncMsgTable</con:name>
           <con:value>asyncmsgrepo</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
         </con:property>
         <con:property>
           <con:name>BirthTime</con:name>
@@ -13244,7 +13291,7 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-13T08:34:04Z</con:value>
+          <con:value>2015-11-14T01:44:22Z</con:value>
         </con:property>
         <con:property>
           <con:name>Endpoint-AuditLogQuery</con:name>
@@ -13283,12 +13330,48 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>http://localhost:8080/CONNECTAdapter/EntitySubscriptionManager</con:value>
         </con:property>
         <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>E</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventDateTime</con:name>
+          <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110112</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Query</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
+        </con:property>
+        <con:property>
           <con:name>ExpirationDate</con:name>
           <con:value>20100520</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
+          <con:value>2015-12-14T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>FamilyName</con:name>
@@ -13343,6 +13426,122 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
         </con:property>
         <con:property>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
+          <con:value>LivingSubject.administrativeGender</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
+          <con:value>M</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectBirthTime.semanticsText</con:name>
+          <con:value>LivingSubject.birthTime</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectBirthTime.value.@value</con:name>
+          <con:value>19630804</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectId.value.@root</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.semanticsText</con:name>
+          <con:value>LivingSubject.name</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.value.family</con:name>
+          <con:value>Younger</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
+          <con:value>FAM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.value.given</con:name>
+          <con:value>Gallow</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
+          <con:value>GIV</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
+          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>24</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
+          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
+        </con:property>
+        <con:property>
           <con:name>PatientCorrelationDB</con:name>
           <con:value>patientcorrelationdb</con:value>
         </con:property>
@@ -13361,6 +13560,14 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
         <con:property>
           <con:name>PurposeOfDisclosure</con:name>
           <con:value>Mental</con:value>
+        </con:property>
+        <con:property>
+          <con:name>queryId.@extension</con:name>
+          <con:value>-abd3453dcd24wkkks545</con:value>
+        </con:property>
+        <con:property>
+          <con:name>queryId.@root</con:name>
+          <con:value>2.2</con:value>
         </con:property>
         <con:property>
           <con:name>RealAA</con:name>
@@ -13387,8 +13594,16 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>D123401</con:value>
         </con:property>
         <con:property>
+          <con:name>responseModalityCode.@code</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responsePriorityCode.@code</con:name>
+          <con:value>I</con:value>
+        </con:property>
+        <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/13/2015 08:24:04</con:value>
+          <con:value>11/14/2015 01:34:22</con:value>
         </con:property>
         <con:property>
           <con:name>SSN</con:name>
@@ -13396,11 +13611,15 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
         </con:property>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-13T08:24:04Z</con:value>
+          <con:value>2015-11-14T01:34:22Z</con:value>
         </con:property>
         <con:property>
           <con:name>State</con:name>
           <con:value>FL</con:value>
+        </con:property>
+        <con:property>
+          <con:name>statusCode.@code</con:name>
+          <con:value>new</con:value>
         </con:property>
         <con:property>
           <con:name>StreetAddress</con:name>
@@ -13443,324 +13662,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>12345</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110112</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>24</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectBirthTime.semanticsText</con:name>
-          <con:value>LivingSubject.birthTime</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
-          <con:value>GIV</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventDateTime</con:name>
-          <con:value>2015-04-02T13:47:30.199Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
-          <con:value>FAM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responseModalityCode.@code</con:name>
-          <con:value>R</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectBirthTime.value.@value</con:name>
-          <con:value>19630804</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
-          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
-          <con:value>checks --></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectId.value.@root</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.semanticsText</con:name>
-          <con:value>LivingSubject.name</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responsePriorityCode.@code</con:name>
-          <con:value>I</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncReq</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Destination--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.value.family</con:name>
-          <con:value>Younger</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.value.given</con:name>
-          <con:value>Gallow</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
-          <con:value>LivingSubject.administrativeGender</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
-          <con:value>110152</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>E</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>queryId.@root</con:name>
-          <con:value>2.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
-          <con:value>M</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>queryId.@extension</con:name>
-          <con:value>-abd3453dcd24wkkks545</con:value>
-        </con:property>
-        <con:property>
-          <con:name>statusCode.@code</con:name>
-          <con:value>new</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
-          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
-        </con:property>
-        <con:property>
           <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
+          <con:value>true</con:value>
         </con:property>
         <con:property>
           <con:name>AuditOff</con:name>
-          <con:value>true</con:value>
+          <con:value>false</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -13774,6 +13681,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Patient Discovery Deferred Resp" type="request" id="d4b958b7-b678-4810-97d5-cd9bf9cd77f2">
@@ -14126,28 +14039,178 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="51e31a14-520c-4ebe-9d91-1614db33b08d">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
-	
 }
-	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
+	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1) - ACK")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
 {
  	testRunner.fail( "Incorrect AuditLogging property found for this service testcase" )
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-InitiatingGateway(1.1) - ACK">
+        <con:settings/>
+        <con:config>
+          <script><![CDATA[context.withSql('AuditRepoDB') {sql ->
+def nhinAuditMessage_22_Outbound = sql.firstRow('SELECT CONVERT(message USING utf8) FROM ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
+def parsedXmlMessage = new XmlSlurper().parseText(nhinAuditMessage_22_Outbound)
+
+parsedXmlMessage.EventIdentification.find{
+	assert it.@EventActionCode == context.findProperty( "EventIdentification.@EventActionCode" )
+	//assert it.@EventDateTime == context.findProperty( "EventIdentification.@EventDateTime" )
+     assert it.@EventOutcomeIndicator == context.findProperty( "EventIdentification.@EventOutcomeIndicator" )
+	assert it.EventID.@code == context.findProperty( "EventIdentification.EventID.@code" )
+	assert it.EventID.@codeSystemName == context.findProperty( "EventIdentification.EventID.@codeSystemName" )
+	assert it.EventID.@displayName == context.findProperty( "EventIdentification.EventID.@displayName" )
+	assert it.EventTypeCode.@code == context.findProperty( "EventIdentification.EventTypeCode.@code" )
+	assert it.EventTypeCode.@codeSystemName == context.findProperty( "EventIdentification.EventTypeCode.@codeSystemName" )
+	assert it.EventTypeCode.@displayName == context.findProperty( "EventIdentification.EventTypeCode.@displayName" )	
+}
+
+//check for ActiveParticipant Source details
+if (!parsedXmlMessage.ActiveParticipant[0].RoleIDCode.@displayName.isEmpty() && parsedXmlMessage.ActiveParticipant[0].RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@displayName" )){
+	parsedXmlMessage.ActiveParticipant[0].each{ node ->
+	     assert node.@UserID == context.findProperty( "ActiveParticipant_Source.@UserID" )	     
+     	assert node.@UserName == context.findProperty( "ActiveParticipant_Source.@UserName" )
+	     assert(!node.@AlternativeUserID.isEmpty())
+     	assert node.@UserIsRequestor == context.findProperty( "ActiveParticipant_Source.@UserIsRequestor" )
+     	assert(!node.@NetworkAccessPointTypeCode.isEmpty())
+   	 	def NetworkAccessPointTypeCode = node.@NetworkAccessPointTypeCode
+   	 	assert NetworkAccessPointTypeCode == 1 || NetworkAccessPointTypeCode == 2
+     	assert(!node.@NetworkAccessPointID.isEmpty())
+     	def NetworkAccessPointID = node.@NetworkAccessPointID
+     	if (NetworkAccessPointTypeCode == 1) {
+
+     		assert node.@NetworkAccessPointID == context.findProperty( "ActiveParticipant_Source.@NetworkAccessPointID" )
+     		
+     	} else {
+
+     		def x = ~/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
+     		def matcher = (NetworkAccessPointID =~ x)  
+			assert matcher.matches()
+     		
+     	}
+          assert node.RoleIDCode.@code == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@code" )
+     	assert node.RoleIDCode.@codeSystemName == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@codeSystemName" )
+     	assert node.RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@displayName" )	     
+	}
+}
+
+//check for ActiveParticipant Destination details
+if (!parsedXmlMessage.ActiveParticipant[1].RoleIDCode.@displayName.isEmpty() && parsedXmlMessage.ActiveParticipant[1].RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@displayName" )){
+	parsedXmlMessage.ActiveParticipant[1].each{ node ->
+	     assert node.@UserID == context.findProperty( "ActiveParticipant_Dest.@UserID" )	     
+   	     if(!node.@UserName.isEmpty()){
+	     	assert node.@UserName == context.findProperty( "ActiveParticipant_Dest.@UserNamee" )
+	     }
+     	assert node.@UserIsRequestor == context.findProperty( "ActiveParticipant_Dest.@UserIsRequestor" )
+     	assert(!node.@NetworkAccessPointTypeCode.isEmpty())
+   	 	def NetworkAccessPointTypeCode = node.@NetworkAccessPointTypeCode
+   	 	assert NetworkAccessPointTypeCode == 1 || NetworkAccessPointTypeCode == 2
+     	assert(!node.@NetworkAccessPointID.isEmpty())
+     	def NetworkAccessPointID = node.@NetworkAccessPointID
+     	if (NetworkAccessPointTypeCode == 1) {
+
+     		assert node.@NetworkAccessPointID == context.findProperty( "ActiveParticipant_Dest.@NetworkAccessPointID" )
+     		
+     	} else {
+
+     		def x = ~/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
+     		def matcher = (NetworkAccessPointID =~ x)  
+			assert matcher.matches()
+     		
+     	}
+          assert node.RoleIDCode.@code == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@code" )
+     	assert node.RoleIDCode.@codeSystemName == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@codeSystemName" )
+     	assert node.RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@displayName" )	     
+	}
+}
+parsedXmlMessage.AuditSourceIdentification.find{
+		if(!it.@AuditEnterpriseSiteID.isEmpty()){
+			assert it.@AuditEnterpriseSiteID == context.findProperty( "AuditSourceIdentification.@AuditEnterpriseSiteID" )
+		}
+		if(!it.@AuditSourceTypeCode.isEmpty()){			
+			assert it.@AuditSourceTypeCode == context.findProperty( "AuditSourceIdentification.@AuditSourceTypeCode" )
+		}
+		if(!it.@AuditSourceID.isEmpty()){
+			assert it.@AuditSourceID == context.findProperty( "AuditSourceIdentification.@AuditSourceID" )	
+		}
+}
+
+//check for Patient ParticipantObjectIdentification
+if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCode.isEmpty() && parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectTypeCode" )){
+	parsedXmlMessage.ParticipantObjectIdentification[0].each{ node ->
+	     assert node.@ParticipantObjectID == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectID" )
+	     assert node.@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectTypeCode" )     
+   	    	assert node.@ParticipantObjectTypeCodeRole == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole" )	     
+    		assert node.ParticipantObjectIDTypeCode.@code == context.findProperty( "ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code" )
+    		assert node.ParticipantObjectIDTypeCode.@codeSystemName == context.findProperty( "ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName" )
+    		assert node.ParticipantObjectIDTypeCode.@displayName == context.findProperty( "ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName" )
+	}
+ }
+ 
+//check for Query Parameters ParticipantObjectIdentification
+if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeCode.isEmpty() && parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode" )){
+	parsedXmlMessage.ParticipantObjectIdentification[1].each{ node ->
+		if (!node.@ParticipantObjectID.isEmpty()){
+			assert node.@ParticipantObjectID == context.findProperty ( "queryId.@extension" )
+		}	
+	     assert node.@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode" )     
+   	     assert node.@ParticipantObjectTypeCodeRole == context.findProperty( "ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole" )	     
+    		assert node.ParticipantObjectIDTypeCode.@code == context.findProperty( "ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code" )
+    		assert node.ParticipantObjectIDTypeCode.@codeSystemName == context.findProperty( "ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName" )
+    		assert node.ParticipantObjectIDTypeCode.@displayName == context.findProperty( "ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName" )
+
+	 	if(!node.ParticipantObjectQuery.text().isEmpty()){	 		
+	 		byte[] participantobjectQueryDecoded = node.ParticipantObjectQuery.text().decodeBase64()			
+			def parsedParticipantObjectQuery = new XmlSlurper().parseText(new String(participantobjectQueryDecoded))			
+			parsedParticipantObjectQuery.queryId.find{				
+				assert it.@root == context.findProperty( "queryId.@root" )
+				assert it.@extension == context.findProperty ( "queryId.@extension" )
+			}
+			assert parsedParticipantObjectQuery.statusCode.@code == context.findProperty( "statusCode.@code" )
+			assert parsedParticipantObjectQuery.responseModalityCode.@code == context.findProperty( "responseModalityCode.@code" )
+			assert parsedParticipantObjectQuery.responsePriorityCode.@code == context.findProperty( "responsePriorityCode.@code" )
+			parsedParticipantObjectQuery.parameterList.livingSubjectAdministrativeGender.find{
+				assert it.value.@code == context.findProperty ( "parameterList.livingSubjectAdministrativeGender.value.@code" )
+				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectAdministrativeGender.semanticsText.@representation" )
+				assert it.semanticsText.text() == context.findProperty ( "parameterList.livingSubjectAdministrativeGender.semanticsText" )
+			}
+			parsedParticipantObjectQuery.parameterList.livingSubjectBirthTime.find{
+				assert it.value.@value == context.findProperty ( "parameterList.livingSubjectBirthTime.value.@value" )
+				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectBirthTime.semanticsText.@representation" )
+				assert it.semanticsText.text() == context.findProperty ( "parameterList.livingSubjectBirthTime.semanticsText" )
+			}
+			parsedParticipantObjectQuery.parameterList.livingSubjectId.find{
+				assert it.value.@root == context.findProperty ( "parameterList.livingSubjectId.value.@root" )
+				assert it.value.@extension == context.findProperty ( "parameterList.livingSubjectId.value.@extension" )
+				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectId.semanticsText.@representation" )				
+			}
+			parsedParticipantObjectQuery.parameterList.livingSubjectName.find{
+				assert it.value.family.@partType == context.findProperty ( "parameterList.livingSubjectName.value.family.@partType" )
+				assert it.value.family.text() == context.findProperty ( "parameterList.livingSubjectName.value.family" )
+				assert it.value.given.@partType == context.findProperty ( "parameterList.livingSubjectName.value.given.@partType" )
+				assert it.value.given.text() == context.findProperty ( "parameterList.livingSubjectName.value.given" )
+				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectName.semanticsText.@representation" )
+				assert it.semanticsText.text() == context.findProperty ( "parameterList.livingSubjectName.semanticsText" )
+			}			
+	 	}
+	}
+  }
+}]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-RespondingGateway(2.2)">
@@ -14304,170 +14367,15 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeC
 	 	}
 	}
   }
-}]]></script>
-        </con:config>
-      </con:testStep>
-      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-InitiatingGateway(1.1) - ACK">
-        <con:settings/>
-        <con:config>
-          <script><![CDATA[context.withSql('AuditRepoDB') {sql ->
-def nhinAuditMessage_22_Outbound = sql.firstRow('SELECT CONVERT(message USING utf8) FROM ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
-def parsedXmlMessage = new XmlSlurper().parseText(nhinAuditMessage_22_Outbound)
-
-parsedXmlMessage.EventIdentification.find{
-	assert it.@EventActionCode == context.findProperty( "EventIdentification.@EventActionCode" )
-	//assert it.@EventDateTime == context.findProperty( "EventIdentification.@EventDateTime" )
-     assert it.@EventOutcomeIndicator == context.findProperty( "EventIdentification.@EventOutcomeIndicator" )
-	assert it.EventID.@code == context.findProperty( "EventIdentification.EventID.@code" )
-	assert it.EventID.@codeSystemName == context.findProperty( "EventIdentification.EventID.@codeSystemName" )
-	assert it.EventID.@displayName == context.findProperty( "EventIdentification.EventID.@displayName" )
-	assert it.EventTypeCode.@code == context.findProperty( "EventIdentification.EventTypeCode.@code" )
-	assert it.EventTypeCode.@codeSystemName == context.findProperty( "EventIdentification.EventTypeCode.@codeSystemName" )
-	assert it.EventTypeCode.@displayName == context.findProperty( "EventIdentification.EventTypeCode.@displayName" )	
 }
-
-//check for ActiveParticipant Source details
-if (!parsedXmlMessage.ActiveParticipant[0].RoleIDCode.@displayName.isEmpty() && parsedXmlMessage.ActiveParticipant[0].RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@displayName" )){
-	parsedXmlMessage.ActiveParticipant[0].each{ node ->
-	     assert node.@UserID == context.findProperty( "ActiveParticipant_Source.@UserID" )	     
-     	assert node.@UserName == context.findProperty( "ActiveParticipant_Source.@UserName" )
-	     assert(!node.@AlternativeUserID.isEmpty())
-     	assert node.@UserIsRequestor == context.findProperty( "ActiveParticipant_Source.@UserIsRequestor" )
-     	assert(!node.@NetworkAccessPointTypeCode.isEmpty())
-   	 	def NetworkAccessPointTypeCode = node.@NetworkAccessPointTypeCode
-   	 	assert NetworkAccessPointTypeCode == 1 || NetworkAccessPointTypeCode == 2
-     	assert(!node.@NetworkAccessPointID.isEmpty())
-     	def NetworkAccessPointID = node.@NetworkAccessPointID
-     	if (NetworkAccessPointTypeCode == 1) {
-
-     		assert node.@NetworkAccessPointID == context.findProperty( "ActiveParticipant_Source.@NetworkAccessPointID" )
-     		
-     	} else {
-
-     		def x = ~/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
-     		def matcher = (NetworkAccessPointID =~ x)  
-			assert matcher.matches()
-     		
-     	}
-          assert node.RoleIDCode.@code == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@code" )
-     	assert node.RoleIDCode.@codeSystemName == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@codeSystemName" )
-     	assert node.RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@displayName" )	     
-	}
-}
-
-//check for ActiveParticipant Destination details
-if (!parsedXmlMessage.ActiveParticipant[1].RoleIDCode.@displayName.isEmpty() && parsedXmlMessage.ActiveParticipant[1].RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@displayName" )){
-	parsedXmlMessage.ActiveParticipant[1].each{ node ->
-	     assert node.@UserID == context.findProperty( "ActiveParticipant_Dest.@UserID" )	     
-   	     if(!node.@UserName.isEmpty()){
-	     	assert node.@UserName == context.findProperty( "ActiveParticipant_Dest.@UserNamee" )
-	     }
-     	assert node.@UserIsRequestor == context.findProperty( "ActiveParticipant_Dest.@UserIsRequestor" )
-     	assert(!node.@NetworkAccessPointTypeCode.isEmpty())
-   	 	def NetworkAccessPointTypeCode = node.@NetworkAccessPointTypeCode
-   	 	assert NetworkAccessPointTypeCode == 1 || NetworkAccessPointTypeCode == 2
-     	assert(!node.@NetworkAccessPointID.isEmpty())
-     	def NetworkAccessPointID = node.@NetworkAccessPointID
-     	if (NetworkAccessPointTypeCode == 1) {
-
-     		assert node.@NetworkAccessPointID == context.findProperty( "ActiveParticipant_Dest.@NetworkAccessPointID" )
-     		
-     	} else {
-
-     		def x = ~/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
-     		def matcher = (NetworkAccessPointID =~ x)  
-			assert matcher.matches()
-     		
-     	}
-          assert node.RoleIDCode.@code == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@code" )
-     	assert node.RoleIDCode.@codeSystemName == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@codeSystemName" )
-     	assert node.RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@displayName" )	     
-	}
-}
-parsedXmlMessage.AuditSourceIdentification.find{
-		if(!it.@AuditEnterpriseSiteID.isEmpty()){
-			assert it.@AuditEnterpriseSiteID == context.findProperty( "AuditSourceIdentification.@AuditEnterpriseSiteID" )
-		}
-		if(!it.@AuditSourceTypeCode.isEmpty()){			
-			assert it.@AuditSourceTypeCode == context.findProperty( "AuditSourceIdentification.@AuditSourceTypeCode" )
-		}
-		if(!it.@AuditSourceID.isEmpty()){
-			assert it.@AuditSourceID == context.findProperty( "AuditSourceIdentification.@AuditSourceID" )	
-		}
-}
-
-//check for Patient ParticipantObjectIdentification
-if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCode.isEmpty() && parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectTypeCode" )){
-	parsedXmlMessage.ParticipantObjectIdentification[0].each{ node ->
-	     assert node.@ParticipantObjectID == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectID" )
-	     assert node.@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectTypeCode" )     
-   	    	assert node.@ParticipantObjectTypeCodeRole == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole" )	     
-    		assert node.ParticipantObjectIDTypeCode.@code == context.findProperty( "ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code" )
-    		assert node.ParticipantObjectIDTypeCode.@codeSystemName == context.findProperty( "ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName" )
-    		assert node.ParticipantObjectIDTypeCode.@displayName == context.findProperty( "ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName" )
-	}
- }
- 
-//check for Query Parameters ParticipantObjectIdentification
-if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeCode.isEmpty() && parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode" )){
-	parsedXmlMessage.ParticipantObjectIdentification[1].each{ node ->
-		if (!node.@ParticipantObjectID.isEmpty()){
-			assert node.@ParticipantObjectID == context.findProperty ( "queryId.@extension" )
-		}	
-	     assert node.@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode" )     
-   	     assert node.@ParticipantObjectTypeCodeRole == context.findProperty( "ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole" )	     
-    		assert node.ParticipantObjectIDTypeCode.@code == context.findProperty( "ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code" )
-    		assert node.ParticipantObjectIDTypeCode.@codeSystemName == context.findProperty( "ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName" )
-    		assert node.ParticipantObjectIDTypeCode.@displayName == context.findProperty( "ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName" )
-
-	 	if(!node.ParticipantObjectQuery.text().isEmpty()){	 		
-	 		byte[] participantobjectQueryDecoded = node.ParticipantObjectQuery.text().decodeBase64()			
-			def parsedParticipantObjectQuery = new XmlSlurper().parseText(new String(participantobjectQueryDecoded))			
-			parsedParticipantObjectQuery.queryId.find{				
-				assert it.@root == context.findProperty( "queryId.@root" )
-				assert it.@extension == context.findProperty ( "queryId.@extension" )
-			}
-			assert parsedParticipantObjectQuery.statusCode.@code == context.findProperty( "statusCode.@code" )
-			assert parsedParticipantObjectQuery.responseModalityCode.@code == context.findProperty( "responseModalityCode.@code" )
-			assert parsedParticipantObjectQuery.responsePriorityCode.@code == context.findProperty( "responsePriorityCode.@code" )
-			parsedParticipantObjectQuery.parameterList.livingSubjectAdministrativeGender.find{
-				assert it.value.@code == context.findProperty ( "parameterList.livingSubjectAdministrativeGender.value.@code" )
-				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectAdministrativeGender.semanticsText.@representation" )
-				assert it.semanticsText.text() == context.findProperty ( "parameterList.livingSubjectAdministrativeGender.semanticsText" )
-			}
-			parsedParticipantObjectQuery.parameterList.livingSubjectBirthTime.find{
-				assert it.value.@value == context.findProperty ( "parameterList.livingSubjectBirthTime.value.@value" )
-				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectBirthTime.semanticsText.@representation" )
-				assert it.semanticsText.text() == context.findProperty ( "parameterList.livingSubjectBirthTime.semanticsText" )
-			}
-			parsedParticipantObjectQuery.parameterList.livingSubjectId.find{
-				assert it.value.@root == context.findProperty ( "parameterList.livingSubjectId.value.@root" )
-				assert it.value.@extension == context.findProperty ( "parameterList.livingSubjectId.value.@extension" )
-				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectId.semanticsText.@representation" )				
-			}
-			parsedParticipantObjectQuery.parameterList.livingSubjectName.find{
-				assert it.value.family.@partType == context.findProperty ( "parameterList.livingSubjectName.value.family.@partType" )
-				assert it.value.family.text() == context.findProperty ( "parameterList.livingSubjectName.value.family" )
-				assert it.value.given.@partType == context.findProperty ( "parameterList.livingSubjectName.value.given.@partType" )
-				assert it.value.given.text() == context.findProperty ( "parameterList.livingSubjectName.value.given" )
-				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectName.semanticsText.@representation" )
-				assert it.semanticsText.text() == context.findProperty ( "parameterList.livingSubjectName.semanticsText" )
-			}			
-	 	}
-	}
-  }
-}]]></script>
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -14496,116 +14404,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
         <con:property>
-          <con:name>LocalHCID</con:name>
-          <con:value>1.1</con:value>
+          <con:name>&lt;!--Destination--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>LocalAA</con:name>
-          <con:value>1.1</con:value>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>LocalHCDescription</con:name>
-          <con:value>InternalTest1</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>LocalPatientID</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemoteHCID</con:name>
-          <con:value>2.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemoteAA</con:name>
-          <con:value>2.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemoteHCDescription</con:name>
-          <con:value>InternalTest2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemotePatientID</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>NHINGatewayConfigDir</con:name>
-          <con:value>C:/Sun/AppServer/domains/domain1/config/nhin</con:value>
-        </con:property>
-        <con:property>
-          <con:name>MPIDir</con:name>
-          <con:value>C:/Sun/AppServer/domains/domain1/config</con:value>
-        </con:property>
-        <con:property>
-          <con:name>LocalConfigDir</con:name>
-          <con:value>C:/SelfTest/EndToEndSelfTest</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-DocQuery</con:name>
-          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityDocQueryUnsecured</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-DocRetrieve</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityDocRetrieve</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Reidentification</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubjectDiscovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Subscribe</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationProducer</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Notify</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationConsumer</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Unsubscribe</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubscriptionManager</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-AuditLogQuery</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityAuditQuery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-PatientDiscoveryAsyncReq</con:name>
-          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityPatientDiscoveryDeferredRequestUnsecured</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-PatientDiscoveryAsyncResp</con:name>
-          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityPatientDiscoveryDeferredResponseUnsecured</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBHost</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBPort</con:name>
-          <con:value>3306</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBUser</con:name>
-          <con:value>nhincuser</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBPass</con:name>
-          <con:value>nhincpass</con:value>
-        </con:property>
-        <con:property>
-          <con:name>PatientCorrelationDB</con:name>
-          <con:value>patientcorrelationdb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>PatientCorrelationTable</con:name>
-          <con:value>correlatedidentifiers</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubscriptionDB</con:name>
-          <con:value>subscriptionrepository</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubscriptionTable</con:name>
-          <con:value>subscription</con:value>
+          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
+          <con:value>checks --></con:value>
         </con:property>
         <con:property>
           <con:name>AAMappingDB</con:name>
@@ -14616,6 +14428,122 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>aa_to_home_community_mapping</con:value>
         </con:property>
         <con:property>
+          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncResp</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
+          <con:value>110152</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AQPatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AQUserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
           <con:name>AsyncMsgDB</con:name>
           <con:value>asyncmsgs</con:value>
         </con:property>
@@ -14624,20 +14552,52 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>asyncmsgrepo</con:value>
         </con:property>
         <con:property>
-          <con:name>PseudonymAA</con:name>
-          <con:value>ABC</con:value>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
         </con:property>
         <con:property>
-          <con:name>PseudonymPatientID</con:name>
-          <con:value>PSEUDO001</con:value>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
         </con:property>
         <con:property>
-          <con:name>RealAA</con:name>
-          <con:value>1.1.1</con:value>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
         </con:property>
         <con:property>
-          <con:name>RealPatientID</con:name>
-          <con:value>D1234010050</con:value>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>BirthTime</con:name>
+          <con:value>19630804</con:value>
+        </con:property>
+        <con:property>
+          <con:name>City</con:name>
+          <con:value>Melbourne</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Country</con:name>
+          <con:value>US</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DBHost</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DBPass</con:name>
+          <con:value>nhincpass</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DBPort</con:name>
+          <con:value>3306</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DBUser</con:name>
+          <con:value>nhincuser</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DOB</con:name>
+          <con:value>19800516</con:value>
         </con:property>
         <con:property>
           <con:name>DQDocID</con:name>
@@ -14648,10 +14608,6 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>D123401</con:value>
         </con:property>
         <con:property>
-          <con:name>DynamicDQDocID</con:name>
-          <con:value>103.8.9284320.020.3590.75^1266324032288</con:value>
-        </con:property>
-        <con:property>
           <con:name>DRDocID</con:name>
           <con:value>1.123407.777777</con:value>
         </con:property>
@@ -14660,16 +14616,140 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>1</con:value>
         </con:property>
         <con:property>
+          <con:name>DynamicDQDocID</con:name>
+          <con:value>103.8.9284320.020.3590.75^1266324032288</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:44:52Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-AuditLogQuery</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityAuditQuery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-DocQuery</con:name>
+          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityDocQueryUnsecured</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-DocRetrieve</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityDocRetrieve</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-EntityXDRRequest</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityProxyService/EntityXDRRequest</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Notify</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationConsumer</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-PatientDiscoveryAsyncReq</con:name>
+          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityPatientDiscoveryDeferredRequestUnsecured</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-PatientDiscoveryAsyncResp</con:name>
+          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityPatientDiscoveryDeferredResponseUnsecured</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Reidentification</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubjectDiscovery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Subscribe</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationProducer</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Unsubscribe</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubscriptionManager</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>E</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventDateTime</con:name>
+          <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110112</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Query</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ExpirationDate</con:name>
+          <con:value>20100520</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>FamilyName</con:name>
+          <con:value>Younger</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Gender</con:name>
+          <con:value>M</con:value>
+        </con:property>
+        <con:property>
+          <con:name>GivenName</con:name>
+          <con:value>Gallow</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalAA</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalConfigDir</con:name>
+          <con:value>C:/SelfTest/EndToEndSelfTest</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalHCDescription</con:name>
+          <con:value>InternalTest1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalHCID</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalPatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>MPIDir</con:name>
+          <con:value>C:/Sun/AppServer/domains/domain1/config</con:value>
+        </con:property>
+        <con:property>
+          <con:name>NHINGatewayConfigDir</con:name>
+          <con:value>C:/Sun/AppServer/domains/domain1/config/nhin</con:value>
+        </con:property>
+        <con:property>
           <con:name>NotificationEndpoint</con:name>
           <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/NotificationConsumerService/HiemNotify</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubscriptionEndpoint</con:name>
-          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/NotificationProducerService/HiemSubscription</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubscribePatientID</con:name>
-          <con:value>D123401</con:value>
         </con:property>
         <con:property>
           <con:name>NotifySubscriptionID</con:name>
@@ -14680,232 +14760,40 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
         </con:property>
         <con:property>
-          <con:name>UnSubscriptionID</con:name>
-          <con:value>3e74139f-5271-4db1-98c0-88748fa3e4e3</con:value>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
+          <con:value>LivingSubject.administrativeGender</con:value>
         </con:property>
         <con:property>
-          <con:name>SubscriptionManagerEndpointAddress</con:name>
-          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
         </con:property>
         <con:property>
-          <con:name>AQUserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AQPatientID</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-EntityXDRRequest</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityProxyService/EntityXDRRequest</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Gender</con:name>
+          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
           <con:value>M</con:value>
-        </con:property>
-        <con:property>
-          <con:name>BirthTime</con:name>
-          <con:value>19630804</con:value>
-        </con:property>
-        <con:property>
-          <con:name>FamilyName</con:name>
-          <con:value>Younger</con:value>
-        </con:property>
-        <con:property>
-          <con:name>GivenName</con:name>
-          <con:value>Gallow</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubjectID</con:name>
-          <con:value>1111</con:value>
-        </con:property>
-        <con:property>
-          <con:name>UniquePatientId</con:name>
-          <con:value>1111^^^&amp;amp;1.1&amp;amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>StreetAddress</con:name>
-          <con:value>123 Johnson Rd</con:value>
-        </con:property>
-        <con:property>
-          <con:name>City</con:name>
-          <con:value>Melbourne</con:value>
-        </con:property>
-        <con:property>
-          <con:name>State</con:name>
-          <con:value>FL</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ZipCode</con:name>
-          <con:value>12345</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Country</con:name>
-          <con:value>US</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SSN</con:name>
-          <con:value>123456789</con:value>
-        </con:property>
-        <con:property>
-          <con:name>PurposeOfDisclosure</con:name>
-          <con:value>Mental</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ExpirationDate</con:name>
-          <con:value>20100520</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DOB</con:name>
-          <con:value>19800516</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-13T08:34:32Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/13/2015 08:24:32</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-13T08:24:32Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110112</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>24</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectBirthTime.semanticsText</con:name>
           <con:value>LivingSubject.birthTime</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
-          <con:value>GIV</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>D123402^^^&amp;2.2&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventDateTime</con:name>
-          <con:value>2015-04-02T13:47:30.199Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
-          <con:value>FAM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responseModalityCode.@code</con:name>
-          <con:value>R</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
+          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectBirthTime.value.@value</con:name>
           <con:value>19630804</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
-          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
+          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
-          <con:value>checks --></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
+          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
+          <con:value>D123401</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectId.value.@root</con:name>
           <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectName.semanticsText</con:name>
@@ -14916,184 +14804,204 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>TXT</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responsePriorityCode.@code</con:name>
-          <con:value>I</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncResp</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Destination--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
           <con:name>parameterList.livingSubjectName.value.family</con:name>
           <con:value>Younger</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
+          <con:value>FAM</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectName.value.given</con:name>
           <con:value>Gallow</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
+          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
+          <con:value>GIV</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>D123402^^^&amp;2.2&amp;ISO</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
-          <con:value>LivingSubject.administrativeGender</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
-          <con:value>110152</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>E</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
           <con:value>2</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
         </con:property>
         <con:property>
-          <con:name>queryId.@root</con:name>
-          <con:value>2.2</con:value>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
+          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
           <con:value>2</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>24</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
           <con:value>IHE Transactions</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
-          <con:value>M</con:value>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>queryId.@extension</con:name>
-          <con:value>-abd3453dcd24wkkks545</con:value>
-        </con:property>
-        <con:property>
-          <con:name>statusCode.@code</con:name>
-          <con:value>new</con:value>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
           <con:value>D123402^^^&amp;2.2&amp;ISO</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
+          <con:name>PatientCorrelationDB</con:name>
+          <con:value>patientcorrelationdb</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
+          <con:name>PatientCorrelationTable</con:name>
+          <con:value>correlatedidentifiers</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
+          <con:name>PseudonymAA</con:name>
+          <con:value>ABC</con:value>
+        </con:property>
+        <con:property>
+          <con:name>PseudonymPatientID</con:name>
+          <con:value>PSEUDO001</con:value>
+        </con:property>
+        <con:property>
+          <con:name>PurposeOfDisclosure</con:name>
+          <con:value>Mental</con:value>
+        </con:property>
+        <con:property>
+          <con:name>queryId.@extension</con:name>
+          <con:value>-abd3453dcd24wkkks545</con:value>
+        </con:property>
+        <con:property>
+          <con:name>queryId.@root</con:name>
+          <con:value>2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RealAA</con:name>
+          <con:value>1.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RealPatientID</con:name>
+          <con:value>D1234010050</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemoteAA</con:name>
+          <con:value>2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemoteHCDescription</con:name>
+          <con:value>InternalTest2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemoteHCID</con:name>
+          <con:value>2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemotePatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responseModalityCode.@code</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responsePriorityCode.@code</con:name>
+          <con:value>I</con:value>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:34:52</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SSN</con:name>
+          <con:value>123456789</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:34:52Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>State</con:name>
+          <con:value>FL</con:value>
+        </con:property>
+        <con:property>
+          <con:name>statusCode.@code</con:name>
+          <con:value>new</con:value>
+        </con:property>
+        <con:property>
+          <con:name>StreetAddress</con:name>
+          <con:value>123 Johnson Rd</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubjectID</con:name>
+          <con:value>1111</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscribePatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionDB</con:name>
+          <con:value>subscriptionrepository</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionEndpoint</con:name>
+          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/NotificationProducerService/HiemSubscription</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionManagerEndpointAddress</con:name>
+          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionTable</con:name>
+          <con:value>subscription</con:value>
+        </con:property>
+        <con:property>
+          <con:name>UniquePatientId</con:name>
+          <con:value>1111^^^&amp;amp;1.1&amp;amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>UnSubscriptionID</con:name>
+          <con:value>3e74139f-5271-4db1-98c0-88748fa3e4e3</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ZipCode</con:name>
+          <con:value>12345</con:value>
         </con:property>
         <con:property>
           <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
+          <con:value>true</con:value>
         </con:property>
         <con:property>
           <con:name>AuditOff</con:name>
-          <con:value>true</con:value>
+          <con:value>false</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -15107,6 +15015,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Set Up PassThru" id="caff061a-5bd3-4a12-a6df-a994848bd800">
@@ -15581,7 +15495,7 @@ nhinc.FileUtils.createOrUpdateConnection("internalConnectionInfo.xml", dir, "1.1
       <con:testStep type="groovy" name="Verify Audit Logs" id="64fe5440-433b-4a61-9595-325885f88e42">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
@@ -15590,12 +15504,11 @@ context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 }
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -15906,18 +15819,15 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
 	 	}
 	}
   }
-}]]></script>
+}
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -15925,9 +15835,6 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 //context.setGatewayStandard(false);
 //log.info ("Setting the gateway to Passthrough");
 
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -15941,353 +15848,225 @@ if (propertiesFile.exists()) {
  }
 }</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp','true', log);
+
 //context.setGatewayStandard(true);
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
         <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-13T08:25:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-13T08:35:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/13/2015 08:25:00</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIiB4bWxuczpuczU9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246cGF0aWVudGNvcnJlbGF0aW9uZmFjYWRlIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmFkbWluaXN0cmF0aXZlR2VuZGVyPC9zZW1hbnRpY3NUZXh0PjwvbGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPjxsaXZpbmdTdWJqZWN0QmlydGhUaW1lPjx2YWx1ZSB2YWx1ZT0iMTk2MzA4MDQiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmJpcnRoVGltZTwvc2VtYW50aWNzVGV4dD48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgPC92YWx1ZT48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0Lm5hbWU8L3NlbWFudGljc1RleHQ+PC9saXZpbmdTdWJqZWN0TmFtZT48L3BhcmFtZXRlckxpc3Q+PC9xdWVyeUJ5UGFyYW1ldGVyPg==</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
-          <con:value>anonymus</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
-          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
         </con:property>
         <con:property>
           <con:name>&lt;!--Human</con:name>
           <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>E</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
-          <con:value>110152</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectSensitivity</con:name>
+          <con:name>&lt;!--Source--></con:name>
           <con:value/>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
+          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
+          <con:value>checks --></con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.@AlternativeUserID</con:name>
           <con:value>19233@192.168.1.1</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110112</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectSensitivity</con:name>
-          <con:value/>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
           <con:value>307969004</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventDateTime</con:name>
-          <con:value>2015-04-02T13:47:30.199Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>24</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
           <con:value>Human Requestor</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>2</con:value>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscovery</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>1111^^^&amp;1.1&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@value</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxuczM6Q09SRUVudmVsb3BlUmVhbFRpbWVSZXF1ZXN0IHhtbG5zOm5zMj0iaHR0cDovL3d3dy5jYXFoLm9yZy9TT0FQL1dTREwvQ09SRVJ1bGUyLjIuMC54c2QiIHhtbG5zOm5zMz0idXJuOm9yZzpjYXFoOnNvYXA6d3NkbDpjb3JlcnVsZTJfMl8wIj48UGF5bG9hZFR5cGU+WDEyXzI3MF9SZXF1ZXN0XzAwNTAxMFgyNzlBMTwvUGF5bG9hZFR5cGU+PFByb2Nlc3NpbmdNb2RlPlJlYWxUaW1lPC9Qcm9jZXNzaW5nTW9kZT48UGF5bG9hZElEPmY4MWQ0ZmFlLTdkZWMtMTFkMC1hNzY1LTAwYTBjOTFlNmJmNjwvUGF5bG9hZElEPjxUaW1lU3RhbXA+MjAwNy0wOC0zMFQxMDoyMDozNFo8L1RpbWVTdGFtcD48U2VuZGVySUQ+SG9zcGl0YWxBPC9TZW5kZXJJRD48UmVjZWl2ZXJJRD5QYXllckI8L1JlY2VpdmVySUQ+PENPUkVSdWxlVmVyc2lvbj4yLjIuMDwvQ09SRVJ1bGVWZXJzaW9uPjxQYXlsb2FkPjwvUGF5bG9hZD48L25zMzpDT1JFRW52ZWxvcGVSZWFsVGltZVJlcXVlc3Q+</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0idXJuOmdvdjpoaHM6ZmhhOm5oaW5jOmNvbW1vbjpwYXRpZW50Y29ycmVsYXRpb25mYWNhZGUiIHhtbG5zOm5zNT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmFkbWluaXN0cmF0aXZlR2VuZGVyPC9zZW1hbnRpY3NUZXh0PjwvbGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPjxsaXZpbmdTdWJqZWN0QmlydGhUaW1lPjx2YWx1ZSB2YWx1ZT0iMTk2MzA4MDQiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmJpcnRoVGltZTwvc2VtYW50aWNzVGV4dD48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgPC92YWx1ZT48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0Lm5hbWU8L3NlbWFudGljc1RleHQ+PC9saXZpbmdTdWJqZWN0TmFtZT48L3BhcmFtZXRlckxpc3Q+PC9xdWVyeUJ5UGFyYW1ldGVyPg==</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDetail.@value</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxuczM6Q09SRUVudmVsb3BlUmVhbFRpbWVSZXF1ZXN0IHhtbG5zOm5zMj0iaHR0cDovL3d3dy5jYXFoLm9yZy9TT0FQL1dTREwvQ09SRVJ1bGUyLjIuMC54c2QiIHhtbG5zOm5zMz0idXJuOm9yZzpjYXFoOnNvYXA6d3NkbDpjb3JlcnVsZTJfMl8wIj48UGF5bG9hZFR5cGU+WDEyXzI3MF9SZXF1ZXN0XzAwNTAxMFgyNzlBMTwvUGF5bG9hZFR5cGU+PFByb2Nlc3NpbmdNb2RlPlJlYWxUaW1lPC9Qcm9jZXNzaW5nTW9kZT48UGF5bG9hZElEPmY4MWQ0ZmFlLTdkZWMtMTFkMC1hNzY1LTAwYTBjOTFlNmJmNjwvUGF5bG9hZElEPjxUaW1lU3RhbXA+MjAwNy0wOC0zMFQxMDoyMDozNFo8L1RpbWVTdGFtcD48U2VuZGVySUQ+SG9zcGl0YWxBPC9TZW5kZXJJRD48UmVjZWl2ZXJJRD5QYXllckI8L1JlY2VpdmVySUQ+PENPUkVSdWxlVmVyc2lvbj4yLjIuMDwvQ09SRVJ1bGVWZXJzaW9uPjxQYXlsb2FkPjwvUGF5bG9hZD48L25zMzpDT1JFRW52ZWxvcGVSZWFsVGltZVJlcXVlc3Q+</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
+          <con:value>110152</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query_Response.ParticipantObjectQuery</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIiB4bWxuczpuczU9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246cGF0aWVudGNvcnJlbGF0aW9uZmFjYWRlIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PGxpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PHZhbHVlIHZhbHVlPSIxOTYzMDgwNCIvPjxzZW1hbnRpY3NUZXh0IHJlcHJlc2VudGF0aW9uPSJUWFQiLz48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgCQk8L3ZhbHVlPjxzZW1hbnRpY3NUZXh0IHJlcHJlc2VudGF0aW9uPSJUWFQiLz48L2xpdmluZ1N1YmplY3ROYW1lPjwvcGFyYW1ldGVyTGlzdD48L3F1ZXJ5QnlQYXJhbWV0ZXI+</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail</con:name>
-          <con:value>test</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDetail</con:name>
-          <con:value>test</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
           <con:value>2</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectName.@value</con:name>
-          <con:value>anonymus</con:value>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
-          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:45:23Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>E</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventDateTime</con:name>
+          <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110112</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Query</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
+          <con:value>LivingSubject.administrativeGender</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
+          <con:value>M</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectBirthTime.semanticsText</con:name>
           <con:value>LivingSubject.birthTime</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
-          <con:value>GIV</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
-          <con:value>FAM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responseModalityCode.@code</con:name>
-          <con:value>R</con:value>
+          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectBirthTime.value.@value</con:name>
           <con:value>19630804</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
-          <con:value>checks --></con:value>
+          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
+          <con:value>1111</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectId.value.@root</con:name>
@@ -16302,60 +16081,180 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>TXT</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
-          <con:value>1111</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responsePriorityCode.@code</con:name>
-          <con:value>I</con:value>
-        </con:property>
-        <con:property>
           <con:name>parameterList.livingSubjectName.value.family</con:name>
           <con:value>Younger</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
+          <con:value>FAM</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectName.value.given</con:name>
           <con:value>Gallow</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
+          <con:value>GIV</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
-          <con:value>LivingSubject.administrativeGender</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>1111^^^&amp;1.1&amp;ISO</con:value>
         </con:property>
         <con:property>
-          <con:name>queryId.@root</con:name>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectName</con:name>
           <con:value>1.1</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
-          <con:value>M</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail</con:name>
+          <con:value>test</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@value</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxuczM6Q09SRUVudmVsb3BlUmVhbFRpbWVSZXF1ZXN0IHhtbG5zOm5zMj0iaHR0cDovL3d3dy5jYXFoLm9yZy9TT0FQL1dTREwvQ09SRVJ1bGUyLjIuMC54c2QiIHhtbG5zOm5zMz0idXJuOm9yZzpjYXFoOnNvYXA6d3NkbDpjb3JlcnVsZTJfMl8wIj48UGF5bG9hZFR5cGU+WDEyXzI3MF9SZXF1ZXN0XzAwNTAxMFgyNzlBMTwvUGF5bG9hZFR5cGU+PFByb2Nlc3NpbmdNb2RlPlJlYWxUaW1lPC9Qcm9jZXNzaW5nTW9kZT48UGF5bG9hZElEPmY4MWQ0ZmFlLTdkZWMtMTFkMC1hNzY1LTAwYTBjOTFlNmJmNjwvUGF5bG9hZElEPjxUaW1lU3RhbXA+MjAwNy0wOC0zMFQxMDoyMDozNFo8L1RpbWVTdGFtcD48U2VuZGVySUQ+SG9zcGl0YWxBPC9TZW5kZXJJRD48UmVjZWl2ZXJJRD5QYXllckI8L1JlY2VpdmVySUQ+PENPUkVSdWxlVmVyc2lvbj4yLjIuMDwvQ09SRVJ1bGVWZXJzaW9uPjxQYXlsb2FkPjwvUGF5bG9hZD48L25zMzpDT1JFRW52ZWxvcGVSZWFsVGltZVJlcXVlc3Q+</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
+          <con:value>anonymus</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectName.@value</con:name>
+          <con:value>anonymus</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0idXJuOmdvdjpoaHM6ZmhhOm5oaW5jOmNvbW1vbjpwYXRpZW50Y29ycmVsYXRpb25mYWNhZGUiIHhtbG5zOm5zNT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmFkbWluaXN0cmF0aXZlR2VuZGVyPC9zZW1hbnRpY3NUZXh0PjwvbGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPjxsaXZpbmdTdWJqZWN0QmlydGhUaW1lPjx2YWx1ZSB2YWx1ZT0iMTk2MzA4MDQiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmJpcnRoVGltZTwvc2VtYW50aWNzVGV4dD48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgPC92YWx1ZT48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0Lm5hbWU8L3NlbWFudGljc1RleHQ+PC9saXZpbmdTdWJqZWN0TmFtZT48L3BhcmFtZXRlckxpc3Q+PC9xdWVyeUJ5UGFyYW1ldGVyPg==</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
+          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>24</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDetail</con:name>
+          <con:value>test</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDetail.@value</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxuczM6Q09SRUVudmVsb3BlUmVhbFRpbWVSZXF1ZXN0IHhtbG5zOm5zMj0iaHR0cDovL3d3dy5jYXFoLm9yZy9TT0FQL1dTREwvQ09SRVJ1bGUyLjIuMC54c2QiIHhtbG5zOm5zMz0idXJuOm9yZzpjYXFoOnNvYXA6d3NkbDpjb3JlcnVsZTJfMl8wIj48UGF5bG9hZFR5cGU+WDEyXzI3MF9SZXF1ZXN0XzAwNTAxMFgyNzlBMTwvUGF5bG9hZFR5cGU+PFByb2Nlc3NpbmdNb2RlPlJlYWxUaW1lPC9Qcm9jZXNzaW5nTW9kZT48UGF5bG9hZElEPmY4MWQ0ZmFlLTdkZWMtMTFkMC1hNzY1LTAwYTBjOTFlNmJmNjwvUGF5bG9hZElEPjxUaW1lU3RhbXA+MjAwNy0wOC0zMFQxMDoyMDozNFo8L1RpbWVTdGFtcD48U2VuZGVySUQ+SG9zcGl0YWxBPC9TZW5kZXJJRD48UmVjZWl2ZXJJRD5QYXllckI8L1JlY2VpdmVySUQ+PENPUkVSdWxlVmVyc2lvbj4yLjIuMDwvQ09SRVJ1bGVWZXJzaW9uPjxQYXlsb2FkPjwvUGF5bG9hZD48L25zMzpDT1JFRW52ZWxvcGVSZWFsVGltZVJlcXVlc3Q+</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIiB4bWxuczpuczU9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246cGF0aWVudGNvcnJlbGF0aW9uZmFjYWRlIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmFkbWluaXN0cmF0aXZlR2VuZGVyPC9zZW1hbnRpY3NUZXh0PjwvbGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPjxsaXZpbmdTdWJqZWN0QmlydGhUaW1lPjx2YWx1ZSB2YWx1ZT0iMTk2MzA4MDQiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmJpcnRoVGltZTwvc2VtYW50aWNzVGV4dD48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgPC92YWx1ZT48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0Lm5hbWU8L3NlbWFudGljc1RleHQ+PC9saXZpbmdTdWJqZWN0TmFtZT48L3BhcmFtZXRlckxpc3Q+PC9xdWVyeUJ5UGFyYW1ldGVyPg==</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query_Response.ParticipantObjectQuery</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIiB4bWxuczpuczU9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246cGF0aWVudGNvcnJlbGF0aW9uZmFjYWRlIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PGxpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PHZhbHVlIHZhbHVlPSIxOTYzMDgwNCIvPjxzZW1hbnRpY3NUZXh0IHJlcHJlc2VudGF0aW9uPSJUWFQiLz48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgCQk8L3ZhbHVlPjxzZW1hbnRpY3NUZXh0IHJlcHJlc2VudGF0aW9uPSJUWFQiLz48L2xpdmluZ1N1YmplY3ROYW1lPjwvcGFyYW1ldGVyTGlzdD48L3F1ZXJ5QnlQYXJhbWV0ZXI+</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
+          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
         </con:property>
         <con:property>
           <con:name>queryId.@extension</con:name>
           <con:value>-abd3453dcd24wkkks545</con:value>
         </con:property>
         <con:property>
+          <con:name>queryId.@root</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responseModalityCode.@code</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responsePriorityCode.@code</con:name>
+          <con:value>I</con:value>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:35:23</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:35:23Z</con:value>
+        </con:property>
+        <con:property>
           <con:name>statusCode.@code</con:name>
           <con:value>new</con:value>
-        </con:property>
-        <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditOff</con:name>
-          <con:value>true</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -16369,6 +16268,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="update config" type="groovy" id="a8567aa6-bd18-48da-9992-0788937c45cb">
@@ -16708,21 +16613,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="e58a476e-bafe-4823-8b20-ba397960005b">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
-	}
+}
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -17005,18 +16909,15 @@ if(!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCo
 	 	} 
   	}
   }
-}]]></script>
+}
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
@@ -17025,9 +16926,6 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 //log.info ("Setting the gateway to Passthrough");
 
 
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
@@ -17047,48 +16945,68 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 //log.info ("Setting the gateway to Standard");</con:tearDownScript>
       <con:properties>
         <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-13T08:26:08Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-13T08:36:08Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/13/2015 08:26:08</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>FullPatientID</con:name>
-          <con:value>'D123401^^^&amp;amp;1.1&amp;amp;ISO'</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>24</con:value>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@type</con:name>
-          <con:value>QueryEncoding</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
-          <con:value>anonymus</con:value>
+          <con:name>&lt;--Document</con:name>
+          <con:value>--></con:value>
+        </con:property>
+        <con:property>
+          <con:name>&lt;--Patient--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>&lt;--RESPONDER--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@UserID</con:name>
@@ -17099,260 +17017,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>false</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-38</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>ITI-38</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Patient--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Document</con:name>
-          <con:value>--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--RESPONDER--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@value</con:name>
-          <con:value>UTF-8</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>E</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
           <con:value>110152</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.1</con:value>
-        </con:property>
-        <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110112</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventDateTime</con:name>
-          <con:value>2015-04-02T13:47:30.199Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ResponderActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentQuery/2_0/NhinService/RespondingGateway_Query_Service/DocQuery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectID</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@value</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@type</con:name>
-          <con:value>urn:ihe:iti:xca:2010:homeCommunityId</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
-          <con:value>Export</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
-          <con:value>unknown</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectQuery</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxBZGhvY1F1ZXJ5UmVxdWVzdCB4bWx....</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parsedParticipantObjectQuery.AdhocQuery.Slot.ValueList.Value.PatientID</con:name>
-          <con:value>D123401</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest_g0.@UserID</con:name>
@@ -17363,20 +17041,232 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>https://localhost:8181/Gateway/DocumentQuery/3_0/NhinService/RespondingGateway_Query_Service/DocQuery</con:value>
         </con:property>
         <con:property>
-          <con:name>RetrieveDocuments</con:name>
+          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
           <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:46:24Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>E</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventDateTime</con:name>
+          <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110112</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Query</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-38</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Query</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
+          <con:value>Export</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>FullPatientID</con:name>
+          <con:value>'D123401^^^&amp;amp;1.1&amp;amp;ISO'</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parsedParticipantObjectQuery.AdhocQuery.Slot.ValueList.Value.PatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
+          <con:value>anonymus</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
+          <con:value>unknown</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>24</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@type</con:name>
+          <con:value>QueryEncoding</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@value</con:name>
+          <con:value>UTF-8</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@type</con:name>
+          <con:value>urn:ihe:iti:xca:2010:homeCommunityId</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@value</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>ITI-38</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Query</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectQuery</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxBZGhvY1F1ZXJ5UmVxdWVzdCB4bWx....</con:value>
         </con:property>
         <con:property>
           <con:name>QueryForDocuments</con:name>
           <con:value>false</con:value>
         </con:property>
         <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
+          <con:name>ResponderActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentQuery/2_0/NhinService/RespondingGateway_Query_Service/DocQuery</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditOff</con:name>
+          <con:name>RetrieveDocuments</con:name>
           <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:36:24</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:36:24Z</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -17390,6 +17280,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Document Retrieve" type="request" id="455761ae-828f-4317-b59f-1d9dd06cf8be">
@@ -17690,27 +17586,26 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="e63fc577-4966-462f-85f0-b563f0d69c37">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
- {
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments', log) == "true")
+{
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
 }
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
- }
- else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
- {
+}
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments', log) == "false")
+{
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
+	}
+	testRunner.gotoStepByName( "Success")
 }
-testRunner.testCase.setPropertyValue('AuditOff', 'true')
-testRunner.gotoStepByName( "Success")
- }
- else
- {
+else
+{
  	testRunner.fail( "Incorrect AuditLogging property found for this service testcase" )
- }</script>
+}</script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-InitiatingGateway(1.1)">
@@ -17973,28 +17868,22 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
 	 	}	  
 	}
  }
-}]]></script>
+}
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
 nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
 //context.setGatewayStandard(false);
 //log.info ("Setting the gateway to Passthrough");
-
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -18166,7 +18055,7 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-13T08:36:23Z</con:value>
+          <con:value>2015-11-14T01:46:38Z</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.@EventActionCode</con:name>
@@ -18218,7 +18107,7 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
+          <con:value>2015-12-14T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
@@ -18334,19 +18223,11 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/13/2015 08:26:23</con:value>
+          <con:value>11/14/2015 01:36:38</con:value>
         </con:property>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-13T08:26:23Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditOff</con:name>
-          <con:value>true</con:value>
+          <con:value>2015-11-14T01:36:38Z</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -18741,19 +18622,19 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-13T08:26:51Z</con:value>
+          <con:value>2015-11-14T01:36:53Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-13T08:36:51Z</con:value>
+          <con:value>2015-11-14T01:46:53Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/13/2015 08:26:51</con:value>
+          <con:value>11/14/2015 01:36:53</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
+          <con:value>2015-12-14T00:00:00Z</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -18767,6 +18648,12 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep type="request" name="RealTimeTransaction" id="d3a9e147-d602-4df0-8919-1d0bac3cc2e0">
@@ -19043,7 +18930,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
       <con:testStep type="groovy" name="Verify Audit Logs" id="8845ff85-4918-48d9-b290-6058585f59c0">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSRealTime', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
@@ -19052,12 +18939,11 @@ context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 }
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSRealTime', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -19285,26 +19171,22 @@ parsedXmlMessage.ParticipantObjectIdentification.find{
 		//assert it.ParticipantObjectDetail.@value == context.findProperty( "ParticipantObjectIdentification.ParticipantObjectDetail.@value.inbound" ) 
 	}
  } 
-}</script>
+}
+
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSRealTime',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")</script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSRealTime',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
 nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
 
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSRealTime', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -19321,24 +19203,132 @@ if (propertiesFile.exists()) {
 nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSRealTime','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-13T08:29:34Z</con:value>
+          <con:name>&lt;!--Destination--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-13T08:39:34Z</con:value>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/13/2015 08:29:34</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
+          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.5</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.@UserIsRequestor</con:name>
           <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Public Health</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/CORE_X12DocumentSubmission/1_0/X12DocumentSubmission_Service</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
+          <con:value>110152</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
         </con:property>
         <con:property>
           <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
@@ -19349,39 +19339,87 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>urn:oid:1.1</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110112</con:value>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:46:58Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode.Create</con:name>
+          <con:value>C</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.@EventDateTime</con:name>
           <con:value>2015-04-02T13:47:30.199Z</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.1</con:value>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110112</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.EventID.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>f81d4fae-7dec-11d0-a765-00a0c91e6bf6</con:value>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Export</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>20</con:value>
+          <con:name>EventIdentification.EventID.@displayName.Import</con:name>
+          <con:value>Import</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName.Inbound</con:name>
+          <con:value>Import</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>X12</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>CAQH CORE Transactions</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
           <con:value>NwHIN CAQH CORE X12 Document Submission</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Source--></con:name>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>f81d4fae-7dec-11d0-a765-00a0c91e6bf6</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID.inbound</con:name>
+          <con:value>a81d44ae-7dec-11d0-a765-00a0c91e6ba0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID.response</con:name>
+          <con:value>a81d44ae-7dec-11d0-a765-00a0c91e6ba0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>20</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDataLifeCycle</con:name>
           <con:value/>
         </con:property>
         <con:property>
@@ -19389,163 +19427,27 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxuczM6Q09SRUVudmVsb3BlUmVhbFRpbWVSZXF1ZXN0IHhtbG5zOm5zMj0iaHR0cDovL3d3dy5jYXFoLm9yZy9TT0FQL1dTREwvQ09SRVJ1bGUyLjIuMC54c2QiIHhtbG5zOm5zMz0idXJuOm9yZzpjYXFoOnNvYXA6d3NkbDpjb3JlcnVsZTJfMl8wIj48UGF5bG9hZFR5cGU+WDEyXzI3MF9SZXF1ZXN0XzAwNTAxMFgyNzlBMTwvUGF5bG9hZFR5cGU+PFByb2Nlc3NpbmdNb2RlPlJlYWxUaW1lPC9Qcm9jZXNzaW5nTW9kZT48UGF5bG9hZElEPmY4MWQ0ZmFlLTdkZWMtMTFkMC1hNzY1LTAwYTBjOTFlNmJmNjwvUGF5bG9hZElEPjxUaW1lU3RhbXA+MjAwNy0wOC0zMFQxMDoyMDozNFo8L1RpbWVTdGFtcD48U2VuZGVySUQ+SG9zcGl0YWxBPC9TZW5kZXJJRD48UmVjZWl2ZXJJRD5QYXllckI8L1JlY2VpdmVySUQ+PENPUkVSdWxlVmVyc2lvbj4yLjIuMDwvQ09SRVJ1bGVWZXJzaW9uPjxQYXlsb2FkPjwvUGF5bG9hZD48L25zMzpDT1JFRW52ZWxvcGVSZWFsVGltZVJlcXVlc3Q+</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>R</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Destination--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Payload Identifier</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>X12</con:value>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@value.inbound</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxuczM6Q09SRUVudmVsb3BlUmVhbFRpbWVSZXNwb25zZSB4bWxuczpuczI9Imh0dHA6Ly93d3cuY2FxaC5vcmcvU09BUC9XU0RML0NPUkVSdWxlMi4yLjAueHNkIiB4bWxuczpuczM9InVybjpvcmc6Y2FxaDpzb2FwOndzZGw6Y29yZXJ1bGUyXzJfMCI+PFBheWxvYWRUeXBlPkNvcmVFbnZlbG9wZUVycm9yPC9QYXlsb2FkVHlwZT48UHJvY2Vzc2luZ01vZGU+UmVhbFRpbWU8L1Byb2Nlc3NpbmdNb2RlPjxQYXlsb2FkSUQ+ZjgxZDRmYWUtN2RlYy0xMWQwLWE3NjUtMDBhMGM5MWU2YmY2PC9QYXlsb2FkSUQ+PFRpbWVTdGFtcD4yMDE1LTExLTA2IDA2OjMwOjA2LjczNTwvVGltZVN0YW1wPjxTZW5kZXJJRD5Ib3NwaXRhbEE8L1NlbmRlcklEPjxSZWNlaXZlcklEPlBheWVyQjwvUmVjZWl2ZXJJRD48Q09SRVJ1bGVWZXJzaW9uPjIuMi4wPC9DT1JFUnVsZVZlcnNpb24+PFBheWxvYWQ+PC9QYXlsb2FkPjxFcnJvckNvZGU+UmVjZWl2ZXI8L0Vycm9yQ29kZT48RXJyb3JNZXNzYWdlPkZhaWxlZCB0byBjb25uZWN0IHRvIGJhY2tlbmQgYWRhcHRlciB0byBwcm9jZXNzIHRoZSBtZXNzYWdlPC9FcnJvck1lc3NhZ2U+PC9uczM6Q09SRUVudmVsb3BlUmVhbFRpbWVSZXNwb25zZT4=</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
           <con:value>f81d4fae-7dec-11d0-a765-00a0c91e6bf6</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>CAQH CORE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Export</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Public Health</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code.inbound</con:name>
+          <con:value>a81d44ae-7dec-11d0-a765-00a0c91e6ba0</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
           <con:value>CAQH CORE Connectivity Metadata</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.5</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/CORE_X12DocumentSubmission/1_0/X12DocumentSubmission_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
-          <con:value>110152</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Payload Identifier</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectSensitivity</con:name>
           <con:value/>
         </con:property>
         <con:property>
@@ -19553,48 +19455,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code.inbound</con:name>
-          <con:value>a81d44ae-7dec-11d0-a765-00a0c91e6ba0</con:value>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectSensitivity</con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID.inbound</con:name>
-          <con:value>a81d44ae-7dec-11d0-a765-00a0c91e6ba0</con:value>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:36:58</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@value.inbound</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxuczM6Q09SRUVudmVsb3BlUmVhbFRpbWVSZXNwb25zZSB4bWxuczpuczI9Imh0dHA6Ly93d3cuY2FxaC5vcmcvU09BUC9XU0RML0NPUkVSdWxlMi4yLjAueHNkIiB4bWxuczpuczM9InVybjpvcmc6Y2FxaDpzb2FwOndzZGw6Y29yZXJ1bGUyXzJfMCI+PFBheWxvYWRUeXBlPkNvcmVFbnZlbG9wZUVycm9yPC9QYXlsb2FkVHlwZT48UHJvY2Vzc2luZ01vZGU+UmVhbFRpbWU8L1Byb2Nlc3NpbmdNb2RlPjxQYXlsb2FkSUQ+ZjgxZDRmYWUtN2RlYy0xMWQwLWE3NjUtMDBhMGM5MWU2YmY2PC9QYXlsb2FkSUQ+PFRpbWVTdGFtcD4yMDE1LTExLTA2IDA2OjMwOjA2LjczNTwvVGltZVN0YW1wPjxTZW5kZXJJRD5Ib3NwaXRhbEE8L1NlbmRlcklEPjxSZWNlaXZlcklEPlBheWVyQjwvUmVjZWl2ZXJJRD48Q09SRVJ1bGVWZXJzaW9uPjIuMi4wPC9DT1JFUnVsZVZlcnNpb24+PFBheWxvYWQ+PC9QYXlsb2FkPjxFcnJvckNvZGU+UmVjZWl2ZXI8L0Vycm9yQ29kZT48RXJyb3JNZXNzYWdlPkZhaWxlZCB0byBjb25uZWN0IHRvIGJhY2tlbmQgYWRhcHRlciB0byBwcm9jZXNzIHRoZSBtZXNzYWdlPC9FcnJvck1lc3NhZ2U+PC9uczM6Q09SRUVudmVsb3BlUmVhbFRpbWVSZXNwb25zZT4=</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode.Create</con:name>
-          <con:value>C</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName.Import</con:name>
-          <con:value>Import</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName.Inbound</con:name>
-          <con:value>Import</con:value>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:36:58Z</con:value>
         </con:property>
         <con:property>
           <con:name>X12RealTimePayload</con:name>
           <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4NCjxDbGluaWNhbERvY3VtZW50IG1vb2RDb2RlPSJFVk4iIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyINCiAgICB4bWxuczp4c2k9Imh0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID.response</con:name>
-          <con:value>a81d44ae-7dec-11d0-a765-00a0c91e6ba0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditOff</con:name>
-          <con:value>true</con:value>
         </con:property>
       </con:properties>
     </con:testCase>
@@ -19607,6 +19481,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Delay">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep type="request" name="BatchSubmitTransaction" id="f300d214-aa28-48af-9146-aa4d6b193921">
@@ -19879,27 +19759,26 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="delay" name="Wait for Audit table to populate">
         <con:settings/>
         <con:config>
-          <delay>2000</delay>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Verify Audit Logs" id="5f2a20a9-b0d2-4f97-905a-64e5c59c297e">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSGenericBatchRequest', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
-	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]	
-	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]	
+	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
+	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
 }
-	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
+	testRunner.gotoStepByName( "Verify Message-NhinOutbound-InitiatingGateway(2.2)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSGenericBatchRequest', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -20122,26 +20001,21 @@ parsedXmlMessage.ParticipantObjectIdentification.find{
 	//we are going to just check if the X12 Envelope value is not null, since the payload id is going to unique for each response
 	assert(!it.ParticipantObjectDetail.@value.isEmpty())
 } 
-}</script>
+}
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSGenericBatchRequest',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")</script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSGenericBatchRequest',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
 nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
 
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSGenericBatchRequest', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -20158,32 +20032,56 @@ if (propertiesFile.exists()) {
 nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSGenericBatchRequest','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-13T08:27:07Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-13T08:37:07Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/13/2015 08:27:07</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
+        </con:property>
+        <con:property>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Public Health</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@UserID</con:name>
@@ -20194,104 +20092,88 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>false</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>X12</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>CAQH CORE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Payload Identifier</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>R</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
           <con:value>110152</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+        </con:property>
+        <con:property>
           <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
           <con:value>DoD</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Export</con:value>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>20</con:value>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:47:13Z</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>R</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>NwHIN CAQH CORE X12 Document Submission</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110112</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
+          <con:name>EventIdentification.@EventActionCode.Create</con:name>
+          <con:value>C</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.@EventDateTime</con:name>
@@ -20302,116 +20184,100 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>0</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>CAQH CORE Connectivity Metadata</con:value>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110112</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Public Health</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>f81d4fae-7dec-11d0-a765-00a0c91e6bf6</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>f81d4fae-7dec-11d0-a765-00a0c91e6bf6</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@value</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxuczM6Q09SRUVudmVsb3BlUmVhbFRpbWVSZXF1ZXN0IHhtbG5zOm5zMj0iaHR0cDovL3d3dy5jYXFoLm9yZy9TT0FQL1dTREwvQ09SRVJ1bGUyLjIuMC54c2QiIHhtbG5zOm5zMz0idXJuOm9yZzpjYXFoOnNvYXA6d3NkbDpjb3JlcnVsZTJfMl8wIj48UGF5bG9hZFR5cGU+WDEyXzI3MF9SZXF1ZXN0XzAwNTAxMFgyNzlBMTwvUGF5bG9hZFR5cGU+PFByb2Nlc3NpbmdNb2RlPlJlYWxUaW1lPC9Qcm9jZXNzaW5nTW9kZT48UGF5bG9hZElEPmY4MWQ0ZmFlLTdkZWMtMTFkMC1hNzY1LTAwYTBjOTFlNmJmNjwvUGF5bG9hZElEPjxUaW1lU3RhbXA+MjAwNy0wOC0zMFQxMDoyMDozNFo8L1RpbWVTdGFtcD48U2VuZGVySUQ+SG9zcGl0YWxBPC9TZW5kZXJJRD48UmVjZWl2ZXJJRD5QYXllckI8L1JlY2VpdmVySUQ+PENPUkVSdWxlVmVyc2lvbj4yLjIuMDwvQ09SRVJ1bGVWZXJzaW9uPjxQYXlsb2FkPjwvUGF5bG9hZD48L25zMzpDT1JFRW52ZWxvcGVSZWFsVGltZVJlcXVlc3Q+</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode.Create</con:name>
-          <con:value>C</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID.inbound</con:name>
-          <con:value>a81d44ae-7dec-11d0-a765-00a0c91e6ba0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
-          <con:value>false</con:value>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Export</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.EventID.@displayName.Inbound</con:name>
           <con:value>Import</con:value>
         </con:property>
         <con:property>
-          <con:name>X12GenericBatchPayload</con:name>
-          <con:value>cid:60987661826</con:value>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>X12</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>CAQH CORE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>NwHIN CAQH CORE X12 Document Submission</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>f81d4fae-7dec-11d0-a765-00a0c91e6bf6</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID.inbound</con:name>
+          <con:value>a81d44ae-7dec-11d0-a765-00a0c91e6ba0</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification.@ParticipantObjectID.response</con:name>
           <con:value>a81d44ae-7dec-11d0-a765-00a0c91e6ba0</con:value>
         </con:property>
         <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditOff</con:name>
-          <con:value>false</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>20</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@value</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxuczM6Q09SRUVudmVsb3BlUmVhbFRpbWVSZXF1ZXN0IHhtbG5zOm5zMj0iaHR0cDovL3d3dy5jYXFoLm9yZy9TT0FQL1dTREwvQ09SRVJ1bGUyLjIuMC54c2QiIHhtbG5zOm5zMz0idXJuOm9yZzpjYXFoOnNvYXA6d3NkbDpjb3JlcnVsZTJfMl8wIj48UGF5bG9hZFR5cGU+WDEyXzI3MF9SZXF1ZXN0XzAwNTAxMFgyNzlBMTwvUGF5bG9hZFR5cGU+PFByb2Nlc3NpbmdNb2RlPlJlYWxUaW1lPC9Qcm9jZXNzaW5nTW9kZT48UGF5bG9hZElEPmY4MWQ0ZmFlLTdkZWMtMTFkMC1hNzY1LTAwYTBjOTFlNmJmNjwvUGF5bG9hZElEPjxUaW1lU3RhbXA+MjAwNy0wOC0zMFQxMDoyMDozNFo8L1RpbWVTdGFtcD48U2VuZGVySUQ+SG9zcGl0YWxBPC9TZW5kZXJJRD48UmVjZWl2ZXJJRD5QYXllckI8L1JlY2VpdmVySUQ+PENPUkVSdWxlVmVyc2lvbj4yLjIuMDwvQ09SRVJ1bGVWZXJzaW9uPjxQYXlsb2FkPjwvUGF5bG9hZD48L25zMzpDT1JFRW52ZWxvcGVSZWFsVGltZVJlcXVlc3Q+</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>f81d4fae-7dec-11d0-a765-00a0c91e6bf6</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>CAQH CORE Connectivity Metadata</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Payload Identifier</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:37:13</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:37:13Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>X12GenericBatchPayload</con:name>
+          <con:value>cid:60987661826</con:value>
         </con:property>
       </con:properties>
     </con:testCase>
@@ -20424,6 +20290,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Delay">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep type="request" name="BatchSubmitTransaction" id="aae3ac29-535c-4b12-9f16-1a8be9eec3b1">
@@ -20706,21 +20578,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="20ec8422-75b2-4ebb-9cdc-9718cb060aba">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSGenericBatchResponse', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
 }
-	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
+	testRunner.gotoStepByName( "Verify Message-NhinOutbound-InitiatingGateway(2.2))")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSGenericBatchResponse', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -20946,26 +20817,20 @@ parsedXmlMessage.ParticipantObjectIdentification.find{
 	assert it.ParticipantObjectIDTypeCode.@displayName == context.findProperty( "ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName" )
 	assert (!it.ParticipantObjectDetail.@value.isEmpty())
 } 
-}</script>
+}
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSGenericBatchResponse',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")</script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSGenericBatchResponse',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);
 nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
 
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSGenericBatchResponse', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -20982,36 +20847,56 @@ if (propertiesFile.exists()) {
 nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'CORE_X12DSGenericBatchResponse','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-13T08:27:23Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-13T08:37:23Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/13/2015 08:27:23</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
+          <con:name>&lt;!--Source--></con:name>
           <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Public Health</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@UserID</con:name>
@@ -21022,104 +20907,88 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>false</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>X12</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>CAQH CORE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Payload Identifier</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>R</con:value>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
           <con:value>110152</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Export</con:value>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>20</con:value>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
+          <con:value>false</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>NwHIN CAQH CORE X12 Document Submission</con:value>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110112</con:value>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectSensitivity</con:name>
-          <con:value/>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:47:29Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode.Create</con:name>
+          <con:value>C</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.@EventDateTime</con:name>
@@ -21130,104 +20999,92 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>0</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>CAQH CORE Connectivity Metadata</con:value>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110112</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>f81d4fae-7dec-11d0-a765-00a0c91e6bf6</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>f81d4fae-7dec-11d0-a765-00a0c91e6bf6</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@value</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxuczM6Q09SRUVudmVsb3BlUmVhbFRpbWVSZXF1ZXN0IHhtbG5zOm5zMj0iaHR0cDovL3d3dy5jYXFoLm9yZy9TT0FQL1dTREwvQ09SRVJ1bGUyLjIuMC54c2QiIHhtbG5zOm5zMz0idXJuOm9yZzpjYXFoOnNvYXA6d3NkbDpjb3JlcnVsZTJfMl8wIj48UGF5bG9hZFR5cGU+WDEyXzI3MF9SZXF1ZXN0XzAwNTAxMFgyNzlBMTwvUGF5bG9hZFR5cGU+PFByb2Nlc3NpbmdNb2RlPlJlYWxUaW1lPC9Qcm9jZXNzaW5nTW9kZT48UGF5bG9hZElEPmY4MWQ0ZmFlLTdkZWMtMTFkMC1hNzY1LTAwYTBjOTFlNmJmNjwvUGF5bG9hZElEPjxUaW1lU3RhbXA+MjAwNy0wOC0zMFQxMDoyMDozNFo8L1RpbWVTdGFtcD48U2VuZGVySUQ+SG9zcGl0YWxBPC9TZW5kZXJJRD48UmVjZWl2ZXJJRD5QYXllckI8L1JlY2VpdmVySUQ+PENPUkVSdWxlVmVyc2lvbj4yLjIuMDwvQ09SRVJ1bGVWZXJzaW9uPjxQYXlsb2FkPjwvUGF5bG9hZD48L25zMzpDT1JFRW52ZWxvcGVSZWFsVGltZVJlcXVlc3Q+</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Public Health</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode.Create</con:name>
-          <con:value>C</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
-          <con:value>false</con:value>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Export</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.EventID.@displayName.Inbound</con:name>
           <con:value>Import</con:value>
         </con:property>
         <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>X12</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>CAQH CORE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>NwHIN CAQH CORE X12 Document Submission</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>f81d4fae-7dec-11d0-a765-00a0c91e6bf6</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>20</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@value</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxuczM6Q09SRUVudmVsb3BlUmVhbFRpbWVSZXF1ZXN0IHhtbG5zOm5zMj0iaHR0cDovL3d3dy5jYXFoLm9yZy9TT0FQL1dTREwvQ09SRVJ1bGUyLjIuMC54c2QiIHhtbG5zOm5zMz0idXJuOm9yZzpjYXFoOnNvYXA6d3NkbDpjb3JlcnVsZTJfMl8wIj48UGF5bG9hZFR5cGU+WDEyXzI3MF9SZXF1ZXN0XzAwNTAxMFgyNzlBMTwvUGF5bG9hZFR5cGU+PFByb2Nlc3NpbmdNb2RlPlJlYWxUaW1lPC9Qcm9jZXNzaW5nTW9kZT48UGF5bG9hZElEPmY4MWQ0ZmFlLTdkZWMtMTFkMC1hNzY1LTAwYTBjOTFlNmJmNjwvUGF5bG9hZElEPjxUaW1lU3RhbXA+MjAwNy0wOC0zMFQxMDoyMDozNFo8L1RpbWVTdGFtcD48U2VuZGVySUQ+SG9zcGl0YWxBPC9TZW5kZXJJRD48UmVjZWl2ZXJJRD5QYXllckI8L1JlY2VpdmVySUQ+PENPUkVSdWxlVmVyc2lvbj4yLjIuMDwvQ09SRVJ1bGVWZXJzaW9uPjxQYXlsb2FkPjwvUGF5bG9hZD48L25zMzpDT1JFRW52ZWxvcGVSZWFsVGltZVJlcXVlc3Q+</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>f81d4fae-7dec-11d0-a765-00a0c91e6bf6</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>CAQH CORE Connectivity Metadata</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Payload Identifier</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:37:29</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:37:29Z</con:value>
+        </con:property>
+        <con:property>
           <con:name>X12GenericBatchPayload</con:name>
           <con:value>cid:60987661826</con:value>
-        </con:property>
-        <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditOff</con:name>
-          <con:value>true</con:value>
         </con:property>
       </con:properties>
     </con:testCase>
@@ -21297,6 +21154,10 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
     <con:property>
       <con:name>AsyncMsgTable</con:name>
       <con:value>asyncmsgrepo</con:value>
+    </con:property>
+    <con:property>
+      <con:name>auditLoggingStatusFileName</con:name>
+      <con:value>audit.properties</con:value>
     </con:property>
     <con:property>
       <con:name>AuditMessage.xmlns</con:name>
@@ -21384,7 +21245,7 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
     </con:property>
     <con:property>
       <con:name>GatewayPropDir</con:name>
-      <con:value>C:\jboss-as-7.1.1.Final\modules\org\connectopensource\configuration\main</con:value>
+      <con:value/>
     </con:property>
     <con:property>
       <con:name>Gender</con:name>
@@ -21493,10 +21354,6 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
     <con:property>
       <con:name>ZipCode</con:name>
       <con:value>12345</con:value>
-    </con:property>
-    <con:property>
-      <con:name>auditLoggingStatusFileName</con:name>
-      <con:value>audit.properties</con:value>
     </con:property>
   </con:properties>
   <con:afterLoadScript>def propertiesFilename = project.path[0..(project.path.size()-4)] + 'properties'

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/RetrieveDocumentAuditLog.properties
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/RetrieveDocumentAuditLog.properties
@@ -29,6 +29,7 @@ ActiveParticipant.RoleIDCode.@displayName=Human Requestor
 ActiveParticipant_Source_g1.@UserID=https://localhost:8181/Gateway/DocumentRetrieve/3_0/NhinService/RespondingGateway_Retrieve_Service/DocRetrieve
 ActiveParticipant_Source_g0.@UserID=http://localhost:8080/Gateway/DocumentRetrieve/2_0/EntityService/EntityDocRetrieve
 ActiveParticipant_Source.@UserIsRequestor=false
+ActiveParticipant_Source.@UserName=Karl Skagerberg
 ActiveParticipant_Source.@NetworkAccessPointID=localhost
 ActiveParticipant_Source.@NetworkAccessPointTypeCode=2
 

--- a/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/AuditLogging-Standard-soapui-project.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/AuditLogging-Standard-soapui-project.xml
@@ -617,6 +617,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -950,7 +951,12 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
@@ -958,6 +964,7 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -970,7 +977,8 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
@@ -1611,6 +1619,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -1810,7 +1819,12 @@ parsedXmlMessage.AuditSourceIdentification.find{
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
@@ -1818,6 +1832,7 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -1830,7 +1845,8 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
@@ -2517,6 +2533,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -2758,7 +2775,12 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeC
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
@@ -2766,6 +2788,7 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -2778,7 +2801,8 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
@@ -3401,6 +3425,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -3721,7 +3746,12 @@ if (parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCo
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
@@ -3729,7 +3759,7 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -3742,7 +3772,8 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>LocalHCID</con:name>
@@ -4724,6 +4755,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -5044,7 +5076,12 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeC
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
@@ -5053,6 +5090,7 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -5065,7 +5103,8 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>LocalHCID</con:name>
@@ -6013,6 +6052,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -6327,7 +6367,12 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
@@ -6335,6 +6380,7 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -6347,7 +6393,8 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
@@ -7134,6 +7181,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -7420,7 +7468,12 @@ if(!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCo
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
@@ -7428,6 +7481,7 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -7440,7 +7494,8 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
@@ -7780,6 +7835,12 @@ if (propertiesFile.exists()) {
 }</script>
         </con:config>
       </con:testStep>
+      <con:testStep type="delay" name="Wait for Audit table to populate">
+        <con:settings/>
+        <con:config>
+          <delay>2000</delay>
+        </con:config>
+      </con:testStep>
       <con:testStep name="Document Retrieve" type="request" id="0b684917-158e-4591-ab73-952037ca7338">
         <con:settings/>
         <con:config xsi:type="con:RequestStep" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -8069,12 +8130,6 @@ if (propertiesFile.exists()) {
           </con:request>
         </con:config>
       </con:testStep>
-      <con:testStep type="delay" name="Wait for Audit table to populate">
-        <con:settings/>
-        <con:config>
-          <delay>2000</delay>
-        </con:config>
-      </con:testStep>
       <con:testStep type="groovy" name="Verify Audit Logs" id="837f4e46-0ed2-4b1f-8da7-261fcad448be">
         <con:settings/>
         <con:config>
@@ -8092,6 +8147,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -8364,7 +8420,12 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
@@ -8372,6 +8433,7 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -8384,7 +8446,8 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>CorrectedRemoteHCID</con:name>
@@ -9684,6 +9747,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -10017,7 +10081,12 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
@@ -10025,6 +10094,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -10037,23 +10107,24 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-12T17:18:11Z</con:value>
+          <con:value>2015-11-13T09:02:55Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-12T17:28:11Z</con:value>
+          <con:value>2015-11-13T09:12:55Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/12/2015 17:18:11</con:value>
+          <con:value>11/13/2015 09:02:55</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
@@ -10297,7 +10368,11 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>auditLogStatus</con:name>
-          <con:value>true</con:value>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
+          <con:value>false</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -10679,6 +10754,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -10877,7 +10953,12 @@ parsedXmlMessage.AuditSourceIdentification.find{
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
@@ -10885,6 +10966,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -10897,23 +10979,24 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-12T17:32:40Z</con:value>
+          <con:value>2015-11-13T09:00:23Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-12T17:42:40Z</con:value>
+          <con:value>2015-11-13T09:10:23Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/12/2015 17:32:40</con:value>
+          <con:value>11/13/2015 09:00:23</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
@@ -11069,7 +11152,11 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>auditLogStatus</con:name>
-          <con:value>true</con:value>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
+          <con:value>false</con:value>
         </con:property>
       </con:properties>
     </con:testCase>
@@ -11585,6 +11672,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -11826,7 +11914,12 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeC
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
@@ -11834,6 +11927,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -11846,23 +11940,24 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-12T17:18:42Z</con:value>
+          <con:value>2015-11-13T09:04:07Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-12T17:28:42Z</con:value>
+          <con:value>2015-11-13T09:14:07Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/12/2015 17:18:42</con:value>
+          <con:value>11/13/2015 09:04:07</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
@@ -12106,7 +12201,11 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>auditLogStatus</con:name>
-          <con:value>true</con:value>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
+          <con:value>false</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -12470,6 +12569,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -12789,7 +12889,12 @@ if (parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCo
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
@@ -12797,6 +12902,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -12809,7 +12915,8 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>LocalHCID</con:name>
@@ -13073,19 +13180,19 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-12T17:18:59Z</con:value>
+          <con:value>2015-11-13T09:13:10Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-12T17:28:59Z</con:value>
+          <con:value>2015-11-13T09:23:10Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/12/2015 17:18:59</con:value>
+          <con:value>11/13/2015 09:13:10</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.EventID.@code</con:name>
@@ -13401,7 +13508,11 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>auditLogStatus</con:name>
-          <con:value>true</con:value>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
+          <con:value>false</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -13791,6 +13902,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -14111,7 +14223,12 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeC
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
@@ -14120,6 +14237,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -14132,7 +14250,8 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>LocalHCID</con:name>
@@ -14400,19 +14519,19 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-12T17:29:12Z</con:value>
+          <con:value>2015-11-13T09:22:06Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/12/2015 17:19:12</con:value>
+          <con:value>11/13/2015 09:12:06</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-12T17:19:12Z</con:value>
+          <con:value>2015-11-13T09:12:06Z</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.EventID.@code</con:name>
@@ -14728,7 +14847,11 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>auditLogStatus</con:name>
-          <con:value>true</con:value>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
+          <con:value>false</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -15080,6 +15203,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -15395,7 +15519,12 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
@@ -15403,7 +15532,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -15416,23 +15545,24 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-12T17:19:30Z</con:value>
+          <con:value>2015-11-13T09:11:23Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-12T17:29:30Z</con:value>
+          <con:value>2015-11-13T09:21:23Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/12/2015 17:19:30</con:value>
+          <con:value>11/13/2015 09:11:23</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
+          <con:value>2015-12-13T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
@@ -15832,6 +15962,10 @@ if (propertiesFile.exists()) {
         </con:property>
         <con:property>
           <con:name>auditLogStatus</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
           <con:value>true</con:value>
         </con:property>
       </con:properties>
@@ -16199,6 +16333,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -16487,7 +16622,12 @@ if(!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCo
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
@@ -16496,6 +16636,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -16508,7 +16649,8 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
@@ -17157,6 +17299,7 @@ else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
+	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -17431,7 +17574,12 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script/>
+          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
+{
+testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
+testRunner.gotoStepByName( "Clear Audit Logs")
+}</script>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
@@ -17440,6 +17588,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
 
 def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments', log);
 testCase.setPropertyValue('auditLogStatus', auditLogStatus)
+testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -17452,7 +17601,8 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>CorrectedRemoteHCID</con:name>
@@ -18327,7 +18477,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
     </con:property>
     <con:property>
       <con:name>GatewayPropDir</con:name>
-      <con:value/>
+      <con:value>C:\jboss-as-7.1.1.Final\modules\org\connectopensource\configuration\main</con:value>
     </con:property>
     <con:property>
       <con:name>Gender</con:name>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/AuditLogging-Standard-soapui-project.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/AuditLogging-Standard-soapui-project.xml
@@ -117,6 +117,12 @@
 			}</script>
         </con:config>
       </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
+        </con:config>
+      </con:testStep>
       <con:testStep name="Doc Submission Deferred Req" type="request" id="5494696d-5ac3-4ba0-bac8-7a1fbae89475">
         <con:settings/>
         <con:config xsi:type="con:RequestStep" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -603,21 +609,20 @@
       <con:testStep type="groovy" name="Verify Audit Logs" id="9af1f656-9833-42d1-8b82-b79f779c22ae">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
-	}
+}
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -945,26 +950,20 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
 	 	}
 	}
   }
-}]]></script>
+}
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
 nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
-
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -977,188 +976,239 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq','true', log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
       <con:properties>
-        <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-12T17:26:06Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-12T17:36:06Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/12/2015 17:26:06</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
         <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>submission set classificationNode</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
-          <con:value>C</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-41</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@code</con:name>
-          <con:value>110107</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Patient--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Submission</con:name>
-          <con:value>Set --></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
         </con:property>
         <con:property>
           <con:name>&lt;!--Human</con:name>
           <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
+          <con:name>&lt;--Patient--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>R</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
-          <con:value>110152</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Export</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
+          <con:name>&lt;--Submission</con:name>
+          <con:value>Set --></con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.@AlternativeUserID</con:name>
           <con:value>19233@192.168.1.1</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Provide and Register Document Set-b</con:value>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110106</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
           <con:value>307969004</con:value>
         </con:property>
         <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID_g0</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/1_1/NhinService/XDRRequest_Service</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID_g1</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/NhinService/XDRRequest_Service</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
+          <con:value>110152</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:24:18Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
           <con:name>EventIdentification.@EventDateTime</con:name>
           <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110106</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Export</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-41</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Provide and Register Document Set-b</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
+          <con:value>C</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@code</con:name>
+          <con:value>110107</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
+          <con:value>Import</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>SELF-5^^^&amp;1.3.6.1.4.1.21367.2005.3.7&amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectID</con:name>
+          <con:value>1.3.6.1.4.1.21367.2005.3.9999.33</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCodeRole</con:name>
@@ -1169,76 +1219,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>urn:uuid:a54d6aa5-d40d-43f9-88c5-b4633d873bdd</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
           <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
           <con:value>IHE XDS Metadata</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>2</con:value>
+          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>submission set classificationNode</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:14:18</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>SELF-5^^^&amp;1.3.6.1.4.1.21367.2005.3.7&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
-          <con:value>Import</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectID</con:name>
-          <con:value>1.3.6.1.4.1.21367.2005.3.9999.33</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID_g1</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/NhinService/XDRRequest_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID_g0</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/1_1/NhinService/XDRRequest_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>true</con:value>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:14:18Z</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -1252,6 +1246,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 			}</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Doc Submission Deferred Resp" type="request" id="19f9d64a-97d6-46c8-b150-4bd18f70679a">
@@ -1605,21 +1605,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="2518c97d-6055-4a7a-a2bf-4e7af8674da0">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
-	}
+}
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -1813,26 +1812,19 @@ parsedXmlMessage.AuditSourceIdentification.find{
 			assert it.@AuditSourceID == context.findProperty( "AuditSourceIdentification.@AuditSourceID" )	
 		}
   }
-}</script>
+}
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")</script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
 nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
-
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -1845,132 +1837,119 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp','true', log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
       <con:properties>
-        <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-12T17:26:18Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-12T17:36:18Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/12/2015 17:26:18</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
         <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
         </con:property>
         <con:property>
-          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
-          <con:value>R</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
           <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-41</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@code</con:name>
-          <con:value>110106</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
           <con:value>localhost</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>C</con:value>
+          <con:name>ActiveParticipant_Dest.@UserID_g0</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/1_1/NhinService/XDRResponse_Service</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID_g1</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/NhinService/XDRResponse_Service</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
           <con:value>110152</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Import</con:value>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Provide and Register Document Set-b</con:value>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110107</con:value>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:24:32Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>C</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.@EventDateTime</con:name>
@@ -1981,44 +1960,52 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>0</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110107</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Import</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-41</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Provide and Register Document Set-b</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@code</con:name>
+          <con:value>110106</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
           <con:value>Export</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:14:32</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID_g1</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/NhinService/XDRResponse_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID_g0</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/1_1/NhinService/XDRResponse_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>true</con:value>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:14:32Z</con:value>
         </con:property>
       </con:properties>
     </con:testCase>
@@ -2031,6 +2018,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Doc Submission" type="request" id="374acf1c-f106-46a8-81f6-0f256a4fafaa">
@@ -2519,21 +2512,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="49fc03f8-cb24-4bd5-bb32-195ac38c4c29">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
-	}
+}
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -2769,26 +2761,21 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeC
      	assert node.ParticipantObjectIDTypeCode.@displayName == context.findProperty( "ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@displayName" )
   	}
  }
-}]]></script>
+}
+
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
 nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
-
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -2801,48 +2788,67 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission','true', log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
       <con:properties>
-        <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-12T17:26:28Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-12T17:36:28Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/12/2015 17:26:28</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
         <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>submission set classificationNode</con:value>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
-          <con:value>C</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>&lt;--Patient--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>&lt;--Submission</con:name>
+          <con:value>Set --></con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@UserID</con:name>
@@ -2853,204 +2859,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>false</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-41</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@code</con:name>
-          <con:value>110107</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Patient--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Submission</con:name>
-          <con:value>Set --></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>R</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
           <con:value>110152</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Export</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.1</con:value>
-        </con:property>
-        <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Provide and Register Document Set-b</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110106</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventDateTime</con:name>
-          <con:value>2015-04-02T13:47:30.199Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>20</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>urn:uuid:a54d6aa5-d40d-43f9-88c5-b4633d873bdd</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>IHE XDS Metadata</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>SELF-5^^^&amp;1.3.6.1.4.1.21367.2005.3.7&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
-          <con:value>Import</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectID</con:name>
-          <con:value>1.3.6.1.4.1.21367.2005.3.9999.33</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest_g0.@UserID</con:name>
@@ -3061,8 +2883,168 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</con:value>
         </con:property>
         <con:property>
-          <con:name>auditLogStatus</con:name>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
           <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:24:46Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventDateTime</con:name>
+          <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110106</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Export</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-41</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Provide and Register Document Set-b</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
+          <con:value>C</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@code</con:name>
+          <con:value>110107</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
+          <con:value>Import</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>SELF-5^^^&amp;1.3.6.1.4.1.21367.2005.3.7&amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectID</con:name>
+          <con:value>1.3.6.1.4.1.21367.2005.3.9999.33</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>20</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>urn:uuid:a54d6aa5-d40d-43f9-88c5-b4633d873bdd</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>IHE XDS Metadata</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>submission set classificationNode</con:value>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:14:46</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:14:46Z</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -3076,6 +3058,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Patient Discovery Deferred Req" type="request" id="27035536-f9f9-4c4f-8a1a-f709e11aed17">
@@ -3411,21 +3399,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="db7e5156-753b-49f0-97ed-ab389757b9d5">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
-	}
+}
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -3740,26 +3727,20 @@ if (parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCo
 	 	}
 	}
   }
-}]]></script>
+}
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
 nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
-
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -3772,116 +3753,23 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq','true', log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
       <con:properties>
         <con:property>
-          <con:name>LocalHCID</con:name>
-          <con:value>1.1</con:value>
+          <con:name>&lt;!--Destination--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>LocalAA</con:name>
-          <con:value>1.1</con:value>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>LocalHCDescription</con:name>
-          <con:value>InternalTest1</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>LocalPatientID</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemoteHCID</con:name>
-          <con:value>2.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemoteAA</con:name>
-          <con:value>2.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemoteHCDescription</con:name>
-          <con:value>InternalTest2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemotePatientID</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>NHINGatewayConfigDir</con:name>
-          <con:value>C:/Sun/AppServer/domains/domain1/config/nhin</con:value>
-        </con:property>
-        <con:property>
-          <con:name>MPIDir</con:name>
-          <con:value>C:/Sun/AppServer/domains/domain1/config</con:value>
-        </con:property>
-        <con:property>
-          <con:name>LocalConfigDir</con:name>
-          <con:value>C:/SelfTest/EndToEndSelfTest</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-DocQuery</con:name>
-          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityDocQueryUnsecured</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-DocRetrieve</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityDocRetrieve</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Reidentification</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubjectDiscovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Subscribe</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationProducer</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Notify</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationConsumer</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Unsubscribe</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubscriptionManager</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-AuditLogQuery</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityAuditQuery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-PatientDiscoveryAsyncReq</con:name>
-          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityPatientDiscoveryDeferredRequestUnsecured</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBHost</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBPort</con:name>
-          <con:value>3306</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBUser</con:name>
-          <con:value>nhincuser</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBPass</con:name>
-          <con:value>nhincpass</con:value>
-        </con:property>
-        <con:property>
-          <con:name>PatientCorrelationDB</con:name>
-          <con:value>patientcorrelationdb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>PatientCorrelationTable</con:name>
-          <con:value>correlatedidentifiers</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubscriptionDB</con:name>
-          <con:value>subscriptionrepository</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubscriptionTable</con:name>
-          <con:value>subscription</con:value>
+          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
+          <con:value>checks --></con:value>
         </con:property>
         <con:property>
           <con:name>AAMappingDB</con:name>
@@ -3892,80 +3780,120 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>aa_to_home_community_mapping</con:value>
         </con:property>
         <con:property>
-          <con:name>PseudonymAA</con:name>
-          <con:value>ABC</con:value>
+          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.1</con:value>
         </con:property>
         <con:property>
-          <con:name>PseudonymPatientID</con:name>
-          <con:value>PSEUDO001</con:value>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
         </con:property>
         <con:property>
-          <con:name>RealAA</con:name>
-          <con:value>1.1.1</con:value>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
         </con:property>
         <con:property>
-          <con:name>RealPatientID</con:name>
-          <con:value>D1234010050</con:value>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
-          <con:name>DQDocID</con:name>
-          <con:value>1.123401.11111</con:value>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
         </con:property>
         <con:property>
-          <con:name>DQPatientID</con:name>
-          <con:value>D123401</con:value>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
         </con:property>
         <con:property>
-          <con:name>DynamicDQDocID</con:name>
-          <con:value>103.8.9284320.020.3590.75^1266324032288</con:value>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
         </con:property>
         <con:property>
-          <con:name>DRDocID</con:name>
-          <con:value>1.123407.777777</con:value>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
         </con:property>
         <con:property>
-          <con:name>DRRepoID</con:name>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
           <con:value>1</con:value>
         </con:property>
         <con:property>
-          <con:name>NotificationEndpoint</con:name>
-          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/NotificationConsumerService/HiemNotify</con:value>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncReq</con:value>
         </con:property>
         <con:property>
-          <con:name>SubscriptionEndpoint</con:name>
-          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/NotificationProducerService/HiemSubscription</con:value>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
         </con:property>
         <con:property>
-          <con:name>SubscribePatientID</con:name>
-          <con:value>D123401</con:value>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
-          <con:name>NotifySubscriptionID</con:name>
-          <con:value>-f7c1a5d:1204e50e42e:-79eb</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
+          <con:value>110152</con:value>
         </con:property>
         <con:property>
-          <con:name>NotifySubscriptionManagerEndpointAddress</con:name>
-          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>UnSubscriptionID</con:name>
-          <con:value>3e74139f-5271-4db1-98c0-88748fa3e4e3</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
         </con:property>
         <con:property>
-          <con:name>SubscriptionManagerEndpointAddress</con:name>
-          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
+          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
         </con:property>
         <con:property>
-          <con:name>AQUserID</con:name>
-          <con:value>kskagerb</con:value>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
         </con:property>
         <con:property>
           <con:name>AQPatientID</con:name>
           <con:value>D123401</con:value>
         </con:property>
         <con:property>
-          <con:name>Endpoint-EntityXDRRequest</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityProxyService/EntityXDRRequest</con:value>
+          <con:name>AQUserID</con:name>
+          <con:value>kskagerb</con:value>
         </con:property>
         <con:property>
           <con:name>AsyncMsgDB</con:name>
@@ -3976,212 +3904,244 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>asyncmsgrepo</con:value>
         </con:property>
         <con:property>
-          <con:name>Gender</con:name>
-          <con:value>M</con:value>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
         </con:property>
         <con:property>
-          <con:name>BirthTime</con:name>
-          <con:value>19630804</con:value>
-        </con:property>
-        <con:property>
-          <con:name>FamilyName</con:name>
-          <con:value>Younger</con:value>
-        </con:property>
-        <con:property>
-          <con:name>GivenName</con:name>
-          <con:value>Gallow</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubjectID</con:name>
-          <con:value>1111</con:value>
-        </con:property>
-        <con:property>
-          <con:name>UniquePatientId</con:name>
-          <con:value>1111^^^&amp;amp;1.1&amp;amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>StreetAddress</con:name>
-          <con:value>123 Johnson Rd</con:value>
-        </con:property>
-        <con:property>
-          <con:name>City</con:name>
-          <con:value>Melbourne</con:value>
-        </con:property>
-        <con:property>
-          <con:name>State</con:name>
-          <con:value>FL</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ZipCode</con:name>
-          <con:value>12345</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Country</con:name>
-          <con:value>US</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SSN</con:name>
-          <con:value>123456789</con:value>
-        </con:property>
-        <con:property>
-          <con:name>PurposeOfDisclosure</con:name>
-          <con:value>Mental</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ExpirationDate</con:name>
-          <con:value>20100520</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DOB</con:name>
-          <con:value>19800516</con:value>
-        </con:property>
-        <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-12T17:26:39Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-12T17:36:39Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/12/2015 17:26:39</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110112</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
         </con:property>
         <con:property>
           <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
           <con:value>urn:oid:1.1</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
+          <con:name>BirthTime</con:name>
+          <con:value>19630804</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:name>City</con:name>
+          <con:value>Melbourne</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Country</con:name>
+          <con:value>US</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DBHost</con:name>
           <con:value>localhost</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
+          <con:name>DBPass</con:name>
+          <con:value>nhincpass</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
+          <con:name>DBPort</con:name>
+          <con:value>3306</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>24</con:value>
+          <con:name>DBUser</con:name>
+          <con:value>nhincuser</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectBirthTime.semanticsText</con:name>
-          <con:value>LivingSubject.birthTime</con:value>
+          <con:name>DOB</con:name>
+          <con:value>19800516</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
+          <con:name>DQDocID</con:name>
+          <con:value>1.123401.11111</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
+          <con:name>DQPatientID</con:name>
+          <con:value>D123401</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>DRDocID</con:name>
+          <con:value>1.123407.777777</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
+          <con:name>DRRepoID</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
-          <con:value>GIV</con:value>
+          <con:name>DynamicDQDocID</con:name>
+          <con:value>103.8.9284320.020.3590.75^1266324032288</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:29:46Z</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
+          <con:name>Endpoint-AuditLogQuery</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityAuditQuery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-DocQuery</con:name>
+          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityDocQueryUnsecured</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-DocRetrieve</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityDocRetrieve</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-EntityXDRRequest</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityProxyService/EntityXDRRequest</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Notify</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationConsumer</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-PatientDiscoveryAsyncReq</con:name>
+          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityPatientDiscoveryDeferredRequestUnsecured</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Reidentification</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubjectDiscovery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Subscribe</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationProducer</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Unsubscribe</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubscriptionManager</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>E</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.@EventDateTime</con:name>
           <con:value>2015-04-02T13:47:30.199Z</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
-          <con:value>FAM</con:value>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110112</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>responseModalityCode.@code</con:name>
-          <con:value>R</con:value>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Query</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.1</con:value>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ExpirationDate</con:name>
+          <con:value>20100520</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>FamilyName</con:name>
+          <con:value>Younger</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Gender</con:name>
+          <con:value>M</con:value>
+        </con:property>
+        <con:property>
+          <con:name>GivenName</con:name>
+          <con:value>Gallow</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalAA</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalConfigDir</con:name>
+          <con:value>C:/SelfTest/EndToEndSelfTest</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalHCDescription</con:name>
+          <con:value>InternalTest1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalHCID</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalPatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>MPIDir</con:name>
+          <con:value>C:/Sun/AppServer/domains/domain1/config</con:value>
+        </con:property>
+        <con:property>
+          <con:name>NHINGatewayConfigDir</con:name>
+          <con:value>C:/Sun/AppServer/domains/domain1/config/nhin</con:value>
+        </con:property>
+        <con:property>
+          <con:name>NotificationEndpoint</con:name>
+          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/NotificationConsumerService/HiemNotify</con:value>
+        </con:property>
+        <con:property>
+          <con:name>NotifySubscriptionID</con:name>
+          <con:value>-f7c1a5d:1204e50e42e:-79eb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>NotifySubscriptionManagerEndpointAddress</con:name>
+          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
+          <con:value>LivingSubject.administrativeGender</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
+          <con:value>M</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectBirthTime.semanticsText</con:name>
+          <con:value>LivingSubject.birthTime</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectBirthTime.value.@value</con:name>
           <con:value>19630804</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
-          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
+          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
-          <con:value>checks --></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
+          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
+          <con:value>D123401</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectId.value.@root</con:name>
           <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectName.semanticsText</con:name>
@@ -4192,180 +4152,196 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>TXT</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responsePriorityCode.@code</con:name>
-          <con:value>I</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncReq</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Destination--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
           <con:name>parameterList.livingSubjectName.value.family</con:name>
           <con:value>Younger</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
+          <con:value>FAM</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectName.value.given</con:name>
           <con:value>Gallow</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
+          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
+          <con:value>GIV</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
-          <con:value>LivingSubject.administrativeGender</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
-          <con:value>110152</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>E</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
           <con:value>2</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
         </con:property>
         <con:property>
-          <con:name>queryId.@root</con:name>
-          <con:value>2.2</con:value>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
+          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
           <con:value>2</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>24</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
           <con:value>IHE Transactions</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
-          <con:value>M</con:value>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>queryId.@extension</con:name>
-          <con:value>-abd3453dcd24wkkks545</con:value>
-        </con:property>
-        <con:property>
-          <con:name>statusCode.@code</con:name>
-          <con:value>new</con:value>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
           <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
+          <con:name>PatientCorrelationDB</con:name>
+          <con:value>patientcorrelationdb</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
+          <con:name>PatientCorrelationTable</con:name>
+          <con:value>correlatedidentifiers</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
+          <con:name>PseudonymAA</con:name>
+          <con:value>ABC</con:value>
         </con:property>
         <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>true</con:value>
+          <con:name>PseudonymPatientID</con:name>
+          <con:value>PSEUDO001</con:value>
+        </con:property>
+        <con:property>
+          <con:name>PurposeOfDisclosure</con:name>
+          <con:value>Mental</con:value>
+        </con:property>
+        <con:property>
+          <con:name>queryId.@extension</con:name>
+          <con:value>-abd3453dcd24wkkks545</con:value>
+        </con:property>
+        <con:property>
+          <con:name>queryId.@root</con:name>
+          <con:value>2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RealAA</con:name>
+          <con:value>1.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RealPatientID</con:name>
+          <con:value>D1234010050</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemoteAA</con:name>
+          <con:value>2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemoteHCDescription</con:name>
+          <con:value>InternalTest2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemoteHCID</con:name>
+          <con:value>2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemotePatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responseModalityCode.@code</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responsePriorityCode.@code</con:name>
+          <con:value>I</con:value>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:19:46</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SSN</con:name>
+          <con:value>123456789</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:19:46Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>State</con:name>
+          <con:value>FL</con:value>
+        </con:property>
+        <con:property>
+          <con:name>statusCode.@code</con:name>
+          <con:value>new</con:value>
+        </con:property>
+        <con:property>
+          <con:name>StreetAddress</con:name>
+          <con:value>123 Johnson Rd</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubjectID</con:name>
+          <con:value>1111</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscribePatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionDB</con:name>
+          <con:value>subscriptionrepository</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionEndpoint</con:name>
+          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/NotificationProducerService/HiemSubscription</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionManagerEndpointAddress</con:name>
+          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionTable</con:name>
+          <con:value>subscription</con:value>
+        </con:property>
+        <con:property>
+          <con:name>UniquePatientId</con:name>
+          <con:value>1111^^^&amp;amp;1.1&amp;amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>UnSubscriptionID</con:name>
+          <con:value>3e74139f-5271-4db1-98c0-88748fa3e4e3</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ZipCode</con:name>
+          <con:value>12345</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -4379,6 +4355,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Patient Discovery Deferred Resp" type="request" id="8f330759-6996-44bf-9d4c-da74d3459571">
@@ -4740,7 +4722,7 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="e87c68a1-d465-4a76-8ca4-b06010e140bd">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
@@ -4750,12 +4732,11 @@ context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 }
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -5070,27 +5051,23 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeC
 	 	}
 	}
   }
-}]]></script>
+}
+
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
 nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
 
 
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -5107,116 +5084,20 @@ if (propertiesFile.exists()) {
 nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
-          <con:name>LocalHCID</con:name>
-          <con:value>1.1</con:value>
+          <con:name>&lt;!--Destination--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>LocalAA</con:name>
-          <con:value>1.1</con:value>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>LocalHCDescription</con:name>
-          <con:value>InternalTest1</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>LocalPatientID</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemoteHCID</con:name>
-          <con:value>2.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemoteAA</con:name>
-          <con:value>2.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemoteHCDescription</con:name>
-          <con:value>InternalTest2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemotePatientID</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>NHINGatewayConfigDir</con:name>
-          <con:value>C:/Sun/AppServer/domains/domain1/config/nhin</con:value>
-        </con:property>
-        <con:property>
-          <con:name>MPIDir</con:name>
-          <con:value>C:/Sun/AppServer/domains/domain1/config</con:value>
-        </con:property>
-        <con:property>
-          <con:name>LocalConfigDir</con:name>
-          <con:value>C:/SelfTest/EndToEndSelfTest</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-DocQuery</con:name>
-          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityDocQueryUnsecured</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-DocRetrieve</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityDocRetrieve</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Reidentification</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubjectDiscovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Subscribe</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationProducer</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Notify</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationConsumer</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Unsubscribe</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubscriptionManager</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-AuditLogQuery</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityAuditQuery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-PatientDiscoveryAsyncReq</con:name>
-          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityPatientDiscoveryDeferredRequestUnsecured</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-PatientDiscoveryAsyncResp</con:name>
-          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityPatientDiscoveryDeferredResponseUnsecured</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBHost</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBPort</con:name>
-          <con:value>3306</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBUser</con:name>
-          <con:value>nhincuser</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBPass</con:name>
-          <con:value>nhincpass</con:value>
-        </con:property>
-        <con:property>
-          <con:name>PatientCorrelationDB</con:name>
-          <con:value>patientcorrelationdb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>PatientCorrelationTable</con:name>
-          <con:value>correlatedidentifiers</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubscriptionDB</con:name>
-          <con:value>subscriptionrepository</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubscriptionTable</con:name>
-          <con:value>subscription</con:value>
+          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
+          <con:value>checks --></con:value>
         </con:property>
         <con:property>
           <con:name>AAMappingDB</con:name>
@@ -5227,6 +5108,122 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>aa_to_home_community_mapping</con:value>
         </con:property>
         <con:property>
+          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncResp</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
+          <con:value>110152</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AQPatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AQUserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
           <con:name>AsyncMsgDB</con:name>
           <con:value>asyncmsgs</con:value>
         </con:property>
@@ -5235,20 +5232,52 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>asyncmsgrepo</con:value>
         </con:property>
         <con:property>
-          <con:name>PseudonymAA</con:name>
-          <con:value>ABC</con:value>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
         </con:property>
         <con:property>
-          <con:name>PseudonymPatientID</con:name>
-          <con:value>PSEUDO001</con:value>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
         </con:property>
         <con:property>
-          <con:name>RealAA</con:name>
-          <con:value>1.1.1</con:value>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
         </con:property>
         <con:property>
-          <con:name>RealPatientID</con:name>
-          <con:value>D1234010050</con:value>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>BirthTime</con:name>
+          <con:value>19630804</con:value>
+        </con:property>
+        <con:property>
+          <con:name>City</con:name>
+          <con:value>Melbourne</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Country</con:name>
+          <con:value>US</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DBHost</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DBPass</con:name>
+          <con:value>nhincpass</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DBPort</con:name>
+          <con:value>3306</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DBUser</con:name>
+          <con:value>nhincuser</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DOB</con:name>
+          <con:value>19800516</con:value>
         </con:property>
         <con:property>
           <con:name>DQDocID</con:name>
@@ -5259,10 +5288,6 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>D123401</con:value>
         </con:property>
         <con:property>
-          <con:name>DynamicDQDocID</con:name>
-          <con:value>103.8.9284320.020.3590.75^1266324032288</con:value>
-        </con:property>
-        <con:property>
           <con:name>DRDocID</con:name>
           <con:value>1.123407.777777</con:value>
         </con:property>
@@ -5271,16 +5296,140 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>1</con:value>
         </con:property>
         <con:property>
+          <con:name>DynamicDQDocID</con:name>
+          <con:value>103.8.9284320.020.3590.75^1266324032288</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:30:26Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-AuditLogQuery</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityAuditQuery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-DocQuery</con:name>
+          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityDocQueryUnsecured</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-DocRetrieve</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityDocRetrieve</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-EntityXDRRequest</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityProxyService/EntityXDRRequest</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Notify</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationConsumer</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-PatientDiscoveryAsyncReq</con:name>
+          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityPatientDiscoveryDeferredRequestUnsecured</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-PatientDiscoveryAsyncResp</con:name>
+          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityPatientDiscoveryDeferredResponseUnsecured</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Reidentification</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubjectDiscovery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Subscribe</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationProducer</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Unsubscribe</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubscriptionManager</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>E</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventDateTime</con:name>
+          <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110112</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Query</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ExpirationDate</con:name>
+          <con:value>20100520</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>FamilyName</con:name>
+          <con:value>Younger</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Gender</con:name>
+          <con:value>M</con:value>
+        </con:property>
+        <con:property>
+          <con:name>GivenName</con:name>
+          <con:value>Gallow</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalAA</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalConfigDir</con:name>
+          <con:value>C:/SelfTest/EndToEndSelfTest</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalHCDescription</con:name>
+          <con:value>InternalTest1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalHCID</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalPatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>MPIDir</con:name>
+          <con:value>C:/Sun/AppServer/domains/domain1/config</con:value>
+        </con:property>
+        <con:property>
+          <con:name>NHINGatewayConfigDir</con:name>
+          <con:value>C:/Sun/AppServer/domains/domain1/config/nhin</con:value>
+        </con:property>
+        <con:property>
           <con:name>NotificationEndpoint</con:name>
           <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/NotificationConsumerService/HiemNotify</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubscriptionEndpoint</con:name>
-          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/NotificationProducerService/HiemSubscription</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubscribePatientID</con:name>
-          <con:value>D123401</con:value>
         </con:property>
         <con:property>
           <con:name>NotifySubscriptionID</con:name>
@@ -5291,232 +5440,40 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
         </con:property>
         <con:property>
-          <con:name>UnSubscriptionID</con:name>
-          <con:value>3e74139f-5271-4db1-98c0-88748fa3e4e3</con:value>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
+          <con:value>LivingSubject.administrativeGender</con:value>
         </con:property>
         <con:property>
-          <con:name>SubscriptionManagerEndpointAddress</con:name>
-          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
         </con:property>
         <con:property>
-          <con:name>AQUserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AQPatientID</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-EntityXDRRequest</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityProxyService/EntityXDRRequest</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Gender</con:name>
+          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
           <con:value>M</con:value>
-        </con:property>
-        <con:property>
-          <con:name>BirthTime</con:name>
-          <con:value>19630804</con:value>
-        </con:property>
-        <con:property>
-          <con:name>FamilyName</con:name>
-          <con:value>Younger</con:value>
-        </con:property>
-        <con:property>
-          <con:name>GivenName</con:name>
-          <con:value>Gallow</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubjectID</con:name>
-          <con:value>1111</con:value>
-        </con:property>
-        <con:property>
-          <con:name>UniquePatientId</con:name>
-          <con:value>1111^^^&amp;amp;1.1&amp;amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>StreetAddress</con:name>
-          <con:value>123 Johnson Rd</con:value>
-        </con:property>
-        <con:property>
-          <con:name>City</con:name>
-          <con:value>Melbourne</con:value>
-        </con:property>
-        <con:property>
-          <con:name>State</con:name>
-          <con:value>FL</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ZipCode</con:name>
-          <con:value>12345</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Country</con:name>
-          <con:value>US</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SSN</con:name>
-          <con:value>123456789</con:value>
-        </con:property>
-        <con:property>
-          <con:name>PurposeOfDisclosure</con:name>
-          <con:value>Mental</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ExpirationDate</con:name>
-          <con:value>20100520</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DOB</con:name>
-          <con:value>19800516</con:value>
-        </con:property>
-        <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-12T17:26:50Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-12T17:36:50Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/12/2015 17:26:50</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110112</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>24</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectBirthTime.semanticsText</con:name>
           <con:value>LivingSubject.birthTime</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
-          <con:value>GIV</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>D123402^^^&amp;2.2&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventDateTime</con:name>
-          <con:value>2015-04-02T13:47:30.199Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
-          <con:value>FAM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responseModalityCode.@code</con:name>
-          <con:value>R</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
+          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectBirthTime.value.@value</con:name>
           <con:value>19630804</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
-          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
+          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
-          <con:value>checks --></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
+          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
+          <con:value>D123401</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectId.value.@root</con:name>
           <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectName.semanticsText</con:name>
@@ -5527,180 +5484,196 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>TXT</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responsePriorityCode.@code</con:name>
-          <con:value>I</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncResp</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Destination--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
           <con:name>parameterList.livingSubjectName.value.family</con:name>
           <con:value>Younger</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
+          <con:value>FAM</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectName.value.given</con:name>
           <con:value>Gallow</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
+          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
+          <con:value>GIV</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>D123402^^^&amp;2.2&amp;ISO</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
-          <con:value>LivingSubject.administrativeGender</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
-          <con:value>110152</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>E</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
           <con:value>2</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
         </con:property>
         <con:property>
-          <con:name>queryId.@root</con:name>
-          <con:value>2.2</con:value>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
+          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
           <con:value>2</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>24</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
           <con:value>IHE Transactions</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
-          <con:value>M</con:value>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>queryId.@extension</con:name>
-          <con:value>-abd3453dcd24wkkks545</con:value>
-        </con:property>
-        <con:property>
-          <con:name>statusCode.@code</con:name>
-          <con:value>new</con:value>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
           <con:value>D123402^^^&amp;2.2&amp;ISO</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
+          <con:name>PatientCorrelationDB</con:name>
+          <con:value>patientcorrelationdb</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
+          <con:name>PatientCorrelationTable</con:name>
+          <con:value>correlatedidentifiers</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
+          <con:name>PseudonymAA</con:name>
+          <con:value>ABC</con:value>
         </con:property>
         <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>true</con:value>
+          <con:name>PseudonymPatientID</con:name>
+          <con:value>PSEUDO001</con:value>
+        </con:property>
+        <con:property>
+          <con:name>PurposeOfDisclosure</con:name>
+          <con:value>Mental</con:value>
+        </con:property>
+        <con:property>
+          <con:name>queryId.@extension</con:name>
+          <con:value>-abd3453dcd24wkkks545</con:value>
+        </con:property>
+        <con:property>
+          <con:name>queryId.@root</con:name>
+          <con:value>2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RealAA</con:name>
+          <con:value>1.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RealPatientID</con:name>
+          <con:value>D1234010050</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemoteAA</con:name>
+          <con:value>2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemoteHCDescription</con:name>
+          <con:value>InternalTest2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemoteHCID</con:name>
+          <con:value>2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemotePatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responseModalityCode.@code</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responsePriorityCode.@code</con:name>
+          <con:value>I</con:value>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:20:26</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SSN</con:name>
+          <con:value>123456789</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:20:26Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>State</con:name>
+          <con:value>FL</con:value>
+        </con:property>
+        <con:property>
+          <con:name>statusCode.@code</con:name>
+          <con:value>new</con:value>
+        </con:property>
+        <con:property>
+          <con:name>StreetAddress</con:name>
+          <con:value>123 Johnson Rd</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubjectID</con:name>
+          <con:value>1111</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscribePatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionDB</con:name>
+          <con:value>subscriptionrepository</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionEndpoint</con:name>
+          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/NotificationProducerService/HiemSubscription</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionManagerEndpointAddress</con:name>
+          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionTable</con:name>
+          <con:value>subscription</con:value>
+        </con:property>
+        <con:property>
+          <con:name>UniquePatientId</con:name>
+          <con:value>1111^^^&amp;amp;1.1&amp;amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>UnSubscriptionID</con:name>
+          <con:value>3e74139f-5271-4db1-98c0-88748fa3e4e3</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ZipCode</con:name>
+          <con:value>12345</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -5714,6 +5687,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="clear correlations table" type="groovy" id="6ddef972-5912-4e28-bfa7-7ef65ed4fba7">
@@ -6038,7 +6017,7 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="b081fc33-6e40-4f46-a408-2cc98a6ca5fb">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
@@ -6047,12 +6026,11 @@ context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 }
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -6361,26 +6339,20 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
 	 	}
 	}
   }
-}]]></script>
+}
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
 nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
-
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -6397,356 +6369,224 @@ if (propertiesFile.exists()) {
 nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-12T17:27:03Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-12T17:37:03Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/12/2015 17:27:03</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
+          <con:name>&lt;!--ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2--></con:value>
         </con:property>
         <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
-          <con:value>ICA8cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+DQogIDxzdGF0dXNDb2RlIGNvZGU9Im5ldyIvPg0KICA8cmVzcG9uc2VNb2RhbGl0eUNvZGUgY29kZT0iUiIvPg0KICA8cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPg0KICA8cGFyYW1ldGVyTGlzdD4NCiAgICA8bGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPg0KICAgICAgPHZhbHVlIGNvZGU9Ik0iLz4NCiAgICAgIDxzZW1hbnRpY3NUZXh0IHJlcHJlc2VudGF0aW9uPSJUWFQiPkxpdmluZ1N1YmplY3QuYWRtaW5pc3RyYXRpdmVHZW5kZXI8L3NlbWFudGljc1RleHQ+DQogICAgPC9saXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+DQogICAgPGxpdmluZ1N1YmplY3RCaXJ0aFRpbWU+DQogICAgICA8dmFsdWUgdmFsdWU9IjE5NjMwODA0Ii8+DQogICAgICA8c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmJpcnRoVGltZTwvc2VtYW50aWNzVGV4dD4NCiAgICA8L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+DQogICAgPGxpdmluZ1N1YmplY3RJZD4NCiAgICAgIDx2YWx1ZSByb290PSIxLjEiIGV4dGVuc2lvbj0iMTExMSIvPg0KICAgICAgPHNlbWFudGljc1RleHQgcmVwcmVzZW50YXRpb249IlRYVCIvPg0KICAgIDwvbGl2aW5nU3ViamVjdElkPg0KICAgIDxsaXZpbmdTdWJqZWN0TmFtZT4NCiAgICAgIDx2YWx1ZT4NCiAgICAgICAgPGZhbWlseSBwYXJ0VHlwZT0iRkFNIj5Zb3VuZ2VyPC9mYW1pbHk+DQogICAgICAgIDxnaXZlbiBwYXJ0VHlwZT0iR0lWIj5HYWxsb3c8L2dpdmVuPg0KICAgICAgPC92YWx1ZT4NCiAgICAgIDxzZW1hbnRpY3NUZXh0IHJlcHJlc2VudGF0aW9uPSJUWFQiPkxpdmluZ1N1YmplY3QubmFtZTwvc2VtYW50aWNzVGV4dD4NCiAgICA8L2xpdmluZ1N1YmplY3ROYW1lPg0KICA8L3BhcmFtZXRlckxpc3Q+</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
-          <con:value>anonymus</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
-          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
           <con:name>&lt;!--Human</con:name>
           <con:value>Requestor--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>E</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
-          <con:value>110152</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110112</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventDateTime</con:name>
-          <con:value>2015-04-02T13:47:30.199Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>24</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>2</con:value>
         </con:property>
         <con:property>
           <con:name>&lt;!--Source--></con:name>
           <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>1111^^^&amp;1.1&amp;ISO</con:value>
+          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
+          <con:value>checks --></con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@value</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIiB4bWxuczpuczU9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246cGF0aWVudGNvcnJlbGF0aW9uZmFjYWRlIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmFkbWluaXN0cmF0aXZlR2VuZGVyPC9zZW1hbnRpY3NUZXh0PjwvbGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPjxsaXZpbmdTdWJqZWN0QmlydGhUaW1lPjx2YWx1ZSB2YWx1ZT0iMTk2MzA4MDQiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmJpcnRoVGltZTwvc2VtYW50aWNzVGV4dD48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgPC92YWx1ZT48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0Lm5hbWU8L3NlbWFudGljc1RleHQ+PC9saXZpbmdTdWJqZWN0TmFtZT48L3BhcmFtZXRlckxpc3Q+PC9xdWVyeUJ5UGFyYW1ldGVyPg==</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0idXJuOmdvdjpoaHM6ZmhhOm5oaW5jOmNvbW1vbjpwYXRpZW50Y29ycmVsYXRpb25mYWNhZGUiIHhtbG5zOm5zNT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmFkbWluaXN0cmF0aXZlR2VuZGVyPC9zZW1hbnRpY3NUZXh0PjwvbGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPjxsaXZpbmdTdWJqZWN0QmlydGhUaW1lPjx2YWx1ZSB2YWx1ZT0iMTk2MzA4MDQiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmJpcnRoVGltZTwvc2VtYW50aWNzVGV4dD48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgPC92YWx1ZT48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0Lm5hbWU8L3NlbWFudGljc1RleHQ+PC9saXZpbmdTdWJqZWN0TmFtZT48L3BhcmFtZXRlckxpc3Q+PC9xdWVyeUJ5UGFyYW1ldGVyPg==</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDetail.@value</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIiB4bWxuczpuczU9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246cGF0aWVudGNvcnJlbGF0aW9uZmFjYWRlIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmFkbWluaXN0cmF0aXZlR2VuZGVyPC9zZW1hbnRpY3NUZXh0PjwvbGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPjxsaXZpbmdTdWJqZWN0QmlydGhUaW1lPjx2YWx1ZSB2YWx1ZT0iMTk2MzA4MDQiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmJpcnRoVGltZTwvc2VtYW50aWNzVGV4dD48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgPC92YWx1ZT48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0Lm5hbWU8L3NlbWFudGljc1RleHQ+PC9saXZpbmdTdWJqZWN0TmFtZT48L3BhcmFtZXRlckxpc3Q+PC9xdWVyeUJ5UGFyYW1ldGVyPg==</con:value>
+          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.1</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.@UserID</con:name>
           <con:value>kskagerb</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName.@value</con:name>
-          <con:value>anonymus</con:value>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectName.@value</con:name>
-          <con:value>anonymus</con:value>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery.@value</con:name>
-          <con:value>test</con:value>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectQuery.@value</con:name>
-          <con:value>test</con:value>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail</con:name>
-          <con:value>test</con:value>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscovery</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDetail</con:name>
-          <con:value>test</con:value>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
+          <con:value>110152</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
           <con:value>2</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
-          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:27:39Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>E</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventDateTime</con:name>
+          <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110112</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Query</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
+          <con:value>LivingSubject.administrativeGender</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
+          <con:value>M</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectBirthTime.semanticsText</con:name>
           <con:value>LivingSubject.birthTime</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
-          <con:value>GIV</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
-          <con:value>FAM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responseModalityCode.@code</con:name>
-          <con:value>R</con:value>
+          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectBirthTime.value.@value</con:name>
           <con:value>19630804</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
-          <con:value>checks --></con:value>
+          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
+          <con:value>1111</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectId.value.@root</con:name>
@@ -6761,60 +6601,188 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>TXT</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
-          <con:value>1111</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responsePriorityCode.@code</con:name>
-          <con:value>I</con:value>
-        </con:property>
-        <con:property>
           <con:name>parameterList.livingSubjectName.value.family</con:name>
           <con:value>Younger</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
+          <con:value>FAM</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectName.value.given</con:name>
           <con:value>Gallow</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
+          <con:value>GIV</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
-          <con:value>LivingSubject.administrativeGender</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>1111^^^&amp;1.1&amp;ISO</con:value>
         </con:property>
         <con:property>
-          <con:name>queryId.@root</con:name>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectName</con:name>
           <con:value>1.1</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
-          <con:value>M</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail</con:name>
+          <con:value>test</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@value</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIiB4bWxuczpuczU9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246cGF0aWVudGNvcnJlbGF0aW9uZmFjYWRlIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmFkbWluaXN0cmF0aXZlR2VuZGVyPC9zZW1hbnRpY3NUZXh0PjwvbGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPjxsaXZpbmdTdWJqZWN0QmlydGhUaW1lPjx2YWx1ZSB2YWx1ZT0iMTk2MzA4MDQiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmJpcnRoVGltZTwvc2VtYW50aWNzVGV4dD48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgPC92YWx1ZT48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0Lm5hbWU8L3NlbWFudGljc1RleHQ+PC9saXZpbmdTdWJqZWN0TmFtZT48L3BhcmFtZXRlckxpc3Q+PC9xdWVyeUJ5UGFyYW1ldGVyPg==</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
+          <con:value>anonymus</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectName.@value</con:name>
+          <con:value>anonymus</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0idXJuOmdvdjpoaHM6ZmhhOm5oaW5jOmNvbW1vbjpwYXRpZW50Y29ycmVsYXRpb25mYWNhZGUiIHhtbG5zOm5zNT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmFkbWluaXN0cmF0aXZlR2VuZGVyPC9zZW1hbnRpY3NUZXh0PjwvbGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPjxsaXZpbmdTdWJqZWN0QmlydGhUaW1lPjx2YWx1ZSB2YWx1ZT0iMTk2MzA4MDQiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmJpcnRoVGltZTwvc2VtYW50aWNzVGV4dD48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgPC92YWx1ZT48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0Lm5hbWU8L3NlbWFudGljc1RleHQ+PC9saXZpbmdTdWJqZWN0TmFtZT48L3BhcmFtZXRlckxpc3Q+PC9xdWVyeUJ5UGFyYW1ldGVyPg==</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery.@value</con:name>
+          <con:value>test</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
+          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>24</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDetail</con:name>
+          <con:value>test</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDetail.@value</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIiB4bWxuczpuczU9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246cGF0aWVudGNvcnJlbGF0aW9uZmFjYWRlIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmFkbWluaXN0cmF0aXZlR2VuZGVyPC9zZW1hbnRpY3NUZXh0PjwvbGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPjxsaXZpbmdTdWJqZWN0QmlydGhUaW1lPjx2YWx1ZSB2YWx1ZT0iMTk2MzA4MDQiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmJpcnRoVGltZTwvc2VtYW50aWNzVGV4dD48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgPC92YWx1ZT48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0Lm5hbWU8L3NlbWFudGljc1RleHQ+PC9saXZpbmdTdWJqZWN0TmFtZT48L3BhcmFtZXRlckxpc3Q+PC9xdWVyeUJ5UGFyYW1ldGVyPg==</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName.@value</con:name>
+          <con:value>anonymus</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
+          <con:value>ICA8cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+DQogIDxzdGF0dXNDb2RlIGNvZGU9Im5ldyIvPg0KICA8cmVzcG9uc2VNb2RhbGl0eUNvZGUgY29kZT0iUiIvPg0KICA8cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPg0KICA8cGFyYW1ldGVyTGlzdD4NCiAgICA8bGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPg0KICAgICAgPHZhbHVlIGNvZGU9Ik0iLz4NCiAgICAgIDxzZW1hbnRpY3NUZXh0IHJlcHJlc2VudGF0aW9uPSJUWFQiPkxpdmluZ1N1YmplY3QuYWRtaW5pc3RyYXRpdmVHZW5kZXI8L3NlbWFudGljc1RleHQ+DQogICAgPC9saXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+DQogICAgPGxpdmluZ1N1YmplY3RCaXJ0aFRpbWU+DQogICAgICA8dmFsdWUgdmFsdWU9IjE5NjMwODA0Ii8+DQogICAgICA8c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmJpcnRoVGltZTwvc2VtYW50aWNzVGV4dD4NCiAgICA8L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+DQogICAgPGxpdmluZ1N1YmplY3RJZD4NCiAgICAgIDx2YWx1ZSByb290PSIxLjEiIGV4dGVuc2lvbj0iMTExMSIvPg0KICAgICAgPHNlbWFudGljc1RleHQgcmVwcmVzZW50YXRpb249IlRYVCIvPg0KICAgIDwvbGl2aW5nU3ViamVjdElkPg0KICAgIDxsaXZpbmdTdWJqZWN0TmFtZT4NCiAgICAgIDx2YWx1ZT4NCiAgICAgICAgPGZhbWlseSBwYXJ0VHlwZT0iRkFNIj5Zb3VuZ2VyPC9mYW1pbHk+DQogICAgICAgIDxnaXZlbiBwYXJ0VHlwZT0iR0lWIj5HYWxsb3c8L2dpdmVuPg0KICAgICAgPC92YWx1ZT4NCiAgICAgIDxzZW1hbnRpY3NUZXh0IHJlcHJlc2VudGF0aW9uPSJUWFQiPkxpdmluZ1N1YmplY3QubmFtZTwvc2VtYW50aWNzVGV4dD4NCiAgICA8L2xpdmluZ1N1YmplY3ROYW1lPg0KICA8L3BhcmFtZXRlckxpc3Q+</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectQuery.@value</con:name>
+          <con:value>test</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
+          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
         </con:property>
         <con:property>
           <con:name>queryId.@extension</con:name>
           <con:value>-abd3453dcd24wkkks545</con:value>
         </con:property>
         <con:property>
+          <con:name>queryId.@root</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responseModalityCode.@code</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responsePriorityCode.@code</con:name>
+          <con:value>I</con:value>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:17:39</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:17:39Z</con:value>
+        </con:property>
+        <con:property>
           <con:name>statusCode.@code</con:name>
           <con:value>new</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>true</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -6828,6 +6796,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="update config" type="groovy" id="9c194669-54ec-49d2-a5a9-eda6665ce6c5">
@@ -7167,21 +7141,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="8aa56f04-4f6c-4395-8925-6018498b8eea">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
-	}
+}
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -7462,26 +7435,22 @@ if(!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCo
 	 	} 
   	}
   }
-}]]></script>
+}
+
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
 nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
 
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -7494,52 +7463,71 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments','true', log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
       <con:properties>
-        <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-12T17:27:16Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-12T17:37:16Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/12/2015 17:27:16</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>FullPatientID</con:name>
-          <con:value>'D123401^^^&amp;amp;1.1&amp;amp;ISO'</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
         <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>24</con:value>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@type</con:name>
-          <con:value>QueryEncoding</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
-          <con:value>anonymus</con:value>
+          <con:name>&lt;--Document</con:name>
+          <con:value>--></con:value>
+        </con:property>
+        <con:property>
+          <con:name>&lt;--Patient--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>&lt;--RESPONDER--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@UserID</con:name>
@@ -7550,264 +7538,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>false</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-38</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>ITI-38</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Patient--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Document</con:name>
-          <con:value>--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@value</con:name>
-          <con:value>UTF-8</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>E</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
           <con:value>110152</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.1</con:value>
-        </con:property>
-        <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110112</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventDateTime</con:name>
-          <con:value>2015-04-02T13:47:30.199Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectID</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@value</con:name>
-          <con:value>urn:oid:2.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>D123401^^^&amp;2.2&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@type</con:name>
-          <con:value>urn:ihe:iti:xca:2010:homeCommunityId</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
-          <con:value>Export</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
-          <con:value>unknown</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectQuery</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxBZGhvY1F1ZXJ5UmVxdWVzdCB4bWx....</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--RESPONDER--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ResponderActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentQuery/2_0/NhinService/RespondingGateway_Query_Service/DocQuery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ResponderActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>3732@GFE-ONC-WDEV22</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parsedParticipantObjectQuery.AdhocQuery.Slot.ValueList.Value.PatientID</con:name>
-          <con:value>D123401</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest_g0.@UserID</con:name>
@@ -7818,8 +7562,236 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>https://localhost:8181/Gateway/DocumentQuery/3_0/NhinService/RespondingGateway_Query_Service/DocQuery</con:value>
         </con:property>
         <con:property>
+          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:28:06Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>E</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventDateTime</con:name>
+          <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110112</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Query</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-38</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Query</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
+          <con:value>Export</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>FullPatientID</con:name>
+          <con:value>'D123401^^^&amp;amp;1.1&amp;amp;ISO'</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parsedParticipantObjectQuery.AdhocQuery.Slot.ValueList.Value.PatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>D123401^^^&amp;2.2&amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
+          <con:value>anonymus</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
+          <con:value>unknown</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>24</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@type</con:name>
+          <con:value>QueryEncoding</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@value</con:name>
+          <con:value>UTF-8</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@type</con:name>
+          <con:value>urn:ihe:iti:xca:2010:homeCommunityId</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@value</con:name>
+          <con:value>urn:oid:2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>ITI-38</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Query</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectQuery</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxBZGhvY1F1ZXJ5UmVxdWVzdCB4bWx....</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ResponderActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>3732@GFE-ONC-WDEV22</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ResponderActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentQuery/2_0/NhinService/RespondingGateway_Query_Service/DocQuery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:18:06</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:18:06Z</con:value>
+        </con:property>
+        <con:property>
           <con:name>auditLogStatus</con:name>
           <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditOff</con:name>
+          <con:value>false</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -7835,10 +7807,10 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 }</script>
         </con:config>
       </con:testStep>
-      <con:testStep type="delay" name="Wait for Audit table to populate">
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
         <con:settings/>
         <con:config>
-          <delay>2000</delay>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Document Retrieve" type="request" id="0b684917-158e-4591-ab73-952037ca7338">
@@ -8130,24 +8102,29 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           </con:request>
         </con:config>
       </con:testStep>
+      <con:testStep type="delay" name="Wait for Audit table to populate">
+        <con:settings/>
+        <con:config>
+          <delay>2000</delay>
+        </con:config>
+      </con:testStep>
       <con:testStep type="groovy" name="Verify Audit Logs" id="837f4e46-0ed2-4b1f-8da7-261fcad448be">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
-	}
+}
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -8414,26 +8391,19 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
 	 	}	  
 	}
  }
-}]]></script>
+}
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
 nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
-
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -8446,55 +8416,18 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments','true', log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
       <con:properties>
         <con:property>
-          <con:name>CorrectedRemoteHCID</con:name>
-          <con:value>urn:oid:2.2</con:value>
+          <con:name>&lt;!--Destination--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-12T17:27:28Z</con:value>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-12T17:37:28Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/12/2015 17:27:28</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@value</con:name>
-          <con:value>urn:oid:2.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110107</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
-          <con:value>anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
+          <con:name>&lt;!--Source--></con:name>
           <con:value/>
         </con:property>
         <con:property>
@@ -8502,272 +8435,112 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>--></con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Retrieve</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail_one.@value</con:name>
-          <con:value>homeCommunityID</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectDataLifeCycle</con:name>
+          <con:name>&lt;--Patient--></con:name>
           <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>500000000^^^&amp;1.1&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventDateTime</con:name>
-          <con:value>2015-04-02T13:47:30.199Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.@AlternativeUserID</con:name>
           <con:value>19233@192.168.1.1</con:value>
         </con:property>
         <con:property>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
           <con:name>ActiveParticipant.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@code</con:name>
-          <con:value>110106</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
-          <con:value>unknown</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@value</con:name>
-          <con:value>ihe:RepositoryUniqueId</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-39</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Destination--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Patient--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectQuery</con:name>
-          <con:value>unknown</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>9</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>3</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail_one.@type</con:name>
-          <con:value>ihe:homeCommunityID</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Import</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
-          <con:value>110152</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>C</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@type</con:name>
-          <con:value>ihe:homeCommunityID</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
-          <con:value>Export</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectID</con:name>
-          <con:value>1.123407.777777</con:value>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
           <con:value>SNOMED_CT</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentRetrieve/3_0/NhinService/RespondingGateway_Retrieve_Service/DocRetrieve</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
-          <con:value>R</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Report Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@value</con:name>
-          <con:value>1</con:value>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
           <con:value>19233@192.168.1.2</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@type</con:name>
-          <con:value>Repository Unique Id</con:value>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@type</con:name>
-          <con:value>Repository Unique Id</con:value>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
+          <con:value>110152</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentRetrieve/3_0/NhinService/RespondingGateway_Retrieve_Service/DocRetrieve</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source_g0.@UserID</con:name>
@@ -8778,8 +8551,200 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>https://localhost:8181/Gateway/DocumentRetrieve/3_0/NhinService/RespondingGateway_Retrieve_Service/DocRetrieve</con:value>
         </con:property>
         <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>true</con:value>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>CorrectedRemoteHCID</con:name>
+          <con:value>urn:oid:2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:29:03Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>C</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventDateTime</con:name>
+          <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110107</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Import</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-39</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Retrieve</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@code</con:name>
+          <con:value>110106</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
+          <con:value>Export</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>500000000^^^&amp;1.1&amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@type</con:name>
+          <con:value>Repository Unique Id</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@value</con:name>
+          <con:value>ihe:RepositoryUniqueId</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail_one.@type</con:name>
+          <con:value>ihe:homeCommunityID</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail_one.@value</con:name>
+          <con:value>homeCommunityID</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
+          <con:value>anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
+          <con:value>unknown</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectID</con:name>
+          <con:value>1.123407.777777</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>3</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@type</con:name>
+          <con:value>Repository Unique Id</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@value</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@type</con:name>
+          <con:value>ihe:homeCommunityID</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@value</con:name>
+          <con:value>urn:oid:2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>9</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Report Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectQuery</con:name>
+          <con:value>unknown</con:value>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:19:03</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:19:03Z</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -9172,19 +9137,19 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-12T17:27:45Z</con:value>
+          <con:value>2015-11-14T01:16:10Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-12T17:37:45Z</con:value>
+          <con:value>2015-11-14T01:26:10Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/12/2015 17:27:45</con:value>
+          <con:value>11/14/2015 01:16:10</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
+          <con:value>2015-12-14T00:00:00Z</con:value>
         </con:property>
       </con:properties>
     </con:testCase>
@@ -9242,6 +9207,12 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Doc Submission Deferred Req" type="request" id="eff8f56f-58c6-4a3b-8e58-0a3e6ee0750b">
@@ -9733,21 +9704,20 @@ nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.pr
       <con:testStep type="groovy" name="Verify Audit Logs" id="9b286e1c-cf4f-4a95-971b-c012ef67150f">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
-	}
+}
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -10075,26 +10045,22 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
 	 	}
 	}
   }
-}]]></script>
+}
+
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
 nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
 
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -10107,188 +10073,239 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredReq','true', log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
       <con:properties>
-        <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-13T09:02:55Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-13T09:12:55Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/13/2015 09:02:55</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
         <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>submission set classificationNode</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
-          <con:value>C</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-41</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@code</con:name>
-          <con:value>110107</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Patient--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Submission</con:name>
-          <con:value>Set --></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
         </con:property>
         <con:property>
           <con:name>&lt;!--Human</con:name>
           <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
+          <con:name>&lt;--Patient--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>R</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
-          <con:value>110152</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Export</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
+          <con:name>&lt;--Submission</con:name>
+          <con:value>Set --></con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.@AlternativeUserID</con:name>
           <con:value>19233@192.168.1.1</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Provide and Register Document Set-b</con:value>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110106</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
           <con:value>307969004</con:value>
         </con:property>
         <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID_g0</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/1_1/NhinService/XDRRequest_Service</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID_g1</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/NhinService/XDRRequest_Service</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
+          <con:value>110152</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:31:41Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
           <con:name>EventIdentification.@EventDateTime</con:name>
           <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110106</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Export</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-41</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Provide and Register Document Set-b</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
+          <con:value>C</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@code</con:name>
+          <con:value>110107</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
+          <con:value>Import</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>SELF-5^^^&amp;1.3.6.1.4.1.21367.2005.3.7&amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectID</con:name>
+          <con:value>1.3.6.1.4.1.21367.2005.3.9999.33</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCodeRole</con:name>
@@ -10299,80 +10316,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>urn:uuid:a54d6aa5-d40d-43f9-88c5-b4633d873bdd</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
           <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
           <con:value>IHE XDS Metadata</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>2</con:value>
+          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>submission set classificationNode</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:21:41</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>SELF-5^^^&amp;1.3.6.1.4.1.21367.2005.3.7&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
-          <con:value>Import</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectID</con:name>
-          <con:value>1.3.6.1.4.1.21367.2005.3.9999.33</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID_g1</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/NhinService/XDRRequest_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID_g0</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/1_1/NhinService/XDRRequest_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditOff</con:name>
-          <con:value>false</con:value>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:21:41Z</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -10386,6 +10343,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Doc Submission Deferred Resp" type="request" id="e54c0271-bbdd-4a97-82f7-8b2e2ac234f2">
@@ -10739,22 +10702,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="1beb8e26-5072-49a0-ac2f-43a76017455b">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
-	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where  direction="Nhin Outbound" and remoteHcid="2.2"')[0]
-	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where  direction="Nhin Outbound" and remoteHcid="1.1"')[0]
-	
+	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
+	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
 }
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -10947,26 +10908,22 @@ parsedXmlMessage.AuditSourceIdentification.find{
 			assert it.@AuditSourceID == context.findProperty( "AuditSourceIdentification.@AuditSourceID" )	
 		}
   }
-}</script>
+}
+
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")</script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
 nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
 
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -10979,132 +10936,119 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmissionDeferredResp','true', log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
       <con:properties>
-        <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-13T09:00:23Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-13T09:10:23Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/13/2015 09:00:23</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
         <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
         </con:property>
         <con:property>
-          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
-          <con:value>R</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
           <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-41</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@code</con:name>
-          <con:value>110106</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
           <con:value>localhost</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>C</con:value>
+          <con:name>ActiveParticipant_Dest.@UserID_g0</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/1_1/NhinService/XDRResponse_Service</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID_g1</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/NhinService/XDRResponse_Service</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
           <con:value>110152</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Import</con:value>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Provide and Register Document Set-b</con:value>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110107</con:value>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:31:58Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>C</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.@EventDateTime</con:name>
@@ -11115,48 +11059,52 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>0</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110107</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Import</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-41</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Provide and Register Document Set-b</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@code</con:name>
+          <con:value>110106</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
           <con:value>Export</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:21:58</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID_g1</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/NhinService/XDRResponse_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID_g0</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/1_1/NhinService/XDRResponse_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditOff</con:name>
-          <con:value>false</con:value>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:21:58Z</con:value>
         </con:property>
       </con:properties>
     </con:testCase>
@@ -11169,6 +11117,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Doc Submission" type="request" id="29f4a6f6-7da9-485f-a6fe-0aac2b25df4d">
@@ -11657,22 +11611,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="2eb71bf5-f7f8-4bb7-a788-fc4eda18b04d">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
 }
-
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -11908,26 +11860,20 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeC
      	assert node.ParticipantObjectIDTypeCode.@displayName == context.findProperty( "ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@displayName" )
   	}
  }
-}]]></script>
+}
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
 nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
-
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -11940,48 +11886,67 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'DocSubmission','true', log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
       <con:properties>
-        <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-13T09:04:07Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-13T09:14:07Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/13/2015 09:04:07</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
         <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>submission set classificationNode</con:value>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
-          <con:value>C</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>&lt;--Patient--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>&lt;--Submission</con:name>
+          <con:value>Set --></con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@UserID</con:name>
@@ -11992,136 +11957,168 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>false</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-41</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@code</con:name>
-          <con:value>110107</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Patient--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Submission</con:name>
-          <con:value>Set --></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>R</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
           <con:value>110152</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
+          <con:name>ActiveParticipant_Dest_g0.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/1_1/DocumentRepositoryXDR_Service</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Export</con:value>
+          <con:name>ActiveParticipant_Dest_g1.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Provide and Register Document Set-b</con:value>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:32:13Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventDateTime</con:name>
+          <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.EventID.@code</con:name>
           <con:value>110106</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Export</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.@EventDateTime</con:name>
-          <con:value>2015-04-02T13:47:30.199Z</con:value>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-41</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Provide and Register Document Set-b</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
+          <con:value>C</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@code</con:name>
+          <con:value>110107</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
+          <con:value>Import</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>SELF-5^^^&amp;1.3.6.1.4.1.21367.2005.3.7&amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectID</con:name>
+          <con:value>1.3.6.1.4.1.21367.2005.3.9999.33</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectTypeCodeRole</con:name>
@@ -12132,80 +12129,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>urn:uuid:a54d6aa5-d40d-43f9-88c5-b4633d873bdd</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
           <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
           <con:value>IHE XDS Metadata</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>2</con:value>
+          <con:name>ParticipantObjectIdentification_Set.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>submission set classificationNode</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:22:13</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>SELF-5^^^&amp;1.3.6.1.4.1.21367.2005.3.7&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
-          <con:value>Import</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Set.@ParticipantObjectID</con:name>
-          <con:value>1.3.6.1.4.1.21367.2005.3.9999.33</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest_g1.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest_g0.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentSubmission/1_1/DocumentRepositoryXDR_Service</con:value>
-        </con:property>
-        <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditOff</con:name>
-          <con:value>false</con:value>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:22:13Z</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -12219,6 +12156,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Patient Discovery Deferred Req" type="request" id="a49a8d24-19ba-4232-a4fa-a58cc9365089">
@@ -12554,22 +12497,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="0fa073f7-7cd1-403b-a396-78420ded9acd">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
-	
 }
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -12883,26 +12824,21 @@ if (parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCo
 	 	}
 	}
   }
-}]]></script>
+}
+
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
 nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
-
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -12915,116 +12851,23 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredReq','true', log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
       <con:properties>
         <con:property>
-          <con:name>LocalHCID</con:name>
-          <con:value>1.1</con:value>
+          <con:name>&lt;!--Destination--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>LocalAA</con:name>
-          <con:value>1.1</con:value>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>LocalHCDescription</con:name>
-          <con:value>InternalTest1</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>LocalPatientID</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemoteHCID</con:name>
-          <con:value>2.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemoteAA</con:name>
-          <con:value>2.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemoteHCDescription</con:name>
-          <con:value>InternalTest2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemotePatientID</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>NHINGatewayConfigDir</con:name>
-          <con:value>C:/Sun/AppServer/domains/domain1/config/nhin</con:value>
-        </con:property>
-        <con:property>
-          <con:name>MPIDir</con:name>
-          <con:value>C:/Sun/AppServer/domains/domain1/config</con:value>
-        </con:property>
-        <con:property>
-          <con:name>LocalConfigDir</con:name>
-          <con:value>C:/SelfTest/EndToEndSelfTest</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-DocQuery</con:name>
-          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityDocQueryUnsecured</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-DocRetrieve</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityDocRetrieve</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Reidentification</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubjectDiscovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Subscribe</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationProducer</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Notify</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationConsumer</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Unsubscribe</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubscriptionManager</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-AuditLogQuery</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityAuditQuery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-PatientDiscoveryAsyncReq</con:name>
-          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityPatientDiscoveryDeferredRequestUnsecured</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBHost</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBPort</con:name>
-          <con:value>3306</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBUser</con:name>
-          <con:value>nhincuser</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBPass</con:name>
-          <con:value>nhincpass</con:value>
-        </con:property>
-        <con:property>
-          <con:name>PatientCorrelationDB</con:name>
-          <con:value>patientcorrelationdb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>PatientCorrelationTable</con:name>
-          <con:value>correlatedidentifiers</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubscriptionDB</con:name>
-          <con:value>subscriptionrepository</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubscriptionTable</con:name>
-          <con:value>subscription</con:value>
+          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
+          <con:value>checks --></con:value>
         </con:property>
         <con:property>
           <con:name>AAMappingDB</con:name>
@@ -13035,80 +12878,120 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>aa_to_home_community_mapping</con:value>
         </con:property>
         <con:property>
-          <con:name>PseudonymAA</con:name>
-          <con:value>ABC</con:value>
+          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.1</con:value>
         </con:property>
         <con:property>
-          <con:name>PseudonymPatientID</con:name>
-          <con:value>PSEUDO001</con:value>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
         </con:property>
         <con:property>
-          <con:name>RealAA</con:name>
-          <con:value>1.1.1</con:value>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
         </con:property>
         <con:property>
-          <con:name>RealPatientID</con:name>
-          <con:value>D1234010050</con:value>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
-          <con:name>DQDocID</con:name>
-          <con:value>1.123401.11111</con:value>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
         </con:property>
         <con:property>
-          <con:name>DQPatientID</con:name>
-          <con:value>D123401</con:value>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
         </con:property>
         <con:property>
-          <con:name>DynamicDQDocID</con:name>
-          <con:value>103.8.9284320.020.3590.75^1266324032288</con:value>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
         </con:property>
         <con:property>
-          <con:name>DRDocID</con:name>
-          <con:value>1.123407.777777</con:value>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
         </con:property>
         <con:property>
-          <con:name>DRRepoID</con:name>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
           <con:value>1</con:value>
         </con:property>
         <con:property>
-          <con:name>NotificationEndpoint</con:name>
-          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/NotificationConsumerService/HiemNotify</con:value>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncReq</con:value>
         </con:property>
         <con:property>
-          <con:name>SubscriptionEndpoint</con:name>
-          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/NotificationProducerService/HiemSubscription</con:value>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
         </con:property>
         <con:property>
-          <con:name>SubscribePatientID</con:name>
-          <con:value>D123401</con:value>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
-          <con:name>NotifySubscriptionID</con:name>
-          <con:value>-f7c1a5d:1204e50e42e:-79eb</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
+          <con:value>110152</con:value>
         </con:property>
         <con:property>
-          <con:name>NotifySubscriptionManagerEndpointAddress</con:name>
-          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>UnSubscriptionID</con:name>
-          <con:value>3e74139f-5271-4db1-98c0-88748fa3e4e3</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
         </con:property>
         <con:property>
-          <con:name>SubscriptionManagerEndpointAddress</con:name>
-          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
+          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
         </con:property>
         <con:property>
-          <con:name>AQUserID</con:name>
-          <con:value>kskagerb</con:value>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
         </con:property>
         <con:property>
           <con:name>AQPatientID</con:name>
           <con:value>D123401</con:value>
         </con:property>
         <con:property>
-          <con:name>Endpoint-EntityXDRRequest</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityProxyService/EntityXDRRequest</con:value>
+          <con:name>AQUserID</con:name>
+          <con:value>kskagerb</con:value>
         </con:property>
         <con:property>
           <con:name>AsyncMsgDB</con:name>
@@ -13119,212 +13002,244 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>asyncmsgrepo</con:value>
         </con:property>
         <con:property>
-          <con:name>Gender</con:name>
-          <con:value>M</con:value>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
         </con:property>
         <con:property>
-          <con:name>BirthTime</con:name>
-          <con:value>19630804</con:value>
-        </con:property>
-        <con:property>
-          <con:name>FamilyName</con:name>
-          <con:value>Younger</con:value>
-        </con:property>
-        <con:property>
-          <con:name>GivenName</con:name>
-          <con:value>Gallow</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubjectID</con:name>
-          <con:value>1111</con:value>
-        </con:property>
-        <con:property>
-          <con:name>UniquePatientId</con:name>
-          <con:value>1111^^^&amp;amp;1.1&amp;amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>StreetAddress</con:name>
-          <con:value>123 Johnson Rd</con:value>
-        </con:property>
-        <con:property>
-          <con:name>City</con:name>
-          <con:value>Melbourne</con:value>
-        </con:property>
-        <con:property>
-          <con:name>State</con:name>
-          <con:value>FL</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ZipCode</con:name>
-          <con:value>12345</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Country</con:name>
-          <con:value>US</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SSN</con:name>
-          <con:value>123456789</con:value>
-        </con:property>
-        <con:property>
-          <con:name>PurposeOfDisclosure</con:name>
-          <con:value>Mental</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ExpirationDate</con:name>
-          <con:value>20100520</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DOB</con:name>
-          <con:value>19800516</con:value>
-        </con:property>
-        <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-13T09:13:10Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-13T09:23:10Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/13/2015 09:13:10</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110112</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
         </con:property>
         <con:property>
           <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
           <con:value>urn:oid:1.1</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
+          <con:name>BirthTime</con:name>
+          <con:value>19630804</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:name>City</con:name>
+          <con:value>Melbourne</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Country</con:name>
+          <con:value>US</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DBHost</con:name>
           <con:value>localhost</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
+          <con:name>DBPass</con:name>
+          <con:value>nhincpass</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
+          <con:name>DBPort</con:name>
+          <con:value>3306</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>24</con:value>
+          <con:name>DBUser</con:name>
+          <con:value>nhincuser</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectBirthTime.semanticsText</con:name>
-          <con:value>LivingSubject.birthTime</con:value>
+          <con:name>DOB</con:name>
+          <con:value>19800516</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
+          <con:name>DQDocID</con:name>
+          <con:value>1.123401.11111</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
+          <con:name>DQPatientID</con:name>
+          <con:value>D123401</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>DRDocID</con:name>
+          <con:value>1.123407.777777</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
+          <con:name>DRRepoID</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
-          <con:value>GIV</con:value>
+          <con:name>DynamicDQDocID</con:name>
+          <con:value>103.8.9284320.020.3590.75^1266324032288</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:32:29Z</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
+          <con:name>Endpoint-AuditLogQuery</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityAuditQuery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-DocQuery</con:name>
+          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityDocQueryUnsecured</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-DocRetrieve</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityDocRetrieve</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-EntityXDRRequest</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityProxyService/EntityXDRRequest</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Notify</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationConsumer</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-PatientDiscoveryAsyncReq</con:name>
+          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityPatientDiscoveryDeferredRequestUnsecured</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Reidentification</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubjectDiscovery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Subscribe</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationProducer</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Unsubscribe</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubscriptionManager</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>E</con:value>
         </con:property>
         <con:property>
           <con:name>EventIdentification.@EventDateTime</con:name>
           <con:value>2015-04-02T13:47:30.199Z</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
-          <con:value>FAM</con:value>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110112</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>responseModalityCode.@code</con:name>
-          <con:value>R</con:value>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Query</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.1</con:value>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ExpirationDate</con:name>
+          <con:value>20100520</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>FamilyName</con:name>
+          <con:value>Younger</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Gender</con:name>
+          <con:value>M</con:value>
+        </con:property>
+        <con:property>
+          <con:name>GivenName</con:name>
+          <con:value>Gallow</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalAA</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalConfigDir</con:name>
+          <con:value>C:/SelfTest/EndToEndSelfTest</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalHCDescription</con:name>
+          <con:value>InternalTest1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalHCID</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalPatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>MPIDir</con:name>
+          <con:value>C:/Sun/AppServer/domains/domain1/config</con:value>
+        </con:property>
+        <con:property>
+          <con:name>NHINGatewayConfigDir</con:name>
+          <con:value>C:/Sun/AppServer/domains/domain1/config/nhin</con:value>
+        </con:property>
+        <con:property>
+          <con:name>NotificationEndpoint</con:name>
+          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/NotificationConsumerService/HiemNotify</con:value>
+        </con:property>
+        <con:property>
+          <con:name>NotifySubscriptionID</con:name>
+          <con:value>-f7c1a5d:1204e50e42e:-79eb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>NotifySubscriptionManagerEndpointAddress</con:name>
+          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
+          <con:value>LivingSubject.administrativeGender</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
+          <con:value>M</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectBirthTime.semanticsText</con:name>
+          <con:value>LivingSubject.birthTime</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectBirthTime.value.@value</con:name>
           <con:value>19630804</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
-          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
+          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
-          <con:value>checks --></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
+          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
+          <con:value>D123401</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectId.value.@root</con:name>
           <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectName.semanticsText</con:name>
@@ -13335,184 +13250,196 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>TXT</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responsePriorityCode.@code</con:name>
-          <con:value>I</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncReq</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Destination--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
           <con:name>parameterList.livingSubjectName.value.family</con:name>
           <con:value>Younger</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
+          <con:value>FAM</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectName.value.given</con:name>
           <con:value>Gallow</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
+          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
+          <con:value>GIV</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
-          <con:value>LivingSubject.administrativeGender</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
-          <con:value>110152</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>E</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
           <con:value>2</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
         </con:property>
         <con:property>
-          <con:name>queryId.@root</con:name>
-          <con:value>2.2</con:value>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
+          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
           <con:value>2</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>24</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
           <con:value>IHE Transactions</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
-          <con:value>M</con:value>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>queryId.@extension</con:name>
-          <con:value>-abd3453dcd24wkkks545</con:value>
-        </con:property>
-        <con:property>
-          <con:name>statusCode.@code</con:name>
-          <con:value>new</con:value>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
           <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
+          <con:name>PatientCorrelationDB</con:name>
+          <con:value>patientcorrelationdb</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
+          <con:name>PatientCorrelationTable</con:name>
+          <con:value>correlatedidentifiers</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
+          <con:name>PseudonymAA</con:name>
+          <con:value>ABC</con:value>
         </con:property>
         <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
+          <con:name>PseudonymPatientID</con:name>
+          <con:value>PSEUDO001</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditOff</con:name>
-          <con:value>false</con:value>
+          <con:name>PurposeOfDisclosure</con:name>
+          <con:value>Mental</con:value>
+        </con:property>
+        <con:property>
+          <con:name>queryId.@extension</con:name>
+          <con:value>-abd3453dcd24wkkks545</con:value>
+        </con:property>
+        <con:property>
+          <con:name>queryId.@root</con:name>
+          <con:value>2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RealAA</con:name>
+          <con:value>1.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RealPatientID</con:name>
+          <con:value>D1234010050</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemoteAA</con:name>
+          <con:value>2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemoteHCDescription</con:name>
+          <con:value>InternalTest2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemoteHCID</con:name>
+          <con:value>2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemotePatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responseModalityCode.@code</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responsePriorityCode.@code</con:name>
+          <con:value>I</con:value>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:22:29</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SSN</con:name>
+          <con:value>123456789</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:22:29Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>State</con:name>
+          <con:value>FL</con:value>
+        </con:property>
+        <con:property>
+          <con:name>statusCode.@code</con:name>
+          <con:value>new</con:value>
+        </con:property>
+        <con:property>
+          <con:name>StreetAddress</con:name>
+          <con:value>123 Johnson Rd</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubjectID</con:name>
+          <con:value>1111</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscribePatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionDB</con:name>
+          <con:value>subscriptionrepository</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionEndpoint</con:name>
+          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/NotificationProducerService/HiemSubscription</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionManagerEndpointAddress</con:name>
+          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionTable</con:name>
+          <con:value>subscription</con:value>
+        </con:property>
+        <con:property>
+          <con:name>UniquePatientId</con:name>
+          <con:value>1111^^^&amp;amp;1.1&amp;amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>UnSubscriptionID</con:name>
+          <con:value>3e74139f-5271-4db1-98c0-88748fa3e4e3</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ZipCode</con:name>
+          <con:value>12345</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -13526,6 +13453,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Patient Discovery Deferred Resp" type="request" id="53ed50fb-ec85-4d41-b161-a0cc67d1266f">
@@ -13887,7 +13820,7 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="75840f83-2ae6-4898-8c2e-6c61104588a2">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
@@ -13895,20 +13828,171 @@ context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
 	
 }
-	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
+	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1) - ACK")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
 {
  	testRunner.fail( "Incorrect AuditLogging property found for this service testcase" )
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-InitiatingGateway(1.1) - ACK">
+        <con:settings/>
+        <con:config>
+          <script><![CDATA[context.withSql('AuditRepoDB') {sql ->
+def nhinAuditMessage_22_Outbound = sql.firstRow('SELECT CONVERT(message USING utf8) FROM ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
+def parsedXmlMessage = new XmlSlurper().parseText(nhinAuditMessage_22_Outbound)
+
+parsedXmlMessage.EventIdentification.find{
+	assert it.@EventActionCode == context.findProperty( "EventIdentification.@EventActionCode" )
+	//assert it.@EventDateTime == context.findProperty( "EventIdentification.@EventDateTime" )
+     assert it.@EventOutcomeIndicator == context.findProperty( "EventIdentification.@EventOutcomeIndicator" )
+	assert it.EventID.@code == context.findProperty( "EventIdentification.EventID.@code" )
+	assert it.EventID.@codeSystemName == context.findProperty( "EventIdentification.EventID.@codeSystemName" )
+	assert it.EventID.@displayName == context.findProperty( "EventIdentification.EventID.@displayName" )
+	assert it.EventTypeCode.@code == context.findProperty( "EventIdentification.EventTypeCode.@code" )
+	assert it.EventTypeCode.@codeSystemName == context.findProperty( "EventIdentification.EventTypeCode.@codeSystemName" )
+	assert it.EventTypeCode.@displayName == context.findProperty( "EventIdentification.EventTypeCode.@displayName" )	
+}
+
+//check for ActiveParticipant Source details
+if (!parsedXmlMessage.ActiveParticipant[0].RoleIDCode.@displayName.isEmpty() && parsedXmlMessage.ActiveParticipant[0].RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@displayName" )){
+	parsedXmlMessage.ActiveParticipant[0].each{ node ->
+	     assert node.@UserID == context.findProperty( "ActiveParticipant_Source.@UserID" )	     
+     	assert node.@UserName == context.findProperty( "ActiveParticipant_Source.@UserName" )
+	     assert(!node.@AlternativeUserID.isEmpty())
+     	assert node.@UserIsRequestor == context.findProperty( "ActiveParticipant_Source.@UserIsRequestor" )
+     	assert(!node.@NetworkAccessPointTypeCode.isEmpty())
+   	 	def NetworkAccessPointTypeCode = node.@NetworkAccessPointTypeCode
+   	 	assert NetworkAccessPointTypeCode == 1 || NetworkAccessPointTypeCode == 2
+     	assert(!node.@NetworkAccessPointID.isEmpty())
+     	def NetworkAccessPointID = node.@NetworkAccessPointID
+     	if (NetworkAccessPointTypeCode == 1) {
+
+     		assert node.@NetworkAccessPointID == context.findProperty( "ActiveParticipant_Source.@NetworkAccessPointID" )
+     		
+     	} else {
+
+     		def x = ~/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
+     		def matcher = (NetworkAccessPointID =~ x)  
+			assert matcher.matches()
+     		
+     	}
+          assert node.RoleIDCode.@code == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@code" )
+     	assert node.RoleIDCode.@codeSystemName == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@codeSystemName" )
+     	assert node.RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@displayName" )	     
+	}
+}
+
+//check for ActiveParticipant Destination details
+if (!parsedXmlMessage.ActiveParticipant[1].RoleIDCode.@displayName.isEmpty() && parsedXmlMessage.ActiveParticipant[1].RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@displayName" )){
+	parsedXmlMessage.ActiveParticipant[1].each{ node ->
+	     assert node.@UserID == context.findProperty( "ActiveParticipant_Dest.@UserID" )	     
+   	     if(!node.@UserName.isEmpty()){
+	     	assert node.@UserName == context.findProperty( "ActiveParticipant_Dest.@UserNamee" )
+	     }
+     	assert node.@UserIsRequestor == context.findProperty( "ActiveParticipant_Dest.@UserIsRequestor" )
+     	assert(!node.@NetworkAccessPointTypeCode.isEmpty())
+   	 	def NetworkAccessPointTypeCode = node.@NetworkAccessPointTypeCode
+   	 	assert NetworkAccessPointTypeCode == 1 || NetworkAccessPointTypeCode == 2
+     	assert(!node.@NetworkAccessPointID.isEmpty())
+     	def NetworkAccessPointID = node.@NetworkAccessPointID
+     	if (NetworkAccessPointTypeCode == 1) {
+
+     		assert node.@NetworkAccessPointID == context.findProperty( "ActiveParticipant_Dest.@NetworkAccessPointID" )
+     		
+     	} else {
+
+     		def x = ~/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
+     		def matcher = (NetworkAccessPointID =~ x)  
+			assert matcher.matches()
+     		
+     	}
+          assert node.RoleIDCode.@code == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@code" )
+     	assert node.RoleIDCode.@codeSystemName == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@codeSystemName" )
+     	assert node.RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@displayName" )	     
+	}
+}
+parsedXmlMessage.AuditSourceIdentification.find{
+		if(!it.@AuditEnterpriseSiteID.isEmpty()){
+			assert it.@AuditEnterpriseSiteID == context.findProperty( "AuditSourceIdentification.@AuditEnterpriseSiteID" )
+		}
+		if(!it.@AuditSourceTypeCode.isEmpty()){			
+			assert it.@AuditSourceTypeCode == context.findProperty( "AuditSourceIdentification.@AuditSourceTypeCode" )
+		}
+		if(!it.@AuditSourceID.isEmpty()){
+			assert it.@AuditSourceID == context.findProperty( "AuditSourceIdentification.@AuditSourceID" )	
+		}
+}
+
+//check for Patient ParticipantObjectIdentification
+if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCode.isEmpty() && parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectTypeCode" )){
+	parsedXmlMessage.ParticipantObjectIdentification[0].each{ node ->
+	     assert node.@ParticipantObjectID == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectID" )
+	     assert node.@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectTypeCode" )     
+   	    	assert node.@ParticipantObjectTypeCodeRole == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole" )	     
+    		assert node.ParticipantObjectIDTypeCode.@code == context.findProperty( "ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code" )
+    		assert node.ParticipantObjectIDTypeCode.@codeSystemName == context.findProperty( "ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName" )
+    		assert node.ParticipantObjectIDTypeCode.@displayName == context.findProperty( "ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName" )
+	}
+ }
+ 
+//check for Query Parameters ParticipantObjectIdentification
+if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeCode.isEmpty() && parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode" )){
+	parsedXmlMessage.ParticipantObjectIdentification[1].each{ node ->
+		if (!node.@ParticipantObjectID.isEmpty()){
+			assert node.@ParticipantObjectID == context.findProperty ( "queryId.@extension" )
+		}	
+	     assert node.@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode" )     
+   	     assert node.@ParticipantObjectTypeCodeRole == context.findProperty( "ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole" )	     
+    		assert node.ParticipantObjectIDTypeCode.@code == context.findProperty( "ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code" )
+    		assert node.ParticipantObjectIDTypeCode.@codeSystemName == context.findProperty( "ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName" )
+    		assert node.ParticipantObjectIDTypeCode.@displayName == context.findProperty( "ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName" )
+
+	 	if(!node.ParticipantObjectQuery.text().isEmpty()){	 		
+	 		byte[] participantobjectQueryDecoded = node.ParticipantObjectQuery.text().decodeBase64()			
+			def parsedParticipantObjectQuery = new XmlSlurper().parseText(new String(participantobjectQueryDecoded))			
+			parsedParticipantObjectQuery.queryId.find{				
+				assert it.@root == context.findProperty( "queryId.@root" )
+				assert it.@extension == context.findProperty ( "queryId.@extension" )
+			}
+			assert parsedParticipantObjectQuery.statusCode.@code == context.findProperty( "statusCode.@code" )
+			assert parsedParticipantObjectQuery.responseModalityCode.@code == context.findProperty( "responseModalityCode.@code" )
+			assert parsedParticipantObjectQuery.responsePriorityCode.@code == context.findProperty( "responsePriorityCode.@code" )
+			parsedParticipantObjectQuery.parameterList.livingSubjectAdministrativeGender.find{
+				assert it.value.@code == context.findProperty ( "parameterList.livingSubjectAdministrativeGender.value.@code" )
+				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectAdministrativeGender.semanticsText.@representation" )
+				assert it.semanticsText.text() == context.findProperty ( "parameterList.livingSubjectAdministrativeGender.semanticsText" )
+			}
+			parsedParticipantObjectQuery.parameterList.livingSubjectBirthTime.find{
+				assert it.value.@value == context.findProperty ( "parameterList.livingSubjectBirthTime.value.@value" )
+				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectBirthTime.semanticsText.@representation" )
+				assert it.semanticsText.text() == context.findProperty ( "parameterList.livingSubjectBirthTime.semanticsText" )
+			}
+			parsedParticipantObjectQuery.parameterList.livingSubjectId.find{
+				assert it.value.@root == context.findProperty ( "parameterList.livingSubjectId.value.@root" )
+				assert it.value.@extension == context.findProperty ( "parameterList.livingSubjectId.value.@extension" )
+				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectId.semanticsText.@representation" )				
+			}
+			parsedParticipantObjectQuery.parameterList.livingSubjectName.find{
+				assert it.value.family.@partType == context.findProperty ( "parameterList.livingSubjectName.value.family.@partType" )
+				assert it.value.family.text() == context.findProperty ( "parameterList.livingSubjectName.value.family" )
+				assert it.value.given.@partType == context.findProperty ( "parameterList.livingSubjectName.value.given.@partType" )
+				assert it.value.given.text() == context.findProperty ( "parameterList.livingSubjectName.value.given" )
+				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectName.semanticsText.@representation" )
+				assert it.semanticsText.text() == context.findProperty ( "parameterList.livingSubjectName.semanticsText" )
+			}			
+	 	}
+	}
+  }
+}]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-RespondingGateway(2.2)">
@@ -14065,179 +14149,21 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeC
 	 	}
 	}
   }
-}]]></script>
-        </con:config>
-      </con:testStep>
-      <con:testStep type="groovy" name="VerifyMessage-NhinOutbound-InitiatingGateway(1.1) - ACK">
-        <con:settings/>
-        <con:config>
-          <script><![CDATA[context.withSql('AuditRepoDB') {sql ->
-def nhinAuditMessage_22_Outbound = sql.firstRow('SELECT CONVERT(message USING utf8) FROM ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
-def parsedXmlMessage = new XmlSlurper().parseText(nhinAuditMessage_22_Outbound)
-
-parsedXmlMessage.EventIdentification.find{
-	assert it.@EventActionCode == context.findProperty( "EventIdentification.@EventActionCode" )
-	//assert it.@EventDateTime == context.findProperty( "EventIdentification.@EventDateTime" )
-     assert it.@EventOutcomeIndicator == context.findProperty( "EventIdentification.@EventOutcomeIndicator" )
-	assert it.EventID.@code == context.findProperty( "EventIdentification.EventID.@code" )
-	assert it.EventID.@codeSystemName == context.findProperty( "EventIdentification.EventID.@codeSystemName" )
-	assert it.EventID.@displayName == context.findProperty( "EventIdentification.EventID.@displayName" )
-	assert it.EventTypeCode.@code == context.findProperty( "EventIdentification.EventTypeCode.@code" )
-	assert it.EventTypeCode.@codeSystemName == context.findProperty( "EventIdentification.EventTypeCode.@codeSystemName" )
-	assert it.EventTypeCode.@displayName == context.findProperty( "EventIdentification.EventTypeCode.@displayName" )	
 }
 
-//check for ActiveParticipant Source details
-if (!parsedXmlMessage.ActiveParticipant[0].RoleIDCode.@displayName.isEmpty() && parsedXmlMessage.ActiveParticipant[0].RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@displayName" )){
-	parsedXmlMessage.ActiveParticipant[0].each{ node ->
-	     assert node.@UserID == context.findProperty( "ActiveParticipant_Source.@UserID" )	     
-     	assert node.@UserName == context.findProperty( "ActiveParticipant_Source.@UserName" )
-	     assert(!node.@AlternativeUserID.isEmpty())
-     	assert node.@UserIsRequestor == context.findProperty( "ActiveParticipant_Source.@UserIsRequestor" )
-     	assert(!node.@NetworkAccessPointTypeCode.isEmpty())
-   	 	def NetworkAccessPointTypeCode = node.@NetworkAccessPointTypeCode
-   	 	assert NetworkAccessPointTypeCode == 1 || NetworkAccessPointTypeCode == 2
-     	assert(!node.@NetworkAccessPointID.isEmpty())
-     	def NetworkAccessPointID = node.@NetworkAccessPointID
-     	if (NetworkAccessPointTypeCode == 1) {
 
-     		assert node.@NetworkAccessPointID == context.findProperty( "ActiveParticipant_Source.@NetworkAccessPointID" )
-     		
-     	} else {
-
-     		def x = ~/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
-     		def matcher = (NetworkAccessPointID =~ x)  
-			assert matcher.matches()
-     		
-     	}
-          assert node.RoleIDCode.@code == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@code" )
-     	assert node.RoleIDCode.@codeSystemName == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@codeSystemName" )
-     	assert node.RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Source.RoleIDCode.@displayName" )	     
-	}
-}
-
-//check for ActiveParticipant Destination details
-if (!parsedXmlMessage.ActiveParticipant[1].RoleIDCode.@displayName.isEmpty() && parsedXmlMessage.ActiveParticipant[1].RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@displayName" )){
-	parsedXmlMessage.ActiveParticipant[1].each{ node ->
-	     assert node.@UserID == context.findProperty( "ActiveParticipant_Dest.@UserID" )	     
-   	     if(!node.@UserName.isEmpty()){
-	     	assert node.@UserName == context.findProperty( "ActiveParticipant_Dest.@UserNamee" )
-	     }
-     	assert node.@UserIsRequestor == context.findProperty( "ActiveParticipant_Dest.@UserIsRequestor" )
-     	assert(!node.@NetworkAccessPointTypeCode.isEmpty())
-   	 	def NetworkAccessPointTypeCode = node.@NetworkAccessPointTypeCode
-   	 	assert NetworkAccessPointTypeCode == 1 || NetworkAccessPointTypeCode == 2
-     	assert(!node.@NetworkAccessPointID.isEmpty())
-     	def NetworkAccessPointID = node.@NetworkAccessPointID
-     	if (NetworkAccessPointTypeCode == 1) {
-
-     		assert node.@NetworkAccessPointID == context.findProperty( "ActiveParticipant_Dest.@NetworkAccessPointID" )
-     		
-     	} else {
-
-     		def x = ~/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
-     		def matcher = (NetworkAccessPointID =~ x)  
-			assert matcher.matches()
-     		
-     	}
-          assert node.RoleIDCode.@code == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@code" )
-     	assert node.RoleIDCode.@codeSystemName == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@codeSystemName" )
-     	assert node.RoleIDCode.@displayName == context.findProperty( "ActiveParticipant_Dest.RoleIDCode.@displayName" )	     
-	}
-}
-parsedXmlMessage.AuditSourceIdentification.find{
-		if(!it.@AuditEnterpriseSiteID.isEmpty()){
-			assert it.@AuditEnterpriseSiteID == context.findProperty( "AuditSourceIdentification.@AuditEnterpriseSiteID" )
-		}
-		if(!it.@AuditSourceTypeCode.isEmpty()){			
-			assert it.@AuditSourceTypeCode == context.findProperty( "AuditSourceIdentification.@AuditSourceTypeCode" )
-		}
-		if(!it.@AuditSourceID.isEmpty()){
-			assert it.@AuditSourceID == context.findProperty( "AuditSourceIdentification.@AuditSourceID" )	
-		}
-}
-
-//check for Patient ParticipantObjectIdentification
-if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCode.isEmpty() && parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectTypeCode" )){
-	parsedXmlMessage.ParticipantObjectIdentification[0].each{ node ->
-	     assert node.@ParticipantObjectID == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectID" )
-	     assert node.@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectTypeCode" )     
-   	    	assert node.@ParticipantObjectTypeCodeRole == context.findProperty( "ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole" )	     
-    		assert node.ParticipantObjectIDTypeCode.@code == context.findProperty( "ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code" )
-    		assert node.ParticipantObjectIDTypeCode.@codeSystemName == context.findProperty( "ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName" )
-    		assert node.ParticipantObjectIDTypeCode.@displayName == context.findProperty( "ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName" )
-	}
- }
- 
-//check for Query Parameters ParticipantObjectIdentification
-if (!parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeCode.isEmpty() && parsedXmlMessage.ParticipantObjectIdentification[1].@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode" )){
-	parsedXmlMessage.ParticipantObjectIdentification[1].each{ node ->
-		if (!node.@ParticipantObjectID.isEmpty()){
-			assert node.@ParticipantObjectID == context.findProperty ( "queryId.@extension" )
-		}	
-	     assert node.@ParticipantObjectTypeCode == context.findProperty( "ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode" )     
-   	     assert node.@ParticipantObjectTypeCodeRole == context.findProperty( "ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole" )	     
-    		assert node.ParticipantObjectIDTypeCode.@code == context.findProperty( "ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code" )
-    		assert node.ParticipantObjectIDTypeCode.@codeSystemName == context.findProperty( "ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName" )
-    		assert node.ParticipantObjectIDTypeCode.@displayName == context.findProperty( "ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName" )
-
-	 	if(!node.ParticipantObjectQuery.text().isEmpty()){	 		
-	 		byte[] participantobjectQueryDecoded = node.ParticipantObjectQuery.text().decodeBase64()			
-			def parsedParticipantObjectQuery = new XmlSlurper().parseText(new String(participantobjectQueryDecoded))			
-			parsedParticipantObjectQuery.queryId.find{				
-				assert it.@root == context.findProperty( "queryId.@root" )
-				assert it.@extension == context.findProperty ( "queryId.@extension" )
-			}
-			assert parsedParticipantObjectQuery.statusCode.@code == context.findProperty( "statusCode.@code" )
-			assert parsedParticipantObjectQuery.responseModalityCode.@code == context.findProperty( "responseModalityCode.@code" )
-			assert parsedParticipantObjectQuery.responsePriorityCode.@code == context.findProperty( "responsePriorityCode.@code" )
-			parsedParticipantObjectQuery.parameterList.livingSubjectAdministrativeGender.find{
-				assert it.value.@code == context.findProperty ( "parameterList.livingSubjectAdministrativeGender.value.@code" )
-				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectAdministrativeGender.semanticsText.@representation" )
-				assert it.semanticsText.text() == context.findProperty ( "parameterList.livingSubjectAdministrativeGender.semanticsText" )
-			}
-			parsedParticipantObjectQuery.parameterList.livingSubjectBirthTime.find{
-				assert it.value.@value == context.findProperty ( "parameterList.livingSubjectBirthTime.value.@value" )
-				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectBirthTime.semanticsText.@representation" )
-				assert it.semanticsText.text() == context.findProperty ( "parameterList.livingSubjectBirthTime.semanticsText" )
-			}
-			parsedParticipantObjectQuery.parameterList.livingSubjectId.find{
-				assert it.value.@root == context.findProperty ( "parameterList.livingSubjectId.value.@root" )
-				assert it.value.@extension == context.findProperty ( "parameterList.livingSubjectId.value.@extension" )
-				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectId.semanticsText.@representation" )				
-			}
-			parsedParticipantObjectQuery.parameterList.livingSubjectName.find{
-				assert it.value.family.@partType == context.findProperty ( "parameterList.livingSubjectName.value.family.@partType" )
-				assert it.value.family.text() == context.findProperty ( "parameterList.livingSubjectName.value.family" )
-				assert it.value.given.@partType == context.findProperty ( "parameterList.livingSubjectName.value.given.@partType" )
-				assert it.value.given.text() == context.findProperty ( "parameterList.livingSubjectName.value.given" )
-				assert it.semanticsText.@representation == context.findProperty ( "parameterList.livingSubjectName.semanticsText.@representation" )
-				assert it.semanticsText.text() == context.findProperty ( "parameterList.livingSubjectName.semanticsText" )
-			}			
-	 	}
-	}
-  }
-}]]></script>
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
 nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
-
-
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -14250,120 +14176,23 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscoveryDeferredResp','true', log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
       <con:properties>
         <con:property>
-          <con:name>LocalHCID</con:name>
-          <con:value>1.1</con:value>
+          <con:name>&lt;!--Destination--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>LocalAA</con:name>
-          <con:value>1.1</con:value>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>LocalHCDescription</con:name>
-          <con:value>InternalTest1</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>LocalPatientID</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemoteHCID</con:name>
-          <con:value>2.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemoteAA</con:name>
-          <con:value>2.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemoteHCDescription</con:name>
-          <con:value>InternalTest2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>RemotePatientID</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>NHINGatewayConfigDir</con:name>
-          <con:value>C:/Sun/AppServer/domains/domain1/config/nhin</con:value>
-        </con:property>
-        <con:property>
-          <con:name>MPIDir</con:name>
-          <con:value>C:/Sun/AppServer/domains/domain1/config</con:value>
-        </con:property>
-        <con:property>
-          <con:name>LocalConfigDir</con:name>
-          <con:value>C:/SelfTest/EndToEndSelfTest</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-DocQuery</con:name>
-          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityDocQueryUnsecured</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-DocRetrieve</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityDocRetrieve</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Reidentification</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubjectDiscovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Subscribe</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationProducer</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Notify</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationConsumer</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-Unsubscribe</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubscriptionManager</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-AuditLogQuery</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityAuditQuery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-PatientDiscoveryAsyncReq</con:name>
-          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityPatientDiscoveryDeferredRequestUnsecured</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-PatientDiscoveryAsyncResp</con:name>
-          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityPatientDiscoveryDeferredResponseUnsecured</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBHost</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBPort</con:name>
-          <con:value>3306</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBUser</con:name>
-          <con:value>nhincuser</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DBPass</con:name>
-          <con:value>nhincpass</con:value>
-        </con:property>
-        <con:property>
-          <con:name>PatientCorrelationDB</con:name>
-          <con:value>patientcorrelationdb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>PatientCorrelationTable</con:name>
-          <con:value>correlatedidentifiers</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubscriptionDB</con:name>
-          <con:value>subscriptionrepository</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubscriptionTable</con:name>
-          <con:value>subscription</con:value>
+          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
+          <con:value>checks --></con:value>
         </con:property>
         <con:property>
           <con:name>AAMappingDB</con:name>
@@ -14374,6 +14203,122 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>aa_to_home_community_mapping</con:value>
         </con:property>
         <con:property>
+          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncResp</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
+          <con:value>110152</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AQPatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AQUserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
           <con:name>AsyncMsgDB</con:name>
           <con:value>asyncmsgs</con:value>
         </con:property>
@@ -14382,20 +14327,52 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>asyncmsgrepo</con:value>
         </con:property>
         <con:property>
-          <con:name>PseudonymAA</con:name>
-          <con:value>ABC</con:value>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
         </con:property>
         <con:property>
-          <con:name>PseudonymPatientID</con:name>
-          <con:value>PSEUDO001</con:value>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
         </con:property>
         <con:property>
-          <con:name>RealAA</con:name>
-          <con:value>1.1.1</con:value>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
         </con:property>
         <con:property>
-          <con:name>RealPatientID</con:name>
-          <con:value>D1234010050</con:value>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>BirthTime</con:name>
+          <con:value>19630804</con:value>
+        </con:property>
+        <con:property>
+          <con:name>City</con:name>
+          <con:value>Melbourne</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Country</con:name>
+          <con:value>US</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DBHost</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DBPass</con:name>
+          <con:value>nhincpass</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DBPort</con:name>
+          <con:value>3306</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DBUser</con:name>
+          <con:value>nhincuser</con:value>
+        </con:property>
+        <con:property>
+          <con:name>DOB</con:name>
+          <con:value>19800516</con:value>
         </con:property>
         <con:property>
           <con:name>DQDocID</con:name>
@@ -14406,10 +14383,6 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>D123401</con:value>
         </con:property>
         <con:property>
-          <con:name>DynamicDQDocID</con:name>
-          <con:value>103.8.9284320.020.3590.75^1266324032288</con:value>
-        </con:property>
-        <con:property>
           <con:name>DRDocID</con:name>
           <con:value>1.123407.777777</con:value>
         </con:property>
@@ -14418,16 +14391,140 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>1</con:value>
         </con:property>
         <con:property>
+          <con:name>DynamicDQDocID</con:name>
+          <con:value>103.8.9284320.020.3590.75^1266324032288</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:32:44Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-AuditLogQuery</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityAuditQuery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-DocQuery</con:name>
+          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityDocQueryUnsecured</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-DocRetrieve</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityDocRetrieve</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-EntityXDRRequest</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityProxyService/EntityXDRRequest</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Notify</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationConsumer</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-PatientDiscoveryAsyncReq</con:name>
+          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityPatientDiscoveryDeferredRequestUnsecured</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-PatientDiscoveryAsyncResp</con:name>
+          <con:value>http://localhost:8080/CONNECTGateway/EntityService/EntityPatientDiscoveryDeferredResponseUnsecured</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Reidentification</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubjectDiscovery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Subscribe</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntityNotificationProducer</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Endpoint-Unsubscribe</con:name>
+          <con:value>http://localhost:8080/CONNECTAdapter/EntitySubscriptionManager</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>E</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventDateTime</con:name>
+          <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110112</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Query</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ExpirationDate</con:name>
+          <con:value>20100520</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>FamilyName</con:name>
+          <con:value>Younger</con:value>
+        </con:property>
+        <con:property>
+          <con:name>Gender</con:name>
+          <con:value>M</con:value>
+        </con:property>
+        <con:property>
+          <con:name>GivenName</con:name>
+          <con:value>Gallow</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalAA</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalConfigDir</con:name>
+          <con:value>C:/SelfTest/EndToEndSelfTest</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalHCDescription</con:name>
+          <con:value>InternalTest1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalHCID</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>LocalPatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>MPIDir</con:name>
+          <con:value>C:/Sun/AppServer/domains/domain1/config</con:value>
+        </con:property>
+        <con:property>
+          <con:name>NHINGatewayConfigDir</con:name>
+          <con:value>C:/Sun/AppServer/domains/domain1/config/nhin</con:value>
+        </con:property>
+        <con:property>
           <con:name>NotificationEndpoint</con:name>
           <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/NotificationConsumerService/HiemNotify</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubscriptionEndpoint</con:name>
-          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/NotificationProducerService/HiemSubscription</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubscribePatientID</con:name>
-          <con:value>D123401</con:value>
         </con:property>
         <con:property>
           <con:name>NotifySubscriptionID</con:name>
@@ -14438,232 +14535,40 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
         </con:property>
         <con:property>
-          <con:name>UnSubscriptionID</con:name>
-          <con:value>3e74139f-5271-4db1-98c0-88748fa3e4e3</con:value>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
+          <con:value>LivingSubject.administrativeGender</con:value>
         </con:property>
         <con:property>
-          <con:name>SubscriptionManagerEndpointAddress</con:name>
-          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
         </con:property>
         <con:property>
-          <con:name>AQUserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AQPatientID</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Endpoint-EntityXDRRequest</con:name>
-          <con:value>http://localhost:8080/CONNECTAdapter/EntityProxyService/EntityXDRRequest</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Gender</con:name>
+          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
           <con:value>M</con:value>
-        </con:property>
-        <con:property>
-          <con:name>BirthTime</con:name>
-          <con:value>19630804</con:value>
-        </con:property>
-        <con:property>
-          <con:name>FamilyName</con:name>
-          <con:value>Younger</con:value>
-        </con:property>
-        <con:property>
-          <con:name>GivenName</con:name>
-          <con:value>Gallow</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SubjectID</con:name>
-          <con:value>1111</con:value>
-        </con:property>
-        <con:property>
-          <con:name>UniquePatientId</con:name>
-          <con:value>1111^^^&amp;amp;1.1&amp;amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>StreetAddress</con:name>
-          <con:value>123 Johnson Rd</con:value>
-        </con:property>
-        <con:property>
-          <con:name>City</con:name>
-          <con:value>Melbourne</con:value>
-        </con:property>
-        <con:property>
-          <con:name>State</con:name>
-          <con:value>FL</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ZipCode</con:name>
-          <con:value>12345</con:value>
-        </con:property>
-        <con:property>
-          <con:name>Country</con:name>
-          <con:value>US</con:value>
-        </con:property>
-        <con:property>
-          <con:name>SSN</con:name>
-          <con:value>123456789</con:value>
-        </con:property>
-        <con:property>
-          <con:name>PurposeOfDisclosure</con:name>
-          <con:value>Mental</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ExpirationDate</con:name>
-          <con:value>20100520</con:value>
-        </con:property>
-        <con:property>
-          <con:name>DOB</con:name>
-          <con:value>19800516</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-13T09:22:06Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/13/2015 09:12:06</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-13T09:12:06Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110112</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>24</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectBirthTime.semanticsText</con:name>
           <con:value>LivingSubject.birthTime</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
-          <con:value>GIV</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>D123402^^^&amp;2.2&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventDateTime</con:name>
-          <con:value>2015-04-02T13:47:30.199Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
-          <con:value>FAM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responseModalityCode.@code</con:name>
-          <con:value>R</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
+          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectBirthTime.value.@value</con:name>
           <con:value>19630804</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
-          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
+          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
-          <con:value>checks --></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
+          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
+          <con:value>D123401</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectId.value.@root</con:name>
           <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectName.semanticsText</con:name>
@@ -14674,184 +14579,196 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>TXT</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responsePriorityCode.@code</con:name>
-          <con:value>I</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscoveryAsyncResp</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Destination--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
           <con:name>parameterList.livingSubjectName.value.family</con:name>
           <con:value>Younger</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
+          <con:value>FAM</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectName.value.given</con:name>
           <con:value>Gallow</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
+          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
+          <con:value>GIV</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>D123402^^^&amp;2.2&amp;ISO</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
-          <con:value>LivingSubject.administrativeGender</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
-          <con:value>110152</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>E</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
           <con:value>2</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
         </con:property>
         <con:property>
-          <con:name>queryId.@root</con:name>
-          <con:value>2.2</con:value>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
+          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
           <con:value>2</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>24</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
           <con:value>IHE Transactions</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
-          <con:value>M</con:value>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>queryId.@extension</con:name>
-          <con:value>-abd3453dcd24wkkks545</con:value>
-        </con:property>
-        <con:property>
-          <con:name>statusCode.@code</con:name>
-          <con:value>new</con:value>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
         </con:property>
         <con:property>
           <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
           <con:value>D123402^^^&amp;2.2&amp;ISO</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
+          <con:name>PatientCorrelationDB</con:name>
+          <con:value>patientcorrelationdb</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
+          <con:name>PatientCorrelationTable</con:name>
+          <con:value>correlatedidentifiers</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
+          <con:name>PseudonymAA</con:name>
+          <con:value>ABC</con:value>
         </con:property>
         <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
+          <con:name>PseudonymPatientID</con:name>
+          <con:value>PSEUDO001</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditOff</con:name>
-          <con:value>false</con:value>
+          <con:name>PurposeOfDisclosure</con:name>
+          <con:value>Mental</con:value>
+        </con:property>
+        <con:property>
+          <con:name>queryId.@extension</con:name>
+          <con:value>-abd3453dcd24wkkks545</con:value>
+        </con:property>
+        <con:property>
+          <con:name>queryId.@root</con:name>
+          <con:value>2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RealAA</con:name>
+          <con:value>1.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RealPatientID</con:name>
+          <con:value>D1234010050</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemoteAA</con:name>
+          <con:value>2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemoteHCDescription</con:name>
+          <con:value>InternalTest2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemoteHCID</con:name>
+          <con:value>2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>RemotePatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responseModalityCode.@code</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responsePriorityCode.@code</con:name>
+          <con:value>I</con:value>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:22:44</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SSN</con:name>
+          <con:value>123456789</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:22:44Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>State</con:name>
+          <con:value>FL</con:value>
+        </con:property>
+        <con:property>
+          <con:name>statusCode.@code</con:name>
+          <con:value>new</con:value>
+        </con:property>
+        <con:property>
+          <con:name>StreetAddress</con:name>
+          <con:value>123 Johnson Rd</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubjectID</con:name>
+          <con:value>1111</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscribePatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionDB</con:name>
+          <con:value>subscriptionrepository</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionEndpoint</con:name>
+          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/NotificationProducerService/HiemSubscription</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionManagerEndpointAddress</con:name>
+          <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
+        </con:property>
+        <con:property>
+          <con:name>SubscriptionTable</con:name>
+          <con:value>subscription</con:value>
+        </con:property>
+        <con:property>
+          <con:name>UniquePatientId</con:name>
+          <con:value>1111^^^&amp;amp;1.1&amp;amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>UnSubscriptionID</con:name>
+          <con:value>3e74139f-5271-4db1-98c0-88748fa3e4e3</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ZipCode</con:name>
+          <con:value>12345</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -14865,6 +14782,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="clear correlations table" type="groovy" id="fecaa138-e608-4f78-956b-50aafd6eb321">
@@ -15189,7 +15112,7 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="c5eb777c-ace8-40f7-be9f-836ad52b1295">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
@@ -15198,12 +15121,11 @@ context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 }
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -15513,26 +15435,22 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
 	 	}
 	}
   }
-}]]></script>
+}
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
 nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
 
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
+
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -15545,360 +15463,223 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'PatientDiscovery','true', log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
       <con:properties>
-        <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-13T09:11:23Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-13T09:21:23Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/13/2015 09:11:23</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-13T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
         <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0idXJuOmdvdjpoaHM6ZmhhOm5oaW5jOmNvbW1vbjpwYXRpZW50Y29ycmVsYXRpb25mYWNhZGUiIHhtbG5zOm5zNT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmFkbWluaXN0cmF0aXZlR2VuZGVyPC9zZW1hbnRpY3NUZXh0PjwvbGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPjxsaXZpbmdTdWJqZWN0QmlydGhUaW1lPjx2YWx1ZSB2YWx1ZT0iMTk2MzA4MDQiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmJpcnRoVGltZTwvc2VtYW50aWNzVGV4dD48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgPC92YWx1ZT48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0Lm5hbWU8L3NlbWFudGljc1RleHQ+PC9saXZpbmdTdWJqZWN0TmFtZT48L3BhcmFtZXRlckxpc3Q+PC9xdWVyeUJ5UGFyYW1ldGVyPg==</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
-          <con:value>anonymus</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>ITI-55</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
-          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
         </con:property>
         <con:property>
           <con:name>&lt;!--Human</con:name>
           <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>E</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
-          <con:value>110152</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectSensitivity</con:name>
+          <con:name>&lt;!--Source--></con:name>
           <con:value/>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
+          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
+          <con:value>checks --></con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.@AlternativeUserID</con:name>
           <con:value>19233@192.168.1.1</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Patient Discovery</con:value>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110112</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectSensitivity</con:name>
-          <con:value/>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
           <con:value>307969004</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventDateTime</con:name>
-          <con:value>2015-04-02T13:47:30.199Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>24</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
           <con:value>Human Requestor</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
         </con:property>
         <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>2</con:value>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/PatientDiscovery/1_0/NhinService/NhinPatientDiscovery</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>1111^^^&amp;1.1&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@value</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxuczM6Q09SRUVudmVsb3BlUmVhbFRpbWVSZXF1ZXN0IHhtbG5zOm5zMj0iaHR0cDovL3d3dy5jYXFoLm9yZy9TT0FQL1dTREwvQ09SRVJ1bGUyLjIuMC54c2QiIHhtbG5zOm5zMz0idXJuOm9yZzpjYXFoOnNvYXA6d3NkbDpjb3JlcnVsZTJfMl8wIj48UGF5bG9hZFR5cGU+WDEyXzI3MF9SZXF1ZXN0XzAwNTAxMFgyNzlBMTwvUGF5bG9hZFR5cGU+PFByb2Nlc3NpbmdNb2RlPlJlYWxUaW1lPC9Qcm9jZXNzaW5nTW9kZT48UGF5bG9hZElEPmY4MWQ0ZmFlLTdkZWMtMTFkMC1hNzY1LTAwYTBjOTFlNmJmNjwvUGF5bG9hZElEPjxUaW1lU3RhbXA+MjAwNy0wOC0zMFQxMDoyMDozNFo8L1RpbWVTdGFtcD48U2VuZGVySUQ+SG9zcGl0YWxBPC9TZW5kZXJJRD48UmVjZWl2ZXJJRD5QYXllckI8L1JlY2VpdmVySUQ+PENPUkVSdWxlVmVyc2lvbj4yLjIuMDwvQ09SRVJ1bGVWZXJzaW9uPjxQYXlsb2FkPjwvUGF5bG9hZD48L25zMzpDT1JFRW52ZWxvcGVSZWFsVGltZVJlcXVlc3Q+</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0idXJuOmdvdjpoaHM6ZmhhOm5oaW5jOmNvbW1vbjpwYXRpZW50Y29ycmVsYXRpb25mYWNhZGUiIHhtbG5zOm5zNT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmFkbWluaXN0cmF0aXZlR2VuZGVyPC9zZW1hbnRpY3NUZXh0PjwvbGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPjxsaXZpbmdTdWJqZWN0QmlydGhUaW1lPjx2YWx1ZSB2YWx1ZT0iMTk2MzA4MDQiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmJpcnRoVGltZTwvc2VtYW50aWNzVGV4dD48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgPC92YWx1ZT48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0Lm5hbWU8L3NlbWFudGljc1RleHQ+PC9saXZpbmdTdWJqZWN0TmFtZT48L3BhcmFtZXRlckxpc3Q+PC9xdWVyeUJ5UGFyYW1ldGVyPg==</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDetail.@value</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxuczM6Q09SRUVudmVsb3BlUmVhbFRpbWVSZXF1ZXN0IHhtbG5zOm5zMj0iaHR0cDovL3d3dy5jYXFoLm9yZy9TT0FQL1dTREwvQ09SRVJ1bGUyLjIuMC54c2QiIHhtbG5zOm5zMz0idXJuOm9yZzpjYXFoOnNvYXA6d3NkbDpjb3JlcnVsZTJfMl8wIj48UGF5bG9hZFR5cGU+WDEyXzI3MF9SZXF1ZXN0XzAwNTAxMFgyNzlBMTwvUGF5bG9hZFR5cGU+PFByb2Nlc3NpbmdNb2RlPlJlYWxUaW1lPC9Qcm9jZXNzaW5nTW9kZT48UGF5bG9hZElEPmY4MWQ0ZmFlLTdkZWMtMTFkMC1hNzY1LTAwYTBjOTFlNmJmNjwvUGF5bG9hZElEPjxUaW1lU3RhbXA+MjAwNy0wOC0zMFQxMDoyMDozNFo8L1RpbWVTdGFtcD48U2VuZGVySUQ+SG9zcGl0YWxBPC9TZW5kZXJJRD48UmVjZWl2ZXJJRD5QYXllckI8L1JlY2VpdmVySUQ+PENPUkVSdWxlVmVyc2lvbj4yLjIuMDwvQ09SRVJ1bGVWZXJzaW9uPjxQYXlsb2FkPjwvUGF5bG9hZD48L25zMzpDT1JFRW52ZWxvcGVSZWFsVGltZVJlcXVlc3Q+</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
+          <con:value>110152</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName.@value</con:name>
-          <con:value>anonymus</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectName.@value</con:name>
-          <con:value>anonymus</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery.@value</con:name>
-          <con:value>test</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectQuery.@value</con:name>
-          <con:value>test</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail</con:name>
-          <con:value>test</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDetail</con:name>
-          <con:value>test</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
           <con:value>2</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
-          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor.inbound</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:33:01Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>E</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventDateTime</con:name>
+          <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110112</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Query</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
+          <con:value>LivingSubject.administrativeGender</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
+          <con:value>M</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectBirthTime.semanticsText</con:name>
           <con:value>LivingSubject.birthTime</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
-          <con:value>GIV</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
-          <con:value>FAM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responseModalityCode.@code</con:name>
-          <con:value>R</con:value>
+          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectBirthTime.value.@value</con:name>
           <con:value>19630804</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;--ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
-          <con:value>checks --></con:value>
+          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
+          <con:value>TXT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
+          <con:value>1111</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectId.value.@root</con:name>
@@ -15913,60 +15694,188 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>TXT</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectId.value.@extension</con:name>
-          <con:value>1111</con:value>
-        </con:property>
-        <con:property>
-          <con:name>responsePriorityCode.@code</con:name>
-          <con:value>I</con:value>
-        </con:property>
-        <con:property>
           <con:name>parameterList.livingSubjectName.value.family</con:name>
           <con:value>Younger</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parameterList.livingSubjectName.value.family.@partType</con:name>
+          <con:value>FAM</con:value>
         </con:property>
         <con:property>
           <con:name>parameterList.livingSubjectName.value.given</con:name>
           <con:value>Gallow</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>parameterList.livingSubjectName.value.given.@partType</con:name>
+          <con:value>GIV</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectId.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.semanticsText</con:name>
-          <con:value>LivingSubject.administrativeGender</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>1111^^^&amp;1.1&amp;ISO</con:value>
         </con:property>
         <con:property>
-          <con:name>queryId.@root</con:name>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectName</con:name>
           <con:value>1.1</con:value>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectBirthTime.semanticsText.@representation</con:name>
-          <con:value>TXT</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>parameterList.livingSubjectAdministrativeGender.value.@code</con:name>
-          <con:value>M</con:value>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail</con:name>
+          <con:value>test</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@value</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxuczM6Q09SRUVudmVsb3BlUmVhbFRpbWVSZXF1ZXN0IHhtbG5zOm5zMj0iaHR0cDovL3d3dy5jYXFoLm9yZy9TT0FQL1dTREwvQ09SRVJ1bGUyLjIuMC54c2QiIHhtbG5zOm5zMz0idXJuOm9yZzpjYXFoOnNvYXA6d3NkbDpjb3JlcnVsZTJfMl8wIj48UGF5bG9hZFR5cGU+WDEyXzI3MF9SZXF1ZXN0XzAwNTAxMFgyNzlBMTwvUGF5bG9hZFR5cGU+PFByb2Nlc3NpbmdNb2RlPlJlYWxUaW1lPC9Qcm9jZXNzaW5nTW9kZT48UGF5bG9hZElEPmY4MWQ0ZmFlLTdkZWMtMTFkMC1hNzY1LTAwYTBjOTFlNmJmNjwvUGF5bG9hZElEPjxUaW1lU3RhbXA+MjAwNy0wOC0zMFQxMDoyMDozNFo8L1RpbWVTdGFtcD48U2VuZGVySUQ+SG9zcGl0YWxBPC9TZW5kZXJJRD48UmVjZWl2ZXJJRD5QYXllckI8L1JlY2VpdmVySUQ+PENPUkVSdWxlVmVyc2lvbj4yLjIuMDwvQ09SRVJ1bGVWZXJzaW9uPjxQYXlsb2FkPjwvUGF5bG9hZD48L25zMzpDT1JFRW52ZWxvcGVSZWFsVGltZVJlcXVlc3Q+</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
+          <con:value>anonymus</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectName.@value</con:name>
+          <con:value>anonymus</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0idXJuOmdvdjpoaHM6ZmhhOm5oaW5jOmNvbW1vbjpwYXRpZW50Y29ycmVsYXRpb25mYWNhZGUiIHhtbG5zOm5zNT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmFkbWluaXN0cmF0aXZlR2VuZGVyPC9zZW1hbnRpY3NUZXh0PjwvbGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPjxsaXZpbmdTdWJqZWN0QmlydGhUaW1lPjx2YWx1ZSB2YWx1ZT0iMTk2MzA4MDQiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmJpcnRoVGltZTwvc2VtYW50aWNzVGV4dD48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgPC92YWx1ZT48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0Lm5hbWU8L3NlbWFudGljc1RleHQ+PC9saXZpbmdTdWJqZWN0TmFtZT48L3BhcmFtZXRlckxpc3Q+PC9xdWVyeUJ5UGFyYW1ldGVyPg==</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery.@value</con:name>
+          <con:value>test</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectID</con:name>
+          <con:value>a797fa28-45fd-4a29-867d-32f3301e73fe</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>24</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDetail</con:name>
+          <con:value>test</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectDetail.@value</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxuczM6Q09SRUVudmVsb3BlUmVhbFRpbWVSZXF1ZXN0IHhtbG5zOm5zMj0iaHR0cDovL3d3dy5jYXFoLm9yZy9TT0FQL1dTREwvQ09SRVJ1bGUyLjIuMC54c2QiIHhtbG5zOm5zMz0idXJuOm9yZzpjYXFoOnNvYXA6d3NkbDpjb3JlcnVsZTJfMl8wIj48UGF5bG9hZFR5cGU+WDEyXzI3MF9SZXF1ZXN0XzAwNTAxMFgyNzlBMTwvUGF5bG9hZFR5cGU+PFByb2Nlc3NpbmdNb2RlPlJlYWxUaW1lPC9Qcm9jZXNzaW5nTW9kZT48UGF5bG9hZElEPmY4MWQ0ZmFlLTdkZWMtMTFkMC1hNzY1LTAwYTBjOTFlNmJmNjwvUGF5bG9hZElEPjxUaW1lU3RhbXA+MjAwNy0wOC0zMFQxMDoyMDozNFo8L1RpbWVTdGFtcD48U2VuZGVySUQ+SG9zcGl0YWxBPC9TZW5kZXJJRD48UmVjZWl2ZXJJRD5QYXllckI8L1JlY2VpdmVySUQ+PENPUkVSdWxlVmVyc2lvbj4yLjIuMDwvQ09SRVJ1bGVWZXJzaW9uPjxQYXlsb2FkPjwvUGF5bG9hZD48L25zMzpDT1JFRW52ZWxvcGVSZWFsVGltZVJlcXVlc3Q+</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>ITI-55</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Patient Discovery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectName.@value</con:name>
+          <con:value>anonymus</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectQuery</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxxdWVyeUJ5UGFyYW1ldGVyIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyIgeG1sbnM6bnMyPSJ1cm46aGw3LW9yZzpzZHRjIiB4bWxuczpuczM9InVybjpnb3Y6aGhzOmZoYTpuaGluYzpjb21tb246bmhpbmNjb21tb24iIHhtbG5zOm5zND0idXJuOmdvdjpoaHM6ZmhhOm5oaW5jOmNvbW1vbjpwYXRpZW50Y29ycmVsYXRpb25mYWNhZGUiIHhtbG5zOm5zNT0iaHR0cDovL3d3dy53My5vcmcvMjAwNS8wOC9hZGRyZXNzaW5nIj48cXVlcnlJZCByb290PSIxLjEiIGV4dGVuc2lvbj0iLWFiZDM0NTNkY2QyNHdra2tzNTQ1Ii8+PHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+PHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiLz48cmVzcG9uc2VQcmlvcml0eUNvZGUgY29kZT0iSSIvPjxwYXJhbWV0ZXJMaXN0PjxsaXZpbmdTdWJqZWN0QWRtaW5pc3RyYXRpdmVHZW5kZXI+PHZhbHVlIGNvZGU9Ik0iLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmFkbWluaXN0cmF0aXZlR2VuZGVyPC9zZW1hbnRpY3NUZXh0PjwvbGl2aW5nU3ViamVjdEFkbWluaXN0cmF0aXZlR2VuZGVyPjxsaXZpbmdTdWJqZWN0QmlydGhUaW1lPjx2YWx1ZSB2YWx1ZT0iMTk2MzA4MDQiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0LmJpcnRoVGltZTwvc2VtYW50aWNzVGV4dD48L2xpdmluZ1N1YmplY3RCaXJ0aFRpbWU+PGxpdmluZ1N1YmplY3RJZD48dmFsdWUgcm9vdD0iMS4xIiBleHRlbnNpb249IjExMTEiLz48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIi8+PC9saXZpbmdTdWJqZWN0SWQ+PGxpdmluZ1N1YmplY3ROYW1lPjx2YWx1ZT48ZmFtaWx5IHBhcnRUeXBlPSJGQU0iPllvdW5nZXI8L2ZhbWlseT48Z2l2ZW4gcGFydFR5cGU9IkdJViI+R2FsbG93PC9naXZlbj4KICAgICAgICAgICAgICAgICAgICAgICAgPC92YWx1ZT48c2VtYW50aWNzVGV4dCByZXByZXNlbnRhdGlvbj0iVFhUIj5MaXZpbmdTdWJqZWN0Lm5hbWU8L3NlbWFudGljc1RleHQ+PC9saXZpbmdTdWJqZWN0TmFtZT48L3BhcmFtZXRlckxpc3Q+PC9xdWVyeUJ5UGFyYW1ldGVyPg==</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectQuery.@value</con:name>
+          <con:value>test</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Query.ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Responder.@ParticipantObjectID</con:name>
+          <con:value>D123401^^^&amp;1.1&amp;ISO</con:value>
         </con:property>
         <con:property>
           <con:name>queryId.@extension</con:name>
           <con:value>-abd3453dcd24wkkks545</con:value>
         </con:property>
         <con:property>
+          <con:name>queryId.@root</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responseModalityCode.@code</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>responsePriorityCode.@code</con:name>
+          <con:value>I</con:value>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:23:01</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:23:01Z</con:value>
+        </con:property>
+        <con:property>
           <con:name>statusCode.@code</con:name>
           <con:value>new</con:value>
-        </con:property>
-        <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditOff</con:name>
-          <con:value>true</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -15980,6 +15889,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="update config" type="groovy" id="b5d8f64c-b7a3-4266-b2a3-67a407f1ce13">
@@ -16319,7 +16234,7 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="d0a30f1e-d90a-48b8-8eb6-1ebfb6ad8004">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
@@ -16328,12 +16243,11 @@ context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 }
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -16616,27 +16530,21 @@ if(!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeCo
 	 	} 
   	}
   }
-}]]></script>
+}
+
+
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
 nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
-
-
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -16649,52 +16557,71 @@ if (propertiesFile.exists()) {
      testCase.setPropertyValue(key, value)
  }
 }</con:setupScript>
-      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'QueryForDocuments','true', log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty('GatewayPropDir'), log);</con:tearDownScript>
       <con:properties>
-        <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-12T17:19:50Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-12T17:29:50Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/12/2015 17:19:50</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>FullPatientID</con:name>
-          <con:value>'D123401^^^&amp;amp;1.1&amp;amp;ISO'</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
         <con:property>
           <con:name>&lt;!--Destination--></con:name>
           <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>24</con:value>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@type</con:name>
-          <con:value>QueryEncoding</con:value>
+          <con:name>&lt;!--Source--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
-          <con:value>anonymus</con:value>
+          <con:name>&lt;--Document</con:name>
+          <con:value>--></con:value>
+        </con:property>
+        <con:property>
+          <con:name>&lt;--Patient--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>&lt;--RESPONDER--></con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
+          <con:value>SNOMED_CT</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@UserID</con:name>
@@ -16705,260 +16632,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>false</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-38</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>ITI-38</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Patient--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Document</con:name>
-          <con:value>--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@value</con:name>
-          <con:value>UTF-8</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserName</con:name>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>E</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
           <con:value>110152</con:value>
         </con:property>
         <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
-          <con:value>SNOMED_CT</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.1</con:value>
-        </con:property>
-        <con:property>
           <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
           <con:value>DCM</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Query</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110112</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventDateTime</con:name>
-          <con:value>2015-04-02T13:47:30.199Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectID</con:name>
-          <con:value>D123401</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@value</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>D123401^^^&amp;2.2&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@type</con:name>
-          <con:value>urn:ihe:iti:xca:2010:homeCommunityId</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
-          <con:value>Export</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
-          <con:value>unknown</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectQuery</con:name>
-          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxBZGhvY1F1ZXJ5UmVxdWVzdCB4bWx....</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--RESPONDER--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ResponderActiveParticipant_Dest.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentQuery/2_0/NhinService/RespondingGateway_Query_Service/DocQuery</con:value>
-        </con:property>
-        <con:property>
-          <con:name>parsedParticipantObjectQuery.AdhocQuery.Slot.ValueList.Value.PatientID</con:name>
-          <con:value>D123401</con:value>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest_g0.@UserID</con:name>
@@ -16969,8 +16656,224 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>https://localhost:8181/Gateway/DocumentQuery/3_0/NhinService/RespondingGateway_Query_Service/DocQuery</con:value>
         </con:property>
         <con:property>
-          <con:name>auditLogStatus</con:name>
+          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
           <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:33:20Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>E</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventDateTime</con:name>
+          <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110112</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Query</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-38</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Query</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
+          <con:value>Export</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>FullPatientID</con:name>
+          <con:value>'D123401^^^&amp;amp;1.1&amp;amp;ISO'</con:value>
+        </con:property>
+        <con:property>
+          <con:name>parsedParticipantObjectQuery.AdhocQuery.Slot.ValueList.Value.PatientID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>D123401^^^&amp;2.2&amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
+          <con:value>anonymus</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
+          <con:value>unknown</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectID</con:name>
+          <con:value>D123401</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>24</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@type</con:name>
+          <con:value>QueryEncoding</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@value</con:name>
+          <con:value>UTF-8</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@type</con:name>
+          <con:value>urn:ihe:iti:xca:2010:homeCommunityId</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@value</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>ITI-38</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Query</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectQuery</con:name>
+          <con:value>PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxBZGhvY1F1ZXJ5UmVxdWVzdCB4bWx....</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ResponderActiveParticipant_Dest.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentQuery/2_0/NhinService/RespondingGateway_Query_Service/DocQuery</con:value>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:23:20</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:23:20Z</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -16984,6 +16887,12 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
 	sql.execute('delete from ' + context.findProperty('AuditRepoTable'))
 	sql.execute('alter table ' + context.findProperty('AuditRepoTable') + ' AUTO_INCREMENT=1')
 }</script>
+        </con:config>
+      </con:testStep>
+      <con:testStep type="delay" name="Wait to Clear Audit logs">
+        <con:settings/>
+        <con:config>
+          <delay>3000</delay>
         </con:config>
       </con:testStep>
       <con:testStep name="Document Retrieve" type="request" id="c97198c8-448c-4153-9c9c-e57740dc5fb8">
@@ -17284,22 +17193,20 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
       <con:testStep type="groovy" name="Verify Audit Logs" id="1dbff829-fbb6-4825-ae7b-f224906e0299">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "true")
+          <script>if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments', log) == "true")
 {
 context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 2 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
-	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where  direction="Nhin Outbound" and remoteHcid="2.2"')[0]
-	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where  direction="Nhin Outbound" and remoteHcid="1.1"')[0]
-	
+	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="2.2"')[0]
+	assert 1 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable') + ' where direction="Nhin Outbound" and remoteHcid="1.1"')[0]
 }
 	testRunner.gotoStepByName( "VerifyMessage-NhinOutbound-InitiatingGateway(1.1)")
 }
-else if ( testRunner.testCase.getPropertyValue("auditLogStatus") == "false")
+else if (  nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments', log) == "false")
 {
  	context.withSql(context.findProperty('AuditRepoDB')) {sql ->
 	assert 0 == sql.firstRow('select count(*) from ' + context.findProperty('AuditRepoTable'))[0]
 	}
-	testRunner.testCase.setPropertyValue('AuditOff', 'true')
 	testRunner.gotoStepByName( "Success")
 }
 else
@@ -17568,27 +17475,20 @@ if (!parsedXmlMessage.ParticipantObjectIdentification[0].@ParticipantObjectTypeC
 	 	}	  
 	}
  }
-}]]></script>
+}
+nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments',"false", log);
+testRunner.gotoStepByName( "Clear Audit Logs")]]></script>
         </con:config>
       </con:testStep>
       <con:testStep type="groovy" name="Success">
         <con:settings/>
         <con:config>
-          <script>if ( testRunner.testCase.getPropertyValue("AuditOff") == "false")
-{
-testRunner.testCase.setPropertyValue('auditLogStatus', 'false')
-nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments',''+testRunner.testCase.getPropertyValue("auditLogStatus"), log);
-testRunner.gotoStepByName( "Clear Audit Logs")
-}</script>
+          <script/>
         </con:config>
       </con:testStep>
       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty('GatewayPropDir'), log);
 nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
 
-
-def auditLogStatus = nhinc.FileUtils.readProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments', log);
-testCase.setPropertyValue('auditLogStatus', auditLogStatus)
-testCase.setPropertyValue('AuditOff', 'false')
 
 def groovyUtils = new com.eviware.soapui.support.GroovyUtils(context)
 def projectPath = groovyUtils.projectPath
@@ -17605,51 +17505,15 @@ if (propertiesFile.exists()) {
 nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.findProperty('auditLoggingStatusFileName'),'RetrieveDocuments','true', log);</con:tearDownScript>
       <con:properties>
         <con:property>
-          <con:name>CorrectedRemoteHCID</con:name>
-          <con:value>urn:oid:2.2</con:value>
+          <con:name>&lt;!--Destination--></con:name>
+          <con:value/>
         </con:property>
         <con:property>
-          <con:name>startDate</con:name>
-          <con:value>2015-11-12T17:20:05Z</con:value>
+          <con:name>&lt;!--Human</con:name>
+          <con:value>Requestor--></con:value>
         </con:property>
         <con:property>
-          <con:name>endDate</con:name>
-          <con:value>2015-11-12T17:30:05Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>sigDate</con:name>
-          <con:value>11/12/2015 17:20:05</con:value>
-        </con:property>
-        <con:property>
-          <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@value</con:name>
-          <con:value>urn:oid:2.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@code</con:name>
-          <con:value>110107</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
-          <con:value>urn:oid:1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
-          <con:value>anonymus</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserID</con:name>
-          <con:value>kskagerb</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
+          <con:name>&lt;!--Source--></con:name>
           <con:value/>
         </con:property>
         <con:property>
@@ -17657,272 +17521,112 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>--></con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
-          <con:value>Cross Gateway Retrieve</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
-          <con:value>Destination</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail_one.@value</con:name>
-          <con:value>homeCommunityID</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
-          <con:value>localhost</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectDataLifeCycle</con:name>
+          <con:name>&lt;--Patient--></con:name>
           <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
-          <con:value>307969004</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
-          <con:value>500000000^^^&amp;1.1&amp;ISO</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventDateTime</con:name>
-          <con:value>2015-04-02T13:47:30.199Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
-          <con:value>Source</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.@AlternativeUserID</con:name>
           <con:value>19233@192.168.1.1</con:value>
         </con:property>
         <con:property>
+          <con:name>ActiveParticipant.@UserID</con:name>
+          <con:value>kskagerb</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
           <con:name>ActiveParticipant.@UserName</con:name>
           <con:value>Karl Skagerberg</con:value>
         </con:property>
         <con:property>
-          <con:name>&lt;!--Human</con:name>
-          <con:value>Requestor--></con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@code</con:name>
-          <con:value>110106</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
-          <con:value>unknown</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditMessage.xmlns</con:name>
-          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@value</con:name>
-          <con:value>ihe:RepositoryUniqueId</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
-          <con:value>DoD</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
-          <con:value>IHE Transactions</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventTypeCode.@code</con:name>
-          <con:value>ITI-39</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
-          <con:value>1010</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
-          <con:value>0</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Patient Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserID</con:name>
-          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Destination--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
-          <con:value>false</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;--Patient--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectQuery</con:name>
-          <con:value>unknown</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
-          <con:value>Human Requestor</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>9</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCodeRole</con:name>
-          <con:value>3</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
-          <con:value>true</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail_one.@type</con:name>
-          <con:value>ihe:homeCommunityID</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
-          <con:value>19233@192.168.1.2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@displayName</con:name>
-          <con:value>Import</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
-          <con:value>110153</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
-          <con:value>110152</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.@EventActionCode</con:name>
-          <con:value>C</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@type</con:name>
-          <con:value>ihe:homeCommunityID</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
-          <con:value>Export</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectID</con:name>
-          <con:value>1.123407.777777</con:value>
+          <con:name>ActiveParticipant.RoleIDCode.@code</con:name>
+          <con:value>307969004</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant.RoleIDCode.@codeSystemName</con:name>
           <con:value>SNOMED_CT</con:value>
         </con:property>
         <con:property>
-          <con:name>ActiveParticipant_Source.@UserID</con:name>
-          <con:value>https://localhost:8181/Gateway/DocumentRetrieve/3_0/NhinService/RespondingGateway_Retrieve_Service/DocRetrieve</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>&lt;!--Source--></con:name>
-          <con:value/>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectName</con:name>
-          <con:value>1.1</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
-          <con:value>DCM</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
-          <con:value>2</con:value>
-        </con:property>
-        <con:property>
-          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
-          <con:value>R</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ActiveParticipant_Dest.@UserName</con:name>
-          <con:value>Karl Skagerberg</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@displayName</con:name>
-          <con:value>Report Number</con:value>
-        </con:property>
-        <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@value</con:name>
-          <con:value>1</con:value>
+          <con:name>ActiveParticipant.RoleIDCode.@displayName</con:name>
+          <con:value>Human Requestor</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Dest.@AlternativeUserID</con:name>
           <con:value>19233@192.168.1.2</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@type</con:name>
-          <con:value>Repository Unique Id</con:value>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@type</con:name>
-          <con:value>Repository Unique Id</con:value>
+          <con:name>ActiveParticipant_Dest.@NetworkAccessPointTypeCode</con:name>
+          <con:value>1</con:value>
         </con:property>
         <con:property>
-          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
-          <con:value>RFC-3881</con:value>
+          <con:name>ActiveParticipant_Dest.@UserID</con:name>
+          <con:value>http://www.w3.org/2005/08/addressing/anonymous</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserIsRequestor</con:name>
+          <con:value>true</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@code</con:name>
+          <con:value>110152</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest.RoleIDCode.@displayName</con:name>
+          <con:value>Destination</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Dest_Initiator.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@AlternativeUserID</con:name>
+          <con:value>19233@192.168.1.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointID</con:name>
+          <con:value>localhost</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@NetworkAccessPointTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserID</con:name>
+          <con:value>https://localhost:8181/Gateway/DocumentRetrieve/3_0/NhinService/RespondingGateway_Retrieve_Service/DocRetrieve</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserIsRequestor</con:name>
+          <con:value>false</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.@UserName</con:name>
+          <con:value>Karl Skagerberg</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@code</con:name>
+          <con:value>110153</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ActiveParticipant_Source.RoleIDCode.@displayName</con:name>
+          <con:value>Source</con:value>
         </con:property>
         <con:property>
           <con:name>ActiveParticipant_Source_g0.@UserID</con:name>
@@ -17933,8 +17637,200 @@ nhinc.FileUtils.updateProperty(context.findProperty('GatewayPropDir'),context.fi
           <con:value>https://localhost:8181/Gateway/DocumentRetrieve/3_0/NhinService/RespondingGateway_Retrieve_Service/DocRetrieve</con:value>
         </con:property>
         <con:property>
-          <con:name>auditLogStatus</con:name>
-          <con:value>true</con:value>
+          <con:name>AuditMessage.xmlns</con:name>
+          <con:value>http://nhinc.services.com/schema/auditmessage</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditEnterpriseSiteID</con:name>
+          <con:value>DoD</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceID</con:name>
+          <con:value>urn:oid:1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>AuditSourceIdentification.@AuditSourceTypeCode</con:name>
+          <con:value>1010</con:value>
+        </con:property>
+        <con:property>
+          <con:name>CorrectedRemoteHCID</con:name>
+          <con:value>urn:oid:2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>endDate</con:name>
+          <con:value>2015-11-14T01:33:36Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventActionCode</con:name>
+          <con:value>C</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventDateTime</con:name>
+          <con:value>2015-04-02T13:47:30.199Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.@EventOutcomeIndicator</con:name>
+          <con:value>0</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@code</con:name>
+          <con:value>110107</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@codeSystemName</con:name>
+          <con:value>DCM</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventID.@displayName</con:name>
+          <con:value>Import</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@code</con:name>
+          <con:value>ITI-39</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@codeSystemName</con:name>
+          <con:value>IHE Transactions</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification.EventTypeCode.@displayName</con:name>
+          <con:value>Cross Gateway Retrieve</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.@EventActionCode</con:name>
+          <con:value>R</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@code</con:name>
+          <con:value>110106</con:value>
+        </con:property>
+        <con:property>
+          <con:name>EventIdentification_Responder.EventID.@displayName</con:name>
+          <con:value>Export</con:value>
+        </con:property>
+        <con:property>
+          <con:name>expireDate</con:name>
+          <con:value>2015-12-14T00:00:00Z</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectID</con:name>
+          <con:value>500000000^^^&amp;1.1&amp;ISO</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCode</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@type</con:name>
+          <con:value>Repository Unique Id</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail.@value</con:name>
+          <con:value>ihe:RepositoryUniqueId</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail_one.@type</con:name>
+          <con:value>ihe:homeCommunityID</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectDetail_one.@value</con:name>
+          <con:value>homeCommunityID</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Patient Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectName</con:name>
+          <con:value>anonymus</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification.ParticipantObjectQuery</con:name>
+          <con:value>unknown</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectDataLifeCycle</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectID</con:name>
+          <con:value>1.123407.777777</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectSensitivity</con:name>
+          <con:value/>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCode</con:name>
+          <con:value>2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.@ParticipantObjectTypeCodeRole</con:name>
+          <con:value>3</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@type</con:name>
+          <con:value>Repository Unique Id</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail.@value</con:name>
+          <con:value>1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@type</con:name>
+          <con:value>ihe:homeCommunityID</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectDetail_1.@value</con:name>
+          <con:value>urn:oid:2.2</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@code</con:name>
+          <con:value>9</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@codeSystemName</con:name>
+          <con:value>RFC-3881</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectIDTypeCode.@displayName</con:name>
+          <con:value>Report Number</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectName</con:name>
+          <con:value>1.1</con:value>
+        </con:property>
+        <con:property>
+          <con:name>ParticipantObjectIdentification_Document.ParticipantObjectQuery</con:name>
+          <con:value>unknown</con:value>
+        </con:property>
+        <con:property>
+          <con:name>sigDate</con:name>
+          <con:value>11/14/2015 01:23:36</con:value>
+        </con:property>
+        <con:property>
+          <con:name>startDate</con:name>
+          <con:value>2015-11-14T01:23:36Z</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -18327,19 +18223,19 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2015-11-12T17:20:26Z</con:value>
+          <con:value>2015-11-14T01:23:53Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2015-11-12T17:30:26Z</con:value>
+          <con:value>2015-11-14T01:33:53Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/12/2015 17:20:26</con:value>
+          <con:value>11/14/2015 01:23:53</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2015-12-12T00:00:00Z</con:value>
+          <con:value>2015-12-14T00:00:00Z</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -18402,6 +18298,10 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
     <con:property>
       <con:name>AsyncMsgTable</con:name>
       <con:value>asyncmsgrepo</con:value>
+    </con:property>
+    <con:property>
+      <con:name>auditLoggingStatusFileName</con:name>
+      <con:value>audit.properties</con:value>
     </con:property>
     <con:property>
       <con:name>AuditRepoDB</con:name>
@@ -18477,7 +18377,7 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
     </con:property>
     <con:property>
       <con:name>GatewayPropDir</con:name>
-      <con:value>C:\jboss-as-7.1.1.Final\modules\org\connectopensource\configuration\main</con:value>
+      <con:value/>
     </con:property>
     <con:property>
       <con:name>Gender</con:name>
@@ -18578,10 +18478,6 @@ nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.pr
     <con:property>
       <con:name>ZipCode</con:name>
       <con:value>12345</con:value>
-    </con:property>
-    <con:property>
-      <con:name>auditLoggingStatusFileName</con:name>
-      <con:value>audit.properties</con:value>
     </con:property>
   </con:properties>
   <con:afterLoadScript>def propertiesFilename = project.path[0..(project.path.size()-4)] + 'properties'

--- a/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/RetrieveDocumentAuditLog.properties
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/AuditLogging-Standard/RetrieveDocumentAuditLog.properties
@@ -29,6 +29,7 @@ ActiveParticipant.RoleIDCode.@displayName=Human Requestor
 ActiveParticipant_Source_g1.@UserID=https://localhost:8181/Gateway/DocumentRetrieve/3_0/NhinService/RespondingGateway_Retrieve_Service/DocRetrieve
 ActiveParticipant_Source_g0.@UserID=https://localhost:8181/Gateway/DocumentRetrieve/2_0/NhinService/RespondingGateway_Retrieve_Service/DocRetrieve
 ActiveParticipant_Source.@UserIsRequestor=false
+ActiveParticipant_Source.@UserName=Karl Skagerberg
 ActiveParticipant_Source.@NetworkAccessPointID=localhost
 ActiveParticipant_Source.@NetworkAccessPointTypeCode=2
 ActiveParticipant_Source.RoleIDCode.@code=110153


### PR DESCRIPTION
Regression suite Audit Logging On / Off changes are done for both Standard and Passthrough mode. Assertions and check is made to see whether audit logging is off and on for each service. Based on audit logging status from audit.properties check is made to verify number of database entries.
With this ticket, changes related to FHAC-654 is also done as a part of this commit. Changes are made for both Standard and Passthrough mode for replacing communityid with remoteHcid and messageType with direction field
