### PR TITLE
FHAC-689 Implement Audit Query DAO calls for Audit Viewer

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/resources/auditrepo.hbm.xml
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/resources/auditrepo.hbm.xml
@@ -13,8 +13,8 @@
       <column name="id" sql-type="INTEGER"/>
       <generator class="native"/>
     </id>
-    <property name="eventTimeStamp">
-      <column name="eventTimeStamp"/>
+    <property name="eventTimestamp">
+      <column name="eventTimestamp"/>
     </property>
     <property name="eventId">
       <column name="eventId"/>

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAO.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAO.java
@@ -275,6 +275,11 @@ public class AuditRepositoryDAO {
 
                 queryCriteria.add(Restrictions.ge("eventTimestamp", new Date(sdf.parse(startDate).getTime())));
 
+            } else if (NullChecker.isNullish(startDate) && NullChecker.isNotNullish(endDate)) {
+                SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy");
+
+                queryCriteria.add(Restrictions.le("eventTimestamp", new Date(sdf.parse(endDate).getTime())));
+
             }
 
             queryCriteria.setProjection(Projections.projectionList()

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAO.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAO.java
@@ -245,12 +245,12 @@ public class AuditRepositoryDAO {
             }
 
             if (startDate != null && endDate != null) {
-                queryCriteria.add(Expression.between("eventTimestamp", new Date(startDate.getTime()),
-                    new Date(endDate.getTime())));
+                queryCriteria.add(Expression.between("eventTimestamp", startDate,
+                    endDate));
             } else if (startDate != null && endDate == null) {
-                queryCriteria.add(Restrictions.ge("eventTimestamp", new Date(startDate.getTime())));
+                queryCriteria.add(Restrictions.ge("eventTimestamp", startDate));
             } else if (startDate == null && endDate != null) {
-                queryCriteria.add(Restrictions.le("eventTimestamp", new Date(endDate.getTime())));
+                queryCriteria.add(Restrictions.le("eventTimestamp", endDate));
             }
             // if no criteria is passed then it will search full database with above mentioned columns in the result
             queryList = setProjectionFields(queryCriteria).list();

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAO.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAO.java
@@ -27,6 +27,7 @@
 package gov.hhs.fha.nhinc.auditrepository.hibernate;
 
 import gov.hhs.fha.nhinc.auditrepository.hibernate.util.HibernateUtil;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -188,7 +189,12 @@ public class AuditRepositoryDAO {
             Criteria queryCriteria = session.createCriteria(AuditRepositoryRecord.class);
 
             if (NullChecker.isNotNullish(messageId)) {
-                queryCriteria.add(Restrictions.eq("messageId", messageId));
+                if (messageId.startsWith(NhincConstants.WS_SOAP_HEADER_MESSAGE_ID_PREFIX)) {
+                    queryCriteria.add(Restrictions.eq("messageId", messageId));
+                } else {
+                    queryCriteria.add(Restrictions.eq("messageId", NhincConstants.WS_SOAP_HEADER_MESSAGE_ID_PREFIX + messageId));
+
+                }
 
             }
 

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryRecord.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryRecord.java
@@ -36,7 +36,7 @@ import java.sql.Blob;
 public class AuditRepositoryRecord {
 
     private int id = 0;
-    private Date eventTimeStamp;
+    private Date eventTimestamp;
     private String eventId;
     private String userId;
     private String direction;
@@ -107,12 +107,12 @@ public class AuditRepositoryRecord {
         this.remoteHcid = communityId;
     }
 
-    public Date getEventTimeStamp() {
-        return eventTimeStamp;
+    public Date getEventTimestamp() {
+        return eventTimestamp;
     }
 
-    public void setEventTimeStamp(Date timeStamp) {
-        this.eventTimeStamp = timeStamp;
+    public void setEventTimestamp(Date timeStamp) {
+        this.eventTimestamp = timeStamp;
     }
 
     public String getUserId() {

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditDBStoreImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditDBStoreImpl.java
@@ -78,7 +78,7 @@ public class AuditDBStoreImpl implements AuditStore {
 
         XMLGregorianCalendar xMLCalDate = mess.getEventTimestamp();
         if (xMLCalDate != null) {
-            auditRec.setEventTimeStamp(convertXMLGregorianCalendarToDate(xMLCalDate));
+            auditRec.setEventTimestamp(convertXMLGregorianCalendarToDate(xMLCalDate));
         }
         auditRec.setOutcome(mess.getEventOutcomeIndicator().intValue());
         auditRec.setEventType(mess.getEventType());

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAOTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAOTest.java
@@ -40,9 +40,8 @@ import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.junit.Ignore;
+import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -62,6 +61,7 @@ public class AuditRepositoryDAOTest {
     private String relatesTo = null;
     private List<AuditRepositoryRecord> responseList = null;
     private static final AuditRepositoryDAO auditLogDao = AuditRepositoryDAO.getAuditRepositoryDAOInstance();
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(AuditRepositoryDAOTest.class);
 
     private AuditRepositoryDAO auditDao = null;
 
@@ -174,7 +174,7 @@ public class AuditRepositoryDAOTest {
             responseList = auditLogDao.queryByAuditOptions(outcome, eventType, userId, remoteHcid, startDate, endDate);
             assertNotNull(responseList);
         } catch (ParseException ex) {
-            Logger.getLogger(AuditRepositoryDAOTest.class.getName()).log(Level.SEVERE, null, ex);
+            LOG.error("Exception occurred due to :" + ex.getLocalizedMessage(), ex);
         }
     }
 
@@ -193,7 +193,7 @@ public class AuditRepositoryDAOTest {
             responseList = auditLogDao.queryByAuditOptions(outcome, eventType, userId, remoteHcid, startDate, endDate);
             assertNotNull(responseList);
         } catch (ParseException ex) {
-            Logger.getLogger(AuditRepositoryDAOTest.class.getName()).log(Level.SEVERE, null, ex);
+            LOG.error("Exception occurred due to :" + ex.getLocalizedMessage(), ex);
         }
     }
 

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAOTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAOTest.java
@@ -95,7 +95,7 @@ public class AuditRepositoryDAOTest {
         //All data elements for auditrepo should be added for junit Tests when work on auditrepo adapter data
         //persistence
         record.setDirection("Record 1 - Message Type");
-        record.setEventTimeStamp(now);
+        record.setEventTimestamp(now);
         record.setUserId("UnitTest1");
         eventLogList.add(record);
 
@@ -128,8 +128,7 @@ public class AuditRepositoryDAOTest {
     public void testQueryAuditViewerByMessageIdAndCheckPrecedence() {
         messageId = "urn:uuid%";
         outcome = 0;
-        responseList = auditLogDao.queryAuditViewer(messageId, relatesTo, outcome, eventType, userId, remoteHcid,
-            startDate, endDate);
+        responseList = auditLogDao.queryAuditRecords(messageId, relatesTo);
         assertNotNull(responseList);
 
     }
@@ -153,8 +152,7 @@ public class AuditRepositoryDAOTest {
     @Test
     public void testQueryAuditViewerByEventTypeList() {
         eventType = new ArrayList<>(Arrays.asList("DocSubmissionDeferredReq", "DocSubmission", "QueryForDocuments"));
-        responseList = auditLogDao.queryAuditViewer(messageId, relatesTo, outcome, eventType, userId, remoteHcid,
-            startDate, endDate);
+        responseList = auditLogDao.queryByAuditValues(outcome, eventType, userId, remoteHcid, startDate, endDate);
         assertNotNull(responseList);
     }
 
@@ -165,8 +163,7 @@ public class AuditRepositoryDAOTest {
     @Test
     public void testQueryAuditViewerByDateSearch() {
         startDate = "12/10/2015";
-        responseList = auditLogDao.queryAuditViewer(messageId, relatesTo, outcome, eventType, userId, remoteHcid,
-            startDate, endDate);
+        responseList = auditLogDao.queryByAuditValues(outcome, eventType, userId, remoteHcid, startDate, endDate);
         assertNotNull(responseList);
     }
 
@@ -178,8 +175,7 @@ public class AuditRepositoryDAOTest {
     public void testQueryAuditViewerByStartEndDateSearch() {
         startDate = "12/10/2015";
         endDate = "12/11/2015";
-        responseList = auditLogDao.queryAuditViewer(messageId, relatesTo, outcome, eventType, userId, remoteHcid,
-            startDate, endDate);
+        responseList = auditLogDao.queryByAuditValues(outcome, eventType, userId, remoteHcid, startDate, endDate);
         assertNotNull(responseList);
     }
 

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAOTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAOTest.java
@@ -26,6 +26,9 @@
  */
 package gov.hhs.fha.nhinc.auditrepository.hibernate;
 
+import java.sql.Blob;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 import org.junit.After;
@@ -37,6 +40,8 @@ import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.junit.Ignore;
 
 /**
@@ -52,8 +57,8 @@ public class AuditRepositoryDAOTest {
     private List<String> eventType = null;
     private String userId = null;
     private List<String> remoteHcid = null;
-    private String startDate = null;
-    private String endDate = null;
+    private Date startDate = null;
+    private Date endDate = null;
     private String relatesTo = null;
     private List<AuditRepositoryRecord> responseList = null;
     private static final AuditRepositoryDAO auditLogDao = AuditRepositoryDAO.getAuditRepositoryDAOInstance();
@@ -125,7 +130,7 @@ public class AuditRepositoryDAOTest {
      * AuditRepositoryDAO .
      */
     @Test
-    public void testQueryAuditViewerByMessageIdAndCheckPrecedence() {
+    public void testQueryByMessageIdAndCheckPrecedence() {
         messageId = "urn:uuid%";
         outcome = 0;
         responseList = auditLogDao.queryAuditRecords(messageId, relatesTo);
@@ -138,10 +143,10 @@ public class AuditRepositoryDAOTest {
      * AuditRepositoryDAO .
      */
     @Test
-    public void testQueryAuditViewerByAuditId() {
+    public void testQueryByAuditId() {
         String auditId = "15";
-        responseList = auditLogDao.queryAuditViewerByAuditId(auditId);
-        assertNotNull(responseList);
+        Blob message = auditLogDao.queryByAuditId(auditId);
+        assertNotNull(message);
 
     }
 
@@ -150,9 +155,9 @@ public class AuditRepositoryDAOTest {
      * AuditRepositoryDAO .
      */
     @Test
-    public void testQueryAuditViewerByEventTypeList() {
+    public void testQueryByEventTypeList() {
         eventType = new ArrayList<>(Arrays.asList("DocSubmissionDeferredReq", "DocSubmission", "QueryForDocuments"));
-        responseList = auditLogDao.queryByAuditValues(outcome, eventType, userId, remoteHcid, startDate, endDate);
+        responseList = auditLogDao.queryByAuditOptions(outcome, eventType, userId, remoteHcid, startDate, endDate);
         assertNotNull(responseList);
     }
 
@@ -161,10 +166,16 @@ public class AuditRepositoryDAOTest {
      * AuditRepositoryDAO .
      */
     @Test
-    public void testQueryAuditViewerByDateSearch() {
-        startDate = "12/10/2015";
-        responseList = auditLogDao.queryByAuditValues(outcome, eventType, userId, remoteHcid, startDate, endDate);
-        assertNotNull(responseList);
+    public void testQueryByDateSearch() {
+        try {
+            String dateStr = "12/13/2015 22:53:07";
+            SimpleDateFormat formatter = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss");
+            startDate = formatter.parse(dateStr);
+            responseList = auditLogDao.queryByAuditOptions(outcome, eventType, userId, remoteHcid, startDate, endDate);
+            assertNotNull(responseList);
+        } catch (ParseException ex) {
+            Logger.getLogger(AuditRepositoryDAOTest.class.getName()).log(Level.SEVERE, null, ex);
+        }
     }
 
     /**
@@ -172,11 +183,18 @@ public class AuditRepositoryDAOTest {
      * AuditRepositoryDAO .
      */
     @Test
-    public void testQueryAuditViewerByStartEndDateSearch() {
-        startDate = "12/10/2015";
-        endDate = "12/11/2015";
-        responseList = auditLogDao.queryByAuditValues(outcome, eventType, userId, remoteHcid, startDate, endDate);
-        assertNotNull(responseList);
+    public void testQueryByStartEndDateSearch() {
+        try {
+            String dateStartStr = "12/10/2015 00:00:00";
+            String dateEndStr = "12/11/2015 00:00:00";
+            SimpleDateFormat formatter = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss");
+            startDate = formatter.parse(dateStartStr);
+            endDate = formatter.parse(dateEndStr);
+            responseList = auditLogDao.queryByAuditOptions(outcome, eventType, userId, remoteHcid, startDate, endDate);
+            assertNotNull(responseList);
+        } catch (ParseException ex) {
+            Logger.getLogger(AuditRepositoryDAOTest.class.getName()).log(Level.SEVERE, null, ex);
+        }
     }
 
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAOTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAOTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import org.junit.Ignore;
 
 /**
@@ -46,6 +47,17 @@ import org.junit.Ignore;
 // TODO: Move to an integration test
 public class AuditRepositoryDAOTest {
 
+    private String messageId = null;
+    private Integer outcome = null;
+    private List<String> eventType = null;
+    private String userId = null;
+    private List<String> remoteHcid = null;
+    private String startDate = null;
+    private String endDate = null;
+    private String relatesTo = null;
+    private List<AuditRepositoryRecord> responseList = null;
+    private static final AuditRepositoryDAO auditLogDao = AuditRepositoryDAO.getAuditRepositoryDAOInstance();
+
     private AuditRepositoryDAO auditDao = null;
 
     public AuditRepositoryDAOTest() {
@@ -54,6 +66,7 @@ public class AuditRepositoryDAOTest {
 
     @BeforeClass
     public static void setUpClass() throws Exception {
+
     }
 
     @AfterClass
@@ -62,6 +75,7 @@ public class AuditRepositoryDAOTest {
 
     @Before
     public void setUp() {
+
     }
 
     @After
@@ -104,6 +118,69 @@ public class AuditRepositoryDAOTest {
         List result = auditDao.queryAuditRepositoryOnCriteria(eUserId, ePatientId, startDate, endDate);
         assertNotNull(result);
 
+    }
+
+    /**
+     * Test of queryAuditRepository Viewer with messageId and Outcome to test queryAuditViewer method, of class
+     * AuditRepositoryDAO .
+     */
+    @Test
+    public void testQueryAuditViewerByMessageIdAndCheckPrecedence() {
+        messageId = "urn:uuid%";
+        outcome = 0;
+        responseList = auditLogDao.queryAuditViewer(messageId, relatesTo, outcome, eventType, userId, remoteHcid,
+            startDate, endDate);
+        assertNotNull(responseList);
+
+    }
+
+    /**
+     * Test of queryAuditRepository Viewer with AuditId to test queryAuditViewerByAuditId method, of class
+     * AuditRepositoryDAO .
+     */
+    @Test
+    public void testQueryAuditViewerByAuditId() {
+        String auditId = "15";
+        responseList = auditLogDao.queryAuditViewerByAuditId(auditId);
+        assertNotNull(responseList);
+
+    }
+
+    /**
+     * Test of queryAuditRepository Viewer with list passed for EventType to test queryAuditViewer method, of class
+     * AuditRepositoryDAO .
+     */
+    @Test
+    public void testQueryAuditViewerByEventTypeList() {
+        eventType = new ArrayList<>(Arrays.asList("DocSubmissionDeferredReq", "DocSubmission", "QueryForDocuments"));
+        responseList = auditLogDao.queryAuditViewer(messageId, relatesTo, outcome, eventType, userId, remoteHcid,
+            startDate, endDate);
+        assertNotNull(responseList);
+    }
+
+    /**
+     * Test of queryAuditRepository Viewer with date options to test queryAuditViewer method, of class
+     * AuditRepositoryDAO .
+     */
+    @Test
+    public void testQueryAuditViewerByDateSearch() {
+        startDate = "12/10/2015";
+        responseList = auditLogDao.queryAuditViewer(messageId, relatesTo, outcome, eventType, userId, remoteHcid,
+            startDate, endDate);
+        assertNotNull(responseList);
+    }
+
+    /**
+     * Test of queryAuditRepository Viewer with date options to test queryAuditViewer method, of class
+     * AuditRepositoryDAO .
+     */
+    @Test
+    public void testQueryAuditViewerByStartEndDateSearch() {
+        startDate = "12/10/2015";
+        endDate = "12/11/2015";
+        responseList = auditLogDao.queryAuditViewer(messageId, relatesTo, outcome, eventType, userId, remoteHcid,
+            startDate, endDate);
+        assertNotNull(responseList);
     }
 
 }


### PR DESCRIPTION
We can search audit entries using 3 below options:
1. By MessageId or RelatesTo
2. By EventOutcome or EventType or UserId or Remote HCID or Event Begin Date or Event End date
3. By AuditId
I cannot hook up this DAO query changes to Secured,Unsecured and Java Implementation classes as development is still not ready and it is addressed in upcoming other ticket and it is not addressed as a part of this PR
All the above 3 available search criteria are tested with dummy data and I have also created Junit methods but those are dummy values passed in test methods need to be updated based on database entries
