### PR TITLE
FHAC-633, added audit eleemnts for AdminGUI Audit view

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/transform/audit/AdminDistTransforms.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/transform/audit/AdminDistTransforms.java
@@ -34,6 +34,7 @@ import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.common.nhinccommon.UserType;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import gov.hhs.fha.nhinc.util.HomeCommunityMap;
 import oasis.names.tc.emergency.edxl.de._1.EDXLDistribution;
 import org.apache.log4j.Logger;
@@ -105,8 +106,8 @@ public class AdminDistTransforms {
         result.setEventID(auditMsg.getEventIdentification().getEventID().getDisplayName());
         result.setEventOutcomeIndicator(auditMsg.getEventIdentification().getEventOutcomeIndicator());
         result.setEventTimestamp(auditMsg.getEventIdentification().getEventDateTime());
-
         result.setAssertion(assertion);
+        result.setRelatesTo(getRelatesTo(assertion));
         LOG.trace("Exiting ADTransform-getLogEventRequestType() method.");
 
         return result;
@@ -173,4 +174,9 @@ public class AdminDistTransforms {
     protected String getHomeCommunityFromMapping() {
         return HomeCommunityMap.getLocalHomeCommunityId();
     }
+
+    private String getRelatesTo(AssertionType assertion) {
+        return NullChecker.isNotNullish(assertion.getRelatesToList()) ? assertion.getRelatesToList().get(0) : null;
+    }
+
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/transform/audit/AdminDistTransforms.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/transform/audit/AdminDistTransforms.java
@@ -101,6 +101,8 @@ public class AdminDistTransforms {
         result.setAuditMessage(auditMsg);
         result.setDirection(_interface + " " + direction);
         result.setRemoteHCID(HomeCommunityMap.formatHomeCommunityId(communityId));
+        result.setEventType(NhincConstants.NHIN_ADMIN_DIST_SERVICE_NAME);
+        result.setAssertion(assertion);
         LOG.trace("Exiting ADTransform-getLogEventRequestType() method.");
 
         return result;

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/transform/audit/AdminDistTransforms.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/transform/audit/AdminDistTransforms.java
@@ -102,6 +102,10 @@ public class AdminDistTransforms {
         result.setDirection(_interface + " " + direction);
         result.setRemoteHCID(HomeCommunityMap.formatHomeCommunityId(communityId));
         result.setEventType(NhincConstants.NHIN_ADMIN_DIST_SERVICE_NAME);
+        result.setEventID(auditMsg.getEventIdentification().getEventID().getDisplayName());
+        result.setEventOutcomeIndicator(auditMsg.getEventIdentification().getEventOutcomeIndicator());
+        result.setEventTimestamp(auditMsg.getEventIdentification().getEventDateTime());
+
         result.setAssertion(assertion);
         LOG.trace("Exiting ADTransform-getLogEventRequestType() method.");
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/MessageGeneratorUtils.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/MessageGeneratorUtils.java
@@ -30,6 +30,7 @@ import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunityType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import gov.hhs.fha.nhinc.transform.marshallers.Marshaller;
 import gov.hhs.fha.nhinc.wsa.WSAHeaderHelper;
 import javax.xml.namespace.QName;
@@ -157,4 +158,24 @@ public class MessageGeneratorUtils {
         return (PRPAIN201305UV02) marshaller.unmarshallJaxbElement(jaxbElement, HL7_V3_CONTEXT);
     }
 
+    /**
+     * This message generates a messageId if it is not present and set it in the assertion object. If present it will
+     * format the messsageId and return it back.
+     *
+     * Note: AssertionType is a required element. It can never be null.
+     *
+     * @param assertion
+     * @return messageId
+     */
+    public String generateMessageId(AssertionType assertion) {
+        WSAHeaderHelper wsaHelper = new WSAHeaderHelper();
+        String assertionMsgId = assertion.getMessageId();
+        if (NullChecker.isNotNullish(assertionMsgId)) {
+            return wsaHelper.fixMessageIDPrefix(assertionMsgId);
+        } else {
+            assertionMsgId = wsaHelper.generateMessageID();
+            assertion.setMessageId(assertionMsgId);
+            return assertionMsgId;
+        }
+    }
 }

--- a/Product/Production/Gateway/CONNECTGatewayWeb/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryUnsecuredImpl.java
+++ b/Product/Production/Gateway/CONNECTGatewayWeb/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryUnsecuredImpl.java
@@ -75,7 +75,7 @@ public class AuditRepositoryUnsecuredImpl {
                     secureRequest.setEventOutcomeIndicator(logEventRequest.getEventOutcomeIndicator());
                     secureRequest.setEventTimestamp(logEventRequest.getEventTimestamp());
                     secureRequest.setUserId(logEventRequest.getUserId());
-
+                    secureRequest.setRelatesTo(logEventRequest.getRelatesTo());
                     response = processor.logAudit(secureRequest, assertion);
                 } catch (Exception ex) {
                     String message = "Error occurred calling AuditRepositoryImpl.logAudit. Error: " + ex.getMessage();

--- a/Product/Production/Gateway/CONNECTGatewayWeb/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryUnsecuredImpl.java
+++ b/Product/Production/Gateway/CONNECTGatewayWeb/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryUnsecuredImpl.java
@@ -70,7 +70,7 @@ public class AuditRepositoryUnsecuredImpl {
                     secureRequest.setAuditMessage(logEventRequest.getAuditMessage());
                     secureRequest.setDirection(logEventRequest.getDirection());
                     secureRequest.setRemoteHCID(logEventRequest.getRemoteHCID());
-
+                    secureRequest.setEventType(logEventRequest.getEventType());
                     response = processor.logAudit(secureRequest, assertion);
                 } catch (Exception ex) {
                     String message = "Error occurred calling AuditRepositoryImpl.logAudit. Error: " + ex.getMessage();

--- a/Product/Production/Gateway/CONNECTGatewayWeb/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryUnsecuredImpl.java
+++ b/Product/Production/Gateway/CONNECTGatewayWeb/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryUnsecuredImpl.java
@@ -71,6 +71,11 @@ public class AuditRepositoryUnsecuredImpl {
                     secureRequest.setDirection(logEventRequest.getDirection());
                     secureRequest.setRemoteHCID(logEventRequest.getRemoteHCID());
                     secureRequest.setEventType(logEventRequest.getEventType());
+                    secureRequest.setEventID(logEventRequest.getEventID());
+                    secureRequest.setEventOutcomeIndicator(logEventRequest.getEventOutcomeIndicator());
+                    secureRequest.setEventTimestamp(logEventRequest.getEventTimestamp());
+                    secureRequest.setUserId(logEventRequest.getUserId());
+
                     response = processor.logAudit(secureRequest, assertion);
                 } catch (Exception ex) {
                     String message = "Error occurred calling AuditRepositoryImpl.logAudit. Error: " + ex.getMessage();

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
@@ -104,8 +104,8 @@ public abstract class AuditTransforms<T, K> {
             serviceName);
         auditMsg = getParticipantObjectIdentificationForRequest(request, assertion, auditMsg);
 
-        return buildLogEventRequestType(auditMsg, direction, _interface,
-            getMessageCommunityId(assertion, target, isRequesting));
+        return buildLogEventRequestType(auditMsg, direction, getMessageCommunityId(assertion, target, isRequesting),
+            serviceName, assertion);
     }
 
     /**
@@ -132,8 +132,8 @@ public abstract class AuditTransforms<T, K> {
             serviceName);
         auditMsg = getParticipantObjectIdentificationForResponse(request, response, assertion, auditMsg);
 
-        return buildLogEventRequestType(auditMsg, direction, _interface,
-            getMessageCommunityId(assertion, target, isRequesting));
+        return buildLogEventRequestType(auditMsg, direction, getMessageCommunityId(assertion, target, isRequesting),
+            serviceName, assertion);
     }
 
     /**
@@ -543,14 +543,16 @@ public abstract class AuditTransforms<T, K> {
         return userName;
     }
 
-    private LogEventRequestType buildLogEventRequestType(AuditMessageType auditMsg, String direction,
-        String _interface, String communityId) {
+    private LogEventRequestType buildLogEventRequestType(AuditMessageType auditMsg, String direction, String communityId,
+        String serviceName, AssertionType assertion) {
 
         LogEventRequestType result = new LogEventRequestType();
         result.setAuditMessage(auditMsg);
         result.setDirection(direction);
         //set the target community identifier
         result.setRemoteHCID(communityId);
+        result.setEventType(serviceName);
+        result.setAssertion(assertion);
         return result;
     }
 

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
@@ -563,6 +563,7 @@ public abstract class AuditTransforms<T, K> {
         result.setEventOutcomeIndicator(outcome);
         result.setUserId(userId);
         result.setEventTimestamp(eventDate);
+        result.setRelatesTo(getRelatesTo(assertion));
         return result;
     }
 
@@ -633,5 +634,9 @@ public abstract class AuditTransforms<T, K> {
             }
         }
         return null;
+    }
+
+    private String getRelatesTo(AssertionType assertion) {
+        return NullChecker.isNotNullish(assertion.getRelatesToList()) ? assertion.getRelatesToList().get(0) : null;
     }
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryOrchImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryOrchImpl.java
@@ -188,16 +188,16 @@ public class AuditRepositoryOrchImpl {
         auditRec.setDirection(mess.getDirection());
         auditRec.setMessage(getBlobFromAuditMessage(mess.getAuditMessage()));
 
-        XMLGregorianCalendar xMLCalDate = eventIdentification.getEventDateTime();
+        XMLGregorianCalendar xMLCalDate = mess.getEventTimestamp();
         if (xMLCalDate != null) {
             auditRec.setEventTimeStamp(convertXMLGregorianCalendarToDate(xMLCalDate));
         }
-        auditRec.setOutcome(eventIdentification.getEventOutcomeIndicator().intValue());
+        auditRec.setOutcome(mess.getEventOutcomeIndicator().intValue());
         auditRec.setEventType(mess.getEventType());
-        auditRec.setEventId(eventIdentification.getEventID().getDisplayName());
+        auditRec.setEventId(mess.getEventID());
         auditRec.setMessageId(MessageGeneratorUtils.getInstance().generateMessageId(assertion));
         auditRec.setRelatesTo(getRelatesTo(assertion));
-        auditRec.setUserId(getUserId(mess.getAuditMessage().getActiveParticipant()));
+        auditRec.setUserId(mess.getUserId());
 
         return auditRec;
     }
@@ -296,18 +296,5 @@ public class AuditRepositoryOrchImpl {
 
     private String getRelatesTo(AssertionType assertion) {
         return NullChecker.isNotNullish(assertion.getRelatesToList()) ? assertion.getRelatesToList().get(0) : null;
-    }
-
-    private String getUserId(List<ActiveParticipant> participants) {
-        for (ActiveParticipant obj : participants) {
-            if (NullChecker.isNotNullish(obj.getRoleIDCode())
-                && !obj.getRoleIDCode().get(0).getDisplayName().equals(
-                AuditTransformsConstants.ACTIVE_PARTICIPANT_ROLE_CODE_SOURCE_DISPLAY_NAME)
-                && !obj.getRoleIDCode().get(0).getDisplayName().equals(
-                AuditTransformsConstants.ACTIVE_PARTICIPANT_ROLE_CODE_DESTINATION_DISPLAY_NAME)) {
-                return obj.getUserID();
-            }
-        }
-        return null;
     }
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryOrchImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryOrchImpl.java
@@ -56,12 +56,9 @@ import org.apache.log4j.Logger;
 import org.hibernate.Hibernate;
 
 import com.services.nhinc.schema.auditmessage.AuditMessageType;
-import com.services.nhinc.schema.auditmessage.AuditMessageType.ActiveParticipant;
-import com.services.nhinc.schema.auditmessage.EventIdentificationType;
 import com.services.nhinc.schema.auditmessage.FindAuditEventsResponseType;
 import com.services.nhinc.schema.auditmessage.FindAuditEventsType;
 import com.services.nhinc.schema.auditmessage.ObjectFactory;
-import gov.hhs.fha.nhinc.audit.AuditTransformsConstants;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import gov.hhs.fha.nhinc.util.MessageGeneratorUtils;
 import java.io.IOException;
@@ -175,8 +172,6 @@ public class AuditRepositoryOrchImpl {
 
     protected final AuditRepositoryRecord createDBAuditObj(LogEventSecureRequestType mess, AssertionType assertion) {
         AuditRepositoryRecord auditRec = new AuditRepositoryRecord();
-        EventIdentificationType eventIdentification = mess.getAuditMessage().getEventIdentification();
-
         String eventCommunityId = mess.getRemoteHCID();
         LOG.info("auditSourceID : " + eventCommunityId);
         if (NullChecker.isNotNullish(eventCommunityId)) {
@@ -196,7 +191,7 @@ public class AuditRepositoryOrchImpl {
         auditRec.setEventType(mess.getEventType());
         auditRec.setEventId(mess.getEventID());
         auditRec.setMessageId(MessageGeneratorUtils.getInstance().generateMessageId(assertion));
-        auditRec.setRelatesTo(getRelatesTo(assertion));
+        auditRec.setRelatesTo(mess.getRelatesTo());
         auditRec.setUserId(mess.getUserId());
 
         return auditRec;
@@ -292,9 +287,5 @@ public class AuditRepositoryOrchImpl {
         Date eventDate = cal.getTime();
         LOG.info("eventDate -> " + eventDate);
         return eventDate;
-    }
-
-    private String getRelatesTo(AssertionType assertion) {
-        return NullChecker.isNotNullish(assertion.getRelatesToList()) ? assertion.getRelatesToList().get(0) : null;
     }
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyJavaImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyJavaImpl.java
@@ -56,6 +56,10 @@ public class AuditRepositoryProxyJavaImpl implements AuditRepositoryProxy {
         securedRequest.setDirection(request.getDirection());
         securedRequest.setRemoteHCID(request.getRemoteHCID());
         securedRequest.setEventType(request.getEventType());
+        securedRequest.setEventID(request.getEventID());
+        securedRequest.setEventOutcomeIndicator(request.getEventOutcomeIndicator());
+        securedRequest.setEventTimestamp(request.getEventTimestamp());
+        securedRequest.setUserId(request.getUserId());
         return getAuditRepositoryOrchImpl().logAudit(securedRequest, assertion);
 
     }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyJavaImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyJavaImpl.java
@@ -55,7 +55,7 @@ public class AuditRepositoryProxyJavaImpl implements AuditRepositoryProxy {
         securedRequest.setAuditMessage(request.getAuditMessage());
         securedRequest.setDirection(request.getDirection());
         securedRequest.setRemoteHCID(request.getRemoteHCID());
-
+        securedRequest.setEventType(request.getEventType());
         return getAuditRepositoryOrchImpl().logAudit(securedRequest, assertion);
 
     }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyJavaImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyJavaImpl.java
@@ -60,6 +60,7 @@ public class AuditRepositoryProxyJavaImpl implements AuditRepositoryProxy {
         securedRequest.setEventOutcomeIndicator(request.getEventOutcomeIndicator());
         securedRequest.setEventTimestamp(request.getEventTimestamp());
         securedRequest.setUserId(request.getUserId());
+        securedRequest.setRelatesTo(request.getRelatesTo());
         return getAuditRepositoryOrchImpl().logAudit(securedRequest, assertion);
 
     }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyWebServiceSecuredImpl.java
@@ -73,6 +73,10 @@ public class AuditRepositoryProxyWebServiceSecuredImpl implements AuditRepositor
         secureRequest.setDirection(request.getDirection());
         secureRequest.setRemoteHCID(request.getRemoteHCID());
         secureRequest.setEventType(request.getEventType());
+        secureRequest.setEventID(request.getEventID());
+        secureRequest.setEventOutcomeIndicator(request.getEventOutcomeIndicator());
+        secureRequest.setEventTimestamp(request.getEventTimestamp());
+        secureRequest.setUserId(request.getUserId());
 
         try {
             String url = oProxyHelper.getUrlLocalHomeCommunity(NhincConstants.AUDIT_REPO_SECURE_SERVICE_NAME);

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyWebServiceSecuredImpl.java
@@ -72,6 +72,7 @@ public class AuditRepositoryProxyWebServiceSecuredImpl implements AuditRepositor
         }
         secureRequest.setDirection(request.getDirection());
         secureRequest.setRemoteHCID(request.getRemoteHCID());
+        secureRequest.setEventType(request.getEventType());
 
         try {
             String url = oProxyHelper.getUrlLocalHomeCommunity(NhincConstants.AUDIT_REPO_SECURE_SERVICE_NAME);

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyWebServiceSecuredImpl.java
@@ -77,6 +77,7 @@ public class AuditRepositoryProxyWebServiceSecuredImpl implements AuditRepositor
         secureRequest.setEventOutcomeIndicator(request.getEventOutcomeIndicator());
         secureRequest.setEventTimestamp(request.getEventTimestamp());
         secureRequest.setUserId(request.getUserId());
+        secureRequest.setRelatesTo(request.getRelatesTo());
 
         try {
             String url = oProxyHelper.getUrlLocalHomeCommunity(NhincConstants.AUDIT_REPO_SECURE_SERVICE_NAME);

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformsTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/audit/transform/AuditTransformsTest.java
@@ -116,6 +116,12 @@ public abstract class AuditTransformsTest<T, K> {
             eventIdentificationType.getEventTypeCode().get(0).getCodeSystemName());
         assertEquals("EventTypeCode.DisplayName mismatch", getAuditTransforms().getServiceEventTypeCodeDisplayName(),
             eventIdentificationType.getEventTypeCode().get(0).getDisplayName());
+        assertEquals("EventId.DisplayName and LogEventRequestType.EventId mismatch",
+            eventIdentificationType.getEventID().getDisplayName(), request.getEventID());
+        assertEquals("EventOutcomeIndicator and LogEventRequestType.EventOutcomeIndicator mismatch",
+            eventIdentificationType.getEventOutcomeIndicator().toString(), request.getEventOutcomeIndicator().toString());
+        assertEquals("EventDateTime and LogEventRequestType.EventTimestamp mismatch",
+            eventIdentificationType.getEventDateTime(), request.getEventTimestamp());
     }
 
     /**
@@ -151,6 +157,8 @@ public abstract class AuditTransformsTest<T, K> {
                 .getCodeSystemName(), userActiveParticipant.getRoleIDCode().get(0).getCodeSystemName());
             assertEquals("RoleIDCode.DisplayName mismatch", assertion.getUserInfo().getRoleCoded().getDisplayName(),
                 userActiveParticipant.getRoleIDCode().get(0).getDisplayName());
+            assertEquals("UserID and LogEventRequestType.UserId mismatch", userActiveParticipant.getUserID(),
+                request.getUserId());
         }
 
         // TODO: Should there be an else case here?

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryOrchImplTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryOrchImplTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.auditrepository.nhinc;
+
+import com.services.nhinc.schema.auditmessage.AuditMessageType;
+import com.services.nhinc.schema.auditmessage.EventIdentificationType;
+import gov.hhs.fha.nhinc.auditrepository.hibernate.AuditRepositoryRecord;
+import gov.hhs.fha.nhinc.common.auditlog.LogEventSecureRequestType;
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.UserType;
+import gov.hhs.fha.nhinc.transform.audit.AuditDataTransformHelper;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
+
+/**
+ *
+ * @author tjafri
+ */
+public class AuditRepositoryOrchImplTest {
+
+    private final String EVENT_TYPE = "TestService";
+    private final String EVENT_ID_CODE = "110112";
+    private final String EVENT_ID_CODE_SYS_NAME = "DCM";
+    private final String EVENT_ID_CODE_DISP_NAME = "Query";
+    private final String DIRECTION = "Outbound";
+    private final String EVENT_ACTION_CODE = "R";
+    private final String USER_NAME = "testUser";
+    private final String RELATES_TO_1 = "val1";
+    private final String RELATES_TO_2 = "val2";
+
+    @Test
+    public void testCreateDBAuditObj() {
+        AuditRepositoryOrchImpl auditRepo = new AuditRepositoryOrchImpl();
+        LogEventSecureRequestType auditObj = createLogEventSecureObj();
+        AssertionType assertion = createAssertion();
+        AuditRepositoryRecord dbRec = auditRepo.createDBAuditObj(auditObj, assertion);
+        assertEquals("AuditRepositoryRecord.Direction mismatch", dbRec.getDirection(), auditObj.getDirection());
+        assertEquals("AuditRepositoryRecord.EventType mismatch", dbRec.getEventType(), EVENT_TYPE);
+        assertEquals("AuditRepositoryRecord.EventId mismatch", dbRec.getEventId(), EVENT_ID_CODE_DISP_NAME);
+        assertEquals("AuditRepositoryRecord.RelatesTo", dbRec.getRelatesTo(), RELATES_TO_1);
+        assertNotNull("AuditRepositoryRecord.MessageId", dbRec.getMessageId());
+    }
+
+    private LogEventSecureRequestType createLogEventSecureObj() {
+        LogEventSecureRequestType logObj = new LogEventSecureRequestType();
+        logObj.setEventType(EVENT_TYPE);
+        logObj.setDirection(DIRECTION);
+        logObj.setAuditMessage(createAuditMessageType());
+        return logObj;
+    }
+
+    private AuditMessageType createAuditMessageType() {
+        AuditMessageType auditObj = new AuditMessageType();
+        auditObj.setEventIdentification(createEventIdentification());
+        return auditObj;
+    }
+
+    private EventIdentificationType createEventIdentification() {
+        return AuditDataTransformHelper.createEventIdentification(EVENT_ACTION_CODE, 0,
+            AuditDataTransformHelper.createEventId(EVENT_ID_CODE, null, EVENT_ID_CODE_SYS_NAME, EVENT_ID_CODE_DISP_NAME));
+    }
+
+    private AssertionType createAssertion() {
+        AssertionType assertion = new AssertionType();
+        UserType user = new UserType();
+        user.setUserName(USER_NAME);
+        assertion.setUserInfo(user);
+        assertion.getRelatesToList().add(RELATES_TO_1);
+        assertion.getRelatesToList().add(RELATES_TO_2);
+        return assertion;
+    }
+}

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryOrchImplTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryOrchImplTest.java
@@ -68,9 +68,12 @@ public class AuditRepositoryOrchImplTest {
 
     private LogEventSecureRequestType createLogEventSecureObj() {
         LogEventSecureRequestType logObj = new LogEventSecureRequestType();
+        AuditMessageType audit = createAuditMessageType();
         logObj.setEventType(EVENT_TYPE);
         logObj.setDirection(DIRECTION);
-        logObj.setAuditMessage(createAuditMessageType());
+        logObj.setAuditMessage(audit);
+        logObj.setEventID(audit.getEventIdentification().getEventID().getDisplayName());
+        logObj.setEventOutcomeIndicator(audit.getEventIdentification().getEventOutcomeIndicator());
         return logObj;
     }
 

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryOrchImplTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryOrchImplTest.java
@@ -56,8 +56,8 @@ public class AuditRepositoryOrchImplTest {
     @Test
     public void testCreateDBAuditObj() {
         AuditRepositoryOrchImpl auditRepo = new AuditRepositoryOrchImpl();
-        LogEventSecureRequestType auditObj = createLogEventSecureObj();
         AssertionType assertion = createAssertion();
+        LogEventSecureRequestType auditObj = createLogEventSecureObj(assertion);
         AuditRepositoryRecord dbRec = auditRepo.createDBAuditObj(auditObj, assertion);
         assertEquals("AuditRepositoryRecord.Direction mismatch", dbRec.getDirection(), auditObj.getDirection());
         assertEquals("AuditRepositoryRecord.EventType mismatch", dbRec.getEventType(), EVENT_TYPE);
@@ -66,7 +66,7 @@ public class AuditRepositoryOrchImplTest {
         assertNotNull("AuditRepositoryRecord.MessageId", dbRec.getMessageId());
     }
 
-    private LogEventSecureRequestType createLogEventSecureObj() {
+    private LogEventSecureRequestType createLogEventSecureObj(AssertionType assertion) {
         LogEventSecureRequestType logObj = new LogEventSecureRequestType();
         AuditMessageType audit = createAuditMessageType();
         logObj.setEventType(EVENT_TYPE);
@@ -74,6 +74,7 @@ public class AuditRepositoryOrchImplTest {
         logObj.setAuditMessage(audit);
         logObj.setEventID(audit.getEventIdentification().getEventID().getDisplayName());
         logObj.setEventOutcomeIndicator(audit.getEventIdentification().getEventOutcomeIndicator());
+        logObj.setRelatesTo(assertion.getRelatesToList().get(0));
         return logObj;
     }
 

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/request/inbound/AbstractInboundCORE_X12DSGenericBatchRequest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/request/inbound/AbstractInboundCORE_X12DSGenericBatchRequest.java
@@ -103,7 +103,7 @@ public abstract class AbstractInboundCORE_X12DSGenericBatchRequest implements In
     protected void auditResponseToNhin(COREEnvelopeBatchSubmission request,
         COREEnvelopeBatchSubmissionResponse oResponsse, AssertionType assertion, Properties webContextProperties) {
         auditLogger.auditResponseMessage(request, oResponsse, assertion, null,
-            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE,
+            NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE,
             webContextProperties, NhincConstants.CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME);
     }
 }

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/inbound/AbstractInboundCORE_X12DSGenericBatchResponse.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/inbound/AbstractInboundCORE_X12DSGenericBatchResponse.java
@@ -109,7 +109,7 @@ public abstract class AbstractInboundCORE_X12DSGenericBatchResponse implements I
     protected void auditResponseToNhin(COREEnvelopeBatchSubmission request,
         COREEnvelopeBatchSubmissionResponse oResponse, AssertionType assertion, Properties webContextProperties) {
         getAuditLogger().auditResponseMessage(request, oResponse, assertion, null,
-            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE,
+            NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE,
             webContextProperties, NhincConstants.CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME);
     }
 

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/realtime/inbound/AbstractInboundCORE_X12DSRealTime.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/realtime/inbound/AbstractInboundCORE_X12DSRealTime.java
@@ -95,7 +95,7 @@ public abstract class AbstractInboundCORE_X12DSRealTime implements InboundCORE_X
     protected void auditResponseToNhin(COREEnvelopeRealTimeRequest request, COREEnvelopeRealTimeResponse oResponsse,
         AssertionType assertion, Properties webContextProperties) {
         getAuditLogger().auditResponseMessage(request, oResponsse, assertion, null,
-            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE,
+            NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE,
             webContextProperties, NhincConstants.CORE_X12DS_REALTIME_SERVICE_NAME);
     }
 

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/request/inbound/PassthroughInboundCORE_X12DSGenericBatchReqTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/request/inbound/PassthroughInboundCORE_X12DSGenericBatchReqTest.java
@@ -72,7 +72,7 @@ public class PassthroughInboundCORE_X12DSGenericBatchReqTest {
         batchReq = new PassthroughInboundCORE_X12DSGenericBatchRequest(adpFactory, getAuditLogger(true));
         actualResposne = batchReq.batchSubmitTransaction(request, assertion, webContextProperties);
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResposne),
-            eq(assertion), isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            eq(assertion), isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME),
             any(COREX12BatchSubmissionAuditTransforms.class));
@@ -85,7 +85,7 @@ public class PassthroughInboundCORE_X12DSGenericBatchReqTest {
         batchReq = new PassthroughInboundCORE_X12DSGenericBatchRequest(adpFactory, getAuditLogger(false));
         actualResposne = batchReq.batchSubmitTransaction(request, assertion, webContextProperties);
         verify(mockEJBLogger, never()).auditResponseMessage(eq(request), eq(actualResposne),
-            eq(assertion), isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            eq(assertion), isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME),
             any(COREX12BatchSubmissionAuditTransforms.class));

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/inbound/PassthroughInboundCORE_X12DSGenericBatchResponseTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/inbound/PassthroughInboundCORE_X12DSGenericBatchResponseTest.java
@@ -76,7 +76,7 @@ public class PassthroughInboundCORE_X12DSGenericBatchResponseTest {
 
         assertEquals("Actual and Expected response differ", actualResponse, expectedResponse);
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME), any(COREX12BatchSubmissionAuditTransforms.class));
     }
@@ -94,7 +94,7 @@ public class PassthroughInboundCORE_X12DSGenericBatchResponseTest {
 
         assertEquals("Actual and Expected response differ", actualResponse, expectedResponse);
         verify(mockEJBLogger, never()).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME), any(COREX12BatchSubmissionAuditTransforms.class));
     }

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/realtime/inbound/PassthroughInboundCORE_X12DSRealTimeTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/realtime/inbound/PassthroughInboundCORE_X12DSRealTimeTest.java
@@ -71,7 +71,7 @@ public class PassthroughInboundCORE_X12DSRealTimeTest {
         COREEnvelopeRealTimeResponse actualResponse = realTimeX12.realTimeTransaction(request, assertion,
             webContextProperties);
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.CORE_X12DS_REALTIME_SERVICE_NAME), any(COREX12RealTimeAuditTransforms.class));
     }
@@ -87,7 +87,7 @@ public class PassthroughInboundCORE_X12DSRealTimeTest {
         COREEnvelopeRealTimeResponse actualResponse = realTimeX12.realTimeTransaction(request, assertion,
             webContextProperties);
         verify(mockEJBLogger, never()).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.CORE_X12DS_REALTIME_SERVICE_NAME), any(COREX12RealTimeAuditTransforms.class));
     }

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/inbound/AbstractInboundDocQuery.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/inbound/AbstractInboundDocQuery.java
@@ -37,7 +37,7 @@ import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryResponse;
 public abstract class AbstractInboundDocQuery implements InboundDocQuery {
 
     abstract AdhocQueryResponse processDocQuery(AdhocQueryRequest msg, AssertionType assertion, String hcid,
-            Properties webContextProperties);
+        Properties webContextProperties);
     protected DocQueryAuditLogger auditLogger;
 
     AbstractInboundDocQuery() {
@@ -57,14 +57,14 @@ public abstract class AbstractInboundDocQuery implements InboundDocQuery {
      */
     @Override
     public AdhocQueryResponse respondingGatewayCrossGatewayQuery(AdhocQueryRequest msg, AssertionType assertion,
-            Properties webContextProperties) {
+        Properties webContextProperties) {
         String senderHcid = null;
         if (msg != null) {
             senderHcid = HomeCommunityMap.getCommunityIdFromAssertion(assertion);
         }
 
         AdhocQueryResponse resp = processDocQuery(msg, assertion, HomeCommunityMap.getLocalHomeCommunityId(),
-                webContextProperties);
+            webContextProperties);
 
         auditResponseToNhin(msg, resp, assertion, senderHcid, webContextProperties);
 
@@ -72,9 +72,9 @@ public abstract class AbstractInboundDocQuery implements InboundDocQuery {
     }
 
     protected void auditResponseToNhin(AdhocQueryRequest request, AdhocQueryResponse msg, AssertionType assertion,
-            String requestCommunityID, Properties webContextProperties) {
+        String requestCommunityID, Properties webContextProperties) {
         auditLogger.auditResponseMessage(request, msg, assertion, null,
-                NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE,
-                Boolean.FALSE, webContextProperties, NhincConstants.DOC_QUERY_SERVICE_NAME);
+            NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE,
+            Boolean.FALSE, webContextProperties, NhincConstants.DOC_QUERY_SERVICE_NAME);
     }
 }

