### PR TITLE
FHAC-633: Bug fix for messageId

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/async/AsyncMessageIdExtractor.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/async/AsyncMessageIdExtractor.java
@@ -27,6 +27,8 @@
 package gov.hhs.fha.nhinc.async;
 
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.nhinclib.NullChecker;
+import gov.hhs.fha.nhinc.wsa.WSAHeaderHelper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,6 +47,8 @@ import org.w3c.dom.Element;
  * @author JHOPPESC
  */
 public class AsyncMessageIdExtractor {
+
+    private final WSAHeaderHelper wsaHelper = new WSAHeaderHelper();
 
     protected Element getSoapHeaderElement(WebServiceContext context, String headerName) {
         if (context == null) {
@@ -95,7 +99,8 @@ public class AsyncMessageIdExtractor {
         List<String> relatesToId = new ArrayList<String>();
 
         Element element = getSoapHeaderElement(context, NhincConstants.HEADER_RELATESTO);
-        relatesToId.add(getFirstChildNodeValue(element));
+        String value = getFirstChildNodeValue(element);
+        relatesToId.add(NullChecker.isNotNullish(value) ? wsaHelper.fixMessageIDPrefix(value) : value);
 
         return relatesToId;
     }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/server/BaseService.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/server/BaseService.java
@@ -32,6 +32,7 @@ import gov.hhs.fha.nhinc.cxf.extraction.SAML2AssertionExtractor;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import gov.hhs.fha.nhinc.util.HomeCommunityMap;
+import gov.hhs.fha.nhinc.wsa.WSAHeaderHelper;
 import java.util.List;
 import java.util.Properties;
 import javax.servlet.http.HttpServletRequest;
@@ -49,6 +50,7 @@ import org.apache.cxf.ws.addressing.AddressingProperties;
 public abstract class BaseService {
 
     private AsyncMessageIdExtractor extractor = new AsyncMessageIdExtractor();
+    private final WSAHeaderHelper wsaHelper = new WSAHeaderHelper();
 
     protected AssertionType getAssertion(WebServiceContext context, AssertionType oAssertionIn) {
         AssertionType assertion = null;
@@ -67,6 +69,7 @@ public abstract class BaseService {
             List<String> relatesToList = extractor.getAsyncRelatesTo(context);
             if (NullChecker.isNotNullish(relatesToList)) {
                 assertion.getRelatesToList().add(extractor.getAsyncRelatesTo(context).get(0));
+                assertion = updatePrefixForRelatesToList(assertion);
             }
         }
 
@@ -144,5 +147,17 @@ public abstract class BaseService {
             webContextProperties.put(NhincConstants.INBOUND_REPLY_TO, getInboundReplyToHeader(context));
         }
         return webContextProperties;
+    }
+
+    private AssertionType updatePrefixForRelatesToList(AssertionType assertion) {
+        List<String> relatesToList = assertion.getRelatesToList();
+        if (NullChecker.isNotNullish(relatesToList)) {
+            for (int i = 0; i < relatesToList.size(); i++) {
+                if (NullChecker.isNotNullish(relatesToList.get(i))) {
+                    relatesToList.set(i, wsaHelper.fixMessageIDPrefix(relatesToList.get(i)));
+                }
+            }
+        }
+        return assertion;
     }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/transform/audit/AdminDistTransforms.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/transform/audit/AdminDistTransforms.java
@@ -109,6 +109,7 @@ public class AdminDistTransforms {
         result.setEventTimestamp(auditMsg.getEventIdentification().getEventDateTime());
         result.setAssertion(assertion);
         result.setRelatesTo(getRelatesTo(assertion));
+        result.setRequestMessageId(assertion.getMessageId());
         LOG.trace("Exiting ADTransform-getLogEventRequestType() method.");
 
         return result;

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/MessageGeneratorUtils.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/MessageGeneratorUtils.java
@@ -167,15 +167,16 @@ public class MessageGeneratorUtils {
      * @param assertion
      * @return messageId
      */
-    public String generateMessageId(AssertionType assertion) {
+    public AssertionType generateMessageId(AssertionType assertion) {
         WSAHeaderHelper wsaHelper = new WSAHeaderHelper();
-        String assertionMsgId = assertion.getMessageId();
-        if (NullChecker.isNotNullish(assertionMsgId)) {
-            return wsaHelper.fixMessageIDPrefix(assertionMsgId);
-        } else {
-            assertionMsgId = wsaHelper.generateMessageID();
-            assertion.setMessageId(assertionMsgId);
-            return assertionMsgId;
+        if (assertion != null) {
+            if (NullChecker.isNotNullish(assertion.getMessageId())) {
+                assertion.setMessageId(wsaHelper.fixMessageIDPrefix(assertion.getMessageId()));
+            } else {
+                assertion.setMessageId(wsaHelper.generateMessageID());
+                return assertion;
+            }
         }
+        return assertion;
     }
 }

--- a/Product/Production/Gateway/CONNECTGatewayWeb/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryUnsecuredImpl.java
+++ b/Product/Production/Gateway/CONNECTGatewayWeb/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryUnsecuredImpl.java
@@ -77,6 +77,7 @@ public class AuditRepositoryUnsecuredImpl {
                     secureRequest.setEventTimestamp(logEventRequest.getEventTimestamp());
                     secureRequest.setUserId(logEventRequest.getUserId());
                     secureRequest.setRelatesTo(logEventRequest.getRelatesTo());
+                    secureRequest.setRequestMessageId(logEventRequest.getRequestMessageId());
                     response = processor.logAudit(secureRequest, assertion);
                 } catch (Exception ex) {
                     String message = "Error occurred calling AuditRepositoryImpl.logAudit. Error: " + ex.getMessage();

--- a/Product/Production/Gateway/CONNECTGatewayWeb/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryUnsecuredImpl.java
+++ b/Product/Production/Gateway/CONNECTGatewayWeb/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryUnsecuredImpl.java
@@ -67,7 +67,7 @@ public class AuditRepositoryUnsecuredImpl {
                     AssertionType assertion = logEventRequest.getAssertion();
                     loadAssertion(assertion, context);
 
-                    response = processor.logAudit(createLogSecureEventRequestType(logEventRequest, assertion), assertion);
+                    response = processor.logAudit(createLogSecureEventRequestType(logEventRequest), assertion);
                 } catch (Exception ex) {
                     String message = "Error occurred calling AuditRepositoryImpl.logAudit. Error: " + ex.getMessage();
                     LOG.error(message, ex);
@@ -113,7 +113,7 @@ public class AuditRepositoryUnsecuredImpl {
 
     }
 
-    private LogEventSecureRequestType createLogSecureEventRequestType(LogEventRequestType request, AssertionType assertion) {
+    private LogEventSecureRequestType createLogSecureEventRequestType(LogEventRequestType request) {
         LogEventSecureRequestType secureRequest = new LogEventSecureRequestType();
         secureRequest.setAuditMessage(request.getAuditMessage());
         secureRequest.setDirection(request.getDirection());

--- a/Product/Production/Gateway/CONNECTGatewayWeb/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryUnsecuredImpl.java
+++ b/Product/Production/Gateway/CONNECTGatewayWeb/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryUnsecuredImpl.java
@@ -67,18 +67,7 @@ public class AuditRepositoryUnsecuredImpl {
                     AssertionType assertion = logEventRequest.getAssertion();
                     loadAssertion(assertion, context);
 
-                    LogEventSecureRequestType secureRequest = new LogEventSecureRequestType();
-                    secureRequest.setAuditMessage(logEventRequest.getAuditMessage());
-                    secureRequest.setDirection(logEventRequest.getDirection());
-                    secureRequest.setRemoteHCID(logEventRequest.getRemoteHCID());
-                    secureRequest.setEventType(logEventRequest.getEventType());
-                    secureRequest.setEventID(logEventRequest.getEventID());
-                    secureRequest.setEventOutcomeIndicator(logEventRequest.getEventOutcomeIndicator());
-                    secureRequest.setEventTimestamp(logEventRequest.getEventTimestamp());
-                    secureRequest.setUserId(logEventRequest.getUserId());
-                    secureRequest.setRelatesTo(logEventRequest.getRelatesTo());
-                    secureRequest.setRequestMessageId(logEventRequest.getRequestMessageId());
-                    response = processor.logAudit(secureRequest, assertion);
+                    response = processor.logAudit(createLogSecureEventRequestType(logEventRequest, assertion), assertion);
                 } catch (Exception ex) {
                     String message = "Error occurred calling AuditRepositoryImpl.logAudit. Error: " + ex.getMessage();
                     LOG.error(message, ex);
@@ -124,4 +113,18 @@ public class AuditRepositoryUnsecuredImpl {
 
     }
 
+    private LogEventSecureRequestType createLogSecureEventRequestType(LogEventRequestType request, AssertionType assertion) {
+        LogEventSecureRequestType secureRequest = new LogEventSecureRequestType();
+        secureRequest.setAuditMessage(request.getAuditMessage());
+        secureRequest.setDirection(request.getDirection());
+        secureRequest.setRemoteHCID(request.getRemoteHCID());
+        secureRequest.setEventType(request.getEventType());
+        secureRequest.setEventID(request.getEventID());
+        secureRequest.setEventOutcomeIndicator(request.getEventOutcomeIndicator());
+        secureRequest.setEventTimestamp(request.getEventTimestamp());
+        secureRequest.setUserId(request.getUserId());
+        secureRequest.setRelatesTo(request.getRelatesTo());
+        secureRequest.setRequestMessageId(request.getRequestMessageId());
+        return secureRequest;
+    }
 }

--- a/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/outbound/PassthroughOutboundAdminDistribution.java
+++ b/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/outbound/PassthroughOutboundAdminDistribution.java
@@ -54,11 +54,11 @@ public class PassthroughOutboundAdminDistribution implements OutboundAdminDistri
         this.adDelegate = adDelegate;
     }
 
-
     @Override
     public void sendAlertMessage(RespondingGatewaySendAlertMessageSecuredType message, AssertionType assertion,
-            NhinTargetCommunitiesType target) {
-        RespondingGatewaySendAlertMessageType request = msgUtils.convertToUnsecured(message, assertion, target);
+        NhinTargetCommunitiesType target) {
+        RespondingGatewaySendAlertMessageType request = msgUtils.convertToUnsecured(message,
+            MessageGeneratorUtils.getInstance().generateMessageId(assertion), target);
 
         sendAlertMessage(request, assertion, target);
     }
@@ -68,18 +68,18 @@ public class PassthroughOutboundAdminDistribution implements OutboundAdminDistri
      *
      * @param request
      * @param assertion
-     * @param target
+     * @param targetCommunities
      */
     @Override
     public void sendAlertMessage(RespondingGatewaySendAlertMessageType request, AssertionType assertion,
-            NhinTargetCommunitiesType targetCommunities) {
+        NhinTargetCommunitiesType targetCommunities) {
 
-    	NhinTargetSystemType target = msgUtils.convertFirstToNhinTargetSystemType(targetCommunities);
-        sendToNhin(request, assertion, target);
+        NhinTargetSystemType target = msgUtils.convertFirstToNhinTargetSystemType(targetCommunities);
+        sendToNhin(request, MessageGeneratorUtils.getInstance().generateMessageId(assertion), target);
     }
 
     private void sendToNhin(RespondingGatewaySendAlertMessageType request, AssertionType assertion,
-            NhinTargetSystemType target) {
+        NhinTargetSystemType target) {
 
         OutboundAdminDistributionOrchestratable orchestratable = new OutboundAdminDistributionOrchestratable(adDelegate);
         orchestratable.setRequest(request);

--- a/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/outbound/StandardOutboundAdminDistribution.java
+++ b/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/outbound/StandardOutboundAdminDistribution.java
@@ -43,7 +43,6 @@ import gov.hhs.fha.nhinc.common.nhinccommonentity.RespondingGatewaySendAlertMess
 import gov.hhs.fha.nhinc.connectmgr.ConnectionManagerCache;
 import gov.hhs.fha.nhinc.connectmgr.ConnectionManagerException;
 import gov.hhs.fha.nhinc.connectmgr.UrlInfo;
-import gov.hhs.fha.nhinc.event.DefaultEventDescriptionBuilder;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 
 import java.util.List;

--- a/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/outbound/StandardOutboundAdminDistribution.java
+++ b/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/outbound/StandardOutboundAdminDistribution.java
@@ -64,40 +64,36 @@ public class StandardOutboundAdminDistribution implements OutboundAdminDistribut
     /**
      * This method sends AlertMessage to the target.
      *
-     * @param message
-     *            SendAlertMessage received.
-     * @param assertion
-     *            Assertion received.
-     * @param target
-     *            NhinTargetCommunity received.
+     * @param message SendAlertMessage received.
+     * @param assertion Assertion received.
+     * @param target NhinTargetCommunity received.
      */
     @Override
     @OutboundProcessingEvent(beforeBuilder = ADRequestTransformingBuilder.class,
-            afterReturningBuilder = ADRequestTransformingBuilder.class, serviceType = "Admin Distribution",
-            version = "")
+        afterReturningBuilder = ADRequestTransformingBuilder.class, serviceType = "Admin Distribution",
+        version = "")
     public void sendAlertMessage(RespondingGatewaySendAlertMessageSecuredType message, AssertionType assertion,
-            NhinTargetCommunitiesType target) {
-        RespondingGatewaySendAlertMessageType unsecured = msgUtils.convertToUnsecured(message, assertion, target);
+        NhinTargetCommunitiesType target) {
+        RespondingGatewaySendAlertMessageType unsecured = msgUtils.convertToUnsecured(message,
+            MessageGeneratorUtils.getInstance().generateMessageId(assertion), target);
 
         this.sendAlertMessage(unsecured, assertion, target);
 
     }
 
     /**
-     * @param message
-     *            SendAlerMessage Received.
-     * @param assertion
-     *            Assertion received.
-     * @param target
-     *            NhinTargetCommunity received.
+     * @param message SendAlerMessage Received.
+     * @param assertion Assertion received.
+     * @param target NhinTargetCommunity received.
      */
     @Override
     @OutboundProcessingEvent(beforeBuilder = ADRequestTransformingBuilder.class,
-            afterReturningBuilder = ADRequestTransformingBuilder.class, serviceType = "Admin Distribution",
-            version = "")
+        afterReturningBuilder = ADRequestTransformingBuilder.class, serviceType = "Admin Distribution",
+        version = "")
     public void sendAlertMessage(RespondingGatewaySendAlertMessageType message, AssertionType assertion,
-            NhinTargetCommunitiesType target) {
-        auditMessage(message, assertion, NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
+        NhinTargetCommunitiesType target) {
+        auditMessage(message, MessageGeneratorUtils.getInstance().generateMessageId(assertion),
+            NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
 
         List<UrlInfo> urlInfoList = getEndpoints(target);
 
@@ -123,12 +119,9 @@ public class StandardOutboundAdminDistribution implements OutboundAdminDistribut
     /**
      * This method audits the AdminDist Entity Message.
      *
-     * @param message
-     *            SendAlertMessage received.
-     * @param assertion
-     *            Assertion received.
-     * @param direction
-     *            The direction can be either outbound or inbound.
+     * @param message SendAlertMessage received.
+     * @param assertion Assertion received.
+     * @param direction The direction can be either outbound or inbound.
      */
     protected void auditMessage(RespondingGatewaySendAlertMessageType message, AssertionType assertion, String direction) {
         AcknowledgementType ack = getAuditLogger().auditEntityAdminDist(message, assertion, direction);
@@ -159,8 +152,7 @@ public class StandardOutboundAdminDistribution implements OutboundAdminDistribut
     /**
      * This method returns the list of url's of targetCommunities.
      *
-     * @param targetCommunities
-     *            NhinTargetCommunities received.
+     * @param targetCommunities NhinTargetCommunities received.
      * @return list of urlInfo for target Communities.
      */
     protected List<UrlInfo> getEndpoints(NhinTargetCommunitiesType targetCommunities) {
@@ -168,7 +160,7 @@ public class StandardOutboundAdminDistribution implements OutboundAdminDistribut
 
         try {
             urlInfoList = ConnectionManagerCache.getInstance().getEndpointURLFromNhinTargetCommunities(
-                    targetCommunities, NhincConstants.NHIN_ADMIN_DIST_SERVICE_NAME);
+                targetCommunities, NhincConstants.NHIN_ADMIN_DIST_SERVICE_NAME);
         } catch (ConnectionManagerException ex) {
             LOG.error("Failed to obtain target URLs", ex);
         }
@@ -179,12 +171,9 @@ public class StandardOutboundAdminDistribution implements OutboundAdminDistribut
     /**
      * This method returns boolean for the policyCheck for a specific HCID.
      *
-     * @param request
-     *            SendAlertMessage received.
-     * @param assertion
-     *            Assertion received.
-     * @param hcid
-     *            homeCommunityId to check policy.
+     * @param request SendAlertMessage received.
+     * @param assertion Assertion received.
+     * @param hcid homeCommunityId to check policy.
      * @return true if checkpolicy is permit; else false.
      */
     protected boolean checkPolicy(RespondingGatewaySendAlertMessageType request, AssertionType assertion, String hcid) {
@@ -197,15 +186,12 @@ public class StandardOutboundAdminDistribution implements OutboundAdminDistribut
     /**
      * This method send message to Nhin Proxy.
      *
-     * @param newRequest
-     *            SendAlertMessage received.
-     * @param assertion
-     *            Assertion received.
-     * @param target
-     *            NhinTargetSystem received.
+     * @param newRequest SendAlertMessage received.
+     * @param assertion Assertion received.
+     * @param target NhinTargetSystem received.
      */
     protected void sendToNhinProxy(RespondingGatewaySendAlertMessageType newRequest, AssertionType assertion,
-            NhinTargetSystemType target) {
+        NhinTargetSystemType target) {
         LOG.debug("begin sendToNhinProxy");
         OutboundAdminDistributionDelegate adDelegate = getNewOutboundAdminDistributionDelegate();
         OutboundAdminDistributionOrchestratable orchestratable = new OutboundAdminDistributionOrchestratable(adDelegate);

--- a/Product/Production/Services/AdminDistributionCore/src/test/java/gov/hhs/fha/nhinc/admindistribution/outbound/PassthroughOutboundAdminDistributionTest.java
+++ b/Product/Production/Services/AdminDistributionCore/src/test/java/gov/hhs/fha/nhinc/admindistribution/outbound/PassthroughOutboundAdminDistributionTest.java
@@ -35,6 +35,7 @@ import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
 import gov.hhs.fha.nhinc.common.nhinccommonentity.RespondingGatewaySendAlertMessageSecuredType;
 import gov.hhs.fha.nhinc.common.nhinccommonentity.RespondingGatewaySendAlertMessageType;
+import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
 
@@ -52,7 +53,7 @@ public class PassthroughOutboundAdminDistributionTest {
         PassthroughOutboundAdminDistribution passthroughAdmin = new PassthroughOutboundAdminDistribution(adDelegate);
 
         passthroughAdmin.sendAlertMessage(request, assertion, targetCommunities);
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(adDelegate).process(any(OutboundAdminDistributionOrchestratable.class));
 
     }
@@ -69,7 +70,7 @@ public class PassthroughOutboundAdminDistributionTest {
         PassthroughOutboundAdminDistribution passthroughAdmin = new PassthroughOutboundAdminDistribution(adDelegate);
 
         passthroughAdmin.sendAlertMessage(request, assertion, targetCommunities);
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(adDelegate).process(any(OutboundAdminDistributionOrchestratable.class));
 
     }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
@@ -565,6 +565,7 @@ public abstract class AuditTransforms<T, K> {
         result.setUserId(userId);
         result.setEventTimestamp(eventDate);
         result.setRelatesTo(getRelatesTo(assertion));
+        result.setRequestMessageId(assertion.getMessageId());
         return result;
     }
 

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryOrchImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryOrchImpl.java
@@ -191,7 +191,7 @@ public class AuditRepositoryOrchImpl {
         auditRec.setOutcome(mess.getEventOutcomeIndicator().intValue());
         auditRec.setEventType(mess.getEventType());
         auditRec.setEventId(mess.getEventID());
-        auditRec.setMessageId(MessageGeneratorUtils.getInstance().generateMessageId(assertion));
+        auditRec.setMessageId(mess.getRequestMessageId());
         auditRec.setRelatesTo(mess.getRelatesTo());
         auditRec.setUserId(mess.getUserId());
 

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyJavaImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyJavaImpl.java
@@ -38,8 +38,6 @@ import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
  */
 public class AuditRepositoryProxyJavaImpl implements AuditRepositoryProxy {
 
-    private final LogEventSecureRequestType securedRequest = new LogEventSecureRequestType();
-
     protected AuditRepositoryOrchImpl getAuditRepositoryOrchImpl() {
         return new AuditRepositoryOrchImpl();
     }
@@ -52,6 +50,11 @@ public class AuditRepositoryProxyJavaImpl implements AuditRepositoryProxy {
      */
     @Override
     public AcknowledgementType auditLog(LogEventRequestType request, AssertionType assertion) {
+        return getAuditRepositoryOrchImpl().logAudit(createLogSecureEventRequestType(request), assertion);
+    }
+
+    private LogEventSecureRequestType createLogSecureEventRequestType(LogEventRequestType request) {
+        LogEventSecureRequestType securedRequest = new LogEventSecureRequestType();
         securedRequest.setAuditMessage(request.getAuditMessage());
         securedRequest.setDirection(request.getDirection());
         securedRequest.setRemoteHCID(request.getRemoteHCID());
@@ -62,7 +65,6 @@ public class AuditRepositoryProxyJavaImpl implements AuditRepositoryProxy {
         securedRequest.setUserId(request.getUserId());
         securedRequest.setRelatesTo(request.getRelatesTo());
         securedRequest.setRequestMessageId(request.getRequestMessageId());
-        return getAuditRepositoryOrchImpl().logAudit(securedRequest, assertion);
+        return securedRequest;
     }
-
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyJavaImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyJavaImpl.java
@@ -61,8 +61,8 @@ public class AuditRepositoryProxyJavaImpl implements AuditRepositoryProxy {
         securedRequest.setEventTimestamp(request.getEventTimestamp());
         securedRequest.setUserId(request.getUserId());
         securedRequest.setRelatesTo(request.getRelatesTo());
+        securedRequest.setRequestMessageId(request.getRequestMessageId());
         return getAuditRepositoryOrchImpl().logAudit(securedRequest, assertion);
-
     }
 
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyWebServiceSecuredImpl.java
@@ -55,8 +55,6 @@ public class AuditRepositoryProxyWebServiceSecuredImpl implements AuditRepositor
 
     private AcknowledgementType result = new AcknowledgementType();
 
-    private final LogEventSecureRequestType secureRequest = new LogEventSecureRequestType();
-
     private final String invokeMethodName = "logEvent";
 
     @Override
@@ -68,18 +66,7 @@ public class AuditRepositoryProxyWebServiceSecuredImpl implements AuditRepositor
             synchronized (result) {
                 return result;
             }
-        } else {
-            secureRequest.setAuditMessage(request.getAuditMessage());
         }
-        secureRequest.setDirection(request.getDirection());
-        secureRequest.setRemoteHCID(request.getRemoteHCID());
-        secureRequest.setEventType(request.getEventType());
-        secureRequest.setEventID(request.getEventID());
-        secureRequest.setEventOutcomeIndicator(request.getEventOutcomeIndicator());
-        secureRequest.setEventTimestamp(request.getEventTimestamp());
-        secureRequest.setUserId(request.getUserId());
-        secureRequest.setRelatesTo(request.getRelatesTo());
-        secureRequest.setRequestMessageId(request.getRequestMessageId());
         try {
             String url = oProxyHelper.getUrlLocalHomeCommunity(NhincConstants.AUDIT_REPO_SECURE_SERVICE_NAME);
 
@@ -93,7 +80,7 @@ public class AuditRepositoryProxyWebServiceSecuredImpl implements AuditRepositor
 
                 synchronized (result) {
                     result = (AcknowledgementType) client.invokePort(AuditRepositoryManagerSecuredPortType.class,
-                        invokeMethodName, secureRequest);
+                        invokeMethodName, createLogSecureEventRequestType(request));
                 }
             }
         } catch (Exception e) {
@@ -107,4 +94,18 @@ public class AuditRepositoryProxyWebServiceSecuredImpl implements AuditRepositor
         return result;
     }
 
+    private LogEventSecureRequestType createLogSecureEventRequestType(LogEventRequestType request) {
+        LogEventSecureRequestType secureRequest = new LogEventSecureRequestType();
+        secureRequest.setAuditMessage(request.getAuditMessage());
+        secureRequest.setDirection(request.getDirection());
+        secureRequest.setRemoteHCID(request.getRemoteHCID());
+        secureRequest.setEventType(request.getEventType());
+        secureRequest.setEventID(request.getEventID());
+        secureRequest.setEventOutcomeIndicator(request.getEventOutcomeIndicator());
+        secureRequest.setEventTimestamp(request.getEventTimestamp());
+        secureRequest.setUserId(request.getUserId());
+        secureRequest.setRelatesTo(request.getRelatesTo());
+        secureRequest.setRequestMessageId(request.getRequestMessageId());
+        return secureRequest;
+    }
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyWebServiceSecuredImpl.java
@@ -79,7 +79,7 @@ public class AuditRepositoryProxyWebServiceSecuredImpl implements AuditRepositor
         secureRequest.setEventTimestamp(request.getEventTimestamp());
         secureRequest.setUserId(request.getUserId());
         secureRequest.setRelatesTo(request.getRelatesTo());
-
+        secureRequest.setRequestMessageId(request.getRequestMessageId());
         try {
             String url = oProxyHelper.getUrlLocalHomeCommunity(NhincConstants.AUDIT_REPO_SECURE_SERVICE_NAME);
 

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryOrchImplTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryOrchImplTest.java
@@ -52,6 +52,7 @@ public class AuditRepositoryOrchImplTest {
     private final String USER_NAME = "testUser";
     private final String RELATES_TO_1 = "val1";
     private final String RELATES_TO_2 = "val2";
+    private final String MESSAGE_ID = "MessageId";
 
     @Test
     public void testCreateDBAuditObj() {
@@ -63,6 +64,7 @@ public class AuditRepositoryOrchImplTest {
         assertEquals("AuditRepositoryRecord.EventType mismatch", dbRec.getEventType(), EVENT_TYPE);
         assertEquals("AuditRepositoryRecord.EventId mismatch", dbRec.getEventId(), EVENT_ID_CODE_DISP_NAME);
         assertEquals("AuditRepositoryRecord.RelatesTo", dbRec.getRelatesTo(), RELATES_TO_1);
+        assertNotNull("AuditRepositoryRecord.MessageId", dbRec.getMessageId());
     }
 
     private LogEventSecureRequestType createLogEventSecureObj(AssertionType assertion) {
@@ -74,6 +76,7 @@ public class AuditRepositoryOrchImplTest {
         logObj.setEventID(audit.getEventIdentification().getEventID().getDisplayName());
         logObj.setEventOutcomeIndicator(audit.getEventIdentification().getEventOutcomeIndicator());
         logObj.setRelatesTo(assertion.getRelatesToList().get(0));
+        logObj.setRequestMessageId(MESSAGE_ID);
         return logObj;
     }
 

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryOrchImplTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditRepositoryOrchImplTest.java
@@ -63,7 +63,6 @@ public class AuditRepositoryOrchImplTest {
         assertEquals("AuditRepositoryRecord.EventType mismatch", dbRec.getEventType(), EVENT_TYPE);
         assertEquals("AuditRepositoryRecord.EventId mismatch", dbRec.getEventId(), EVENT_ID_CODE_DISP_NAME);
         assertEquals("AuditRepositoryRecord.RelatesTo", dbRec.getRelatesTo(), RELATES_TO_1);
-        assertNotNull("AuditRepositoryRecord.MessageId", dbRec.getMessageId());
     }
 
     private LogEventSecureRequestType createLogEventSecureObj(AssertionType assertion) {

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/request/outbound/PassthroughOutboundCORE_X12DSGenericBatchRequest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/request/outbound/PassthroughOutboundCORE_X12DSGenericBatchRequest.java
@@ -80,6 +80,7 @@ public class PassthroughOutboundCORE_X12DSGenericBatchRequest implements Outboun
         COREEnvelopeBatchSubmissionResponse oResponse = null;
         NhinTargetSystemType targetSystem = MessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(
             targets);
+        assertion = MessageGeneratorUtils.getInstance().generateMessageId(assertion);
         this.auditRequestToNhin(msg, assertion, targetSystem);
         OutboundCORE_X12DSGenericBatchRequestOrchestratable dsOrchestratable = createOrchestratable(dsDelegate, msg,
             targetSystem, assertion);

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/outbound/PassthroughOutboundCORE_X12DSGenericBatchResponse.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/outbound/PassthroughOutboundCORE_X12DSGenericBatchResponse.java
@@ -63,6 +63,7 @@ public class PassthroughOutboundCORE_X12DSGenericBatchResponse implements Outbou
         AssertionType assertion, NhinTargetCommunitiesType targets, UrlInfoType urlInfo) {
         NhinTargetSystemType targetSystem = MessageGeneratorUtils.getInstance().
             convertFirstToNhinTargetSystemType(targets);
+        assertion = MessageGeneratorUtils.getInstance().generateMessageId(assertion);
         this.auditRequestToNhin(msg, assertion, targetSystem);
         COREEnvelopeBatchSubmissionResponse oResponse;
         OutboundCORE_X12DSGenericBatchResponseDelegate localDelegate = getDelegate();

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/realtime/outbound/PassthroughOutboundCORE_X12DSRealTime.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/docsubmission/realtime/outbound/PassthroughOutboundCORE_X12DSRealTime.java
@@ -75,6 +75,7 @@ public class PassthroughOutboundCORE_X12DSRealTime implements OutboundCORE_X12DS
         NhinTargetCommunitiesType targets, UrlInfoType urlInfo) {
         NhinTargetSystemType targetSystem = MessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(
             targets);
+        assertion = MessageGeneratorUtils.getInstance().generateMessageId(assertion);
         this.auditRequestToNhin(body, assertion, targetSystem);
         OutboundCORE_X12DSRealTimeOrchestratable dsOrchestratable = createOrchestratable(getDelegate(), body,
             targetSystem, assertion);

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/request/outbound/PassthroughOutboundCORE_X12DSGenericBatchRequestTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/request/outbound/PassthroughOutboundCORE_X12DSGenericBatchRequestTest.java
@@ -39,6 +39,7 @@ import gov.hhs.fha.nhinc.corex12.docsubmission.genericbatch.request.entity.Outbo
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import java.util.Properties;
 import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeBatchSubmission;
+import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
@@ -69,6 +70,7 @@ public class PassthroughOutboundCORE_X12DSGenericBatchRequestTest {
         PassthroughOutboundCORE_X12DSGenericBatchRequest x12BatchReq = createGenericBatchRequest(getAuditLogger(true));
         when(mockDelegate.process(any(OutboundCORE_X12DSGenericBatchRequestOrchestratable.class))).thenReturn(mockOrch);
         x12BatchReq.batchSubmitTransaction(msg, assertion, targets, urlInfo);
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(msg), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME),
@@ -80,6 +82,7 @@ public class PassthroughOutboundCORE_X12DSGenericBatchRequestTest {
         PassthroughOutboundCORE_X12DSGenericBatchRequest x12BatchReq = createGenericBatchRequest(getAuditLogger(false));
         when(mockDelegate.process(any(OutboundCORE_X12DSGenericBatchRequestOrchestratable.class))).thenReturn(mockOrch);
         x12BatchReq.batchSubmitTransaction(msg, assertion, targets, urlInfo);
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger, never()).auditRequestMessage(eq(msg), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME),

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/outbound/PassthroughOutboundCORE_X12DSGenericBatchResponseTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/genericbatch/response/outbound/PassthroughOutboundCORE_X12DSGenericBatchResponseTest.java
@@ -41,6 +41,7 @@ import gov.hhs.fha.nhinc.orchestration.OutboundOrchestratable;
 import java.util.Properties;
 import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeBatchSubmission;
 import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeBatchSubmissionResponse;
+import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
@@ -74,6 +75,7 @@ public class PassthroughOutboundCORE_X12DSGenericBatchResponseTest {
         when(mockOrchestratable.getResponse()).thenReturn(successResponse);
         when(mockDelegate.process(any(OutboundOrchestratable.class))).thenReturn(mockOrchestratable);
         batchResp.batchSubmitTransaction(request, assertion, targets, urlInfo);
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger, never()).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE),
             isNull(Properties.class), eq(NhincConstants.CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME),
@@ -86,6 +88,7 @@ public class PassthroughOutboundCORE_X12DSGenericBatchResponseTest {
         when(mockOrchestratable.getResponse()).thenReturn(successResponse);
         when(mockDelegate.process(any(OutboundOrchestratable.class))).thenReturn(mockOrchestratable);
         batchResp.batchSubmitTransaction(request, assertion, targets, urlInfo);
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE),
             isNull(Properties.class), eq(NhincConstants.CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME),

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/realtime/outbound/PassthroughOutboundCORE_X12DSRealTimeTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/docsubmission/realtime/outbound/PassthroughOutboundCORE_X12DSRealTimeTest.java
@@ -44,6 +44,7 @@ import java.util.Properties;
 import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeRealTimeRequest;
 import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeRealTimeResponse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
@@ -76,6 +77,7 @@ public class PassthroughOutboundCORE_X12DSRealTimeTest {
         COREEnvelopeRealTimeResponse actualResponse = realTime.realTimeTransaction(request, assertion,
             createNhinTargetCommunities(), urlInfo);
         assertEquals("Actual and Expected Response differ", expectedResponse, actualResponse);
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.CORE_X12DS_REALTIME_SERVICE_NAME),
@@ -92,6 +94,7 @@ public class PassthroughOutboundCORE_X12DSRealTimeTest {
         COREEnvelopeRealTimeResponse actualResponse = realTime.realTimeTransaction(request, assertion,
             createNhinTargetCommunities(), urlInfo);
         assertEquals("Actual and Expected Response differ", expectedResponse, actualResponse);
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger, never()).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.CORE_X12DS_REALTIME_SERVICE_NAME),

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/outbound/PassthroughOutboundDocQuery.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/outbound/PassthroughOutboundDocQuery.java
@@ -76,7 +76,8 @@ public class PassthroughOutboundDocQuery implements OutboundDocQuery {
             warnTooManyTargets(targetHCID, targets);
         }
 
-        AdhocQueryResponse response = sendRequestToNwhin(request, assertion, target, targetHCID);
+        AdhocQueryResponse response = sendRequestToNwhin(request, MessageGeneratorUtils.getInstance().generateMessageId(
+            assertion), target, targetHCID);
 
         return response;
     }

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/outbound/StandardOutboundDocQuery.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/outbound/StandardOutboundDocQuery.java
@@ -71,7 +71,7 @@ public class StandardOutboundDocQuery implements OutboundDocQuery {
      * @param strategy
      */
     StandardOutboundDocQuery(AggregationStrategy strategy, AggregationService fanoutService,
-            DocQueryPolicyChecker policyChecker) {
+        DocQueryPolicyChecker policyChecker) {
         super();
         this.strategy = strategy;
         this.fanoutService = fanoutService;
@@ -88,14 +88,14 @@ public class StandardOutboundDocQuery implements OutboundDocQuery {
     @Override
     @OutboundProcessingEvent(beforeBuilder = AdhocQueryRequestDescriptionBuilder.class, afterReturningBuilder = AdhocQueryResponseDescriptionBuilder.class, serviceType = "Document Query", version = "")
     public AdhocQueryResponse respondingGatewayCrossGatewayQuery(AdhocQueryRequest adhocQueryRequest,
-            AssertionType assertion, NhinTargetCommunitiesType targets) {
+        AssertionType assertion, NhinTargetCommunitiesType targets) {
         LOG.trace("EntityDocQueryOrchImpl.respondingGatewayCrossGatewayQuery...");
         AdhocQueryResponse response = null;
 
         OutboundDocQueryAggregate aggregate = new OutboundDocQueryAggregate();
 
         List<OutboundOrchestratable> aggregateRequests = fanoutService.createChildRequests(adhocQueryRequest,
-                assertion, targets);
+            MessageGeneratorUtils.getInstance().generateMessageId(assertion), targets);
 
         if (aggregateRequests.isEmpty()) {
             LOG.info("no patient correlation found.");
@@ -103,8 +103,8 @@ public class StandardOutboundDocQuery implements OutboundDocQuery {
             //auditRequest(adhocQueryRequest, assertion, getNhinTarget(targets));
         } else {
             OutboundDocQueryOrchestratable request = new OutboundDocQueryOrchestratable(
-                    new OutboundDocQueryAggregator(), assertion, NhincConstants.DOC_QUERY_SERVICE_NAME,
-                    adhocQueryRequest);
+                new OutboundDocQueryAggregator(), assertion, NhincConstants.DOC_QUERY_SERVICE_NAME,
+                adhocQueryRequest);
 
             aggregate.setRequest(request);
 
@@ -157,13 +157,13 @@ public class StandardOutboundDocQuery implements OutboundDocQuery {
      */
     private AdhocQueryResponse createErrorResponse(String errorCode, String codeContext) {
         return MessageGeneratorUtils.getInstance().createAdhocQueryErrorResponse(codeContext, errorCode,
-                DocumentConstants.XDS_QUERY_RESPONSE_STATUS_FAILURE);
+            DocumentConstants.XDS_QUERY_RESPONSE_STATUS_FAILURE);
     }
 
     private void auditRequest(AdhocQueryRequest request, AssertionType assertion, NhinTargetSystemType target) {
         getAuditLogger().auditRequestMessage(request, assertion, target,
-                NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE,
-                Boolean.TRUE, null, NhincConstants.DOC_QUERY_SERVICE_NAME);
+            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE,
+            Boolean.TRUE, null, NhincConstants.DOC_QUERY_SERVICE_NAME);
 
     }
 

--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/outbound/PassthroughOutboundDocQueryTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/outbound/PassthroughOutboundDocQueryTest.java
@@ -41,7 +41,6 @@ import gov.hhs.fha.nhinc.docquery.entity.OutboundDocQueryDelegate;
 import gov.hhs.fha.nhinc.docquery.entity.OutboundDocQueryOrchestratable;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import java.util.Properties;
-
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryResponse;
 import org.apache.log4j.Logger;
@@ -102,7 +101,7 @@ public class PassthroughOutboundDocQueryTest {
         final String HCID2 = "2.2";
 
         final Logger mockLogger = mock(Logger.class);
-        ArgumentCaptor<Logger> loggerCaptor = ArgumentCaptor.forClass(Logger.class);
+        ArgumentCaptor<Logger> logMessageCaptor = ArgumentCaptor.forClass(Logger.class);
 
         final String compareOutput = "Multiple targets in request message in passthrough mode."
             + "  Only sending to target HCID: " + HCID1 + ".  Not sending request to: " + HCID2 + ".";
@@ -147,9 +146,9 @@ public class PassthroughOutboundDocQueryTest {
         AdhocQueryResponse actualResponse = passthroughDocQuery.respondingGatewayCrossGatewayQuery(request, assertion,
             targets);
 
-        verify(mockLogger).warn(loggerCaptor.capture());
+        verify(mockLogger).warn(logMessageCaptor.capture());
         assertSame(expectedResponse, actualResponse);
-        assertEquals(compareOutput, loggerCaptor.getValue());
+        assertEquals(compareOutput, logMessageCaptor.getValue());
         assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),

--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/outbound/PassthroughOutboundDocQueryTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/outbound/PassthroughOutboundDocQueryTest.java
@@ -43,7 +43,6 @@ import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import java.util.Properties;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryResponse;
-import org.apache.log4j.Logger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -55,6 +54,7 @@ import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import org.slf4j.Logger;
 
 /**
  * @author akong
@@ -101,7 +101,7 @@ public class PassthroughOutboundDocQueryTest {
         final String HCID2 = "2.2";
 
         final Logger mockLogger = mock(Logger.class);
-        ArgumentCaptor<Logger> logMessageCaptor = ArgumentCaptor.forClass(Logger.class);
+        ArgumentCaptor<String> logMessageCaptor = ArgumentCaptor.forClass(String.class);
 
         final String compareOutput = "Multiple targets in request message in passthrough mode."
             + "  Only sending to target HCID: " + HCID1 + ".  Not sending request to: " + HCID2 + ".";

--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/outbound/PassthroughOutboundDocQueryTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/outbound/PassthroughOutboundDocQueryTest.java
@@ -28,6 +28,8 @@ package gov.hhs.fha.nhinc.docquery.outbound;
 
 import gov.hhs.fha.nhinc.audit.ejb.AuditEJBLogger;
 import gov.hhs.fha.nhinc.audit.ejb.impl.AuditEJBLoggerImpl;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.when;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
@@ -39,10 +41,13 @@ import gov.hhs.fha.nhinc.docquery.entity.OutboundDocQueryDelegate;
 import gov.hhs.fha.nhinc.docquery.entity.OutboundDocQueryOrchestratable;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import java.util.Properties;
+
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryResponse;
+import org.apache.log4j.Logger;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNotNull;
+
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import static org.mockito.Matchers.any;
@@ -51,8 +56,6 @@ import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import org.slf4j.Logger;
 
 /**
  * @author akong
@@ -86,6 +89,7 @@ public class PassthroughOutboundDocQueryTest {
             targets);
 
         assertSame(expectedResponse, actualResponse);
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.DOC_QUERY_SERVICE_NAME),
@@ -98,7 +102,7 @@ public class PassthroughOutboundDocQueryTest {
         final String HCID2 = "2.2";
 
         final Logger mockLogger = mock(Logger.class);
-        ArgumentCaptor<String> logMessageCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Logger> loggerCaptor = ArgumentCaptor.forClass(Logger.class);
 
         final String compareOutput = "Multiple targets in request message in passthrough mode."
             + "  Only sending to target HCID: " + HCID1 + ".  Not sending request to: " + HCID2 + ".";
@@ -143,9 +147,10 @@ public class PassthroughOutboundDocQueryTest {
         AdhocQueryResponse actualResponse = passthroughDocQuery.respondingGatewayCrossGatewayQuery(request, assertion,
             targets);
 
-        verify(mockLogger).warn(logMessageCaptor.capture());
+        verify(mockLogger).warn(loggerCaptor.capture());
         assertSame(expectedResponse, actualResponse);
-        assertEquals(compareOutput, logMessageCaptor.getValue());
+        assertEquals(compareOutput, loggerCaptor.getValue());
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.DOC_QUERY_SERVICE_NAME),
@@ -176,6 +181,7 @@ public class PassthroughOutboundDocQueryTest {
             targets);
 
         assertSame(expectedResponse, actualResponse);
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger, never()).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.DOC_QUERY_SERVICE_NAME),
@@ -195,4 +201,5 @@ public class PassthroughOutboundDocQueryTest {
             }
         };
     }
+
 }

--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/outbound/StandardOutboundDocQueryTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/outbound/StandardOutboundDocQueryTest.java
@@ -103,7 +103,7 @@ public class StandardOutboundDocQueryTest {
         AdhocQueryResponse response = entitydocqueryimpl.respondingGatewayCrossGatewayQuery(adhocQueryRequest,
             assertion, targets);
         verify(service).createChildRequests(eq(adhocQueryRequest), eq(assertion), eq(targets));
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger, never()).auditRequestMessage(eq(adhocQueryRequest), eq(assertion), eq(target),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.DOC_QUERY_SERVICE_NAME),
@@ -239,7 +239,7 @@ public class StandardOutboundDocQueryTest {
         AdhocQueryResponse response = entitydocqueryimpl.respondingGatewayCrossGatewayQuery(adhocQueryRequest,
             assertion, targets);
         verify(service).createChildRequests(eq(adhocQueryRequest), eq(assertion), eq(targets));
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger, never()).auditRequestMessage(eq(adhocQueryRequest), eq(assertion), eq(target),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.DOC_QUERY_SERVICE_NAME),
@@ -283,7 +283,7 @@ public class StandardOutboundDocQueryTest {
         when(service.createChildRequests(eq(adhocQueryRequest), eq(assertion), eq(targets))).thenReturn(list);
 
         entitydocqueryimpl.respondingGatewayCrossGatewayQuery(adhocQueryRequest, assertion, targets);
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger, atLeast(1)).auditRequestMessage(eq(adhocQueryRequest), eq(assertion), eq(target),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.DOC_QUERY_SERVICE_NAME),
@@ -323,7 +323,7 @@ public class StandardOutboundDocQueryTest {
         when(service.createChildRequests(eq(adhocQueryRequest), eq(assertion), eq(targets))).thenReturn(list);
 
         entitydocqueryimpl.respondingGatewayCrossGatewayQuery(adhocQueryRequest, assertion, targets);
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger, never()).auditRequestMessage(eq(adhocQueryRequest), eq(assertion), eq(target),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.DOC_QUERY_SERVICE_NAME),

--- a/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/outbound/PassthroughOutboundDocRetrieve.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/outbound/PassthroughOutboundDocRetrieve.java
@@ -83,6 +83,7 @@ public class PassthroughOutboundDocRetrieve extends AbstractOutboundDocRetrieve 
         ADAPTER_API_LEVEL entityAPILevel) {
 
         RetrieveDocumentSetResponseType response = null;
+        assertion = MessageGeneratorUtils.getInstance().generateMessageId(assertion);
         if (validateGuidance(targets, entityAPILevel)) {
 
             NhinTargetSystemType targetSystem = MessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(

--- a/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/outbound/StandardOutboundDocRetrieve.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/outbound/StandardOutboundDocRetrieve.java
@@ -82,7 +82,7 @@ public class StandardOutboundDocRetrieve extends AbstractOutboundDocRetrieve imp
     @OutboundProcessingEvent(beforeBuilder = RetrieveDocumentSetRequestTypeDescriptionBuilder.class, afterReturningBuilder = RetrieveDocumentSetResponseTypeDescriptionBuilder.class, serviceType = "Retrieve Document", version = "")
     public RetrieveDocumentSetResponseType respondingGatewayCrossGatewayRetrieve(RetrieveDocumentSetRequestType request,
         AssertionType assertion, NhinTargetCommunitiesType targets, ADAPTER_API_LEVEL entityAPILevel) {
-
+        assertion = MessageGeneratorUtils.getInstance().generateMessageId(assertion);
         RetrieveDocumentSetResponseType response = null;
         if (validateGuidance(targets, entityAPILevel)) {
 

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/outbound/PassthroughOutboundDocRetrieveTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/outbound/PassthroughOutboundDocRetrieveTest.java
@@ -41,6 +41,7 @@ import ihe.iti.xds_b._2007.RetrieveDocumentSetRequestType;
 import ihe.iti.xds_b._2007.RetrieveDocumentSetResponseType;
 
 import java.util.Properties;
+import static org.junit.Assert.assertNotNull;
 import org.junit.Before;
 
 import org.junit.Test;
@@ -87,7 +88,7 @@ public class PassthroughOutboundDocRetrieveTest extends AbstractOutboundDocRetri
             request, assertion, targets, ADAPTER_API_LEVEL.LEVEL_a0);
 
         assertSame(expectedResponse, actualResponse);
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.DOC_RETRIEVE_SERVICE_NAME),
@@ -110,7 +111,7 @@ public class PassthroughOutboundDocRetrieveTest extends AbstractOutboundDocRetri
             request, assertion, targets, ADAPTER_API_LEVEL.LEVEL_a0);
 
         assertSame(expectedResponse, actualResponse);
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger, never()).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.DOC_RETRIEVE_SERVICE_NAME),

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/outbound/StandardOutboundDocRetrieveTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/outbound/StandardOutboundDocRetrieveTest.java
@@ -96,7 +96,7 @@ public class StandardOutboundDocRetrieveTest extends AbstractOutboundDocRetrieve
             request, assertion, targets, ADAPTER_API_LEVEL.LEVEL_a0);
 
         assertSame(expectedResponse, actualResponse);
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.DOC_RETRIEVE_SERVICE_NAME),
@@ -134,7 +134,7 @@ public class StandardOutboundDocRetrieveTest extends AbstractOutboundDocRetrieve
             request, assertion, targets, ADAPTER_API_LEVEL.LEVEL_a0);
 
         assertSame(expectedResponse, actualResponse);
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger, never()).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.DOC_RETRIEVE_SERVICE_NAME),

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/PassthroughOutboundDocSubmission.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/PassthroughOutboundDocSubmission.java
@@ -59,7 +59,7 @@ public class PassthroughOutboundDocSubmission implements OutboundDocSubmission {
 
         NhinTargetSystemType targetSystem = MessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(
             targets);
-
+        assertion = MessageGeneratorUtils.getInstance().generateMessageId(assertion);
         RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request = createAuditRequest(body, assertion,
             targetSystem);
 

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/StandardOutboundDocSubmission.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/StandardOutboundDocSubmission.java
@@ -64,7 +64,7 @@ public class StandardOutboundDocSubmission implements OutboundDocSubmission {
     public RegistryResponseType provideAndRegisterDocumentSetB(ProvideAndRegisterDocumentSetRequestType body,
         AssertionType assertion, NhinTargetCommunitiesType targets, UrlInfoType urlInfo) {
         RegistryResponseType response = null;
-
+        assertion = MessageGeneratorUtils.getInstance().generateMessageId(assertion);
         RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request = createRequestForInternalProcessing(
             body, targets, urlInfo);
         NhinTargetSystemType target = getMessageGeneratorUtils().convertFirstToNhinTargetSystemType(targets);

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/request/PassthroughOutboundDocSubmissionDeferredRequest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/request/PassthroughOutboundDocSubmissionDeferredRequest.java
@@ -51,7 +51,7 @@ public class PassthroughOutboundDocSubmissionDeferredRequest implements Outbound
     public XDRAcknowledgementType provideAndRegisterDocumentSetBAsyncRequest(
         ProvideAndRegisterDocumentSetRequestType body, AssertionType assertion,
         NhinTargetCommunitiesType targets, UrlInfoType urlInfo) {
-
+        assertion = MessageGeneratorUtils.getInstance().generateMessageId(assertion);
         NhinTargetSystemType targetSystem = MessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(targets);
         auditRequest(body, assertion, targetSystem);
         RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType request = createRequestForInternalProcessing(

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/request/StandardOutboundDocSubmissionDeferredRequest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/request/StandardOutboundDocSubmissionDeferredRequest.java
@@ -68,7 +68,7 @@ public class StandardOutboundDocSubmissionDeferredRequest implements OutboundDoc
         NhinTargetCommunitiesType targets, UrlInfoType urlInfo) {
 
         XDRAcknowledgementType response = null;
-
+        assertion = MessageGeneratorUtils.getInstance().generateMessageId(assertion);
         RespondingGatewayProvideAndRegisterDocumentSetSecuredRequestType internalRequest
             = createRequestForInternalProcessing(request, assertion, targets, urlInfo);
 

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/response/PassthroughOutboundDocSubmissionDeferredResponse.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/response/PassthroughOutboundDocSubmissionDeferredResponse.java
@@ -52,7 +52,7 @@ public class PassthroughOutboundDocSubmissionDeferredResponse implements Outboun
         AssertionType assertion, NhinTargetCommunitiesType targets) {
 
         NhinTargetSystemType targetSystem = msgUtils.convertFirstToNhinTargetSystemType(targets);
-
+        assertion = MessageGeneratorUtils.getInstance().generateMessageId(assertion);
         OutboundDocSubmissionDeferredResponseDelegate delegate = getOutboundDocSubmissionDeferredResponseDelegate();
         OutboundDocSubmissionDeferredResponseOrchestratable dsOrchestratable = createOrchestratable(delegate, body,
             assertion, targetSystem);

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/response/StandardOutboundDocSubmissionDeferredResponse.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/response/StandardOutboundDocSubmissionDeferredResponse.java
@@ -63,7 +63,7 @@ public class StandardOutboundDocSubmissionDeferredResponse implements OutboundDo
         AssertionType assertion, NhinTargetCommunitiesType targets) {
 
         XDRAcknowledgementType response = null;
-
+        assertion = MessageGeneratorUtils.getInstance().generateMessageId(assertion);
         RespondingGatewayProvideAndRegisterDocumentSetSecuredResponseRequestType internalRequest
             = createRequestForInternalProcessing(request, targets);
 

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/PassthroughOutboundDocSubmissionTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/PassthroughOutboundDocSubmissionTest.java
@@ -72,6 +72,7 @@ public class PassthroughOutboundDocSubmissionTest {
 
         assertNotNull(response);
         assertEquals(DocumentConstants.XDS_SUBMISSION_RESPONSE_STATUS_SUCCESS, response.getStatus());
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_SERVICE_NAME),
@@ -90,6 +91,7 @@ public class PassthroughOutboundDocSubmissionTest {
 
         assertNotNull(response);
         assertEquals(DocumentConstants.XDS_SUBMISSION_RESPONSE_STATUS_SUCCESS, response.getStatus());
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger, never()).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_SERVICE_NAME),

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/StandardOutboundDocSubmissionTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/StandardOutboundDocSubmissionTest.java
@@ -111,7 +111,7 @@ public class StandardOutboundDocSubmissionTest {
 
         RegistryResponseType actualResponse = outbound.provideAndRegisterDocumentSetB(request,
             assertion, targets, new UrlInfoType());
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), eq(target),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_SERVICE_NAME),
@@ -139,7 +139,7 @@ public class StandardOutboundDocSubmissionTest {
 
         RegistryResponseType response = outbound.provideAndRegisterDocumentSetB(request,
             assertion, targets, new UrlInfoType());
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), eq(target),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_SERVICE_NAME),
@@ -161,7 +161,7 @@ public class StandardOutboundDocSubmissionTest {
 
         RegistryResponseType response = outbound.provideAndRegisterDocumentSetB(request,
             assertion, null, new UrlInfoType());
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), isNull(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_SERVICE_NAME),
@@ -246,7 +246,7 @@ public class StandardOutboundDocSubmissionTest {
 
         RegistryResponseType actualResponse = outbound.provideAndRegisterDocumentSetB(request,
             assertion, targets, new UrlInfoType());
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger, never()).auditRequestMessage(eq(request), eq(assertion), eq(target),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_SERVICE_NAME),

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/request/PassthroughOutboundDocSubmissionDeferredRequestTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/request/PassthroughOutboundDocSubmissionDeferredRequestTest.java
@@ -73,6 +73,7 @@ public class PassthroughOutboundDocSubmissionDeferredRequestTest {
 
         assertNotNull(response);
         assertEquals(NhincConstants.XDR_ACK_STATUS_MSG, response.getMessage().getStatus());
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME),
@@ -100,6 +101,7 @@ public class PassthroughOutboundDocSubmissionDeferredRequestTest {
 
         assertNotNull(response);
         assertEquals(NhincConstants.XDR_ACK_STATUS_MSG, response.getMessage().getStatus());
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger, never()).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME),

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/request/StandardOutboundDocSubmissionDeferredRequestTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/request/StandardOutboundDocSubmissionDeferredRequestTest.java
@@ -110,6 +110,7 @@ public class StandardOutboundDocSubmissionDeferredRequestTest {
 
         assertNotNull(response);
         assertEquals(NhincConstants.XDR_ACK_STATUS_MSG, response.getMessage().getStatus());
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME),
@@ -137,6 +138,7 @@ public class StandardOutboundDocSubmissionDeferredRequestTest {
 
         assertNotNull(response);
         assertEquals(NhincConstants.XDR_ACK_FAILURE_STATUS_MSG, response.getMessage().getStatus());
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME),
@@ -164,6 +166,7 @@ public class StandardOutboundDocSubmissionDeferredRequestTest {
 
         assertNotNull(response);
         assertEquals(NhincConstants.XDR_ACK_FAILURE_STATUS_MSG, response.getMessage().getStatus());
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME),
@@ -245,6 +248,7 @@ public class StandardOutboundDocSubmissionDeferredRequestTest {
 
         assertNotNull(response);
         assertEquals(NhincConstants.XDR_ACK_STATUS_MSG, response.getMessage().getStatus());
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger, never()).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME),

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/response/PassthroughOutboundDocSubmissionDeferredResponseTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/response/PassthroughOutboundDocSubmissionDeferredResponseTest.java
@@ -71,7 +71,7 @@ public class PassthroughOutboundDocSubmissionDeferredResponseTest {
 
         XDRAcknowledgementType response = runProvideAndRegisterDocumentSetBResponse(request, assertion,
             targetCommunities, getAuditLogger(true));
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), isNotNull(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_RESPONSE_SERVICE_NAME),
@@ -99,7 +99,7 @@ public class PassthroughOutboundDocSubmissionDeferredResponseTest {
 
         XDRAcknowledgementType response = runProvideAndRegisterDocumentSetBResponse(request, assertion,
             targetCommunities, getAuditLogger(false));
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger, never()).auditRequestMessage(eq(request), eq(assertion), isNotNull(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_RESPONSE_SERVICE_NAME),

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/response/StandardOutboundDocSubmissionDeferredResponseTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/response/StandardOutboundDocSubmissionDeferredResponseTest.java
@@ -93,6 +93,7 @@ public class StandardOutboundDocSubmissionDeferredResponseTest {
             createOutboundDocSubmissionDeferredResponseOrchestratable());
 
         XDRAcknowledgementType response = runProvideAndRegisterDocumentSetBAsyncRequest(getAuditLogger(true));
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), isNotNull(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_RESPONSE_SERVICE_NAME),
@@ -113,7 +114,7 @@ public class StandardOutboundDocSubmissionDeferredResponseTest {
             Mockito.any(AssertionType.class))).thenReturn("2.2");
 
         XDRAcknowledgementType response = runProvideAndRegisterDocumentSetBAsyncRequest(getAuditLogger(true));
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), isNotNull(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.NHINC_XDR_RESPONSE_SERVICE_NAME),
@@ -130,6 +131,7 @@ public class StandardOutboundDocSubmissionDeferredResponseTest {
         AssertionType assertionLocal = new AssertionType();
         XDRAcknowledgementType response = runProvideAndRegisterDocumentSetBAsyncRequest_emptyTargets(requestLocal,
             assertionLocal, getAuditLogger(true));
+        assertNotNull("Assertion MessageId is null", assertionLocal.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(requestLocal), eq(assertionLocal),
             isNotNull(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE), isNull(Properties.class),

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/PassthroughOutboundPatientDiscovery.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/PassthroughOutboundPatientDiscovery.java
@@ -139,9 +139,9 @@ public class PassthroughOutboundPatientDiscovery implements OutboundPatientDisco
 
     private void auidtRequest(RespondingGatewayPRPAIN201305UV02RequestType request, AssertionType assertion,
         NhinTargetSystemType target) {
-
-        auditLogger.auditRequestMessage(request.getPRPAIN201305UV02(), assertion, target,
-            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE,
-            null, NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
+        auditLogger.auditRequestMessage(request.getPRPAIN201305UV02(),
+            MessageGeneratorUtils.getInstance().generateMessageId(assertion), target,
+            NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE, null,
+            NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/PassthroughOutboundPatientDiscovery.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/PassthroughOutboundPatientDiscovery.java
@@ -77,7 +77,8 @@ public class PassthroughOutboundPatientDiscovery implements OutboundPatientDisco
     public RespondingGatewayPRPAIN201306UV02ResponseType respondingGatewayPRPAIN201305UV02(
         RespondingGatewayPRPAIN201305UV02RequestType request, AssertionType assertion) {
 
-        RespondingGatewayPRPAIN201306UV02ResponseType response = sendToNhin(request.getPRPAIN201305UV02(), assertion,
+        RespondingGatewayPRPAIN201306UV02ResponseType response = sendToNhin(request.getPRPAIN201305UV02(),
+            MessageGeneratorUtils.getInstance().generateMessageId(assertion),
             msgUtils.convertFirstToNhinTargetSystemType(request.getNhinTargetCommunities()));
         auidtRequest(request, assertion,
             msgUtils.convertFirstToNhinTargetSystemType(request.getNhinTargetCommunities()));
@@ -139,8 +140,7 @@ public class PassthroughOutboundPatientDiscovery implements OutboundPatientDisco
 
     private void auidtRequest(RespondingGatewayPRPAIN201305UV02RequestType request, AssertionType assertion,
         NhinTargetSystemType target) {
-        auditLogger.auditRequestMessage(request.getPRPAIN201305UV02(),
-            MessageGeneratorUtils.getInstance().generateMessageId(assertion), target,
+        auditLogger.auditRequestMessage(request.getPRPAIN201305UV02(), assertion, target,
             NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE, null,
             NhincConstants.PATIENT_DISCOVERY_SERVICE_NAME);
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscovery.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscovery.java
@@ -180,9 +180,8 @@ public class StandardOutboundPatientDiscovery implements OutboundPatientDiscover
                     NhinTargetSystemType target = createNhinTargetSystemType(urlInfo.getHcid());
 
                     // create a new request to send out to each target community
-                    MessageGeneratorUtils.getInstance().generateMessageId(assertion);
-                    RespondingGatewayPRPAIN201305UV02RequestType newRequest = createNewRequest(request, assertion,
-                        urlInfo, urlInfoList.size());
+                    RespondingGatewayPRPAIN201305UV02RequestType newRequest = createNewRequest(request,
+                        MessageGeneratorUtils.getInstance().generateMessageId(assertion), urlInfo, urlInfoList.size());
 
                     if (checkPolicy(newRequest)) {
                         setHomeCommunityIdInRequest(newRequest, urlInfo.getHcid());

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscovery.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscovery.java
@@ -180,6 +180,7 @@ public class StandardOutboundPatientDiscovery implements OutboundPatientDiscover
                     NhinTargetSystemType target = createNhinTargetSystemType(urlInfo.getHcid());
 
                     // create a new request to send out to each target community
+                    MessageGeneratorUtils.getInstance().generateMessageId(assertion);
                     RespondingGatewayPRPAIN201305UV02RequestType newRequest = createNewRequest(request, assertion,
                         urlInfo, urlInfoList.size());
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/request/PassthroughOutboundPatientDiscoveryDeferredRequest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/request/PassthroughOutboundPatientDiscoveryDeferredRequest.java
@@ -76,7 +76,8 @@ public class PassthroughOutboundPatientDiscoveryDeferredRequest extends Abstract
     public MCCIIN000002UV01 processPatientDiscoveryAsyncReq(PRPAIN201305UV02 request, AssertionType assertion,
         NhinTargetCommunitiesType targets) {
 
-        auditRequest(request, assertion, msgUtils.convertFirstToNhinTargetSystemType(targets));
+        auditRequest(request, MessageGeneratorUtils.getInstance().generateMessageId(assertion),
+            msgUtils.convertFirstToNhinTargetSystemType(targets));
         MCCIIN000002UV01 response = sendToNhin(request, assertion, targets);
         return response;
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/request/StandardOutboundPatientDiscoveryDeferredRequest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/request/StandardOutboundPatientDiscoveryDeferredRequest.java
@@ -125,7 +125,8 @@ public class StandardOutboundPatientDiscoveryDeferredRequest extends AbstractOut
         NhinTargetCommunitiesType targets) {
         MCCIIN000002UV01 ack = new MCCIIN000002UV01();
 
-        auditRequest(message, assertion, msgUtils.convertFirstToNhinTargetSystemType(targets));
+        auditRequest(message, MessageGeneratorUtils.getInstance().generateMessageId(assertion),
+            msgUtils.convertFirstToNhinTargetSystemType(targets));
 
         List<UrlInfo> urlInfoList = getTargetEndpoints(targets);
         if (NullChecker.isNotNullish(urlInfoList)) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/AbstractOutboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/AbstractOutboundPatientDiscoveryDeferredResponse.java
@@ -59,7 +59,8 @@ public abstract class AbstractOutboundPatientDiscoveryDeferredResponse implement
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncResp(PRPAIN201306UV02 request, AssertionType assertion,
         NhinTargetCommunitiesType target) {
-        MCCIIN000002UV01 response = process(request, assertion, target);
+        MCCIIN000002UV01 response = process(request, MessageGeneratorUtils.getInstance().generateMessageId(assertion),
+            target);
 
         return response;
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/StandardOutboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/StandardOutboundPatientDiscoveryDeferredResponse.java
@@ -96,7 +96,8 @@ public class StandardOutboundPatientDiscoveryDeferredResponse extends AbstractOu
     @OutboundProcessingEvent(beforeBuilder = PRPAIN201306UV02EventDescriptionBuilder.class, afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class, serviceType = "Patient Discovery Deferred Response", version = "1.0")
     public MCCIIN000002UV01 processPatientDiscoveryAsyncResp(PRPAIN201306UV02 request, AssertionType assertion,
         NhinTargetCommunitiesType target) {
-        MCCIIN000002UV01 response = process(request, assertion, target);
+        MCCIIN000002UV01 response = process(request, MessageGeneratorUtils.getInstance().generateMessageId(assertion),
+            target);
 
         return response;
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/PassthroughOutboundPatientDiscoveryTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/PassthroughOutboundPatientDiscoveryTest.java
@@ -43,6 +43,7 @@ import org.hl7.v3.PRPAIN201305UV02;
 import org.hl7.v3.PRPAIN201306UV02;
 import org.hl7.v3.RespondingGatewayPRPAIN201305UV02RequestType;
 import org.hl7.v3.RespondingGatewayPRPAIN201306UV02ResponseType;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import org.junit.Test;
 import static org.mockito.Matchers.any;
@@ -80,7 +81,7 @@ public class PassthroughOutboundPatientDiscoveryTest {
             .respondingGatewayPRPAIN201305UV02(request, assertion);
 
         assertSame(outOrchestratable.getResponse(), actualMessage.getCommunityResponse().get(0).getPRPAIN201306UV02());
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request.getPRPAIN201305UV02()), any(AssertionType.class), any(
             NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE), isNull(Properties.class),
@@ -105,7 +106,7 @@ public class PassthroughOutboundPatientDiscoveryTest {
             .respondingGatewayPRPAIN201305UV02(request, assertion);
 
         assertSame(outOrchestratable.getResponse(), actualMessage.getCommunityResponse().get(0).getPRPAIN201306UV02());
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger, never()).auditRequestMessage(eq(request.getPRPAIN201305UV02()), any(AssertionType.class),
             any(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE), isNull(Properties.class),

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscoveryTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscoveryTest.java
@@ -118,7 +118,7 @@ public class StandardOutboundPatientDiscoveryTest {
         when(mockOrchestratable.getTarget()).thenReturn(target);
         RespondingGatewayPRPAIN201306UV02ResponseType actualMessage = standardPD.respondingGatewayPRPAIN201305UV02(
             request, assertion);
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request.getPRPAIN201305UV02()), any(AssertionType.class), any(
             NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE), isNull(Properties.class),
@@ -131,6 +131,7 @@ public class StandardOutboundPatientDiscoveryTest {
         request.setPRPAIN201305UV02(new PRPAIN201305UV02());
         request.setNhinTargetCommunities(createNhinTargetCommunitiesType(TARGET_HCID));
         AssertionType assertion = new AssertionType();
+        request.setAssertion(assertion);
         OutboundPatientDiscoveryOrchestratable outOrchestratable = new OutboundPatientDiscoveryOrchestratable();
         outOrchestratable.setResponse(new PRPAIN201306UV02());
 
@@ -138,7 +139,7 @@ public class StandardOutboundPatientDiscoveryTest {
         StandardOutboundPatientDiscovery standardPatientDiscovery = createStandardPDObj(getAuditLogger(false));
         RespondingGatewayPRPAIN201306UV02ResponseType actualMessage = standardPatientDiscovery
             .respondingGatewayPRPAIN201305UV02(request, assertion);
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger, never()).auditRequestMessage(any(PRPAIN201305UV02.class), any(AssertionType.class),
             any(NhinTargetSystemType.class), eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION),
             eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE), isNull(Properties.class),

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/request/PassthroughOutboundPatientDiscoveryDeferredRequestTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/request/PassthroughOutboundPatientDiscoveryDeferredRequestTest.java
@@ -42,6 +42,7 @@ import java.util.Properties;
 
 import org.hl7.v3.MCCIIN000002UV01;
 import org.hl7.v3.PRPAIN201305UV02;
+import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
@@ -83,7 +84,7 @@ public class PassthroughOutboundPatientDiscoveryDeferredRequestTest {
             assertion, targets);
 
         assertSame(expectedResponse, actualResponse);
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME),
@@ -115,7 +116,7 @@ public class PassthroughOutboundPatientDiscoveryDeferredRequestTest {
             assertion, targets);
 
         assertSame(expectedResponse, actualResponse);
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger, never()).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME),

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/request/StandardOutboundPatientDiscoveryDeferredRequestTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/request/StandardOutboundPatientDiscoveryDeferredRequestTest.java
@@ -185,14 +185,13 @@ public class StandardOutboundPatientDiscoveryDeferredRequestTest {
         verify(pd201305Processor).storeLocalMapping(requestArgument.capture());
         assertEquals(request, requestArgument.getValue().getPRPAIN201305UV02());
 
-        verify(correlationDao).saveOrUpdate("messageId", patientId);
-
+        verify(correlationDao).saveOrUpdate("urn:uuid:messageId", patientId);
         // Verify policy is checking the request containing the first target and then the second target
         requestArgument.getAllValues().clear();
         verify(policyChecker, times(2)).checkOutgoingPolicy(requestArgument.capture());
         assertEquals(firstTargetRequest, requestArgument.getAllValues().get(0).getPRPAIN201305UV02());
         assertEquals(secondTargetRequest, requestArgument.getAllValues().get(1).getPRPAIN201305UV02());
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         // Verify audits
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
@@ -225,7 +224,7 @@ public class StandardOutboundPatientDiscoveryDeferredRequestTest {
             "No targets were found for the Patient Discovery Request",
             errorResponse.getAcknowledgement().get(0).getAcknowledgementDetail().get(0).getText().getContent()
             .get(0).toString());
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         // Verify audits
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
@@ -272,13 +271,12 @@ public class StandardOutboundPatientDiscoveryDeferredRequestTest {
         verify(pd201305Processor).storeLocalMapping(requestArgument.capture());
         assertEquals(request, requestArgument.getValue().getPRPAIN201305UV02());
 
-        verify(correlationDao).saveOrUpdate("messageId", patientId);
-
+        verify(correlationDao).saveOrUpdate("urn:uuid:messageId", patientId);
         // Verify policy check
         requestArgument.getAllValues().clear();
         verify(policyChecker).checkOutgoingPolicy(requestArgument.capture());
         assertEquals(firstTargetRequest, requestArgument.getValue().getPRPAIN201305UV02());
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME),
@@ -327,14 +325,13 @@ public class StandardOutboundPatientDiscoveryDeferredRequestTest {
         verify(pd201305Processor).storeLocalMapping(requestArgument.capture());
         assertEquals(request, requestArgument.getValue().getPRPAIN201305UV02());
 
-        verify(correlationDao).saveOrUpdate("messageId", patientId);
-
+        verify(correlationDao).saveOrUpdate("urn:uuid:messageId", patientId);
         // Verify policy is checking the request containing the first target and then the second target
         requestArgument.getAllValues().clear();
         verify(policyChecker, times(2)).checkOutgoingPolicy(requestArgument.capture());
         assertEquals(firstTargetRequest, requestArgument.getAllValues().get(0).getPRPAIN201305UV02());
         assertEquals(secondTargetRequest, requestArgument.getAllValues().get(1).getPRPAIN201305UV02());
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         // Verify audits
         verify(mockEJBLogger, never()).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/PassthroughOutboundPatientDiscoveryDeferredResponseTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/PassthroughOutboundPatientDiscoveryDeferredResponseTest.java
@@ -40,13 +40,13 @@ import java.util.Properties;
 import org.hl7.v3.MCCIIN000002UV01;
 import org.hl7.v3.PRPAIN201306UV02;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
-import org.mockito.Mockito;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -89,7 +89,7 @@ public class PassthroughOutboundPatientDiscoveryDeferredResponseTest {
             .forClass(OutboundPatientDiscoveryDeferredResponseOrchestratable.class);
         verify(delegate).process(orchestratableArgument.capture());
         assertEquals(request, orchestratableArgument.getValue().getRequest());
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
@@ -121,7 +121,7 @@ public class PassthroughOutboundPatientDiscoveryDeferredResponseTest {
             .forClass(OutboundPatientDiscoveryDeferredResponseOrchestratable.class);
         verify(delegate).process(orchestratableArgument.capture());
         assertEquals(request, orchestratableArgument.getValue().getRequest());
-
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger, never()).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/StandardOutboundPatientDiscoveryDeferredResponseTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/StandardOutboundPatientDiscoveryDeferredResponseTest.java
@@ -173,6 +173,7 @@ public class StandardOutboundPatientDiscoveryDeferredResponseTest {
 
         // Verify request from adapter is audited
         requestArgument.getAllValues().clear();
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE),
             isNull(Properties.class), eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
@@ -206,6 +207,7 @@ public class StandardOutboundPatientDiscoveryDeferredResponseTest {
         // Verify request from adapter is audited
         ArgumentCaptor<RespondingGatewayPRPAIN201306UV02RequestType> requestArgument = ArgumentCaptor
             .forClass(RespondingGatewayPRPAIN201306UV02RequestType.class);
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE),
             isNull(Properties.class), eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
@@ -248,6 +250,7 @@ public class StandardOutboundPatientDiscoveryDeferredResponseTest {
         // Verify request from adapter is audited
         ArgumentCaptor<RespondingGatewayPRPAIN201306UV02RequestType> requestArgument = ArgumentCaptor
             .forClass(RespondingGatewayPRPAIN201306UV02RequestType.class);
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE),
             isNull(Properties.class), eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
@@ -312,6 +315,7 @@ public class StandardOutboundPatientDiscoveryDeferredResponseTest {
 
         // Verify request from adapter is audited
         requestArgument.getAllValues().clear();
+        assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         verify(mockEJBLogger, never()).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE), eq(Boolean.TRUE),
             isNull(Properties.class), eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),


### PR DESCRIPTION
1. MessageId is now generated, if not present, at service level instead of Audit Adapter.
2. UnitTest for services were updated to test messageId.
