### PR TITLE
FHAC-690: Create CXF client Adapter proxy for AuditQueryLog Service

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
@@ -311,6 +311,8 @@ public class NhincConstants {
     // Adapter Component MPI constants
     public static final String ADAPTER_COMPONENT_MPI_SERVICE_NAME = "adaptercomponentmpiservice";
     public static final String ADAPTER_COMPONENT_MPI_SECURED_SERVICE_NAME = "adaptercomponentmpisecuredservice";
+    //Adapter Audit Query Service Name
+    public static final String ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME = "auditquerylog";
     // SOAP Headers
     public static final String HTTP_REQUEST_ATTRIBUTE_SOAPMESSAGE = "SoapMessage";
     public static final String WS_SOAP_ENV_URL = "http://www.w3.org/2003/05/soap-envelope";

--- a/Product/Production/Common/Properties/src/main/resources/AuditQueryLogProxyConfig.xml
+++ b/Product/Production/Common/Properties/src/main/resources/AuditQueryLogProxyConfig.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+    <!--
+        The beans available in this file must be identified in the "description" element for the Spring configuration application. Beans are listed between braces 
+	    in the description separated with a comma like the following sample: {somebean,anotherbean}
+    -->
+    <description>Beans included in this file: {auditquerylog}</description>
+
+    <alias alias="auditquerylog" name="auditquerylogwsunsecured" />
+
+    <!-- No-op Implementation -->
+    
+    <bean lazy-init="true" class="gov.hhs.fha.nhinc.auditquerylog.nhinc.proxy.AuditQueryLogProxyNoOpImpl" id="auditquerylognoop" name="auditquerylognoop"> 
+        <meta key="impltype" value="noop"/>
+    </bean> 
+
+    <!-- Java Implementation -->
+    
+    <bean lazy-init="true" class="gov.hhs.fha.nhinc.auditquerylog.nhinc.proxy.AuditQueryLogProxyJavaImpl" id="auditquerylogjava" name="auditquerylogjava"> 
+        <meta key="impltype" value="java"/>
+    </bean> 
+
+    <!-- Unsecured web service Implementation -->
+    
+    <bean lazy-init="true" class="gov.hhs.fha.nhinc.auditquerylog.nhinc.proxy.AuditQueryLogProxyWebServiceUnsecuredImpl" id="auditquerylogwsunsecured" name="auditquerylogwsunsecured"> 
+        <meta key="impltype" value="wsunsecured"/>
+    </bean> 
+
+</beans>

--- a/Product/Production/Common/Properties/src/main/resources/internalConnectionInfo.xml
+++ b/Product/Production/Common/Properties/src/main/resources/internalConnectionInfo.xml
@@ -1126,6 +1126,23 @@
                     <keyedReference tModelKey="uddi:nhin:standard-servicenames" keyName="auditlog" keyValue="auditlog"/>
                 </categoryBag>
             </businessService>
+            
+            <!-- Audit Query Log-->
+            
+            <businessService serviceKey="uddi:nhincnode:auditquerylog">
+                <name xml:lang="en">auditquerylog</name>
+                <bindingTemplates>
+                    <bindingTemplate bindingKey="uddi:nhincnode:auditquerylog" serviceKey="uddi:nhincnode:auditquerylog">
+                        <accessPoint useType="endPoint">http://localhost:8080/CONNECTGateway/GatewayService/AuditQueryLogService</accessPoint>
+                        <categoryBag>
+                            <keyedReference tModelKey="uddi:nhin:versionofservice" keyName="" keyValue="1.0"/>
+                        </categoryBag>
+                    </bindingTemplate>
+                </bindingTemplates>
+                <categoryBag>
+                    <keyedReference tModelKey="uddi:nhin:standard-servicenames" keyName="auditquerylog" keyValue="auditquerylog"/>
+                </categoryBag>
+            </businessService>
 
             <!--  Policy Engine  -->
 

--- a/Product/Production/Gateway/CONNECTGatewayWeb/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/AuditQueryLogUnsecuredImpl.java
+++ b/Product/Production/Gateway/CONNECTGatewayWeb/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/AuditQueryLogUnsecuredImpl.java
@@ -81,7 +81,7 @@ public class AuditQueryLogUnsecuredImpl {
 
         QueryAuditEventsResponseType response = null;
         if (requestAuditEvents != null) {
-            response = getAuditQueryLogImpl().queryAuditEventsByMessageId(requestAuditEvents);
+            response = getAuditQueryLogImpl().queryAuditEventsByMessageIdAndRelatesTo(requestAuditEvents);
         }
         return response;
 

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/retrieve/AuditRetrieve.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/retrieve/AuditRetrieve.java
@@ -38,10 +38,27 @@ import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsResponseType;
  */
 public interface AuditRetrieve {
 
+    /**
+     *
+     * @param request - Request provides search params to retrieve Audit Events. If none of the elements are provided in
+     * request. If optional elements are not provided will return all audit events
+     * @return QueryAuditEventsResponseType
+     */
     public QueryAuditEventsResponseType retrieveAudits(QueryAuditEventsRequestType request);
 
+    /**
+     *
+     * @param request - Request provides search params MessageId and RelatesTo to retrieve Audit Events. If none of the
+     * elements are provided in request. If optional elements are not provided will return all audit events
+     * @return QueryAuditEventsResponseType
+     */
     public QueryAuditEventsResponseType retrieveAuditsByMsgIdAndRelatesToId(
         QueryAuditEventsRequestByRequestMessageId request);
 
+    /**
+     *
+     * @param request - Request provides Id and corresponding Blob will be retrieved.
+     * @return QueryAuditEventsBlobResponse - Response returns Audit Blob message.
+     */
     public QueryAuditEventsBlobResponse retrieveAuditBlob(QueryAuditEventsBlobRequest request);
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/retrieve/AuditRetrieve.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/retrieve/AuditRetrieve.java
@@ -33,6 +33,7 @@ import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsRequestType;
 import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsResponseType;
 
 /**
+ * AuditQueryLog client implementation
  *
  * @author tjafri
  */

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/AuditQueryLogImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/AuditQueryLogImpl.java
@@ -26,23 +26,41 @@
  */
 package gov.hhs.fha.nhinc.auditquerylog;
 
+import gov.hhs.fha.nhinc.audit.retrieve.AuditRetrieveEventsUtil;
+import gov.hhs.fha.nhinc.auditrepository.hibernate.AuditRepositoryDAO;
+import gov.hhs.fha.nhinc.common.auditquerylog.EventTypeList;
 import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsBlobRequest;
 import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsBlobResponse;
 import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsRequestType;
 import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsResponseType;
 import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsRequestByRequestMessageId;
+import gov.hhs.fha.nhinc.common.auditquerylog.RemoteHcidList;
+import java.math.BigInteger;
+import java.util.Date;
+import java.util.List;
+import javax.xml.datatype.XMLGregorianCalendar;
 
 /**
  *
- * @author achidamb
+ * @author tjafri
  */
 public class AuditQueryLogImpl {
 
+    private AuditRepositoryDAO dao;
+    private AuditRetrieveEventsUtil resultUtil = null;
+
+    /**
+     * constructor. initialize AuditRetrieveEventsUtil to build AuditQueryResponse
+     */
+    public AuditQueryLogImpl() {
+        resultUtil = new AuditRetrieveEventsUtil();
+    }
+
     /**
      *
-     * @param requestAuditEvents - Audit Search params will be provided by this requestAuditEvents. The Request may have
-     * Event startDate, Event EndDate, UserId, Remote Org Id and ServiceName/EventType.These are optional parameters. If
-     * none of them is provided all records will be retrieved.
+     * @param request - Audit Search params will be provided by this requestAuditEvents. The Request may have Event
+     * startDate, Event EndDate, UserId, Remote Org Id and ServiceName/EventType.These are optional parameters. If none
+     * of them is provided all records will be retrieved.
      * @return QueryAuditEventsResponseType - The Response will be having EventType or ServiceName, EventStatus- Success
      * or Failure, Event Timestamp, UserId(Human who initiated transaction), Direction (Outbound/Inbound), MessageID
      * -RequestMessageID, RelatesTo (Relates the DeferredRequests and DeferredResponses, Remote Organization Id and
@@ -50,35 +68,80 @@ public class AuditQueryLogImpl {
      *
      * The Adapter logic will be implemented in FHAC-690
      */
-    public QueryAuditEventsResponseType queryAuditEvents(QueryAuditEventsRequestType requestAuditEvents) {
-        return new QueryAuditEventsResponseType();
+    public QueryAuditEventsResponseType queryAuditEvents(QueryAuditEventsRequestType request) {
+        return resultUtil.getQueryAuditEventResponse(getAuditRepositoryDao().queryByAuditOptions(
+            getEventOutcome(request.getEventOutcomeIndicator()), getEventTypes(request.getEventTypeList()),
+            request.getUserId(), getRemoteHcids(request.getRemoteHcidList()), getRequestDate(request.getEventBeginDate()),
+            getRequestDate(request.getEventEndDate())));
+
     }
 
     /**
      *
-     * @param requestAuditEvents - Audit search params MessageId and RelatesTo will be provided by Request. These are
-     * optional fields in requestAuditEvents
+     * @param request - Audit search params MessageId and RelatesTo will be provided by Request. These are optional
+     * fields in requestAuditEvents
      * @return QueryAuditEventsResponseType - The Response will be having EventType or ServiceName, EventStatus- Success
      * or Failure, Event Timestamp, UserId(Human who initiated transaction), Direction (Outbound/Inbound), MessageID
      * -RequestMessageID, RelatesTo (Relates the DeferredRequests and DeferredResponses, Remote Organization Id and
      * Audit Id.
      *
-     * The Adapter logic will be implemented in FHAC-690
      */
     public QueryAuditEventsResponseType queryAuditEventsByMessageId(
-        QueryAuditEventsRequestByRequestMessageId requestAuditEvents) {
-        return new QueryAuditEventsResponseType();
+        QueryAuditEventsRequestByRequestMessageId request) {
+        return resultUtil.getQueryAuditEventResponse(getAuditRepositoryDao().queryAuditRecords(
+            request.getRequestMessageId(), request.getRelatesTo()));
     }
 
     /**
      *
-     * @param requestAuditEvents - Audit search params. Audit Id will be provided by requestAuditEvents.
+     *
+     * @param request - Audit search params. Audit Id will be provided by requestAuditEvents.
      * @return QueryAuditEventsBlobResponse - Response will be having only Audit Blob message.
      *
      * The Adapter logic will be implemented in FHAC-690
      */
-    public QueryAuditEventsBlobResponse queryAuditEventsById(QueryAuditEventsBlobRequest requestAuditEvents) {
-        return new QueryAuditEventsBlobResponse();
+    public QueryAuditEventsBlobResponse queryAuditEventsById(QueryAuditEventsBlobRequest request) {
+        return resultUtil.getQueryAuditEventBlobResponse(getAuditRepositoryDao().queryByAuditId(
+            (new Long(request.getId())).intValue()));
+    }
+
+    /**
+     *
+     * @return AuditRepositoryDAO Instance of AuditRepositoryDAO to query audit events.
+     */
+    protected AuditRepositoryDAO getAuditRepositoryDao() {
+        if (dao == null) {
+            dao = new AuditRepositoryDAO();
+        }
+        return dao;
+    }
+
+    private Date getRequestDate(XMLGregorianCalendar dateObj) {
+        if (dateObj != null) {
+            return dateObj.toGregorianCalendar().getTime();
+        }
+        return null;
+    }
+
+    private Integer getEventOutcome(BigInteger outcome) {
+        if (outcome != null) {
+            return outcome.intValue();
+        }
+        return null;
+    }
+
+    private List<String> getEventTypes(EventTypeList eventList) {
+        if (eventList != null) {
+            eventList.getEventType();
+        }
+        return null;
+    }
+
+    private List<String> getRemoteHcids(RemoteHcidList remoteHcidList) {
+        if (remoteHcidList != null) {
+            remoteHcidList.getRemoteHcid();
+        }
+        return null;
     }
 
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/AuditQueryLogImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/AuditQueryLogImpl.java
@@ -41,6 +41,7 @@ import java.util.List;
 import javax.xml.datatype.XMLGregorianCalendar;
 
 /**
+ * The AuditQueryLog impl is called from Pojo/Service implementation and passes/retrieve params from/to DAO layer.
  *
  * @author tjafri
  */
@@ -66,7 +67,6 @@ public class AuditQueryLogImpl {
      * -RequestMessageID, RelatesTo (Relates the DeferredRequests and DeferredResponses, Remote Organization Id and
      * Audit Id.
      *
-     * The Adapter logic will be implemented in FHAC-690
      */
     public QueryAuditEventsResponseType queryAuditEvents(QueryAuditEventsRequestType request) {
         return resultUtil.getQueryAuditEventResponse(getAuditRepositoryDao().queryByAuditOptions(
@@ -94,11 +94,9 @@ public class AuditQueryLogImpl {
 
     /**
      *
-     *
      * @param request - Audit search params. Audit Id will be provided by requestAuditEvents.
      * @return QueryAuditEventsBlobResponse - Response will be having only Audit Blob message.
      *
-     * The Adapter logic will be implemented in FHAC-690
      */
     public QueryAuditEventsBlobResponse queryAuditEventsById(QueryAuditEventsBlobRequest request) {
         return resultUtil.getQueryAuditEventBlobResponse(getAuditRepositoryDao().queryByAuditId(
@@ -132,14 +130,14 @@ public class AuditQueryLogImpl {
 
     private List<String> getEventTypes(EventTypeList eventList) {
         if (eventList != null) {
-            eventList.getEventType();
+            return eventList.getEventType();
         }
         return null;
     }
 
     private List<String> getRemoteHcids(RemoteHcidList remoteHcidList) {
         if (remoteHcidList != null) {
-            remoteHcidList.getRemoteHcid();
+            return remoteHcidList.getRemoteHcid();
         }
         return null;
     }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/AuditQueryLogImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/AuditQueryLogImpl.java
@@ -47,7 +47,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
 public class AuditQueryLogImpl {
 
     private AuditRepositoryDAO dao;
-    private AuditRetrieveEventsUtil resultUtil = null;
+    private AuditRetrieveEventsUtil resultUtil;
 
     /**
      * constructor. initialize AuditRetrieveEventsUtil to build AuditQueryResponse
@@ -86,7 +86,7 @@ public class AuditQueryLogImpl {
      * Audit Id.
      *
      */
-    public QueryAuditEventsResponseType queryAuditEventsByMessageId(
+    public QueryAuditEventsResponseType queryAuditEventsByMessageIdAndRelatesTo(
         QueryAuditEventsRequestByRequestMessageId request) {
         return resultUtil.getQueryAuditEventResponse(getAuditRepositoryDao().queryAuditRecords(
             request.getRequestMessageId(), request.getRelatesTo()));

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyJavaImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyJavaImpl.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.auditquerylog.nhinc.proxy;
+
+import gov.hhs.fha.nhinc.audit.retrieve.AuditRetrieve;
+import gov.hhs.fha.nhinc.auditquerylog.AuditQueryLogImpl;
+import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsBlobRequest;
+import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsBlobResponse;
+import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsRequestByRequestMessageId;
+import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsRequestType;
+import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsResponseType;
+
+/**
+ *
+ * @author tjafri
+ */
+public class AuditQueryLogProxyJavaImpl implements AuditRetrieve {
+
+    private AuditQueryLogImpl queryImpl = null;
+
+    public AuditQueryLogProxyJavaImpl() {
+        queryImpl = new AuditQueryLogImpl();
+    }
+
+    @Override
+    public QueryAuditEventsResponseType retrieveAudits(QueryAuditEventsRequestType req) {
+        return queryImpl.queryAuditEvents(req);
+    }
+
+    @Override
+    public QueryAuditEventsResponseType retrieveAuditsByMsgIdAndRelatesToId(
+        QueryAuditEventsRequestByRequestMessageId request) {
+        return queryImpl.queryAuditEventsByMessageId(request);
+    }
+
+    @Override
+    public QueryAuditEventsBlobResponse retrieveAuditBlob(QueryAuditEventsBlobRequest request) {
+        return queryImpl.queryAuditEventsById(request);
+    }
+
+}

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyJavaImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyJavaImpl.java
@@ -35,6 +35,7 @@ import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsRequestType;
 import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsResponseType;
 
 /**
+ * Pojo implementation to retrieve Audit events
  *
  * @author tjafri
  */
@@ -46,17 +47,34 @@ public class AuditQueryLogProxyJavaImpl implements AuditRetrieve {
         queryImpl = new AuditQueryLogImpl();
     }
 
+    /**
+     *
+     * @param req - Request provides search params to retrieve Audit Events. If none of the elements are provided in
+     * request. If optional elements are not provided will return all audit events
+     * @return QueryAuditEventsResponseType
+     */
     @Override
     public QueryAuditEventsResponseType retrieveAudits(QueryAuditEventsRequestType req) {
         return queryImpl.queryAuditEvents(req);
     }
 
+    /**
+     *
+     * @param request - Request provides search params MessageId and RelatesTo to retrieve Audit Events. If none of the
+     * elements are provided in request. If optional elements are not provided will return all audit events
+     * @return QueryAuditEventsResponseType
+     */
     @Override
     public QueryAuditEventsResponseType retrieveAuditsByMsgIdAndRelatesToId(
         QueryAuditEventsRequestByRequestMessageId request) {
         return queryImpl.queryAuditEventsByMessageIdAndRelatesTo(request);
     }
 
+    /**
+     *
+     * @param request - Request provides Id and corresponding Blob will be retrieved.
+     * @return QueryAuditEventsBlobResponse - Response returns Audit Blob message.
+     */
     @Override
     public QueryAuditEventsBlobResponse retrieveAuditBlob(QueryAuditEventsBlobRequest request) {
         return queryImpl.queryAuditEventsById(request);

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyJavaImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyJavaImpl.java
@@ -54,7 +54,7 @@ public class AuditQueryLogProxyJavaImpl implements AuditRetrieve {
     @Override
     public QueryAuditEventsResponseType retrieveAuditsByMsgIdAndRelatesToId(
         QueryAuditEventsRequestByRequestMessageId request) {
-        return queryImpl.queryAuditEventsByMessageId(request);
+        return queryImpl.queryAuditEventsByMessageIdAndRelatesTo(request);
     }
 
     @Override

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyNoOpImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyNoOpImpl.java
@@ -24,89 +24,35 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package gov.hhs.fha.nhinc.audit.retrieve.impl;
+package gov.hhs.fha.nhinc.auditquerylog.nhinc.proxy;
 
 import gov.hhs.fha.nhinc.audit.retrieve.AuditRetrieve;
-import gov.hhs.fha.nhinc.audit.retrieve.AuditRetrieveEventsUtil;
-import gov.hhs.fha.nhinc.auditrepository.hibernate.AuditRepositoryDAO;
-import gov.hhs.fha.nhinc.common.auditquerylog.EventTypeList;
 import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsBlobRequest;
 import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsBlobResponse;
 import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsRequestByRequestMessageId;
 import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsRequestType;
 import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsResponseType;
-import gov.hhs.fha.nhinc.common.auditquerylog.RemoteHcidList;
-import java.math.BigInteger;
-import java.util.Date;
-import java.util.List;
-import javax.xml.datatype.XMLGregorianCalendar;
 
 /**
  *
- * @author tjafri
+ * @author achidamb
  */
-public class AuditRetrieveJavaImpl implements AuditRetrieve {
-
-    private AuditRepositoryDAO dao;
-    private AuditRetrieveEventsUtil resultUtil = null;
-
-    public AuditRetrieveJavaImpl() {
-        resultUtil = new AuditRetrieveEventsUtil();
-    }
+public class AuditQueryLogProxyNoOpImpl implements AuditRetrieve {
 
     @Override
-    public QueryAuditEventsResponseType retrieveAudits(QueryAuditEventsRequestType req) {
-        return resultUtil.getQueryAuditEventResponse(getAuditRepositoryDao().queryByAuditOptions(
-            getEventOutcome(req.getEventOutcomeIndicator()), getEventTypes(req.getEventTypeList()),
-            req.getUserId(), getRemoteHcids(req.getRemoteHcidList()), getRequestDate(req.getEventBeginDate()),
-            getRequestDate(req.getEventEndDate())));
+    public QueryAuditEventsResponseType retrieveAudits(QueryAuditEventsRequestType request) {
+        return new QueryAuditEventsResponseType();
     }
 
     @Override
     public QueryAuditEventsResponseType retrieveAuditsByMsgIdAndRelatesToId(
         QueryAuditEventsRequestByRequestMessageId request) {
-        return resultUtil.getQueryAuditEventResponse(getAuditRepositoryDao().queryAuditRecords(
-            request.getRequestMessageId(), request.getRelatesTo()));
+        return new QueryAuditEventsResponseType();
     }
 
     @Override
     public QueryAuditEventsBlobResponse retrieveAuditBlob(QueryAuditEventsBlobRequest request) {
-        return resultUtil.getQueryAuditEventBlobResponse(getAuditRepositoryDao().queryByAuditId(
-            (new Long(request.getId())).intValue()));
+        return new QueryAuditEventsBlobResponse();
     }
 
-    protected AuditRepositoryDAO getAuditRepositoryDao() {
-        if (dao == null) {
-            dao = new AuditRepositoryDAO();
-        }
-        return dao;
-    }
-
-    private Date getRequestDate(XMLGregorianCalendar dateObj) {
-        if (dateObj != null) {
-            return dateObj.toGregorianCalendar().getTime();
-        }
-        return null;
-    }
-
-    private Integer getEventOutcome(BigInteger outcome) {
-        if (outcome != null) {
-            return outcome.intValue();
-        }
-        return null;
-    }
-
-    private List<String> getEventTypes(EventTypeList eventList) {
-        if (eventList != null) {
-            eventList.getEventType();
-        }
-        return null;
-    }
-
-    private List<String> getRemoteHcids(RemoteHcidList remoteHcidList) {
-        if (remoteHcidList != null) {
-            remoteHcidList.getRemoteHcid();
-        }
-        return null;
-    }
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyNoOpImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyNoOpImpl.java
@@ -34,22 +34,40 @@ import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsRequestType;
 import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsResponseType;
 
 /**
+ * NoopImpl returns empty responses for Audit search. The Audit Query Log impl can be turned off by injecting NoopImpl.
  *
  * @author achidamb
  */
 public class AuditQueryLogProxyNoOpImpl implements AuditRetrieve {
 
+    /**
+     *
+     * @param request - Request provides search params to retrieve Audit Events. If none of the elements are provided in
+     * request. If optional elements are not provided will return all audit events
+     * @return QueryAuditEventsResponseType
+     */
     @Override
     public QueryAuditEventsResponseType retrieveAudits(QueryAuditEventsRequestType request) {
         return new QueryAuditEventsResponseType();
     }
 
+    /**
+     *
+     * @param request - Request provides search params MessageId and RelatesTo to retrieve Audit Events. If none of the
+     * elements are provided in request. If optional elements are not provided will return all audit events
+     * @return QueryAuditEventsResponseType
+     */
     @Override
     public QueryAuditEventsResponseType retrieveAuditsByMsgIdAndRelatesToId(
         QueryAuditEventsRequestByRequestMessageId request) {
         return new QueryAuditEventsResponseType();
     }
 
+    /**
+     *
+     * @param request - Request provides Id and corresponding Blob will be retrieved.
+     * @return QueryAuditEventsBlobResponse - Response returns Audit Blob message.
+     */
     @Override
     public QueryAuditEventsBlobResponse retrieveAuditBlob(QueryAuditEventsBlobRequest request) {
         return new QueryAuditEventsBlobResponse();

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyObjectFactory.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyObjectFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.auditquerylog.nhinc.proxy;
+
+import gov.hhs.fha.nhinc.audit.retrieve.AuditRetrieve;
+import gov.hhs.fha.nhinc.proxy.ComponentProxyObjectFactory;
+
+/**
+ *
+ * @author achidamb
+ */
+public class AuditQueryLogProxyObjectFactory extends ComponentProxyObjectFactory {
+
+    //AduitQueryLogProxyConfig File name
+    private static final String CONFIG_FILE_NAME = "AuditQueryLogProxyConfig.xml";
+    private static final String BEAN_NAME = "auditquerylog";
+
+    @Override
+    protected String getConfigFileName() {
+        return CONFIG_FILE_NAME;
+    }
+
+    /**
+     *
+     * @return AuditQueryLog Bean
+     */
+    public AuditRetrieve getAuditRetrieveProxy() {
+        return getBean(BEAN_NAME, AuditRetrieve.class);
+    }
+
+}

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyObjectFactory.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyObjectFactory.java
@@ -30,6 +30,7 @@ import gov.hhs.fha.nhinc.audit.retrieve.AuditRetrieve;
 import gov.hhs.fha.nhinc.proxy.ComponentProxyObjectFactory;
 
 /**
+ * Class returns the Audit QueryLog Client implementor from Spring Proxy configuration files
  *
  * @author achidamb
  */

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyWebServiceUnsecuredImpl.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.auditquerylog.nhinc.proxy;
+
+import gov.hhs.fha.nhinc.audit.retrieve.AuditRetrieve;
+import gov.hhs.fha.nhinc.auditquerylog.nhinc.proxy.service.QueryAuditEventsUnsecuredServicePortDescriptor;
+import gov.hhs.fha.nhinc.auditquerylog.nhinc.proxy.service.QueryByIdUnsecuredServicePortDescriptor;
+import gov.hhs.fha.nhinc.auditquerylog.nhinc.proxy.service.QueryByMessageIdAndRelatesToUnsecuredServicePortDescriptor;
+import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsBlobRequest;
+import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsBlobResponse;
+import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsRequestByRequestMessageId;
+import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsRequestType;
+import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsResponseType;
+import gov.hhs.fha.nhinc.common.nhinccomponentauditquerylog.AuditQueryLogPortType;
+import gov.hhs.fha.nhinc.connectmgr.ConnectionManagerException;
+import gov.hhs.fha.nhinc.messaging.client.CONNECTCXFClientFactory;
+import gov.hhs.fha.nhinc.messaging.client.CONNECTClient;
+import gov.hhs.fha.nhinc.messaging.service.port.ServicePortDescriptor;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.nhinclib.NullChecker;
+import gov.hhs.fha.nhinc.webserviceproxy.WebServiceProxyHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author achidamb
+ */
+public class AuditQueryLogProxyWebServiceUnsecuredImpl implements AuditRetrieve {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AuditQueryLogProxyWebServiceUnsecuredImpl.class);
+    private final WebServiceProxyHelper proxyHelper = new WebServiceProxyHelper();
+    //method names to invoke
+    private final String QUERY_AUDIT_EVENTS = "queryAuditEvents";
+    private final String QUERY_AUDIT_EVENTS_BY_MSG_RELATESTO_ID = "queryAuditEventsByMessageID";
+    private final String QUERY_AUDIT_EVENTS_BY_ID = "queryAuditEventsBlob";
+
+    /**
+     *
+     * @param request - Request provides search params to retrieve Audit Events. If none of the elements are provided in
+     * request. If optional elements are not provided will return all audit events
+     * @return QueryAuditEventsResponseType
+     */
+    @Override
+    public QueryAuditEventsResponseType retrieveAudits(QueryAuditEventsRequestType request) {
+
+        QueryAuditEventsResponseType response = null;
+        try {
+
+            CONNECTClient<AuditQueryLogPortType> client = getCONNECTClient(getQueryAuditEventsPortDescriptor());
+            response = (QueryAuditEventsResponseType) client.invokePort(AuditQueryLogPortType.class,
+                QUERY_AUDIT_EVENTS, request);
+
+        } catch (Exception ex) {
+            LOG.debug("Failed to call the web service " + NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
+                + ex.getLocalizedMessage(), ex);
+        }
+        return response;
+    }
+
+    /**
+     *
+     * @param request - Request provides search params MessageId and RelatesTo to retrieve Audit Events. If none of the
+     * elements are provided in request. If optional elements are not provided will return all audit events
+     * @return QueryAuditEventsResponseType
+     */
+    @Override
+    public QueryAuditEventsResponseType retrieveAuditsByMsgIdAndRelatesToId(
+        QueryAuditEventsRequestByRequestMessageId request) {
+        QueryAuditEventsResponseType response = null;
+        try {
+
+            CONNECTClient<AuditQueryLogPortType> client = getCONNECTClient(
+                getQueryAuditEventsByMessageIdAndRelatesToPortDescriptor());
+            response = (QueryAuditEventsResponseType) client.invokePort(AuditQueryLogPortType.class,
+                QUERY_AUDIT_EVENTS_BY_MSG_RELATESTO_ID, request);
+
+        } catch (Exception ex) {
+            LOG.debug("Failed to call the web service " + NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
+                + ex.getLocalizedMessage(), ex);
+        }
+        return response;
+    }
+
+    /**
+     *
+     * @param request - Request provides Id and corresponding Blob will be retrieved.
+     * @return
+     */
+    @Override
+    public QueryAuditEventsBlobResponse retrieveAuditBlob(QueryAuditEventsBlobRequest request) {
+        QueryAuditEventsBlobResponse response = null;
+        try {
+
+            CONNECTClient<AuditQueryLogPortType> client = getCONNECTClient(getQueryAuditEventsByIdPortDescriptor());
+            response = (QueryAuditEventsBlobResponse) client.invokePort(AuditQueryLogPortType.class,
+                QUERY_AUDIT_EVENTS_BY_ID, request);
+
+        } catch (Exception ex) {
+            LOG.debug("Failed to call the web service " + NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
+                + ex.getLocalizedMessage(), ex);
+        }
+        return response;
+    }
+
+    private String getAdapterQueryLogUnsecuredSerrviceUrl() {
+        String url = null;
+        try {
+            url = proxyHelper.getUrlLocalHomeCommunity(NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME);
+        } catch (ConnectionManagerException ex) {
+            LOG.debug("Error while retrieving url for " + NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
+                + ex.getLocalizedMessage(), ex);
+            return url;
+        } catch (Exception ex) {
+            LOG.debug("Failed to call the web service " + NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
+                + ex.getLocalizedMessage(), ex);
+        }
+        return url;
+    }
+
+    private CONNECTClient<AuditQueryLogPortType> getCONNECTClient(
+        ServicePortDescriptor<AuditQueryLogPortType> portDescriptor) {
+
+        String url = getAdapterQueryLogUnsecuredSerrviceUrl();
+        CONNECTClient<AuditQueryLogPortType> client = null;
+        if (NullChecker.isNotNullish(url)) {
+            client = CONNECTCXFClientFactory.getInstance().getCONNECTClientUnsecured(
+                portDescriptor, url, null);
+        }
+        return client;
+
+    }
+
+    private ServicePortDescriptor<AuditQueryLogPortType> getQueryAuditEventsPortDescriptor() {
+        return new QueryAuditEventsUnsecuredServicePortDescriptor();
+
+    }
+
+    private ServicePortDescriptor<AuditQueryLogPortType> getQueryAuditEventsByMessageIdAndRelatesToPortDescriptor() {
+        return new QueryByMessageIdAndRelatesToUnsecuredServicePortDescriptor();
+
+    }
+
+    private ServicePortDescriptor<AuditQueryLogPortType> getQueryAuditEventsByIdPortDescriptor() {
+        return new QueryByIdUnsecuredServicePortDescriptor();
+
+    }
+}

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyWebServiceUnsecuredImpl.java
@@ -77,8 +77,8 @@ public class AuditQueryLogProxyWebServiceUnsecuredImpl implements AuditRetrieve 
                 QUERY_AUDIT_EVENTS, request);
 
         } catch (Exception ex) {
-            LOG.error("Failed to call the web service {} {}", NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
-                + ex.getLocalizedMessage(), ex);
+            LOG.error("Failed to call the web service {}: {}", NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME,
+                ex.getLocalizedMessage(), ex);
         }
         return response;
     }
@@ -101,8 +101,8 @@ public class AuditQueryLogProxyWebServiceUnsecuredImpl implements AuditRetrieve 
                 QUERY_AUDIT_EVENTS_BY_MSG_RELATESTO_ID, request);
 
         } catch (Exception ex) {
-            LOG.error("Failed to call the web service {} {}", NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
-                + ex.getLocalizedMessage(), ex);
+            LOG.error("Failed to call the web service {}: {}", NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME,
+                ex.getLocalizedMessage(), ex);
         }
         return response;
     }
@@ -122,8 +122,8 @@ public class AuditQueryLogProxyWebServiceUnsecuredImpl implements AuditRetrieve 
                 QUERY_AUDIT_EVENTS_BY_ID, request);
 
         } catch (Exception ex) {
-            LOG.error("Failed to call the web service {} {}", NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
-                + ex.getLocalizedMessage(), ex);
+            LOG.error("Failed to call the web service {}: {}", NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME,
+                ex.getLocalizedMessage(), ex);
         }
         return response;
     }
@@ -133,12 +133,12 @@ public class AuditQueryLogProxyWebServiceUnsecuredImpl implements AuditRetrieve 
         try {
             url = proxyHelper.getUrlLocalHomeCommunity(NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME);
         } catch (ConnectionManagerException ex) {
-            LOG.error("Error while retrieving url for {} {}", NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
-                + ex.getLocalizedMessage(), ex);
+            LOG.error("Error while retrieving url for {}: {}", NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME,
+                ex.getLocalizedMessage(), ex);
             return url;
         } catch (Exception ex) {
-            LOG.error("Failed to call the web service {} {}", NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
-                + ex.getLocalizedMessage(), ex);
+            LOG.error("Failed to call the web service {}: {}", NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME,
+                ex.getLocalizedMessage(), ex);
         }
         return url;
     }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyWebServiceUnsecuredImpl.java
@@ -76,7 +76,7 @@ public class AuditQueryLogProxyWebServiceUnsecuredImpl implements AuditRetrieve 
                 QUERY_AUDIT_EVENTS, request);
 
         } catch (Exception ex) {
-            LOG.debug("Failed to call the web service " + NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
+            LOG.error("Failed to call the web service " + NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
                 + ex.getLocalizedMessage(), ex);
         }
         return response;
@@ -100,7 +100,7 @@ public class AuditQueryLogProxyWebServiceUnsecuredImpl implements AuditRetrieve 
                 QUERY_AUDIT_EVENTS_BY_MSG_RELATESTO_ID, request);
 
         } catch (Exception ex) {
-            LOG.debug("Failed to call the web service " + NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
+            LOG.error("Failed to call the web service " + NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
                 + ex.getLocalizedMessage(), ex);
         }
         return response;
@@ -121,7 +121,7 @@ public class AuditQueryLogProxyWebServiceUnsecuredImpl implements AuditRetrieve 
                 QUERY_AUDIT_EVENTS_BY_ID, request);
 
         } catch (Exception ex) {
-            LOG.debug("Failed to call the web service " + NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
+            LOG.error("Failed to call the web service " + NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
                 + ex.getLocalizedMessage(), ex);
         }
         return response;
@@ -136,7 +136,7 @@ public class AuditQueryLogProxyWebServiceUnsecuredImpl implements AuditRetrieve 
                 + ex.getLocalizedMessage(), ex);
             return url;
         } catch (Exception ex) {
-            LOG.debug("Failed to call the web service " + NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
+            LOG.error("Failed to call the web service " + NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
                 + ex.getLocalizedMessage(), ex);
         }
         return url;

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditQueryLogProxyWebServiceUnsecuredImpl.java
@@ -47,6 +47,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
+ * Webservices client implementation to search Audit events
  *
  * @author achidamb
  */
@@ -76,7 +77,7 @@ public class AuditQueryLogProxyWebServiceUnsecuredImpl implements AuditRetrieve 
                 QUERY_AUDIT_EVENTS, request);
 
         } catch (Exception ex) {
-            LOG.error("Failed to call the web service " + NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
+            LOG.error("Failed to call the web service {} {}", NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
                 + ex.getLocalizedMessage(), ex);
         }
         return response;
@@ -100,7 +101,7 @@ public class AuditQueryLogProxyWebServiceUnsecuredImpl implements AuditRetrieve 
                 QUERY_AUDIT_EVENTS_BY_MSG_RELATESTO_ID, request);
 
         } catch (Exception ex) {
-            LOG.error("Failed to call the web service " + NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
+            LOG.error("Failed to call the web service {} {}", NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
                 + ex.getLocalizedMessage(), ex);
         }
         return response;
@@ -109,7 +110,7 @@ public class AuditQueryLogProxyWebServiceUnsecuredImpl implements AuditRetrieve 
     /**
      *
      * @param request - Request provides Id and corresponding Blob will be retrieved.
-     * @return
+     * @return QueryAuditEventsBlobResponse - Response returns Audit Blob message.
      */
     @Override
     public QueryAuditEventsBlobResponse retrieveAuditBlob(QueryAuditEventsBlobRequest request) {
@@ -121,7 +122,7 @@ public class AuditQueryLogProxyWebServiceUnsecuredImpl implements AuditRetrieve 
                 QUERY_AUDIT_EVENTS_BY_ID, request);
 
         } catch (Exception ex) {
-            LOG.error("Failed to call the web service " + NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
+            LOG.error("Failed to call the web service {} {}", NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
                 + ex.getLocalizedMessage(), ex);
         }
         return response;
@@ -132,11 +133,11 @@ public class AuditQueryLogProxyWebServiceUnsecuredImpl implements AuditRetrieve 
         try {
             url = proxyHelper.getUrlLocalHomeCommunity(NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME);
         } catch (ConnectionManagerException ex) {
-            LOG.debug("Error while retrieving url for " + NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
+            LOG.error("Error while retrieving url for {} {}", NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
                 + ex.getLocalizedMessage(), ex);
             return url;
         } catch (Exception ex) {
-            LOG.error("Failed to call the web service " + NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
+            LOG.error("Failed to call the web service {} {}", NhincConstants.ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME
                 + ex.getLocalizedMessage(), ex);
         }
         return url;

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/service/QueryAuditEventsUnsecuredServicePortDescriptor.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/service/QueryAuditEventsUnsecuredServicePortDescriptor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.auditquerylog.nhinc.proxy.service;
+
+import gov.hhs.fha.nhinc.common.nhinccomponentauditquerylog.AuditQueryLogPortType;
+import gov.hhs.fha.nhinc.messaging.service.port.SOAP12ServicePortDescriptor;
+
+/**
+ *
+ * @author achidamb
+ */
+public class QueryAuditEventsUnsecuredServicePortDescriptor extends
+    SOAP12ServicePortDescriptor<AuditQueryLogPortType> {
+
+    /**
+     *
+     * @return WSAddressingAction
+     */
+    @Override
+    public String getWSAddressingAction() {
+        return "urn:gov:hhs:fha:nhinc:nhinccomponentauditquerylog:QueryAuditEventsRequestType";
+    }
+
+    /**
+     * @return PortType
+     */
+    @Override
+    public Class<AuditQueryLogPortType> getPortClass() {
+        return AuditQueryLogPortType.class;
+    }
+
+}

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/service/QueryAuditEventsUnsecuredServicePortDescriptor.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/service/QueryAuditEventsUnsecuredServicePortDescriptor.java
@@ -30,6 +30,7 @@ import gov.hhs.fha.nhinc.common.nhinccomponentauditquerylog.AuditQueryLogPortTyp
 import gov.hhs.fha.nhinc.messaging.service.port.SOAP12ServicePortDescriptor;
 
 /**
+ * AuditQueryLog PortDesriptor for QueryAuditEvents service based on various params.
  *
  * @author achidamb
  */

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/service/QueryByIdUnsecuredServicePortDescriptor.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/service/QueryByIdUnsecuredServicePortDescriptor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.auditquerylog.nhinc.proxy.service;
+
+import gov.hhs.fha.nhinc.common.nhinccomponentauditquerylog.AuditQueryLogPortType;
+import gov.hhs.fha.nhinc.messaging.service.port.SOAP12ServicePortDescriptor;
+
+/**
+ *
+ * @author achidamb
+ */
+public class QueryByIdUnsecuredServicePortDescriptor extends SOAP12ServicePortDescriptor<AuditQueryLogPortType> {
+
+    /**
+     *
+     * @return WSAddressingAction
+     */
+    @Override
+    public String getWSAddressingAction() {
+        return "urn:gov:hhs:fha:nhinc:nhinccomponentauditquerylog:QueryAuditEventsBlobRequest";
+    }
+
+    /**
+     * @return PortType
+     */
+    @Override
+    public Class<AuditQueryLogPortType> getPortClass() {
+        return AuditQueryLogPortType.class;
+    }
+
+}

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/service/QueryByIdUnsecuredServicePortDescriptor.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/service/QueryByIdUnsecuredServicePortDescriptor.java
@@ -30,6 +30,7 @@ import gov.hhs.fha.nhinc.common.nhinccomponentauditquerylog.AuditQueryLogPortTyp
 import gov.hhs.fha.nhinc.messaging.service.port.SOAP12ServicePortDescriptor;
 
 /**
+ * AuditQueryLog PortDesriptor for Retrieve Audit events Blob
  *
  * @author achidamb
  */

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/service/QueryByMessageIdAndRelatesToUnsecuredServicePortDescriptor.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/service/QueryByMessageIdAndRelatesToUnsecuredServicePortDescriptor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2009-2015, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.auditquerylog.nhinc.proxy.service;
+
+import gov.hhs.fha.nhinc.common.nhinccomponentauditquerylog.AuditQueryLogPortType;
+import gov.hhs.fha.nhinc.messaging.service.port.SOAP12ServicePortDescriptor;
+
+/**
+ *
+ * @author achidamb
+ */
+public class QueryByMessageIdAndRelatesToUnsecuredServicePortDescriptor extends
+    SOAP12ServicePortDescriptor<AuditQueryLogPortType> {
+
+    /**
+     *
+     * @return WSAddressingAction
+     */
+    @Override
+    public String getWSAddressingAction() {
+        return "urn:gov:hhs:fha:nhinc:nhinccomponentauditquerylog:QueryAuditEventsRequestByMessageID";
+    }
+
+    /**
+     * @return PortType
+     */
+    @Override
+    public Class<AuditQueryLogPortType> getPortClass() {
+        return AuditQueryLogPortType.class;
+    }
+
+}

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/service/QueryByMessageIdAndRelatesToUnsecuredServicePortDescriptor.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/service/QueryByMessageIdAndRelatesToUnsecuredServicePortDescriptor.java
@@ -30,6 +30,7 @@ import gov.hhs.fha.nhinc.common.nhinccomponentauditquerylog.AuditQueryLogPortTyp
 import gov.hhs.fha.nhinc.messaging.service.port.SOAP12ServicePortDescriptor;
 
 /**
+ * AuditQueryLog PortDesriptor for Retrieve Audit Events based on MessageId and RelatesTo
  *
  * @author achidamb
  */

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAO.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAO.java
@@ -39,7 +39,6 @@ import org.slf4j.LoggerFactory;
 import org.hibernate.Criteria;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
-import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.hibernate.criterion.Expression;
 import org.hibernate.criterion.Projections;
@@ -53,7 +52,6 @@ import org.hibernate.criterion.Restrictions;
 public class AuditRepositoryDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(AuditRepositoryDAO.class);
-    public static String JAVA_IO_TMPDIR = "java.io.tmpdir";
 
     /**
      * Constructor
@@ -148,7 +146,7 @@ public class AuditRepositoryDAO {
     }
 
     /**
-     * This method does a query to database to get the Audit Log Messages based different options
+     * This method does a query to database to get the Audit Log Messages based on params below
      *
      * @param messageId
      * @param relatesTo
@@ -190,12 +188,13 @@ public class AuditRepositoryDAO {
     /**
      * This method does a query to database to get the Audit Log Messages based different options
      *
-     * @param outcome
-     * @param startDate
-     * @param userId
-     * @param eventTypeList
-     * @param remoteHcidList
-     * @param endDate
+     * @param outcome - status success or failure
+     * @param startDate - Audit Event Start Date
+     * @param userId - Human initiator who initiated transaction. SAML Attribute statement SubjectID.
+     * @param eventTypeList - ServiceNames like PatientDiscovery (PD), DocumentQuery (DQ) and other CONNECT supported
+     * Nwhin services
+     * @param remoteHcidList - Remote Organization ID's
+     * @param endDate - Event End date
      * @return List
      */
     public List<AuditRepositoryRecord> queryByAuditOptions(Integer outcome, List<String> eventTypeList, String userId,
@@ -248,8 +247,8 @@ public class AuditRepositoryDAO {
     /**
      * This method does a query to database to get the Audit Log Blob Messages based on the auditId
      *
-     * @param auditId
-     * @return List
+     * @param auditId - AuidtRepository table Primary Key unique Id
+     * @return Blob - Audit Blob message corresponding to Audit Id supplied
      */
     public Blob queryByAuditId(int auditId) {
 
@@ -274,7 +273,7 @@ public class AuditRepositoryDAO {
     }
 
     /**
-     * Closes the Hibernate Session
+     * TODO will be moved into Util class in future. Closes the Hibernate Session
      *
      * @param session Hibernate session instance
      * @param flush
@@ -289,6 +288,10 @@ public class AuditRepositoryDAO {
         }
     }
 
+    /**
+     *
+     * @return Hibernate session
+     */
     protected Session getSession() {
         return HibernateUtil.getSessionFactory().openSession();
     }

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditquerylog/AuditQueryLogImplTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditquerylog/AuditQueryLogImplTest.java
@@ -24,7 +24,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package gov.hhs.fha.nhinc.audit.retrieve.impl;
+package gov.hhs.fha.nhinc.auditquerylog;
 
 import gov.hhs.fha.nhinc.auditrepository.hibernate.AuditRepositoryDAO;
 import gov.hhs.fha.nhinc.auditrepository.hibernate.AuditRepositoryRecord;
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.when;
  *
  * @author tjafri
  */
-public class AuditRetrieveJavaImplTest {
+public class AuditQueryLogImplTest {
 
     private final String DIRECTION = "Outbound";
     private final String REMOTE_HCID = "2.2";
@@ -62,7 +62,7 @@ public class AuditRetrieveJavaImplTest {
     private final Session mockSession = mock(Session.class);
     private final Criteria mockCriteria = mock(Criteria.class);
     private AuditRepositoryDAO dao = null;
-    private AuditRetrieveJavaImpl auditRetrieve = null;
+    private AuditQueryLogImpl auditRetrieve = null;
 
     @Before
     public void setup() {
@@ -72,7 +72,7 @@ public class AuditRetrieveJavaImplTest {
                 return mockSession;
             }
         };
-        auditRetrieve = new AuditRetrieveJavaImpl() {
+        auditRetrieve = new AuditQueryLogImpl() {
             @Override
             protected AuditRepositoryDAO getAuditRepositoryDao() {
                 return dao;
@@ -86,7 +86,7 @@ public class AuditRetrieveJavaImplTest {
         when(mockCriteria.list()).thenReturn(getAuditRepositoryRecordList());
         QueryAuditEventsRequestType request = new QueryAuditEventsRequestType();
         request.setUserId("testUserId");
-        QueryAuditEventsResponseType response = auditRetrieve.retrieveAudits(request);
+        QueryAuditEventsResponseType response = auditRetrieve.queryAuditEvents(request);
         assertEquals("Response Object size mismatch", response.getQueryAuditEventsResults().size(), 1);
         QueryAuditEventsResults obj = response.getQueryAuditEventsResults().get(0);
         assertEquals("QueryAuditEventsResults.Direction mismatch", obj.getDirection(), DIRECTION);

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditRetrieveDBTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditRetrieveDBTest.java
@@ -24,7 +24,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package gov.hhs.fha.nhinc.audit.retrieve.impl;
+package gov.hhs.fha.nhinc.auditquerylog.nhinc.proxy;
 
 import gov.hhs.fha.nhinc.auditrepository.hibernate.AuditRepositoryDAO;
 import gov.hhs.fha.nhinc.auditrepository.hibernate.AuditRepositoryRecord;
@@ -102,7 +102,7 @@ public class AuditRetrieveDBTest {
 
     @Test
     public void testAuditRetrieveBasedOnUserId() {
-        AuditRetrieveJavaImpl auditImpl = new AuditRetrieveJavaImpl();
+        AuditQueryLogProxyJavaImpl auditImpl = new AuditQueryLogProxyJavaImpl();
         QueryAuditEventsRequestType request = new QueryAuditEventsRequestType();
         request.setUserId(USER_ID);
         QueryAuditEventsResponseType response = auditImpl.retrieveAudits(request);
@@ -111,7 +111,7 @@ public class AuditRetrieveDBTest {
 
     @Test
     public void testAuditRetrieveBasedOnEventOutcome() {
-        AuditRetrieveJavaImpl auditImpl = new AuditRetrieveJavaImpl();
+        AuditQueryLogProxyJavaImpl auditImpl = new AuditQueryLogProxyJavaImpl();
         QueryAuditEventsRequestType request = new QueryAuditEventsRequestType();
         request.setEventOutcomeIndicator(BigInteger.valueOf(0L));
         QueryAuditEventsResponseType response = auditImpl.retrieveAudits(request);
@@ -120,7 +120,7 @@ public class AuditRetrieveDBTest {
 
     @Test
     public void testAuditRetrieveBasedOnEventBeginDate() {
-        AuditRetrieveJavaImpl auditImpl = new AuditRetrieveJavaImpl();
+        AuditQueryLogProxyJavaImpl auditImpl = new AuditQueryLogProxyJavaImpl();
         QueryAuditEventsRequestType request = new QueryAuditEventsRequestType();
         request.setEventBeginDate(convertDateToXMLGregorianCalendar(EVENT_TIMESTAMP));
         QueryAuditEventsResponseType response = auditImpl.retrieveAudits(request);
@@ -130,7 +130,7 @@ public class AuditRetrieveDBTest {
     @Test
     public void testAuditRetrieveBasedOnEventTypes() {
         List<String> eventTypes = new ArrayList<>(Arrays.asList(EVENT_TYPE));
-        AuditRetrieveJavaImpl auditImpl = new AuditRetrieveJavaImpl();
+        AuditQueryLogProxyJavaImpl auditImpl = new AuditQueryLogProxyJavaImpl();
         QueryAuditEventsRequestType request = new QueryAuditEventsRequestType();
         EventTypeList events = new EventTypeList();
         events.getEventType().addAll(eventTypes);
@@ -141,7 +141,7 @@ public class AuditRetrieveDBTest {
 
     @Test
     public void testAuditRetrieveBasedOnAuditId() {
-        AuditRetrieveJavaImpl auditImpl = new AuditRetrieveJavaImpl();
+        AuditQueryLogProxyJavaImpl auditImpl = new AuditQueryLogProxyJavaImpl();
         QueryAuditEventsBlobRequest request = new QueryAuditEventsBlobRequest();
         request.setId(ID);
         QueryAuditEventsBlobResponse blobResponse = auditImpl.retrieveAuditBlob(request);
@@ -150,7 +150,7 @@ public class AuditRetrieveDBTest {
 
     @Test
     public void testAuditRetrieveBasedOnMessageId() {
-        AuditRetrieveJavaImpl auditImpl = new AuditRetrieveJavaImpl();
+        AuditQueryLogProxyJavaImpl auditImpl = new AuditQueryLogProxyJavaImpl();
         QueryAuditEventsRequestByRequestMessageId request = new QueryAuditEventsRequestByRequestMessageId();
         request.setRequestMessageId(MESSAGE_ID);
         auditImpl.retrieveAuditsByMsgIdAndRelatesToId(request);


### PR DESCRIPTION
1. Create AuditQueryLog service Unsecured CXF client.
2. Add Spring Proxy Config file.
3. Add AuditQueryLog Service in interconnectioninfo.xml
4. Create Portdescriptors required for CXF client implementation.