--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/audit/transform/DocQueryAuditTransformsTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/audit/transform/DocQueryAuditTransformsTest.java
@@ -144,6 +144,8 @@ public class DocQueryAuditTransformsTest extends AuditTransformsTest<AdhocQueryR
         testAuditSourceIdentification(auditRequest.getAuditMessage().getAuditSourceIdentification(), assertion);
         testCreateActiveParticipantFromUser(auditRequest, Boolean.TRUE, assertion);
         assertParticipantObjectIdentification(auditRequest, hcid);
+        assertEquals("AuditMessage.Request ServiceName mismatch", auditRequest.getEventType(),
+            NhincConstants.DOC_QUERY_SERVICE_NAME);
     }
 
     private void transformResponseToAuditMsg(AdhocQueryRequest request, AdhocQueryResponse response, String hcid) throws
@@ -184,6 +186,8 @@ public class DocQueryAuditTransformsTest extends AuditTransformsTest<AdhocQueryR
         testGetActiveParticipantSource(auditResponse, Boolean.FALSE, webContextProperties, LOCAL_IP);
         testGetActiveParticipantDestination(auditResponse, Boolean.FALSE, webContextProperties, REMOTE_OBJECT_URL);
         assertParticipantObjectIdentification(auditResponse, hcid);
+        assertEquals("AuditMessage.Response ServiceName mismatch", auditResponse.getEventType(),
+            NhincConstants.DOC_QUERY_SERVICE_NAME);
     }
 
     private void assertParticipantObjectIdentification(LogEventRequestType auditRequest, String hcid) {

--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/inbound/InboundDocQueryTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/inbound/InboundDocQueryTest.java
@@ -107,7 +107,7 @@ public class InboundDocQueryTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), eq(target),
-            eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
+            eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.FALSE), eq(webContextProperties), eq(NhincConstants.DOC_QUERY_SERVICE_NAME),
             any(DocQueryAuditTransforms.class));
     }

