### PR TITLE
FHAC-572: fix BEGIN_INVOCATION_TO_NWHIN entry appears twice in event log

### DIFF
--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/request/PassthroughOutboundDocSubmissionDeferredRequest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/request/PassthroughOutboundDocSubmissionDeferredRequest.java
@@ -60,9 +60,6 @@ public class PassthroughOutboundDocSubmissionDeferredRequest implements Outbound
         OutboundDocSubmissionDeferredRequestDelegate delegate = getOutboundDocSubmissionDeferredRequestDelegate();
         OutboundDocSubmissionDeferredRequestOrchestratable dsOrchestratable = createOrchestratable(delegate, request,
             assertion);
-        XDRAcknowledgementType response = ((OutboundDocSubmissionDeferredRequestOrchestratable) delegate
-            .process(dsOrchestratable)).getResponse();
-
         return ((OutboundDocSubmissionDeferredRequestOrchestratable) delegate
             .process(dsOrchestratable)).getResponse();
     }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/response/PassthroughOutboundDocSubmissionDeferredResponse.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/outbound/deferred/response/PassthroughOutboundDocSubmissionDeferredResponse.java
@@ -58,9 +58,6 @@ public class PassthroughOutboundDocSubmissionDeferredResponse implements Outboun
         OutboundDocSubmissionDeferredResponseOrchestratable dsOrchestratable = createOrchestratable(delegate, body,
             assertion, targetSystem);
         auditRequest(body, assertion, targetSystem);
-        XDRAcknowledgementType response = ((OutboundDocSubmissionDeferredResponseOrchestratable) delegate
-            .process(dsOrchestratable)).getResponse();
-
         return ((OutboundDocSubmissionDeferredResponseOrchestratable) delegate
             .process(dsOrchestratable)).getResponse();
     }


### PR DESCRIPTION
Remove redundancy code which causes entry to log twice in event log.  
