### PR TITLE
Upgrade commons-collections from 3.2.1 to 3.2.2

### DIFF
--- a/Product/pom.xml
+++ b/Product/pom.xml
@@ -679,7 +679,7 @@
             <dependency>
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
-                <version>3.2.1</version>
+                <version>3.2.2</version>
             </dependency>
             <dependency>
                 <groupId>commons-configuration</groupId>


### PR DESCRIPTION
Upgrade commons-collections from 3.2.1 to 3.2.2 according OWASP Dependency checklist.
@christophermay07 @TabassumJafri 