--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/inbound/PassthroughInboundDocQueryTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/inbound/PassthroughInboundDocQueryTest.java
@@ -27,18 +27,7 @@
 package gov.hhs.fha.nhinc.docquery.inbound;
 
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
-import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
-import gov.hhs.fha.nhinc.docquery.audit.transform.DocQueryAuditTransforms;
-import static gov.hhs.fha.nhinc.docquery.inbound.InboundDocQueryTest.request;
-import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
-import java.util.Properties;
-import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryResponse;
-
 import org.junit.Test;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isNull;
-import static org.mockito.Mockito.verify;
 
 /**
  * @author akong

--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/inbound/StandardInboundDocQueryTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/inbound/StandardInboundDocQueryTest.java
@@ -112,7 +112,7 @@ public class StandardInboundDocQueryTest extends InboundDocQueryTest {
         assertEquals(NhincConstants.XDS_REGISTRY_ERROR_SEVERITY_ERROR, actualResponse.getRegistryErrorList()
             .getRegistryError().get(0).getSeverity());
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
-            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.DOC_QUERY_SERVICE_NAME), any(DocQueryAuditTransforms.class));
     }

--- a/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/inbound/BaseInboundDocRetrieve.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/inbound/BaseInboundDocRetrieve.java
@@ -63,6 +63,8 @@ public abstract class BaseInboundDocRetrieve implements InboundDocRetrieve {
      *
      * @param body
      * @param assertion
+     * @param webContextProperties
+     * @return
      */
     abstract public InboundDocRetrieveOrchestratable createInboundOrchestrable(RetrieveDocumentSetRequestType body,
         AssertionType assertion, Properties webContextProperties);
