### PR TITLE
FHAC-602: Configure audit logging for database and file

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
@@ -476,6 +476,8 @@ public class NhincConstants {
 
     // audit logging properties file name
     public static final String AUDIT_LOGGING_PROPERTY_FILE = "audit";
+    public static final String LOG_TO_DATABASE = "LogToDatabase";
+    public static final String LOG_TO_FILE = "LogToFile";
 
     private NhincConstants() {
     }

--- a/Product/Production/Common/Properties/src/main/resources/audit.properties
+++ b/Product/Production/Common/Properties/src/main/resources/audit.properties
@@ -1,5 +1,5 @@
 # This file contains properties to turn on/off ATNA auditlogging through out CONNECT services. A value of true means
-# Audit logging is turned on for that service. 
+# Audit logging is turned on for that service.
 
 #Patient Discovery
 PatientDiscovery=true
@@ -21,3 +21,7 @@ DocSubmissionDeferredResp=true
 CORE_X12DSGenericBatchRequest=true
 CORE_X12DSGenericBatchResponse=true
 CORE_X12DSRealTime=true
+
+#Following properties configure audit logging to be performed on database and/or file.
+LogToDatabase=true
+LogToFile=false

--- a/Product/Production/Common/Properties/src/main/resources/log4j.properties
+++ b/Product/Production/Common/Properties/src/main/resources/log4j.properties
@@ -16,7 +16,7 @@ log4j.logger.gov.hhs.fha.nhinc.saml=WARN
 log4j.logger.gov.hhs.fha.nhinc.callback=WARN
 # raise the level on connection manager to avoid output of the uddi cache (can set to debug if troubleshooting connection manager or need to see values in cache)
 log4j.logger.gov.hhs.fha.nhinc.connectmgr.ConnectionManagerCache=INFO
-# raise the level of WSS4J classes that are printing out debug stack traces 
+# raise the level of WSS4J classes that are printing out debug stack traces
 log4j.logger.org.apache.ws.security.WSSConfig=INFO
 log4j.logger.org.apache.ws.security.util.Loader=INFO
 
@@ -25,7 +25,7 @@ log4j.appender.C=org.apache.log4j.ConsoleAppender
 # info on layout pattern: http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html
 log4j.appender.C.layout=org.apache.log4j.PatternLayout
 log4j.appender.C.Threshold=${log4jDefaultLevel}
-log4j.appender.C.layout.ConversionPattern=[%d{dd/HH:mm:ss:SSS}] %-5p  %-30.30c{1}  %m%n  %X{transaction-id}%n %X{message-id}%n 
+log4j.appender.C.layout.ConversionPattern=[%d{dd/HH:mm:ss:SSS}] %-5p  %-30.30c{1}  %m%n  %X{transaction-id}%n %X{message-id}%n
 # optional Logging context
 #log4j.appender.C.Threshold=INFO
 #log4j.appender.C.layout.ConversionPattern=[%d{dd/HH:mm:ss:SSS}] [context=%-25x] %-5p  %-30.30c{1}  %m%n
@@ -52,3 +52,13 @@ log4j.appender.R.layout.ConversionPattern=[%d{M/d/yyyy}, %d{HH:mm:ss:SSS}] %-5p 
 #log4j.appender.db.Password=nhincpass
 #log4j.appender.db.layout=org.apache.log4j.PatternLayout
 #log4j.appender.db.layout.ConversionPattern=insert into logging.log(context,logLevel,class,message) values('%x','%p','%C','%m')
+
+# AUDIT
+log4j.appender.AUDIT=org.apache.log4j.RollingFileAppender
+log4j.appender.AUDIT.File=${com.sun.aas.instanceRoot}/logs/Audit.log
+log4j.appender.AUDIT.MaxFileSize=100MB
+log4j.appender.AUDIT.MaxBackupIndex=10
+# info on layout pattern: http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html
+log4j.appender.AUDIT.layout=org.apache.log4j.PatternLayout
+log4j.appender.AUDIT.layout.ConversionPattern=[%d{M/d/yyyy}, %d{HH:mm:ss:SSS}] %m%n
+log4j.logger.gov.hhs.fha.nhinc.auditrepository.nhinc.AuditFileStoreImpl=INFO, AUDIT

--- a/Product/Production/Services/AuditRepositoryCore/pom.xml
+++ b/Product/Production/Services/AuditRepositoryCore/pom.xml
@@ -26,7 +26,7 @@
             <groupId>org.connectopensource</groupId>
             <artifactId>AuditRepositoryWebservices</artifactId>
         </dependency>
-        
+
         <!-- Java EE APIs -->
         <dependency>
             <groupId>javax</groupId>
@@ -49,6 +49,10 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditDBStoreImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditDBStoreImpl.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.auditrepository.nhinc;
+
+import com.services.nhinc.schema.auditmessage.AuditMessageType;
+import com.services.nhinc.schema.auditmessage.ObjectFactory;
+import gov.hhs.fha.nhinc.auditrepository.hibernate.AuditRepositoryDAO;
+import gov.hhs.fha.nhinc.auditrepository.hibernate.AuditRepositoryRecord;
+import gov.hhs.fha.nhinc.common.auditlog.LogEventSecureRequestType;
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.nhinclib.NullChecker;
+import gov.hhs.fha.nhinc.transform.marshallers.JAXBContextHandler;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.sql.Blob;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.datatype.XMLGregorianCalendar;
+import org.hibernate.Hibernate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author tjafri
+ */
+public class AuditDBStoreImpl implements AuditStore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AuditDBStoreImpl.class);
+    private static final AuditRepositoryDAO auditLogDao = AuditRepositoryDAO.getAuditRepositoryDAOInstance();
+
+    @Override
+    public boolean saveAuditRecord(LogEventSecureRequestType request, AssertionType assertion) {
+        List<AuditRepositoryRecord> auditRecList = new ArrayList<>();
+        auditRecList.add(createDBAuditObj(request, assertion));
+        LOG.trace("AuditRepositoryOrchImpl.logAudit() -- Calling auditLogDao to insert record into database.");
+        return auditLogDao.insertAuditRepository(auditRecList);
+    }
+
+    protected final AuditRepositoryRecord createDBAuditObj(LogEventSecureRequestType mess, AssertionType assertion) {
+        AuditRepositoryRecord auditRec = new AuditRepositoryRecord();
+        String eventCommunityId = mess.getRemoteHCID();
+        if (NullChecker.isNotNullish(eventCommunityId)) {
+            auditRec.setRemoteHcid(eventCommunityId);
+        } else {
+            auditRec.setRemoteHcid("");
+        }
+
+        auditRec.setDirection(mess.getDirection());
+        auditRec.setMessage(getBlobFromAuditMessage(mess.getAuditMessage()));
+
+        XMLGregorianCalendar xMLCalDate = mess.getEventTimestamp();
+        if (xMLCalDate != null) {
+            auditRec.setEventTimeStamp(convertXMLGregorianCalendarToDate(xMLCalDate));
+        }
+        auditRec.setOutcome(mess.getEventOutcomeIndicator().intValue());
+        auditRec.setEventType(mess.getEventType());
+        auditRec.setEventId(mess.getEventID());
+        auditRec.setMessageId(mess.getRequestMessageId());
+        auditRec.setRelatesTo(mess.getRelatesTo());
+        auditRec.setUserId(mess.getUserId());
+
+        return auditRec;
+    }
+
+    private Blob getBlobFromAuditMessage(AuditMessageType mess) {
+        Blob eventMessage = null;
+        try {
+            JAXBContextHandler oHandler = new JAXBContextHandler();
+            JAXBContext jc = oHandler.getJAXBContext("com.services.nhinc.schema.auditmessage");
+            Marshaller marshaller = jc.createMarshaller();
+            ByteArrayOutputStream baOutStrm = new ByteArrayOutputStream();
+            baOutStrm.reset();
+            ObjectFactory factory = new ObjectFactory();
+            JAXBElement<AuditMessageType> oJaxbElement = factory.createAuditMessage(mess);
+            baOutStrm.close();
+            marshaller.marshal(oJaxbElement, baOutStrm);
+            byte[] buffer = baOutStrm.toByteArray();
+            eventMessage = Hibernate.createBlob(buffer);
+        } catch (JAXBException | IOException e) {
+            LOG.error("Exception during Blob conversion :" + e.getLocalizedMessage(), e);
+        }
+        return eventMessage;
+    }
+
+    /**
+     * This method converts an XMLGregorianCalendar date to java.util.Date
+     *
+     * @param xmlCalDate
+     * @return java.util.Date
+     */
+    private Date convertXMLGregorianCalendarToDate(XMLGregorianCalendar xmlCalDate) {
+        Calendar cal = Calendar.getInstance(Locale.getDefault());
+        LOG.info("cal.getTime() -> " + cal.getTime());
+        cal.setTime(xmlCalDate.toGregorianCalendar().getTime());
+        Date eventDate = cal.getTime();
+        LOG.info("eventDate -> " + eventDate);
+        return eventDate;
+    }
+}

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditDBStoreImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditDBStoreImpl.java
@@ -71,11 +71,7 @@ public class AuditDBStoreImpl implements AuditStore {
     protected final AuditRepositoryRecord createDBAuditObj(LogEventSecureRequestType mess, AssertionType assertion) {
         AuditRepositoryRecord auditRec = new AuditRepositoryRecord();
         String eventCommunityId = mess.getRemoteHCID();
-        if (NullChecker.isNotNullish(eventCommunityId)) {
-            auditRec.setRemoteHcid(eventCommunityId);
-        } else {
-            auditRec.setRemoteHcid("");
-        }
+        auditRec.setRemoteHcid(eventCommunityId);
 
         auditRec.setDirection(mess.getDirection());
         auditRec.setMessage(getBlobFromAuditMessage(mess.getAuditMessage()));

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditFileStoreImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditFileStoreImpl.java
@@ -27,37 +27,50 @@
 package gov.hhs.fha.nhinc.auditrepository.nhinc;
 
 import gov.hhs.fha.nhinc.common.auditlog.LogEventSecureRequestType;
-import gov.hhs.fha.nhinc.common.nhinccommon.AcknowledgementType;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import gov.hhs.fha.nhinc.transform.marshallers.JAXBContextHandler;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.namespace.QName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
  * @author tjafri
  */
-public class AuditRepositoryOrchImplTest {
+public class AuditFileStoreImpl implements AuditStore {
 
-    @Test
-    public void testLogAudit() {
-        AuditRepositoryOrchImpl auditRepo = new AuditRepositoryOrchImpl() {
-            @Override
-            protected boolean isLoggingToDatabaseOn() {
-                return false;
-            }
+    private static final Logger LOG = LoggerFactory.getLogger(AuditFileStoreImpl.class);
+    private static final JAXBContextHandler JAXB_HANDLER = new JAXBContextHandler();
 
-            @Override
-            protected boolean isLoggingToAuditFileOn() {
-                return true;
-            }
-        };
-        AuditFileStoreImpl mockFileStore = mock(AuditFileStoreImpl.class);
-        when(mockFileStore.saveAuditRecord(any(LogEventSecureRequestType.class), any(AssertionType.class))).
-            thenReturn(Boolean.TRUE);
-        AcknowledgementType ack = auditRepo.logAudit(new LogEventSecureRequestType(), new AssertionType());
-        assertEquals("AcknowledgementType message mismatch", ack.getMessage(), "Created Log Message in Audit File...");
+    @Override
+    public boolean saveAuditRecord(LogEventSecureRequestType request, AssertionType assertion) {
+        String auditLogEntry = getAuditString(request);
+        LOG.info(auditLogEntry);
+        return auditLogEntry != null;
     }
+
+    private String getAuditString(LogEventSecureRequestType request) {
+        try {
+            JAXBContext jc = JAXB_HANDLER.getJAXBContext(LogEventSecureRequestType.class);
+            Marshaller marshaller = jc.createMarshaller();
+
+            ByteArrayOutputStream baOutStrm = new ByteArrayOutputStream();
+            baOutStrm.reset();
+            JAXBElement<LogEventSecureRequestType> oJaxbElement = new JAXBElement<>(new QName("uri", "local"),
+                LogEventSecureRequestType.class, request);
+            baOutStrm.close();
+            marshaller.marshal(oJaxbElement, baOutStrm);
+            return new String(baOutStrm.toByteArray());
+        } catch (JAXBException | IOException e) {
+            LOG.error("Exception during Blob conversion :" + e.getLocalizedMessage(), e);
+        }
+        return null;
+    }
+
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditStore.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditStore.java
@@ -27,37 +27,13 @@
 package gov.hhs.fha.nhinc.auditrepository.nhinc;
 
 import gov.hhs.fha.nhinc.common.auditlog.LogEventSecureRequestType;
-import gov.hhs.fha.nhinc.common.nhinccommon.AcknowledgementType;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  *
  * @author tjafri
  */
-public class AuditRepositoryOrchImplTest {
+public interface AuditStore {
 
-    @Test
-    public void testLogAudit() {
-        AuditRepositoryOrchImpl auditRepo = new AuditRepositoryOrchImpl() {
-            @Override
-            protected boolean isLoggingToDatabaseOn() {
-                return false;
-            }
-
-            @Override
-            protected boolean isLoggingToAuditFileOn() {
-                return true;
-            }
-        };
-        AuditFileStoreImpl mockFileStore = mock(AuditFileStoreImpl.class);
-        when(mockFileStore.saveAuditRecord(any(LogEventSecureRequestType.class), any(AssertionType.class))).
-            thenReturn(Boolean.TRUE);
-        AcknowledgementType ack = auditRepo.logAudit(new LogEventSecureRequestType(), new AssertionType());
-        assertEquals("AcknowledgementType message mismatch", ack.getMessage(), "Created Log Message in Audit File...");
-    }
+    public boolean saveAuditRecord(LogEventSecureRequestType request, AssertionType assertion);
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditDBStoreImplTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditDBStoreImplTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.auditrepository.nhinc;
+
+import com.services.nhinc.schema.auditmessage.AuditMessageType;
+import com.services.nhinc.schema.auditmessage.EventIdentificationType;
+import gov.hhs.fha.nhinc.auditrepository.hibernate.AuditRepositoryRecord;
+import gov.hhs.fha.nhinc.common.auditlog.LogEventSecureRequestType;
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.UserType;
+import gov.hhs.fha.nhinc.transform.audit.AuditDataTransformHelper;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
+
+/**
+ *
+ * @author tjafri
+ */
+public class AuditDBStoreImplTest {
+
+    private final String EVENT_TYPE = "TestService";
+    private final String EVENT_ID_CODE = "110112";
+    private final String EVENT_ID_CODE_SYS_NAME = "DCM";
+    private final String EVENT_ID_CODE_DISP_NAME = "Query";
+    private final String DIRECTION = "Outbound";
+    private final String EVENT_ACTION_CODE = "R";
+    private final String USER_NAME = "testUser";
+    private final String RELATES_TO_1 = "val1";
+    private final String RELATES_TO_2 = "val2";
+    private final String MESSAGE_ID = "MessageId";
+
+    @Test
+    public void testCreateDBAuditObj() {
+        AuditDBStoreImpl dbStore = new AuditDBStoreImpl();
+        AssertionType assertion = createAssertion();
+        LogEventSecureRequestType auditObj = createLogEventSecureObj(assertion);
+        AuditRepositoryRecord dbRec = dbStore.createDBAuditObj(auditObj, assertion);
+        assertEquals("AuditRepositoryRecord.Direction mismatch", dbRec.getDirection(), auditObj.getDirection());
+        assertEquals("AuditRepositoryRecord.EventType mismatch", dbRec.getEventType(), EVENT_TYPE);
+        assertEquals("AuditRepositoryRecord.EventId mismatch", dbRec.getEventId(), EVENT_ID_CODE_DISP_NAME);
+        assertEquals("AuditRepositoryRecord.RelatesTo", dbRec.getRelatesTo(), RELATES_TO_1);
+        assertNotNull("AuditRepositoryRecord.MessageId", dbRec.getMessageId());
+    }
+
+    private LogEventSecureRequestType createLogEventSecureObj(AssertionType assertion) {
+        LogEventSecureRequestType logObj = new LogEventSecureRequestType();
+        AuditMessageType audit = createAuditMessageType();
+        logObj.setEventType(EVENT_TYPE);
+        logObj.setDirection(DIRECTION);
+        logObj.setAuditMessage(audit);
+        logObj.setEventID(audit.getEventIdentification().getEventID().getDisplayName());
+        logObj.setEventOutcomeIndicator(audit.getEventIdentification().getEventOutcomeIndicator());
+        logObj.setRelatesTo(assertion.getRelatesToList().get(0));
+        logObj.setRequestMessageId(MESSAGE_ID);
+        return logObj;
+    }
+
+    private AuditMessageType createAuditMessageType() {
+        AuditMessageType auditObj = new AuditMessageType();
+        auditObj.setEventIdentification(createEventIdentification());
+        return auditObj;
+    }
+
+    private EventIdentificationType createEventIdentification() {
+        return AuditDataTransformHelper.createEventIdentification(EVENT_ACTION_CODE, 0,
+            AuditDataTransformHelper.createEventId(EVENT_ID_CODE, null, EVENT_ID_CODE_SYS_NAME, EVENT_ID_CODE_DISP_NAME));
+    }
+
+    private AssertionType createAssertion() {
+        AssertionType assertion = new AssertionType();
+        UserType user = new UserType();
+        user.setUserName(USER_NAME);
+        assertion.setUserInfo(user);
+        assertion.getRelatesToList().add(RELATES_TO_1);
+        assertion.getRelatesToList().add(RELATES_TO_2);
+        return assertion;
+    }
+
+}


### PR DESCRIPTION
1. Added properties in audit.properties to configure audit logging on database and/or file.
2. Refactored AuditRepositoryOrchImpl to log audit enteries in either database, file or both.
3. Update log4.properties to include appender for Audit file.

@Chris and @alameluchidambaram 
