### PR TITLE
Fhac 740

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/event/model/Audit.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/event/model/Audit.java
@@ -26,8 +26,6 @@
  */
 package gov.hhs.fha.nhinc.admingui.event.model;
 
-import java.util.Date;
-
 /**
  *
  * @author achidamb

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/event/model/Audit.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/event/model/Audit.java
@@ -37,7 +37,7 @@ public class Audit {
     private long id;
     private String eventType;
     private String eventOutcomeIndicator;
-    private Date eventTimestamp;
+    private String eventTimestamp;
     private String userId;
     private String messageId;
     private String remoteHcid;
@@ -45,7 +45,6 @@ public class Audit {
     private String relatesTo;
     private String direction;
     private String eventId;
-  
 
     public String getUserId() {
         return userId;
@@ -90,14 +89,14 @@ public class Audit {
     /**
      * @return the eventTimestamp
      */
-    public Date getEventTimestamp() {
+    public String getEventTimestamp() {
         return eventTimestamp;
     }
 
     /**
      * @param eventTimestamp the eventTimestamp to set
      */
-    public void setEventTimestamp(Date eventTimestamp) {
+    public void setEventTimestamp(String eventTimestamp) {
         this.eventTimestamp = eventTimestamp;
     }
 
@@ -157,7 +156,6 @@ public class Audit {
         this.eventId = eventId;
     }
 
-    
     /**
      * @return the id
      */

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/AuditSearchBean.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/AuditSearchBean.java
@@ -33,14 +33,14 @@ import gov.hhs.fha.nhinc.admingui.services.impl.AuditServiceImpl;
 import gov.hhs.fha.nhinc.admingui.util.ConnectionHelper;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
+import gov.hhs.fha.nhinc.util.HomeCommunityMap;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.SessionScoped;
-import org.uddi.api_v3.BusinessEntity;
+import org.apache.commons.lang.time.DateUtils;
 
 /**
  *
@@ -51,7 +51,7 @@ import org.uddi.api_v3.BusinessEntity;
 public class AuditSearchBean {
 
     private String userId;
-    private HashMap<String, BusinessEntity> remoteHcidList;
+    private Map<String, String> remoteHcidMap;
     private Date eventStartDate;
     private Date eventEndDate;
     private List<String> eventTypeList;
@@ -59,40 +59,59 @@ public class AuditSearchBean {
     private String outcomeIndicator;
     private List<String> selectedRemoteHcidList;
     private List<String> selectedEventTypeList;
-    private Map<String, String> eventOutcomeIndicatorMap;
+    private List<String> eventOutcomeIndicatorList;
     private List<Audit> auditRecordList;
     private String auditMessage;
     private boolean auditFound;
     private String messageId;
     private String relatesTo;
     private long id;
+    private Map<String, String> remoteHcidOrgNameMap;
+    private String auditBlobMsg;
+    private final String AUDIT_RECORDS_FOUND = "Audit Records Found";
+    private final String AUDIT_RECORDS_NOT_FOUND = "Audit Records not Found";
 
     public AuditSearchBean() {
         setEventTypeList(populateEventTypeList());
-        setRemoteHcidList(populateRemoteOrgHcid());
+        //This map stores key=Orgname and value =remoteHcid. Need this map for display in the dropdownbox
+        //on AuditSearch screen.
+        setRemoteHcidMap(populateRemoteOrgHcid());
         setEventOutcomeIndicatorList(populateEventOutcomeIndicatorValues());
+        //This map stores key=remoteHcid and value=Orgname. Need this map for datatable display on AuditSearch screen.
+        setRemoteHcidOrgNameMap(populateRemoteHcidAndOrgName());
     }
 
+    /**
+     * This method searches Audit database based on eventoutcome, serviceTypes, userId, remoteHcid, eventstartDate and
+     * eventEndDate
+     */
     public void searchAudit() {
         AuditService impl = new AuditServiceImpl();
-        this.auditRecordList = impl.createMockAuditRecord();
+        this.auditRecordList = impl.searchAuditRecord(getSelectedEventOutcomeIndicator(), getSelectedServiceTypes(),
+            NullChecker.isNotNullishIgnoreSpace(userId) ? userId : null, getRemoteHCIDFromSelectedOrgs(), eventStartDate,
+            createEventEndDateToTimestamp(eventEndDate), getRemoteHcidOrgNameMap());
         if (NullChecker.isNullish(this.auditRecordList)) {
-            this.auditMessage = "Audit Records not found";
+            this.auditMessage = AUDIT_RECORDS_NOT_FOUND;
             auditFound = false;
         } else {
-            this.auditMessage = "Audit Records Found";
+            this.auditMessage = AUDIT_RECORDS_FOUND;
             auditFound = true;
         }
     }
 
+    /**
+     * This method searches Audit database based on messageId and/or relatesTo
+     */
     public void searchAuditMessageId() {
         AuditServiceImpl impl = new AuditServiceImpl();
-        this.auditRecordList = impl.createMockAuditRecord();
+        this.auditRecordList = impl.searchAuditRecordBasedOnMsgIdAndRelatesToId(
+            NullChecker.isNotNullishIgnoreSpace(messageId) ? messageId : null,
+            NullChecker.isNotNullishIgnoreSpace(relatesTo) ? relatesTo : null, getRemoteHcidOrgNameMap());
         if (NullChecker.isNullish(this.auditRecordList)) {
-            this.auditMessage = "Audit Records not found";
+            this.auditMessage = AUDIT_RECORDS_NOT_FOUND;
             auditFound = false;
         } else {
-            this.auditMessage = "Audit Records Found";
+            this.auditMessage = AUDIT_RECORDS_FOUND;
             auditFound = true;
         }
     }
@@ -113,6 +132,7 @@ public class AuditSearchBean {
         }
         this.auditMessage = "";
         this.auditFound = false;
+        this.auditBlobMsg = "";
         return NavigationConstant.AUDIT_SEARCH_PAGE;
     }
 
@@ -132,22 +152,17 @@ public class AuditSearchBean {
         return impl.createMockAuditMessage(id);
     }
 
-    private HashMap<String, BusinessEntity> populateRemoteOrgHcid() {
-        return new ConnectionHelper().getExternalEntitiesMap();
+    private Map<String, String> populateRemoteOrgHcid() {
+        return new ConnectionHelper().getOrgNameRemoteHcidExternalEntities();
 
     }
 
     private List<String> populateEventTypeList() {
-        List<String> serviceNames = new ArrayList<>();
-        serviceNames = NhincConstants.NHIN_SERVICE_NAMES.getServiceNamesList();
-        return serviceNames;
+        return NhincConstants.NHIN_SERVICE_NAMES.getServiceNamesList();
     }
 
-    private Map<String, String> populateEventOutcomeIndicatorValues() {
-        Map<String, String> outcomeList = new HashMap<>();
-        outcomeList.put("Success", "0");
-        outcomeList.put("Failure", "12");
-        return outcomeList;
+    private List<String> populateEventOutcomeIndicatorValues() {
+        return NhincConstants.EVENT_IDENTIFICATION_STATUS.getEventDisplayStatusList();
     }
 
     public String getMessageId() {
@@ -182,12 +197,12 @@ public class AuditSearchBean {
         this.auditRecordList = auditRecordList;
     }
 
-    public Map<String, String> getEventOutcomeIndicatorMap() {
-        return eventOutcomeIndicatorMap;
+    public List<String> getEventOutcomeIndicatorList() {
+        return eventOutcomeIndicatorList;
     }
 
-    private void setEventOutcomeIndicatorList(Map<String, String> eventOutcomeIndicatorMap) {
-        this.eventOutcomeIndicatorMap = eventOutcomeIndicatorMap;
+    private void setEventOutcomeIndicatorList(List<String> eventOutcomeIndicatorList) {
+        this.eventOutcomeIndicatorList = eventOutcomeIndicatorList;
     }
 
     public List<String> getSelectedEventTypeList() {
@@ -222,12 +237,12 @@ public class AuditSearchBean {
         this.activeIndex = activeIndex;
     }
 
-    public HashMap<String, BusinessEntity> getRemoteHcidList() {
-        return this.remoteHcidList;
+    public Map<String, String> getRemoteHcidMap() {
+        return this.remoteHcidMap;
     }
 
-    private void setRemoteHcidList(HashMap<String, BusinessEntity> remoteHcidList) {
-        this.remoteHcidList = remoteHcidList;
+    private void setRemoteHcidMap(Map<String, String> remoteHcidMap) {
+        this.remoteHcidMap = remoteHcidMap;
     }
 
     public Date getEventStartDate() {
@@ -262,6 +277,22 @@ public class AuditSearchBean {
         this.eventTypeList = eventTypeList;
     }
 
+    private Map<String, String> getRemoteHcidOrgNameMap() {
+        return remoteHcidOrgNameMap;
+    }
+
+    private void setRemoteHcidOrgNameMap(Map<String, String> remoteHcidOrgNameMap) {
+        this.remoteHcidOrgNameMap = remoteHcidOrgNameMap;
+    }
+
+    public String getAuditBlobMsg() {
+        return auditBlobMsg;
+    }
+
+    public void setAuditBlobMsg(String auditBlobMsg) {
+        this.auditBlobMsg = auditBlobMsg;
+    }
+
     /**
      * @return the id
      */
@@ -276,4 +307,47 @@ public class AuditSearchBean {
         this.id = id;
     }
 
+    private Integer getSelectedEventOutcomeIndicator() {
+        if (NullChecker.isNotNullish(outcomeIndicator)) {
+            return new Integer(NhincConstants.EVENT_IDENTIFICATION_STATUS.valueOf(outcomeIndicator).
+                getEventStatusCode());
+        }
+        return null;
+    }
+
+    private List<String> getRemoteHCIDFromSelectedOrgs() {
+        if (NullChecker.isNotNullish(selectedRemoteHcidList)) {
+            List<String> selectedRemoteHcid = new ArrayList<>();
+            for (String orgName : selectedRemoteHcidList) {
+                selectedRemoteHcid.add(HomeCommunityMap.getHomeCommunityWithoutPrefix(orgName));
+            }
+            return selectedRemoteHcid;
+        }
+        return null;
+    }
+
+    private List<String> getSelectedServiceTypes() {
+        if (NullChecker.isNotNullish(selectedEventTypeList)) {
+            List<String> serviceType = new ArrayList<>();
+            for (String eventType : selectedEventTypeList) {
+                serviceType.add(NhincConstants.NHIN_SERVICE_NAMES.valueOf(eventType).getUDDIServiceName());
+            }
+            return serviceType;
+        }
+        return null;
+    }
+
+    private Map<String, String> populateRemoteHcidAndOrgName() {
+        return new ConnectionHelper().getRemoteHcidOrgNameMap();
+    }
+
+    //Adding the timestamp part to the endDate
+    private Date createEventEndDateToTimestamp(Date dateObj) {
+        if (dateObj != null) {
+            dateObj = DateUtils.setHours(dateObj, 23);
+            dateObj = DateUtils.setMinutes(dateObj, 59);
+            dateObj = DateUtils.setSeconds(dateObj, 59);
+        }
+        return dateObj;
+    }
 }

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/AuditSearchBean.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/AuditSearchBean.java
@@ -104,7 +104,7 @@ public class AuditSearchBean {
      */
     public void searchAuditMessageId() {
         AuditServiceImpl impl = new AuditServiceImpl();
-        this.auditRecordList = impl.searchAuditRecordBasedOnMsgIdAndRelatesToId(
+        this.auditRecordList = impl.searchAuditRecordBasedOnMsgIdAndRelatesTo(
             NullChecker.isNotNullishIgnoreSpace(messageId) ? messageId.trim() : null,
             NullChecker.isNotNullishIgnoreSpace(relatesTo) ? relatesTo.trim() : null, getRemoteHcidOrgNameMap());
         if (NullChecker.isNullish(this.auditRecordList)) {

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/AuditSearchBean.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/AuditSearchBean.java
@@ -88,7 +88,7 @@ public class AuditSearchBean {
     public void searchAudit() {
         AuditService impl = new AuditServiceImpl();
         this.auditRecordList = impl.searchAuditRecord(getSelectedEventOutcomeIndicator(), getSelectedServiceTypes(),
-            NullChecker.isNotNullishIgnoreSpace(userId) ? userId : null, getRemoteHCIDFromSelectedOrgs(), eventStartDate,
+            NullChecker.isNotNullishIgnoreSpace(userId) ? userId.trim() : null, getRemoteHCIDFromSelectedOrgs(), eventStartDate,
             createEventEndDateToTimestamp(eventEndDate), getRemoteHcidOrgNameMap());
         if (NullChecker.isNullish(this.auditRecordList)) {
             this.auditMessage = AUDIT_RECORDS_NOT_FOUND;
@@ -105,8 +105,8 @@ public class AuditSearchBean {
     public void searchAuditMessageId() {
         AuditServiceImpl impl = new AuditServiceImpl();
         this.auditRecordList = impl.searchAuditRecordBasedOnMsgIdAndRelatesToId(
-            NullChecker.isNotNullishIgnoreSpace(messageId) ? messageId : null,
-            NullChecker.isNotNullishIgnoreSpace(relatesTo) ? relatesTo : null, getRemoteHcidOrgNameMap());
+            NullChecker.isNotNullishIgnoreSpace(messageId) ? messageId.trim() : null,
+            NullChecker.isNotNullishIgnoreSpace(relatesTo) ? relatesTo.trim() : null, getRemoteHcidOrgNameMap());
         if (NullChecker.isNullish(this.auditRecordList)) {
             this.auditMessage = AUDIT_RECORDS_NOT_FOUND;
             auditFound = false;

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/AuditService.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/AuditService.java
@@ -42,7 +42,7 @@ public interface AuditService {
     public List<Audit> searchAuditRecord(Integer outcome, List<String> eventTypeList, String userId,
         List<String> remoteHcidList, Date startDate, Date endDate, Map<String, String> remoteHcidOrgNameMap);
 
-    public List<Audit> searchAuditRecordBasedOnMsgIdAndRelatesToId(String msgId, String relatesTo,
+    public List<Audit> searchAuditRecordBasedOnMsgIdAndRelatesTo(String msgId, String relatesTo,
         Map<String, String> remoteHcidOrgNameMap);
 
     public String fetchAuditBlob(long auditId);

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/AuditService.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/AuditService.java
@@ -27,7 +27,9 @@
 package gov.hhs.fha.nhinc.admingui.services;
 
 import gov.hhs.fha.nhinc.admingui.event.model.Audit;
-import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 
 /**
  *
@@ -35,8 +37,13 @@ import java.util.ArrayList;
  */
 public interface AuditService {
 
-    public ArrayList<Audit> createMockAuditRecord();
-
     public String createMockAuditMessage(long id);
 
+    public List<Audit> searchAuditRecord(Integer outcome, List<String> eventTypeList, String userId,
+        List<String> remoteHcidList, Date startDate, Date endDate, Map<String, String> remoteHcidOrgNameMap);
+
+    public List<Audit> searchAuditRecordBasedOnMsgIdAndRelatesToId(String msgId, String relatesTo,
+        Map<String, String> remoteHcidOrgNameMap);
+
+    public String fetchAuditBlob(long auditId);
 }

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/impl/AuditServiceImpl.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/impl/AuditServiceImpl.java
@@ -184,6 +184,8 @@ public class AuditServiceImpl implements AuditService {
                 obj.setMessageId(auditEvent.getRequestMessageId());
                 obj.setRemoteHcid(getRemoteHcidDisplayName(auditEvent.getRemoteHcid(), remoteOrgMap));
                 obj.setUserId(auditEvent.getUserId());
+                obj.setDirection(auditEvent.getDirection());
+                obj.setRelatesTo(auditEvent.getRelatesTo());
                 auditList.add(obj);
             }
             return auditList;

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/impl/AuditServiceImpl.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/impl/AuditServiceImpl.java
@@ -123,7 +123,7 @@ public class AuditServiceImpl implements AuditService {
      * @return
      */
     @Override
-    public List<Audit> searchAuditRecordBasedOnMsgIdAndRelatesToId(String msgId, String relatesTo,
+    public List<Audit> searchAuditRecordBasedOnMsgIdAndRelatesTo(String msgId, String relatesTo,
         Map<String, String> remoteHcidOrgNameMap) {
         QueryAuditEventsRequestByRequestMessageId auditRequest = new QueryAuditEventsRequestByRequestMessageId();
         auditRequest.setRequestMessageId(msgId);

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/impl/AuditServiceImpl.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/impl/AuditServiceImpl.java
@@ -26,12 +26,40 @@
  */
 package gov.hhs.fha.nhinc.admingui.services.impl;
 
+import com.services.nhinc.schema.auditmessage.AuditMessageType;
+import com.services.nhinc.schema.auditmessage.ObjectFactory;
 import gov.hhs.fha.nhinc.admingui.event.model.Audit;
 import gov.hhs.fha.nhinc.admingui.services.AuditService;
-import java.sql.Timestamp;
-import java.text.ParseException;
+import gov.hhs.fha.nhinc.audit.retrieve.AuditRetrieve;
+import gov.hhs.fha.nhinc.auditquerylog.nhinc.proxy.AuditQueryLogProxyObjectFactory;
+import gov.hhs.fha.nhinc.common.auditquerylog.EventTypeList;
+import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsBlobRequest;
 import java.util.ArrayList;
 import java.util.Date;
+import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsRequestByRequestMessageId;
+import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsRequestType;
+import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsResponseType;
+import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsResults;
+import gov.hhs.fha.nhinc.common.auditquerylog.RemoteHcidList;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.nhinclib.NullChecker;
+import gov.hhs.fha.nhinc.transform.marshallers.JAXBContextHandler;
+import gov.hhs.fha.nhinc.util.HomeCommunityMap;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.text.SimpleDateFormat;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.Map;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,37 +70,11 @@ import org.slf4j.LoggerFactory;
 public class AuditServiceImpl implements AuditService {
 
     private static final Logger LOG = LoggerFactory.getLogger(AuditServiceImpl.class);
+    private static final String EVENT_DATE_FORMAT = "MM/dd/yyyy HH:mm:ss";
+    private AuditRetrieve auditRetrieve = null;
 
-    @Override
-    public ArrayList<Audit> createMockAuditRecord() {
-        Audit audit1 = new Audit();
-        audit1.setEventOutcomeIndicator("Success");
-        audit1.setEventType("QueryForDocuments");
-        audit1.setMessageId("MessageId-1");
-        audit1.setRemoteHcid("2.2");
-        audit1.setUserId("Thomas");
-
-        Audit audit2 = new Audit();
-        audit2.setEventOutcomeIndicator("Success");
-        audit2.setEventType("RetrieveDocuments");
-        audit2.setMessageId("MessageId-2");
-        audit2.setRemoteHcid("3.3");
-        audit2.setUserId("Joe");
-        try {
-            audit1.setEventTimestamp(getTimeStamp());
-            audit2.setEventTimestamp(getTimeStamp());
-        } catch (ParseException ex) {
-            LOG.error("Timestamp  formatting Exception: " + ex.getLocalizedMessage(), ex);
-        }
-        ArrayList<Audit> auditRecord = new ArrayList<>();
-        auditRecord.add(audit1);
-        auditRecord.add(audit2);
-        return auditRecord;
-    }
-
-    private Timestamp getTimeStamp() throws ParseException {
-        Date date = new Date();
-        return new Timestamp(date.getTime());
+    public AuditServiceImpl() {
+        auditRetrieve = new AuditQueryLogProxyObjectFactory().getAuditRetrieveProxy();
     }
 
     public String createMockAuditMessage(long id) {
@@ -80,5 +82,155 @@ public class AuditServiceImpl implements AuditService {
         audit.setMessage("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><AuditMessage xmlns=\"http://nhinc.services.com/schema/auditmessage\"><EventIdentification EventActionCode=\"C\" EventDateTime=\"2015-12-17T00:01:34.113Z\" EventOutcomeIndicator=\"0\"><EventID code=\"110107\" displayName=\"Import\" codeSystemName=\"DCM\"/><EventTypeCode code=\"ITI-41\" displayName=\"Provide and Register Document Set-b\" codeSystemName=\"IHE Transactions\"/></EventIdentification><ActiveParticipant UserID=\"http://www.w3.org/2005/08/addressing/anonymous\" UserName=\"Karl Skagerberg\" UserIsRequestor=\"true\" NetworkAccessPointID=\"127.0.0.1\" NetworkAccessPointTypeCode=\"2\"><RoleIDCode code=\"110153\" displayName=\"Source\" codeSystemName=\"DCM\"/></ActiveParticipant><ActiveParticipant UserID=\"https://localhost:8181/Gateway/DocumentSubmission/2_0/NhinService/XDRRequest_Service\" AlternativeUserID=\"6636@VIMEHTA-F05773\" UserIsRequestor=\"false\" NetworkAccessPointID=\"localhost\" NetworkAccessPointTypeCode=\"1\"><RoleIDCode code=\"110152\" displayName=\"Destination\" codeSystemName=\"DCM\"/></ActiveParticipant><AuditSourceIdentification AuditEnterpriseSiteID=\"DoD\" AuditSourceID=\"urn:oid:1.1\"/><ParticipantObjectIdentification ParticipantObjectID=\"SELF-5^^^&amp;1.3.6.1.4.1.21367.2005.3.7&amp;ISO\" ParticipantObjectTypeCode=\"1\" ParticipantObjectTypeCodeRole=\"1\"><ParticipantObjectIDTypeCode code=\"2\" displayName=\"Patient Number\" codeSystemName=\"RFC-3881\"/></ParticipantObjectIdentification><ParticipantObjectIdentification ParticipantObjectID=\"1.3.6.1.4.1.21367.2005.3.9999.33\" ParticipantObjectTypeCode=\"2\" ParticipantObjectTypeCodeRole=\"20\"><ParticipantObjectIDTypeCode code=\"urn:uuid:a54d6aa5-d40d-43f9-88c5-b4633d873bdd\" displayName=\"submission set classificationNode\" codeSystemName=\"IHE XDS Metadata\"/></ParticipantObjectIdentification></AuditMessage>");
 
         return audit.getMessage();
+    }
+
+    /**
+     * This method searches Audit database based on eventoutcome, serviceTypes, userId, remoteHcid, eventstartDate and
+     * eventEndDate.
+     *
+     * @param outcome
+     * @param eventTypeList
+     * @param userId
+     * @param remoteHcidList
+     * @param startDate
+     * @param endDate
+     * @param remoteHcidOrgNameMap
+     * @return
+     */
+    @Override
+    public List<Audit> searchAuditRecord(Integer outcome, List<String> eventTypeList, String userId,
+        List<String> remoteHcidList, Date startDate, Date endDate, Map<String, String> remoteHcidOrgNameMap) {
+        QueryAuditEventsRequestType auditRequest = new QueryAuditEventsRequestType();
+        auditRequest.setEventOutcomeIndicator(outcome != null ? BigInteger.valueOf(outcome) : null);
+        auditRequest.setEventTypeList(createEventTypeList(eventTypeList));
+        auditRequest.setUserId(userId);
+        auditRequest.setRemoteHcidList(createRemoteHcidList(remoteHcidList));
+        auditRequest.setEventBeginDate(convertDateToXMLGregorianCalendar(startDate));
+        auditRequest.setEventEndDate(convertDateToXMLGregorianCalendar(endDate));
+        return createAuditObjects(auditRetrieve.retrieveAudits(auditRequest), remoteHcidOrgNameMap);
+    }
+
+    /**
+     * This method searches Audit database based on eventoutcome, serviceTypes, userId, remoteHcid, eventstartDate and
+     * eventEndDate
+     */
+    /**
+     * This method searches Audit database based on messageId and\or relatesTo.
+     *
+     * @param msgId
+     * @param relatesTo
+     * @param remoteHcidOrgNameMap
+     * @return
+     */
+    @Override
+    public List<Audit> searchAuditRecordBasedOnMsgIdAndRelatesToId(String msgId, String relatesTo,
+        Map<String, String> remoteHcidOrgNameMap) {
+        QueryAuditEventsRequestByRequestMessageId auditRequest = new QueryAuditEventsRequestByRequestMessageId();
+        auditRequest.setRequestMessageId(msgId);
+        auditRequest.setRelatesTo(relatesTo);
+        return createAuditObjects(auditRetrieve.retrieveAuditsByMsgIdAndRelatesToId(auditRequest), remoteHcidOrgNameMap);
+    }
+
+    @Override
+    public String fetchAuditBlob(long auditId) {
+        QueryAuditEventsBlobRequest request = new QueryAuditEventsBlobRequest();
+        request.setId(auditId);
+        return marshallAuditMessage(auditRetrieve.retrieveAuditBlob(request).getAuditMessage());
+    }
+
+    private EventTypeList createEventTypeList(List<String> eventTypeList) {
+        if (NullChecker.isNotNullish(eventTypeList)) {
+            EventTypeList schemaEventType = new EventTypeList();
+            schemaEventType.getEventType().addAll(eventTypeList);
+            return schemaEventType;
+        }
+        return null;
+    }
+
+    private RemoteHcidList createRemoteHcidList(List<String> remoteHcidList) {
+        if (NullChecker.isNotNullish(remoteHcidList)) {
+            RemoteHcidList schemaHcid = new RemoteHcidList();
+            schemaHcid.getRemoteHcid().addAll(remoteHcidList);
+            return schemaHcid;
+        }
+        return null;
+    }
+
+    private XMLGregorianCalendar convertDateToXMLGregorianCalendar(Date date) {
+        if (date != null) {
+            GregorianCalendar gregorianCalendar = new GregorianCalendar();
+            gregorianCalendar.setTime(date);
+            try {
+                XMLGregorianCalendar cal = DatatypeFactory.newInstance().newXMLGregorianCalendar(gregorianCalendar);
+                LOG.info("{}-{}-{} {}:{}:{} {}", cal.getMonth(), cal.getDay(), cal.getYear(), cal.getHour(),
+                    cal.getMinute(), cal.getSecond(), cal.getTimezone());
+                return cal;
+            } catch (DatatypeConfigurationException ex) {
+                LOG.error("Unable to convert date {} ", ex.getLocalizedMessage(), ex);
+            }
+        }
+        return null;
+    }
+
+    private List<Audit> createAuditObjects(QueryAuditEventsResponseType result, Map<String, String> remoteOrgMap) {
+        if (result != null && NullChecker.isNotNullish(result.getQueryAuditEventsResults())) {
+            List<Audit> auditList = new ArrayList<>();
+            for (QueryAuditEventsResults auditEvent : result.getQueryAuditEventsResults()) {
+                Audit obj = new Audit();
+                obj.setEventOutcomeIndicator(NhincConstants.EVENT_IDENTIFICATION_STATUS.fromDisplayString(
+                    auditEvent.getEventOutcomeIndicator().toString()).name());
+                obj.setEventTimestamp(formateDate(convertXMLGregorianDate(auditEvent.getEventTimestamp())));
+                obj.setEventType(getEventTypeDisplayName(auditEvent.getEventType()));
+                obj.setMessageId(auditEvent.getRequestMessageId());
+                obj.setRemoteHcid(getRemoteHcidDisplayName(auditEvent.getRemoteHcid(), remoteOrgMap));
+                obj.setUserId(auditEvent.getUserId());
+                auditList.add(obj);
+            }
+            return auditList;
+        }
+        return null;
+    }
+
+    private Date convertXMLGregorianDate(XMLGregorianCalendar dateObj) {
+        if (dateObj != null) {
+            return dateObj.toGregorianCalendar().getTime();
+        }
+        return null;
+    }
+
+    private String getEventTypeDisplayName(String eventType) {
+        return eventType != null ? NhincConstants.NHIN_SERVICE_NAMES.fromValueString(eventType).name() : null;
+    }
+
+    private String getRemoteHcidDisplayName(String remoteHcid, Map<String, String> remoteOrgMap) {
+        return remoteOrgMap.get(HomeCommunityMap.formatHomeCommunityId(remoteHcid));
+    }
+
+    private String marshallAuditMessage(AuditMessageType mess) {
+        if (mess != null) {
+            try {
+                JAXBContextHandler oHandler = new JAXBContextHandler();
+                JAXBContext jc = oHandler.getJAXBContext("com.services.nhinc.schema.auditmessage");
+                Marshaller marshaller = jc.createMarshaller();
+                ByteArrayOutputStream baOutStrm = new ByteArrayOutputStream();
+                baOutStrm.reset();
+                ObjectFactory factory = new ObjectFactory();
+                JAXBElement<AuditMessageType> oJaxbElement = factory.createAuditMessage(mess);
+                baOutStrm.close();
+                marshaller.marshal(oJaxbElement, baOutStrm);
+                return baOutStrm.toString();
+            } catch (JAXBException | IOException e) {
+                LOG.error("Exception during Blob conversion {}", e.getLocalizedMessage(), e);
+            }
+        }
+        return null;
+    }
+
+    private String formateDate(Date date) {
+        if (date != null) {
+            SimpleDateFormat sdf = new SimpleDateFormat(EVENT_DATE_FORMAT);
+            return sdf.format(date);
+        }
+        return null;
     }
 }

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/util/ConnectionHelper.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/util/ConnectionHelper.java
@@ -33,6 +33,7 @@ import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import gov.hhs.fha.nhinc.properties.PropertyAccessException;
 import gov.hhs.fha.nhinc.properties.PropertyAccessor;
+import gov.hhs.fha.nhinc.util.HomeCommunityMap;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -143,4 +144,33 @@ public class ConnectionHelper {
         return PropertyAccessor.getInstance();
     }
 
+    public Map<String, String> getOrgNameRemoteHcidExternalEntities() {
+        HashMap<String, String> organizationMap = new HashMap<>();
+        List<BusinessEntity> externalEntityList = new ArrayList<>(getExternalEntitiesMap().values());
+        if (NullChecker.isNotNullish(externalEntityList)) {
+            for (BusinessEntity businessEntity : externalEntityList) {
+                List<KeyedReference> keyedReference = getKeyedReference(businessEntity);
+                if (NullChecker.isNotNullish(keyedReference)) {
+                    organizationMap.put(getEntityName(businessEntity), keyedReference.get(0).getKeyValue());
+                }
+            }
+        }
+        return organizationMap;
+    }
+
+    public Map<String, String> getRemoteHcidOrgNameMap() {
+        HashMap<String, String> organizationMap = new HashMap<>();
+        List<BusinessEntity> entities = getAllBusinessEntities();
+        if (NullChecker.isNotNullish(entities)) {
+            for (BusinessEntity businessEntity : entities) {
+                List<KeyedReference> keyedReference = getKeyedReference(businessEntity);
+                if (NullChecker.isNotNullish(keyedReference)
+                    && NullChecker.isNotNullishIgnoreSpace(keyedReference.get(0).getKeyValue())) {
+                    organizationMap.put(HomeCommunityMap.getHomeCommunityWithoutPrefix(
+                        keyedReference.get(0).getKeyValue()), getEntityName(businessEntity));
+                }
+            }
+        }
+        return organizationMap;
+    }
 }

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/WEB-INF/jboss-web.xml
@@ -14,4 +14,11 @@
         <res-type>javax.sql.DataSource</res-type>
         <res-auth>Container</res-auth>
     </resource-ref>
+
+    <resource-ref>
+        <res-ref-name>jdbc/auditrepo_datasource</res-ref-name>
+        <jndi-name>java:/jdbc/auditrepo_datasource</jndi-name>
+        <res-type>javax.sql.DataSource</res-type>
+        <res-auth>Container</res-auth>
+    </resource-ref>
 </jboss-web>

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/auditLog.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/auditLog.xhtml
@@ -153,8 +153,16 @@
                                                                     #{audit.userId}
                                                             </p:column>
                                                             <p:column>
+                                                                <f:facet name="header">Direction</f:facet>
+                                                                    #{audit.direction}
+                                                            </p:column>
+                                                            <p:column>
                                                                 <f:facet name="header">MessageId</f:facet>
                                                                 <h:outputText value="#{audit.messageId}" />
+                                                            </p:column>
+                                                            <p:column>
+                                                                <f:facet name="header">RelatesTo</f:facet>
+                                                                <h:outputText value="#{audit.relatesTo}" />
                                                             </p:column>
                                                             <p:column>
                                                                 <f:facet name="header">View Audit XML </f:facet>

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/auditLog.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/auditLog.xhtml
@@ -83,14 +83,14 @@
                                                     <span class="col-sm-2">
                                                         <p:selectCheckboxMenu id="menuRemoteHcid" value="#{auditSearchBean.selectedRemoteHcidList}" label="Organization"
                                                                               filter="true" filterMatchMode="startsWith" panelStyle="width:250px">
-                                                            <f:selectItems value="#{auditSearchBean.remoteHcidList}" />
+                                                            <f:selectItems value="#{auditSearchBean.remoteHcidMap}" />
                                                         </p:selectCheckboxMenu>
                                                     </span>
                                                     <h:outputLabel for="eventoutcomeindicator" class="col-sm-1 control-label" id="labeleventOutcomeIndicator" value="Status:" />
                                                     <span class="col-sm-3">
                                                         <h:selectOneMenu class="form-control" id="eventoutcomeindicator" value="#{auditSearchBean.outcomeIndicator}" style="height:32px;width:200px" required="false" >
                                                             <f:selectItem itemLabel="---" itemValue="#{null}" noSelectionOption="true" />
-                                                            <f:selectItems value="#{auditSearchBean.eventOutcomeIndicatorMap}"/>
+                                                            <f:selectItems value="#{auditSearchBean.eventOutcomeIndicatorList}"/>
                                                         </h:selectOneMenu>
                                                     </span>
                                                 </div>
@@ -107,11 +107,11 @@
                                                 <div class="form-group">
                                                     <h:outputLabel for="messageid" class="col-sm-3 control-label" id="labelMessageId" value="MessageId:" />
                                                     <span class="col-sm-3" >
-                                                        <p:inputText styleClass="form-control" value="#{auditSearchBean.messageId}" style="height:32px;width:200px" id="messageId" maxlength="30" required="false" />
+                                                        <p:inputText styleClass="form-control" value="#{auditSearchBean.messageId}" style="height:32px;width:200px" id="messageId" maxlength="50" required="false" />
                                                     </span>
                                                     <h:outputLabel for="relatesto" class="col-sm-3 control-label" id="labelRelatesTo" value="RelatesTo:" />
                                                     <span class="col-sm-3">
-                                                        <p:inputText styleClass="form-control" value="#{auditSearchBean.relatesTo}" style="height:32px;width:200px" id="relatesTo" maxlength="30" required="false" />
+                                                        <p:inputText styleClass="form-control" value="#{auditSearchBean.relatesTo}" style="height:32px;width:200px" id="relatesTo" maxlength="50" required="false" />
                                                     </span>
 
                                                 </div>

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
@@ -79,7 +79,7 @@ public class NhincConstants {
 
         PATIENT_DISCOVERY(PATIENT_DISCOVERY_SERVICE_NAME), PATIENT_DISCOVERY_DEFERRED_REQUEST(
             PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME), PATIENT_DISCOVERY_DEFERRED_RESPONSE(
-                PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
+            PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
         DOCUMENT_QUERY(DOC_QUERY_SERVICE_NAME),
         DOCUMENT_RETRIEVE(DOC_RETRIEVE_SERVICE_NAME),
         DOCUMENT_SUBMISSION(NHINC_XDR_SERVICE_NAME), DOCUMENT_SUBMISSION_DEFERRED_REQUEST(
@@ -117,6 +117,39 @@ public class NhincConstants {
             return serviceNamesList;
         }
     };
+
+    public static enum EVENT_IDENTIFICATION_STATUS {
+        Success("0"), Failure("12");
+        private String statusCode = null;
+
+        EVENT_IDENTIFICATION_STATUS(String statusCode) {
+            this.statusCode = statusCode;
+        }
+
+        public String getEventStatusCode() {
+            return this.statusCode;
+        }
+
+        public static EVENT_IDENTIFICATION_STATUS fromDisplayString(String valueString) {
+            if (valueString != null) {
+                for (EVENT_IDENTIFICATION_STATUS enumValue : EVENT_IDENTIFICATION_STATUS.values()) {
+                    if (valueString.equals(enumValue.statusCode)) {
+                        return enumValue;
+                    }
+                }
+            }
+            throw new IllegalArgumentException("No enum constant " + valueString);
+        }
+
+        public static List<String> getEventDisplayStatusList() {
+            List<String> displayStatusList = new ArrayList<>();
+            for (EVENT_IDENTIFICATION_STATUS m : values()) {
+                displayStatusList.add(m.toString());
+            }
+            return displayStatusList;
+        }
+    };
+
     // Authorization Framework
     public static final String AUTH_FRWK_NAME_ID_FORMAT_EMAIL_ADDRESS = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
     public static final String AUTH_FRWK_NAME_ID_FORMAT_X509 = "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName";

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/HomeCommunityMap.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/HomeCommunityMap.java
@@ -57,6 +57,7 @@ public class HomeCommunityMap {
     private static final Logger LOG = LoggerFactory.getLogger(HomeCommunityMap.class);
     private static ConnectionManagerCache connection = ConnectionManagerCache.getInstance();
     private static PropertyAccessor propertyAccessor = PropertyAccessor.getInstance();
+    private static final String URN_OID_PREFIX = "urn:oid:";
 
     /**
      * This method retrieves the name of the home community baased on the home community Id.
@@ -282,4 +283,12 @@ public class HomeCommunityMap {
         connection = connectionManager;
     }
 
+    public static String getHomeCommunityWithoutPrefix(String hcid) {
+        if (NullChecker.isNotNullish(hcid)) {
+            if (hcid.startsWith(URN_OID_PREFIX)) {
+                return hcid.substring(URN_OID_PREFIX.length());
+            }
+        }
+        return hcid;
+    }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/HomeCommunityMap.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/HomeCommunityMap.java
@@ -57,7 +57,6 @@ public class HomeCommunityMap {
     private static final Logger LOG = LoggerFactory.getLogger(HomeCommunityMap.class);
     private static ConnectionManagerCache connection = ConnectionManagerCache.getInstance();
     private static PropertyAccessor propertyAccessor = PropertyAccessor.getInstance();
-    private static final String URN_OID_PREFIX = "urn:oid:";
 
     /**
      * This method retrieves the name of the home community baased on the home community Id.
@@ -285,8 +284,8 @@ public class HomeCommunityMap {
 
     public static String getHomeCommunityWithoutPrefix(String hcid) {
         if (NullChecker.isNotNullish(hcid)) {
-            if (hcid.startsWith(URN_OID_PREFIX)) {
-                return hcid.substring(URN_OID_PREFIX.length());
+            if (hcid.startsWith(NhincConstants.HCID_PREFIX)) {
+                return hcid.substring(NhincConstants.HCID_PREFIX.length());
             }
         }
         return hcid;

--- a/Product/Production/Common/CONNECTCoreLib/src/main/resources/auditrepo.hbm.xml
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/resources/auditrepo.hbm.xml
@@ -8,43 +8,39 @@
         Purpose of the document follows.
 -->
 <hibernate-mapping>
-  <class name="gov.hhs.fha.nhinc.auditrepository.hibernate.AuditRepositoryRecord" table="auditrepository">
-    <id name="id" type="int">
-      <column name="id" sql-type="INTEGER"/>
-      <generator class="native"/>
-    </id>
-    <property name="eventTimestamp">
-      <column name="eventTimestamp"/>
-    </property>
-    <property name="eventId">
-      <column name="eventId"/>
-    </property>
-    <property name="userId">
-      <column name="userId"/>
-    </property>
-    <property name="eventType">
-      <column name="eventType"/>
-    </property>
-    <property name="outcome">
-      <column name="outcome"/>
-    </property>
-    <property name="messageId">
-      <column name="messageId"/>
-    </property>
-    <property name="relatesTo">
-      <column name="relatesTo"/>
-    </property>
-    <property name="transactionId">
-      <column name="transactionId"/>
-    </property>
-    <property name="remoteHcid">
-      <column name="remoteHcid"/>
-    </property>
-    <property name="direction">
-      <column name="direction"/>
-    </property>
-    <property name="message">
-      <column name="message"/>
-    </property>
-  </class>
+    <class name="gov.hhs.fha.nhinc.auditrepository.hibernate.AuditRepositoryRecord" table="auditrepository">
+        <id name="id" type="long">
+            <generator class="native"/>
+        </id>
+        <property name="eventTimestamp">
+            <column name="eventTimestamp"/>
+        </property>
+        <property name="eventId">
+            <column name="eventId"/>
+        </property>
+        <property name="userId">
+            <column name="userId"/>
+        </property>
+        <property name="eventType">
+            <column name="eventType"/>
+        </property>
+        <property name="outcome">
+            <column name="outcome"/>
+        </property>
+        <property name="messageId">
+            <column name="messageId"/>
+        </property>
+        <property name="relatesTo">
+            <column name="relatesTo"/>
+        </property>
+        <property name="remoteHcid">
+            <column name="remoteHcid"/>
+        </property>
+        <property name="direction">
+            <column name="direction"/>
+        </property>
+        <property name="message">
+            <column name="message"/>
+        </property>
+    </class>
 </hibernate-mapping>

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/AuditQueryLogImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditquerylog/AuditQueryLogImpl.java
@@ -39,6 +39,8 @@ import java.math.BigInteger;
 import java.util.Date;
 import java.util.List;
 import javax.xml.datatype.XMLGregorianCalendar;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The AuditQueryLog impl is called from Pojo/Service implementation and passes/retrieve params from/to DAO layer.
@@ -49,6 +51,7 @@ public class AuditQueryLogImpl {
 
     private AuditRepositoryDAO dao;
     private AuditRetrieveEventsUtil resultUtil;
+    private static final Logger LOG = LoggerFactory.getLogger(AuditQueryLogImpl.class);
 
     /**
      * constructor. initialize AuditRetrieveEventsUtil to build AuditQueryResponse
@@ -99,8 +102,7 @@ public class AuditQueryLogImpl {
      *
      */
     public QueryAuditEventsBlobResponse queryAuditEventsById(QueryAuditEventsBlobRequest request) {
-        return resultUtil.getQueryAuditEventBlobResponse(getAuditRepositoryDao().queryByAuditId(
-            (new Long(request.getId())).intValue()));
+        return resultUtil.getQueryAuditEventBlobResponse(getAuditRepositoryDao().queryByAuditId(request.getId()));
     }
 
     /**
@@ -116,7 +118,10 @@ public class AuditQueryLogImpl {
 
     private Date getRequestDate(XMLGregorianCalendar dateObj) {
         if (dateObj != null) {
-            return dateObj.toGregorianCalendar().getTime();
+            LOG.info("Converting XMLGregorianCalendar to a date object");
+            LOG.info("{}-{}-{} {}:{}:{} {}", dateObj.getMonth(), dateObj.getDay(), dateObj.getYear(), dateObj.getHour(),
+                dateObj.getMinute(), dateObj.getSecond(), dateObj.getTimezone());
+            return new Date(dateObj.toGregorianCalendar().getTimeInMillis());
         }
         return null;
     }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAO.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAO.java
@@ -250,7 +250,7 @@ public class AuditRepositoryDAO {
      * @param auditId - AuidtRepository table Primary Key unique Id
      * @return Blob - Audit Blob message corresponding to Audit Id supplied
      */
-    public Blob queryByAuditId(int auditId) {
+    public Blob queryByAuditId(long auditId) {
 
         Session session = null;
         Blob message = null;

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryRecord.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryRecord.java
@@ -35,7 +35,7 @@ import java.sql.Blob;
  */
 public class AuditRepositoryRecord {
 
-    private long id;
+    private Long id;
     private Date eventTimestamp;
     private String eventId;
     private String userId;
@@ -43,7 +43,6 @@ public class AuditRepositoryRecord {
     private String remoteHcid;
     private String relatesTo;
     private String messageId;
-	private String transactionId;
     private String eventType;
     private int outcome;
     private Blob message;
@@ -131,29 +130,17 @@ public class AuditRepositoryRecord {
         this.messageId = messageId;
     }
 
-
-
     /**
      * @return the id
      */
-    public long getId() {
+    public Long getId() {
         return id;
     }
 
     /**
      * @param id the id to set
      */
-    public void setId(long id) {
+    public void setId(Long id) {
         this.id = id;
     }
-	
-	public String getTransactionId() {
-       return transactionId;
-	 }
-	 
-	 
-	public void setTransactionId(String transactionId) {
-      this.transactionId = transactionId;	 
-	} 
-
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhin/audit/retrieve/AuditRetrieveEventsUtilTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhin/audit/retrieve/AuditRetrieveEventsUtilTest.java
@@ -68,7 +68,7 @@ public class AuditRetrieveEventsUtilTest {
     private final String MESSAGE_ID = "urn:uuid:4abc7cc8-1edc-409d-b061-bf65b21f7b1e";
     private final String RELATES_TO = "urn:uuid:4abc7cc8-1edc-409d-b061-bf65b21f7b1e";
     private final String USER_ID = "wanderson";
-    private final int ID = 1;
+    private final Long ID = 1L;
     private final int OUTCOME = 0;
     private final Date EVENT_TIMESTAMP = Calendar.getInstance().getTime();
     private final String AUDIT_MESSAGE = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
@@ -104,7 +104,7 @@ public class AuditRetrieveEventsUtilTest {
         assertEquals("QueryAuditEventsResults.RequestMessageId mismatch", obj.getRequestMessageId(), MESSAGE_ID);
         assertEquals("QueryAuditEventsResults.RelatesTo(mismatch", obj.getRelatesTo(), RELATES_TO);
         assertEquals("QueryAuditEventsResults.UserId mismatch", obj.getUserId(), USER_ID);
-        assertEquals("QueryAuditEventsResults.id mismatch", obj.getId(), ID);
+        assertEquals("QueryAuditEventsResults.id mismatch", obj.getId(), ID.longValue());
         assertEquals("QueryAuditEventsResults.outcome mismatch", obj.getEventOutcomeIndicator().intValue(), OUTCOME);
         assertEquals("QueryAuditEventsResults.EventTimestamp mismatch",
             obj.getEventTimestamp().toGregorianCalendar().getTime(), EVENT_TIMESTAMP);

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditquerylog/AuditQueryLogImplTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditquerylog/AuditQueryLogImplTest.java
@@ -56,7 +56,7 @@ public class AuditQueryLogImplTest {
     private final String MESSAGE_ID = "urn:uuid:4abc7cc8-1edc-409d-b061-bf65b21f7b1e";
     private final String RELATES_TO = "urn:uuid:4abc7cc8-1edc-409d-b061-bf65b21f7b1e";
     private final String USER_ID = "wanderson";
-    private final int ID = 1;
+    private final Long ID = 1L;
     private final int OUTCOME = 0;
     private final Date EVENT_TIMESTAMP = Calendar.getInstance().getTime();
     private final Session mockSession = mock(Session.class);
@@ -96,7 +96,7 @@ public class AuditQueryLogImplTest {
         assertEquals("QueryAuditEventsResults.RequestMessageId mismatch", obj.getRequestMessageId(), MESSAGE_ID);
         assertEquals("QueryAuditEventsResults.RelatesTo(mismatch", obj.getRelatesTo(), RELATES_TO);
         assertEquals("QueryAuditEventsResults.UserId mismatch", obj.getUserId(), USER_ID);
-        assertEquals("QueryAuditEventsResults.id mismatch", obj.getId(), ID);
+        assertEquals("QueryAuditEventsResults.id mismatch", obj.getId(), ID.longValue());
         assertEquals("QueryAuditEventsResults.outcome mismatch", obj.getEventOutcomeIndicator().intValue(), OUTCOME);
         assertEquals("QueryAuditEventsResults.EventTimestamp mismatch",
             obj.getEventTimestamp().toGregorianCalendar().getTime(), EVENT_TIMESTAMP);

--- a/Product/Production/Services/AuditRepositoryCore/src/test/resources/hibernate/auditrepo.hbm.xml
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/resources/hibernate/auditrepo.hbm.xml
@@ -8,8 +8,7 @@
 -->
 <hibernate-mapping>
     <class name="gov.hhs.fha.nhinc.auditrepository.hibernate.AuditRepositoryRecord" table="auditrepository">
-        <id name="id" type="int">
-            <column name="id" sql-type="INTEGER"/>
+        <id name="id" type="long">
             <generator class="native"/>
         </id>
         <property name="eventTimestamp">
@@ -32,9 +31,6 @@
         </property>
         <property name="relatesTo">
             <column name="relatesTo"/>
-        </property>
-        <property name="transactionId">
-            <column name="transactionId"/>
         </property>
         <property name="remoteHcid">
             <column name="remoteHcid"/>


### PR DESCRIPTION
1. Hooked up Audit service to allow Audit search based on eventoutcome, eventTypes, remoteHcid, userId, eventBeginDate, eventEndDate, messageId and relatesTo on AdminGUI. For search based on eventEndDate, the timestamp is currently defaulted to 23:59:59 in the AuditSearchBean. 
2. Removed the transactionId from auditrepo.hbm.xml files.
3. Updated AuditQueryLog.xsd to define EventBeginDate and EventEndDate of dateTime type.
4. Fixed the AuditLogging to log audits into the database.

@alameluchidambaram, @vdmehta06 