@@ -70,11 +72,12 @@ public abstract class BaseInboundDocRetrieve implements InboundDocRetrieve {
     public void auditResponse(RetrieveDocumentSetRequestType request, RetrieveDocumentSetResponseType response,
         AssertionType assertion, Properties webContextProperties) {
         getAuditLogger().auditResponseMessage(request, response, assertion, null,
-            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE,
+            NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE,
             Boolean.FALSE, webContextProperties,
             NhincConstants.DOC_RETRIEVE_SERVICE_NAME);
     }
 
+    @Override
     public RetrieveDocumentSetResponseType respondingGatewayCrossGatewayRetrieve(RetrieveDocumentSetRequestType body,
         AssertionType assertion, Properties webContextProperties) {
 

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/audit/transform/DocRetrieveAuditTransformsTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/audit/transform/DocRetrieveAuditTransformsTest.java
@@ -141,6 +141,8 @@ public class DocRetrieveAuditTransformsTest
         testAuditSourceIdentification(auditRequest.getAuditMessage().getAuditSourceIdentification(), assertion);
         testCreateActiveParticipantFromUser(auditRequest, Boolean.TRUE, assertion);
         assertParticipantObjectIdentification(auditRequest, assertion);
+        assertEquals("AuditMessage.Request ServiceName mismatch", auditRequest.getEventType(),
+            NhincConstants.DOC_RETRIEVE_SERVICE_NAME);
     }
 
     private void transformResponseToAuditMsg(RetrieveDocumentSetRequestType request,
@@ -182,6 +184,8 @@ public class DocRetrieveAuditTransformsTest
         testAuditSourceIdentification(auditResponse.getAuditMessage().getAuditSourceIdentification(), assertion);
         testGetActiveParticipantDestination(auditResponse, Boolean.FALSE, webContextProperties, REMOTE_IP);
         assertParticipantObjectIdentification(auditResponse, assertion);
+        assertEquals("AuditMessage.Response ServiceName mismatch", auditResponse.getEventType(),
+            NhincConstants.DOC_RETRIEVE_SERVICE_NAME);
     }
 
     private void assertParticipantObjectIdentification(LogEventRequestType auditRequest, AssertionType assertion) {

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/inbound/PassthroughInboundDocRetrieveTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/inbound/PassthroughInboundDocRetrieveTest.java
@@ -101,7 +101,7 @@ public class PassthroughInboundDocRetrieveTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.DOC_RETRIEVE_SERVICE_NAME), any(DocRetrieveAuditTransforms.class));
 
