### PR TITLE
MessageId and relatesTo fix

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/MessageGeneratorUtils.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/MessageGeneratorUtils.java
@@ -170,9 +170,7 @@ public class MessageGeneratorUtils {
     public AssertionType generateMessageId(AssertionType assertion) {
         WSAHeaderHelper wsaHelper = new WSAHeaderHelper();
         if (assertion != null) {
-            if (NullChecker.isNotNullish(assertion.getMessageId())) {
-                assertion.setMessageId(wsaHelper.fixMessageIDPrefix(assertion.getMessageId()));
-            } else {
+            if (NullChecker.isNullish(assertion.getMessageId())) {
                 assertion.setMessageId(wsaHelper.generateMessageID());
                 return assertion;
             }

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/AggregationService.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/AggregationService.java
@@ -251,7 +251,8 @@ public class AggregationService {
     private AssertionType createNewAssertion(AssertionType assertion, int numTargets) {
         AssertionType newAssertion;
         if (numTargets == 1) {
-            newAssertion = MessageGeneratorUtils.getInstance().clone(assertion);
+            newAssertion = MessageGeneratorUtils.getInstance().clone(
+                MessageGeneratorUtils.getInstance().generateMessageId(assertion));
         } else {
             newAssertion = MessageGeneratorUtils.getInstance().cloneWithNewMsgId(assertion);
         }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscovery.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscovery.java
@@ -163,7 +163,6 @@ public class StandardOutboundPatientDiscovery implements OutboundPatientDiscover
 
         RespondingGatewayPRPAIN201306UV02ResponseType response = new RespondingGatewayPRPAIN201306UV02ResponseType();
         NhincConstants.GATEWAY_API_LEVEL gatewayLevel = getGatewayVersion();
-
         try {
             List<UrlInfo> urlInfoList = getEndpoints(request.getNhinTargetCommunities());
             if (NullChecker.isNullish(urlInfoList)) {
@@ -181,7 +180,7 @@ public class StandardOutboundPatientDiscovery implements OutboundPatientDiscover
 
                     // create a new request to send out to each target community
                     RespondingGatewayPRPAIN201305UV02RequestType newRequest = createNewRequest(request,
-                        MessageGeneratorUtils.getInstance().generateMessageId(assertion), urlInfo, urlInfoList.size());
+                        assertion, urlInfo, urlInfoList.size());
 
                     if (checkPolicy(newRequest)) {
                         setHomeCommunityIdInRequest(newRequest, urlInfo.getHcid());
@@ -321,7 +320,8 @@ public class StandardOutboundPatientDiscovery implements OutboundPatientDiscover
 
         AssertionType newAssertion;
         if (numTargets == 1) {
-            newAssertion = MessageGeneratorUtils.getInstance().clone(assertion);
+            newAssertion = MessageGeneratorUtils.getInstance().clone(
+                MessageGeneratorUtils.getInstance().generateMessageId(assertion));
         } else {
             newAssertion = MessageGeneratorUtils.getInstance().cloneWithNewMsgId(assertion);
         }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/request/StandardOutboundPatientDiscoveryDeferredRequest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/request/StandardOutboundPatientDiscoveryDeferredRequest.java
@@ -125,9 +125,6 @@ public class StandardOutboundPatientDiscoveryDeferredRequest extends AbstractOut
         NhinTargetCommunitiesType targets) {
         MCCIIN000002UV01 ack = new MCCIIN000002UV01();
 
-        auditRequest(message, MessageGeneratorUtils.getInstance().generateMessageId(assertion),
-            msgUtils.convertFirstToNhinTargetSystemType(targets));
-
         List<UrlInfo> urlInfoList = getTargetEndpoints(targets);
         if (NullChecker.isNotNullish(urlInfoList)) {
 
@@ -138,6 +135,8 @@ public class StandardOutboundPatientDiscoveryDeferredRequest extends AbstractOut
             for (UrlInfo urlInfo : urlInfoList) {
                 RespondingGatewayPRPAIN201305UV02RequestType newRequest = createNewRespondingGatewayRequestForOneTarget(
                     message, assertion, targets, urlInfo.getHcid());
+
+                auditRequest(message, assertion, msgUtils.convertFirstToNhinTargetSystemType(targets));
 
                 if (isPolicyValid(newRequest)) {
                     ack = sendToNhin(newRequest.getPRPAIN201305UV02(), newRequest.getAssertion(), urlInfo);
@@ -198,7 +197,7 @@ public class StandardOutboundPatientDiscoveryDeferredRequest extends AbstractOut
 
         PRPAIN201305UV02 new201305 = createNewPRPAIN201305UV02ForOneTargetCommunity(message, hcid);
         AssertionType newAssertion = asyncProcessHelper.copyAssertionTypeObject(assertion);
-
+        msgUtils.generateMessageId(newAssertion);
         return msgUtils.createRespondingGatewayRequest(new201305, newAssertion, targets);
     }
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/request/StandardOutboundPatientDiscoveryDeferredRequestTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/request/StandardOutboundPatientDiscoveryDeferredRequestTest.java
@@ -75,6 +75,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -185,7 +186,7 @@ public class StandardOutboundPatientDiscoveryDeferredRequestTest {
         verify(pd201305Processor).storeLocalMapping(requestArgument.capture());
         assertEquals(request, requestArgument.getValue().getPRPAIN201305UV02());
 
-        verify(correlationDao).saveOrUpdate("urn:uuid:messageId", patientId);
+        verify(correlationDao).saveOrUpdate("messageId", patientId);
         // Verify policy is checking the request containing the first target and then the second target
         requestArgument.getAllValues().clear();
         verify(policyChecker, times(2)).checkOutgoingPolicy(requestArgument.capture());
@@ -193,7 +194,7 @@ public class StandardOutboundPatientDiscoveryDeferredRequestTest {
         assertEquals(secondTargetRequest, requestArgument.getAllValues().get(1).getPRPAIN201305UV02());
         assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         // Verify audits
-        verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
+        verify(mockEJBLogger, atLeast(1)).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME),
             any(PatientDiscoveryDeferredRequestAuditTransforms.class));
@@ -226,7 +227,7 @@ public class StandardOutboundPatientDiscoveryDeferredRequestTest {
             .get(0).toString());
         assertNotNull("Assertion MessageId is null", assertion.getMessageId());
         // Verify audits
-        verify(mockEJBLogger).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
+        verify(mockEJBLogger, never()).auditRequestMessage(eq(request), eq(assertion), any(NhinTargetSystemType.class),
             eq(NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION), eq(NhincConstants.AUDIT_LOG_NHIN_INTERFACE),
             eq(Boolean.TRUE), isNull(Properties.class), eq(NhincConstants.PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME),
             any(PatientDiscoveryDeferredRequestAuditTransforms.class));
@@ -271,7 +272,7 @@ public class StandardOutboundPatientDiscoveryDeferredRequestTest {
         verify(pd201305Processor).storeLocalMapping(requestArgument.capture());
         assertEquals(request, requestArgument.getValue().getPRPAIN201305UV02());
 
-        verify(correlationDao).saveOrUpdate("urn:uuid:messageId", patientId);
+        verify(correlationDao).saveOrUpdate("messageId", patientId);
         // Verify policy check
         requestArgument.getAllValues().clear();
         verify(policyChecker).checkOutgoingPolicy(requestArgument.capture());
@@ -325,7 +326,7 @@ public class StandardOutboundPatientDiscoveryDeferredRequestTest {
         verify(pd201305Processor).storeLocalMapping(requestArgument.capture());
         assertEquals(request, requestArgument.getValue().getPRPAIN201305UV02());
 
-        verify(correlationDao).saveOrUpdate("urn:uuid:messageId", patientId);
+        verify(correlationDao).saveOrUpdate("messageId", patientId);
         // Verify policy is checking the request containing the first target and then the second target
         requestArgument.getAllValues().clear();
         verify(policyChecker, times(2)).checkOutgoingPolicy(requestArgument.capture());


### PR DESCRIPTION
1. Fixed BaseService class to first check for MessageId in assertion block for the incoming request. If it is not present, next we look at SOAP headers. If messageId is not present in SOAP header then connect will create one and add it to assertion block.
2. Fixed relatesTo, to not append the incoming value with urn:uuid prefix.
3. Fixed the PD and DQ for fan-out scenario and updated the concerned junit test.

PR assignee:  @jsmith2 and @alameluchidambaram 
