### PR TITLE
FHAC-696: Fixed QA findings

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/async/AsyncMessageIdExtractor.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/async/AsyncMessageIdExtractor.java
@@ -27,7 +27,6 @@
 package gov.hhs.fha.nhinc.async;
 
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
-import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import gov.hhs.fha.nhinc.wsa.WSAHeaderHelper;
 
 import java.util.ArrayList;

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/async/AsyncMessageIdExtractor.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/async/AsyncMessageIdExtractor.java
@@ -99,8 +99,7 @@ public class AsyncMessageIdExtractor {
         List<String> relatesToId = new ArrayList<String>();
 
         Element element = getSoapHeaderElement(context, NhincConstants.HEADER_RELATESTO);
-        String value = getFirstChildNodeValue(element);
-        relatesToId.add(NullChecker.isNotNullish(value) ? wsaHelper.fixMessageIDPrefix(value) : value);
+        relatesToId.add(getFirstChildNodeValue(element));
 
         return relatesToId;
     }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/transform/audit/AdminDistTransforms.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/transform/audit/AdminDistTransforms.java
@@ -36,6 +36,7 @@ import gov.hhs.fha.nhinc.common.nhinccommon.UserType;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import gov.hhs.fha.nhinc.util.HomeCommunityMap;
+import java.util.List;
 import oasis.names.tc.emergency.edxl.de._1.EDXLDistribution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -178,7 +179,11 @@ public class AdminDistTransforms {
     }
 
     private String getRelatesTo(AssertionType assertion) {
-        return NullChecker.isNotNullish(assertion.getRelatesToList()) ? assertion.getRelatesToList().get(0) : null;
+        return NullChecker.isNotNullish(assertion.getRelatesToList()) ? getRelatesToValue(assertion.getRelatesToList())
+            : null;
     }
 
+    private String getRelatesToValue(List<String> relatesTo) {
+        return NullChecker.isNotNullish(relatesTo.get(0)) ? relatesTo.get(0) : null;
+    }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/MessageGeneratorUtils.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/MessageGeneratorUtils.java
@@ -172,7 +172,8 @@ public class MessageGeneratorUtils {
         if (assertion != null) {
             if (NullChecker.isNullish(assertion.getMessageId())) {
                 assertion.setMessageId(wsaHelper.generateMessageID());
-                return assertion;
+            } else {
+                assertion.setMessageId(wsaHelper.fixMessageIDPrefix(assertion.getMessageId()));
             }
         }
         return assertion;

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/transform/AuditTransforms.java
@@ -639,6 +639,11 @@ public abstract class AuditTransforms<T, K> {
     }
 
     private String getRelatesTo(AssertionType assertion) {
-        return NullChecker.isNotNullish(assertion.getRelatesToList()) ? assertion.getRelatesToList().get(0) : null;
+        return NullChecker.isNotNullish(assertion.getRelatesToList()) ? getRelatesToValue(assertion.getRelatesToList())
+            : null;
+    }
+
+    private String getRelatesToValue(List<String> relatesTo) {
+        return NullChecker.isNotNullish(relatesTo.get(0)) ? relatesTo.get(0) : null;
     }
 }


### PR DESCRIPTION
1. Reverted AsyncMessageIdExtractor class changes made for FHAC-633.
2. MessageId is formatted to match the Nwhin layer message.

@alameluchidambaram and @jsmith2 