@@ -145,7 +145,7 @@ public class PassthroughInboundDocRetrieveTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(mockEJBLogger, never()).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.DOC_RETRIEVE_SERVICE_NAME), any(DocRetrieveAuditTransforms.class));
 

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/inbound/StandardInboundDocRetrieveTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/inbound/StandardInboundDocRetrieveTest.java
@@ -116,7 +116,7 @@ public class StandardInboundDocRetrieveTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.DOC_RETRIEVE_SERVICE_NAME), any(DocRetrieveAuditTransforms.class));
 
@@ -161,7 +161,7 @@ public class StandardInboundDocRetrieveTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(mockEJBLogger, never()).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.DOC_RETRIEVE_SERVICE_NAME), any(DocRetrieveAuditTransforms.class));
     }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/AbstractInboundDocSubmission.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/AbstractInboundDocSubmission.java
@@ -40,8 +40,8 @@ public abstract class AbstractInboundDocSubmission implements InboundDocSubmissi
     abstract RegistryResponseType processDocSubmission(ProvideAndRegisterDocumentSetRequestType body,
         AssertionType assertion, Properties webContextProperties);
 
-    private DocSubmissionAuditLogger auditLogger;
-    private AdapterDocSubmissionProxyObjectFactory adapterFactory;
+    private DocSubmissionAuditLogger auditLogger = null;
+    private AdapterDocSubmissionProxyObjectFactory adapterFactory = null;
 
     public AbstractInboundDocSubmission(AdapterDocSubmissionProxyObjectFactory adapterFactory,
         DocSubmissionAuditLogger auditLogger) {
@@ -69,7 +69,7 @@ public abstract class AbstractInboundDocSubmission implements InboundDocSubmissi
     protected void auditResponse(ProvideAndRegisterDocumentSetRequestType request, RegistryResponseType response,
         AssertionType assertion, Properties webContextProperties) {
         auditLogger.auditResponseMessage(request, response, assertion, null,
-            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE,
+            NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE,
             Boolean.FALSE, webContextProperties, NhincConstants.NHINC_XDR_SERVICE_NAME);
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/AbstractInboundDocSubmissionDeferredRequest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/AbstractInboundDocSubmissionDeferredRequest.java
@@ -40,8 +40,8 @@ public abstract class AbstractInboundDocSubmissionDeferredRequest implements Inb
     abstract XDRAcknowledgementType processDocSubmissionRequest(ProvideAndRegisterDocumentSetRequestType body,
         AssertionType assertion);
 
-    private DocSubmissionDeferredRequestAuditLogger auditLogger;
-    private AdapterDocSubmissionDeferredRequestProxyObjectFactory adapterFactory;
+    private DocSubmissionDeferredRequestAuditLogger auditLogger = null;
+    private AdapterDocSubmissionDeferredRequestProxyObjectFactory adapterFactory = null;
 
     public AbstractInboundDocSubmissionDeferredRequest(
         AdapterDocSubmissionDeferredRequestProxyObjectFactory adapterFactory,
@@ -75,7 +75,7 @@ public abstract class AbstractInboundDocSubmissionDeferredRequest implements Inb
 
     protected void auditResponse(ProvideAndRegisterDocumentSetRequestType request, XDRAcknowledgementType response,
         AssertionType assertion, Properties webContextProperties) {
-        auditLogger.auditResponseMessage(request, response, assertion, null, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
+        auditLogger.auditResponseMessage(request, response, assertion, null, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
             NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE, webContextProperties,
             NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME);
     }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/AbstractInboundDocSubmissionDeferredResponse.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/AbstractInboundDocSubmissionDeferredResponse.java
@@ -39,8 +39,8 @@ public abstract class AbstractInboundDocSubmissionDeferredResponse implements In
 
     abstract XDRAcknowledgementType processDocSubmissionResponse(RegistryResponseType body, AssertionType assertion);
 
-    private DSDeferredResponseAuditLogger auditLogger;
-    private AdapterDocSubmissionDeferredResponseProxyObjectFactory adapterFactory;
+    private DSDeferredResponseAuditLogger auditLogger = null;
+    private AdapterDocSubmissionDeferredResponseProxyObjectFactory adapterFactory = null;
 
     public AbstractInboundDocSubmissionDeferredResponse(
         AdapterDocSubmissionDeferredResponseProxyObjectFactory adapterFactory, DSDeferredResponseAuditLogger auditLogger) {
@@ -66,7 +66,7 @@ public abstract class AbstractInboundDocSubmissionDeferredResponse implements In
 
     protected void auditResponse(RegistryResponseType body, XDRAcknowledgementType response, AssertionType assertion,
         Properties webContextProperties) {
-        auditLogger.auditResponseMessage(body, response, assertion, null, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
+        auditLogger.auditResponseMessage(body, response, assertion, null, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
             NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE, webContextProperties,
             NhincConstants.NHINC_XDR_RESPONSE_SERVICE_NAME);
     }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/audit/transform/DSDeferredResponseAuditTransformsTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/audit/transform/DSDeferredResponseAuditTransformsTest.java
@@ -94,6 +94,8 @@ public class DSDeferredResponseAuditTransformsTest extends
         testGetActiveParticipantSource(auditRequest, Boolean.TRUE, null, REQUEST_REMOTE_IP);
         assertEquals("AuditMessage.Request direction mismatch", auditRequest.getDirection(),
             NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
+        assertEquals("AuditMessage.Request ServiceName mismatch", auditRequest.getEventType(),
+            NhincConstants.NHINC_XDR_RESPONSE_SERVICE_NAME);
     }
 
     @Override
@@ -161,6 +163,8 @@ public class DSDeferredResponseAuditTransformsTest extends
         assertEquals(
             "AuditMessage.Response direction mismatch", auditResponse.getDirection(),
             NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
+        assertEquals("AuditMessage.Response ServiceName mismatch", auditResponse.getEventType(),
+            NhincConstants.NHINC_XDR_RESPONSE_SERVICE_NAME);
     }
 
     @Override

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/audit/transform/DocSubmissionAuditTransformsTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/audit/transform/DocSubmissionAuditTransformsTest.java
@@ -105,6 +105,8 @@ public class DocSubmissionAuditTransformsTest extends AuditTransformsTest<
         assertParticipantObjectIdentification(auditRequest.getAuditMessage());
         assertEquals("AuditMessage.Request direction mismatch", auditRequest.getDirection(),
             NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
+        assertEquals("AuditMessage.Request ServiceName mismatch", auditRequest.getEventType(),
+            NhincConstants.NHINC_XDR_SERVICE_NAME);
     }
 
     @Test
@@ -147,6 +149,8 @@ public class DocSubmissionAuditTransformsTest extends AuditTransformsTest<
         assertParticipantObjectIdentification(auditResponse.getAuditMessage());
         assertEquals("AuditMessage.Response direction mismatch", auditResponse.getDirection(),
             NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
+        assertEquals("AuditMessage.Response ServiceName mismatch", auditResponse.getEventType(),
+            NhincConstants.NHINC_XDR_SERVICE_NAME);
     }
 
     @Override

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/audit/transform/DocSubmissionDeferredRequestAuditTransformsTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/audit/transform/DocSubmissionDeferredRequestAuditTransformsTest.java
@@ -106,6 +106,8 @@ public class DocSubmissionDeferredRequestAuditTransformsTest extends AuditTransf
         assertParticipantObjectIdentification(auditRequest.getAuditMessage());
         assertEquals("AuditMessage.Request direction mismatch", auditRequest.getDirection(),
             NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
+        assertEquals("AuditMessage.Request ServiceName mismatch", auditRequest.getEventType(),
+            NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME);
     }
 
     @Test
@@ -148,6 +150,8 @@ public class DocSubmissionDeferredRequestAuditTransformsTest extends AuditTransf
         assertParticipantObjectIdentification(auditResponse.getAuditMessage());
         assertEquals("AuditMessage.Response direction mismatch", auditResponse.getDirection(),
             NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION);
+        assertEquals("AuditMessage.Response ServiceName mismatch", auditResponse.getEventType(),
+            NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME);
     }
 
     @Override

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/PassthroughInboundDocSubmissionTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/PassthroughInboundDocSubmissionTest.java
@@ -86,7 +86,7 @@ public class PassthroughInboundDocSubmissionTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.NHINC_XDR_SERVICE_NAME), any(DocSubmissionAuditTransforms.class));
     }
@@ -108,7 +108,7 @@ public class PassthroughInboundDocSubmissionTest {
             .getRegistryError().get(0).getSeverity());
 
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.NHINC_XDR_SERVICE_NAME), any(DocSubmissionAuditTransforms.class));
     }
@@ -132,7 +132,7 @@ public class PassthroughInboundDocSubmissionTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(mockEJBLogger, never()).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.NHINC_XDR_SERVICE_NAME), any(DocSubmissionAuditTransforms.class));
     }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/StandardInboundDocSubmissionTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/StandardInboundDocSubmissionTest.java
@@ -115,7 +115,7 @@ public class StandardInboundDocSubmissionTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.NHINC_XDR_SERVICE_NAME), any(DocSubmissionAuditTransforms.class));
     }
@@ -149,7 +149,7 @@ public class StandardInboundDocSubmissionTest {
             .getRegistryError().get(0).getSeverity());
 
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.NHINC_XDR_SERVICE_NAME), any(DocSubmissionAuditTransforms.class));
     }
@@ -173,7 +173,7 @@ public class StandardInboundDocSubmissionTest {
             .getRegistryError().get(0).getSeverity());
 
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.NHINC_XDR_SERVICE_NAME), any(DocSubmissionAuditTransforms.class));
     }
@@ -225,7 +225,7 @@ public class StandardInboundDocSubmissionTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(mockEJBLogger, never()).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.NHINC_XDR_SERVICE_NAME), any(DocSubmissionAuditTransforms.class));
     }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/PassthroughInboundDocSubmissionDeferredRequestTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/PassthroughInboundDocSubmissionDeferredRequestTest.java
@@ -86,7 +86,7 @@ public class PassthroughInboundDocSubmissionDeferredRequestTest {
 
         assertSame(expectedResponse, actualResponse);
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
-            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME), any(DocSubmissionDeferredRequestAuditTransforms.class));
     }
@@ -112,7 +112,7 @@ public class PassthroughInboundDocSubmissionDeferredRequestTest {
             getRegistryErrorList().getRegistryError().get(0).getSeverity());
 
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
-            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME), any(DocSubmissionDeferredRequestAuditTransforms.class));
     }
@@ -136,7 +136,7 @@ public class PassthroughInboundDocSubmissionDeferredRequestTest {
 
         assertSame(expectedResponse, actualResponse);
         verify(mockEJBLogger, never()).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
-            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME), any(DocSubmissionDeferredRequestAuditTransforms.class));
     }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/StandardInboundDocSubmissionDeferredRequestTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/request/StandardInboundDocSubmissionDeferredRequestTest.java
@@ -117,7 +117,7 @@ public class StandardInboundDocSubmissionDeferredRequestTest {
 
         assertSame(expectedResponse, actualResponse);
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
-            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME), any(DocSubmissionDeferredRequestAuditTransforms.class));
     }
@@ -153,7 +153,7 @@ public class StandardInboundDocSubmissionDeferredRequestTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
-            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME), any(DocSubmissionDeferredRequestAuditTransforms.class));
     }
@@ -180,7 +180,7 @@ public class StandardInboundDocSubmissionDeferredRequestTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
-            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME), any(DocSubmissionDeferredRequestAuditTransforms.class));
     }
@@ -234,7 +234,7 @@ public class StandardInboundDocSubmissionDeferredRequestTest {
 
         assertSame(expectedResponse, actualResponse);
         verify(mockEJBLogger, never()).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
-            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME), any(DocSubmissionDeferredRequestAuditTransforms.class));
     }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/PassthroughInboundDocSubmissionDeferredResponseTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/PassthroughInboundDocSubmissionDeferredResponseTest.java
@@ -84,7 +84,7 @@ public class PassthroughInboundDocSubmissionDeferredResponseTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(mockEJBLogger).auditResponseMessage(eq(regResponse), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.NHINC_XDR_RESPONSE_SERVICE_NAME), any(DSDeferredResponseAuditTransforms.class));
     }
@@ -115,7 +115,7 @@ public class PassthroughInboundDocSubmissionDeferredResponseTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(mockEJBLogger, never()).auditResponseMessage(eq(regResponse), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.NHINC_XDR_RESPONSE_SERVICE_NAME), any(DSDeferredResponseAuditTransforms.class));
     }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/StandardInboundDocSubmissionDeferredResponseTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/inbound/deferred/response/StandardInboundDocSubmissionDeferredResponseTest.java
@@ -104,7 +104,7 @@ public class StandardInboundDocSubmissionDeferredResponseTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(mockEJBLogger).auditResponseMessage(eq(regResponse), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.NHINC_XDR_RESPONSE_SERVICE_NAME), any(DSDeferredResponseAuditTransforms.class));
     }
@@ -139,7 +139,7 @@ public class StandardInboundDocSubmissionDeferredResponseTest {
             .getRegistryErrorList().getRegistryError().get(0).getSeverity());
 
         verify(mockEJBLogger).auditResponseMessage(eq(regResponse), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.NHINC_XDR_RESPONSE_SERVICE_NAME), any(DSDeferredResponseAuditTransforms.class));
     }
@@ -162,7 +162,7 @@ public class StandardInboundDocSubmissionDeferredResponseTest {
             .getRegistryErrorList().getRegistryError().get(0).getSeverity());
 
         verify(mockEJBLogger).auditResponseMessage(eq(regResponse), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.NHINC_XDR_RESPONSE_SERVICE_NAME), any(DSDeferredResponseAuditTransforms.class));
     }
@@ -210,7 +210,7 @@ public class StandardInboundDocSubmissionDeferredResponseTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(mockEJBLogger, never()).auditResponseMessage(eq(regResponse), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.NHINC_XDR_RESPONSE_SERVICE_NAME), any(DSDeferredResponseAuditTransforms.class));
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/AbstractInboundPatientDiscovery.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/AbstractInboundPatientDiscovery.java
@@ -63,7 +63,7 @@ public abstract class AbstractInboundPatientDiscovery implements InboundPatientD
         Properties webContextProperties) {
 
         getAuditLogger().auditResponseMessage(request, response, assertion, null,
-            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE,
+            NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE,
             webContextProperties, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/request/AbstractInboundPatientDiscoveryDeferredRequest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/request/AbstractInboundPatientDiscoveryDeferredRequest.java
@@ -72,7 +72,7 @@ public abstract class AbstractInboundPatientDiscoveryDeferredRequest implements 
 
     protected void auditResponse(PRPAIN201305UV02 req, MCCIIN000002UV01 resp, AssertionType assertion,
         Properties webContextProperties) {
-        getAuditLogger().auditResponseMessage(req, resp, assertion, null, NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION,
+        getAuditLogger().auditResponseMessage(req, resp, assertion, null, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION,
             NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE, webContextProperties,
             NhincConstants.PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME);
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/AbstractInboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/AbstractInboundPatientDiscoveryDeferredResponse.java
@@ -78,7 +78,7 @@ public abstract class AbstractInboundPatientDiscoveryDeferredResponse implements
     protected void auditResponseToNhin(PRPAIN201306UV02 request, MCCIIN000002UV01 response, AssertionType assertion,
         Properties webContextProperties) {
         getAuditLogger().auditResponseMessage(request, response, assertion, null,
-            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE,
+            NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE,
             webContextProperties, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
     }
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransformsTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryAuditTransformsTest.java
@@ -125,6 +125,8 @@ public class PatientDiscoveryAuditTransformsTest extends AuditTransformsTest<PRP
         testAuditSourceIdentification(auditRequest.getAuditMessage().getAuditSourceIdentification(), assertion);
         testCreateActiveParticipantFromUser(auditRequest, Boolean.TRUE, assertion);
         assertParticipantObjectIdentification(auditRequest);
+        assertEquals("AuditMessage.Request ServiceName mismatch", auditRequest.getEventType(),
+            NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
     }
 
     @Test
@@ -161,7 +163,7 @@ public class PatientDiscoveryAuditTransformsTest extends AuditTransformsTest<PRP
         };
 
         AssertionType assertion = createAssertion();
-        LogEventRequestType auditRequest = transforms.transformResponseToAuditMsg(
+        LogEventRequestType auditResponse = transforms.transformResponseToAuditMsg(
             TestPatientDiscoveryMessageHelper.createPRPAIN201305UV02Request("Gallow", "Younger", "M", "01-12-2967",
                 "1.1", "D123401", "2.2", "abd3453dcd24wkkks545"), TestPatientDiscoveryMessageHelper.
             createPRPAIN201306UV02Response("Gallow", "Younger", "M", "01-12-2967", "1.1", "D123401", "2.2",
@@ -169,12 +171,14 @@ public class PatientDiscoveryAuditTransformsTest extends AuditTransformsTest<PRP
             NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE, webContextProperties,
             NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
 
-        testGetEventIdentificationType(auditRequest, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, Boolean.TRUE);
-        testGetActiveParticipantSource(auditRequest, Boolean.FALSE, webContextProperties, localIp);
-        testGetActiveParticipantDestination(auditRequest, Boolean.FALSE, webContextProperties, remoteObjectUrl);
-        testCreateActiveParticipantFromUser(auditRequest, Boolean.FALSE, assertion);
-        testAuditSourceIdentification(auditRequest.getAuditMessage().getAuditSourceIdentification(), assertion);
-        assertParticipantObjectIdentification(auditRequest);
+        testGetEventIdentificationType(auditResponse, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME, Boolean.TRUE);
+        testGetActiveParticipantSource(auditResponse, Boolean.FALSE, webContextProperties, localIp);
+        testGetActiveParticipantDestination(auditResponse, Boolean.FALSE, webContextProperties, remoteObjectUrl);
+        testCreateActiveParticipantFromUser(auditResponse, Boolean.FALSE, assertion);
+        testAuditSourceIdentification(auditResponse.getAuditMessage().getAuditSourceIdentification(), assertion);
+        assertParticipantObjectIdentification(auditResponse);
+        assertEquals("AuditMessage.Response ServiceName mismatch", auditResponse.getEventType(),
+            NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
     }
 
     private void assertParticipantObjectIdentification(LogEventRequestType auditRequest) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredRequestAuditTransformsTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredRequestAuditTransformsTest.java
@@ -110,6 +110,8 @@ public class PatientDiscoveryDeferredRequestAuditTransformsTest extends AuditTra
             .get(0));
         assertQueryParticipantObjectIdentification(auditRequest.getAuditMessage().getParticipantObjectIdentification().
             get(1));
+        assertEquals("AuditMessage.Request ServiceName mismatch", auditRequest.getEventType(),
+            NhincConstants.PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME);
     }
 
     @Test
@@ -166,6 +168,8 @@ public class PatientDiscoveryDeferredRequestAuditTransformsTest extends AuditTra
             .getAuditMessage().getParticipantObjectIdentification().size(), 1);
         assertQueryParticipantObjectIdentification(auditResponse.getAuditMessage().getParticipantObjectIdentification().
             get(0));
+        assertEquals("AuditMessage.Response ServiceName mismatch", auditResponse.getEventType(),
+            NhincConstants.PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME);
     }
 
     private void assertPatientParticipantObjectIdentification(ParticipantObjectIdentificationType participantPatient) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredResponseAuditTransformsTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredResponseAuditTransformsTest.java
@@ -69,31 +69,31 @@ public class PatientDiscoveryDeferredResponseAuditTransformsTest extends AuditTr
 
         PatientDiscoveryDeferredResponseAuditTransforms transforms
             = new PatientDiscoveryDeferredResponseAuditTransforms() {
-                @Override
-                protected String getLocalHostAddress() {
-                    return remoteIp;
-                }
+            @Override
+            protected String getLocalHostAddress() {
+                return remoteIp;
+            }
 
-                @Override
-                protected String getRemoteHostAddress(Properties webContextProperties) {
-                    if (webContextProperties != null && !webContextProperties.isEmpty() && webContextProperties
+            @Override
+            protected String getRemoteHostAddress(Properties webContextProperties) {
+                if (webContextProperties != null && !webContextProperties.isEmpty() && webContextProperties
                     .getProperty(NhincConstants.REMOTE_HOST_ADDRESS) != null) {
 
-                        return webContextProperties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS);
-                    }
-                    return AuditTransformsConstants.ACTIVE_PARTICIPANT_UNKNOWN_IP_ADDRESS;
+                    return webContextProperties.getProperty(NhincConstants.REMOTE_HOST_ADDRESS);
                 }
+                return AuditTransformsConstants.ACTIVE_PARTICIPANT_UNKNOWN_IP_ADDRESS;
+            }
 
-                @Override
-                protected String getWebServiceUrlFromRemoteObject(NhinTargetSystemType target, String serviceName) {
-                    return remoteObjectUrl;
-                }
+            @Override
+            protected String getWebServiceUrlFromRemoteObject(NhinTargetSystemType target, String serviceName) {
+                return remoteObjectUrl;
+            }
 
-                @Override
-                protected String getPDDeferredRequestInitiatorAddress() {
-                    return localIp;
-                }
-            };
+            @Override
+            protected String getPDDeferredRequestInitiatorAddress() {
+                return localIp;
+            }
+        };
 
         AssertionType assertion = createAssertion();
         LogEventRequestType auditRequest = transforms.transformRequestToAuditMsg(
@@ -108,6 +108,8 @@ public class PatientDiscoveryDeferredResponseAuditTransformsTest extends AuditTr
         testGetActiveParticipantDestination(auditRequest, Boolean.TRUE, webContextProperties, remoteObjectUrl);
         testAuditSourceIdentification(auditRequest.getAuditMessage().getAuditSourceIdentification(), assertion);
         assertParticipantObjectIdentification(auditRequest);
+        assertEquals("AuditMessage.Request ServiceName mismatch", auditRequest.getEventType(),
+            NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
     }
 
     /**
@@ -170,19 +172,21 @@ public class PatientDiscoveryDeferredResponseAuditTransformsTest extends AuditTr
         };
 
         AssertionType assertion = createAssertion();
-        LogEventRequestType auditRequest = transforms.transformResponseToAuditMsg(
+        LogEventRequestType auditResponse = transforms.transformResponseToAuditMsg(
             TestPatientDiscoveryMessageHelper.createPRPAIN201306UV02Response("Gallow", "Younger", "M", "01-12-2967",
                 "1.1", "D123401", "2.2", "abd3453dcd24wkkks545"), new MCCIIN000002UV01(), assertion, createNhinTarget(),
             NhincConstants.AUDIT_LOG_INBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.FALSE,
             webContextProperties, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
 
-        testGetEventIdentificationType(auditRequest, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME,
+        testGetEventIdentificationType(auditResponse, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME,
             Boolean.FALSE);
-        testGetActiveParticipantSource(auditRequest, Boolean.FALSE, webContextProperties, localIp);
-        testGetActiveParticipantDestination(auditRequest, Boolean.FALSE, webContextProperties, remoteObjectUrl);
-        testAuditSourceIdentification(auditRequest.getAuditMessage().getAuditSourceIdentification(), assertion);
-        testCreateActiveParticipantFromUser(auditRequest, Boolean.FALSE, assertion);
-        assertParticipantObjectIdentification(auditRequest);
+        testGetActiveParticipantSource(auditResponse, Boolean.FALSE, webContextProperties, localIp);
+        testGetActiveParticipantDestination(auditResponse, Boolean.FALSE, webContextProperties, remoteObjectUrl);
+        testAuditSourceIdentification(auditResponse.getAuditMessage().getAuditSourceIdentification(), assertion);
+        testCreateActiveParticipantFromUser(auditResponse, Boolean.FALSE, assertion);
+        assertParticipantObjectIdentification(auditResponse);
+        assertEquals("AuditMessage.Response ServiceName mismatch", auditResponse.getEventType(),
+            NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
     }
 
     private void assertParticipantObjectIdentification(LogEventRequestType auditRequest) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/PassthroughInboundPatientDiscoveryTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/PassthroughInboundPatientDiscoveryTest.java
@@ -81,7 +81,7 @@ public class PassthroughInboundPatientDiscoveryTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(mockEJBLogger).auditResponseMessage(any(PRPAIN201305UV02.class), any(PRPAIN201306UV02.class),
-            any(AssertionType.class), isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            any(AssertionType.class), isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME), any(PatientDiscoveryAuditTransforms.class));
     }
@@ -107,7 +107,7 @@ public class PassthroughInboundPatientDiscoveryTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(mockEJBLogger, never()).auditResponseMessage(any(PRPAIN201305UV02.class), any(PRPAIN201306UV02.class),
-            any(AssertionType.class), isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            any(AssertionType.class), isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME), any(PatientDiscoveryAuditTransforms.class));
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/StandardInboundPatientDiscoveryTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/StandardInboundPatientDiscoveryTest.java
@@ -95,7 +95,7 @@ public class StandardInboundPatientDiscoveryTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(mockEJBLogger).auditResponseMessage(any(PRPAIN201305UV02.class), any(PRPAIN201306UV02.class),
-            any(AssertionType.class), isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            any(AssertionType.class), isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME), any(PatientDiscoveryAuditTransforms.class));
     }
@@ -120,7 +120,7 @@ public class StandardInboundPatientDiscoveryTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(mockEJBLogger, never()).auditResponseMessage(any(PRPAIN201305UV02.class), any(PRPAIN201306UV02.class),
-            any(AssertionType.class), isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            any(AssertionType.class), isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME), any(PatientDiscoveryAuditTransforms.class));
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/request/PassthroughInboundPatientDiscoveryDeferredRequestTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/request/PassthroughInboundPatientDiscoveryDeferredRequestTest.java
@@ -80,7 +80,7 @@ public class PassthroughInboundPatientDiscoveryDeferredRequestTest {
 
         assertSame(expectedResponse, actualResponse);
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
-            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(
+            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(
             NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties), eq(
             NhincConstants.PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME), any(
                 PatientDiscoveryDeferredRequestAuditTransforms.class));
@@ -109,7 +109,7 @@ public class PassthroughInboundPatientDiscoveryDeferredRequestTest {
 
         assertSame(expectedResponse, actualResponse);
         verify(mockEJBLogger, never()).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
-            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(
+            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(
             NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties), eq(
             NhincConstants.PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME), any(
                 PatientDiscoveryDeferredRequestAuditTransforms.class));

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/request/StandardInboundPatientDiscoveryDeferredRequestTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/request/StandardInboundPatientDiscoveryDeferredRequestTest.java
@@ -110,7 +110,7 @@ public class StandardInboundPatientDiscoveryDeferredRequestTest {
 
         assertSame(expectedResponse, actualResponse);
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
-            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(
+            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(
             NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties), eq(
             NhincConstants.PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME), any(
                 PatientDiscoveryDeferredRequestAuditTransforms.class));
@@ -148,7 +148,7 @@ public class StandardInboundPatientDiscoveryDeferredRequestTest {
 
         assertSame(expectedErrorResponse, actualResponse);
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
-            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(
+            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(
             NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties), eq(
             NhincConstants.PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME), any(
                 PatientDiscoveryDeferredRequestAuditTransforms.class));
@@ -183,7 +183,7 @@ public class StandardInboundPatientDiscoveryDeferredRequestTest {
 
         assertSame(expectedResponse, actualResponse);
         verify(mockEJBLogger, never()).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion), isNull(
-            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(
+            NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION), eq(
             NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties), eq(
             NhincConstants.PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME), any(
                 PatientDiscoveryDeferredRequestAuditTransforms.class));

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/PassthroughInboundPatientDiscoveryDeferredResponseTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/PassthroughInboundPatientDiscoveryDeferredResponseTest.java
@@ -84,7 +84,7 @@ public class PassthroughInboundPatientDiscoveryDeferredResponseTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
             any(PatientDiscoveryDeferredResponseAuditTransforms.class));
@@ -114,7 +114,7 @@ public class PassthroughInboundPatientDiscoveryDeferredResponseTest {
         assertSame(expectedResponse, actualResponse);
 
         verify(mockEJBLogger, never()).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
             any(PatientDiscoveryDeferredResponseAuditTransforms.class));

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/StandardInboundPatientDiscoveryDeferredResponseTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/inbound/deferred/response/StandardInboundPatientDiscoveryDeferredResponseTest.java
@@ -139,7 +139,7 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
 
         // Verify audits
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
             any(PatientDiscoveryDeferredResponseAuditTransforms.class));
@@ -188,7 +188,7 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
             any(II.class));
 
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
             any(PatientDiscoveryDeferredResponseAuditTransforms.class));
@@ -224,7 +224,7 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
         assertEquals(request, policyReqArgument.getValue().getPRPAIN201306UV02());
 
         verify(mockEJBLogger).auditResponseMessage(eq(request), eq(errorResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
             any(PatientDiscoveryDeferredResponseAuditTransforms.class));
@@ -280,7 +280,7 @@ public class StandardInboundPatientDiscoveryDeferredResponseTest {
 
         // Verify audits
         verify(mockEJBLogger, never()).auditResponseMessage(eq(request), eq(actualResponse), eq(assertion),
-            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
+            isNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_INBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.FALSE), eq(webContextProperties),
             eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
             any(PatientDiscoveryDeferredResponseAuditTransforms.class));


### PR DESCRIPTION
1. Updated code to populate messageId, EventType, EventId, UserId, Outcome and relatesTo in auditRepository table.
2. Fixed src and test classes to populate direction for responding gateway as Inbound.
3. Fixed the AuditTransforms and AdminDistTransform classes to set assertion in LogEventRequestType object.  This was needed for unsecured Audit logging.

@alameluchidambaram , @vdmehta06  and @christophermay07 (optional)
