### PR TITLE
FHAC-777:cxf dependency required in SSA and DOD environment

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/pom.xml
+++ b/Product/Production/Common/CONNECTCoreLib/pom.xml
@@ -36,6 +36,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
         </dependency>
         <dependency>

--- a/Product/pom.xml
+++ b/Product/pom.xml
@@ -162,6 +162,11 @@
                 <artifactId>cxf-tools-validator</artifactId>
                 <version>${cxf.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId>
+                <version>${cxf.version}</version>
+            </dependency>
 
             <!-- Web Services -->
             <dependency>

--- a/Product/pom.xml
+++ b/Product/pom.xml
@@ -166,6 +166,7 @@
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId>
                 <version>${cxf.version}</version>
+                <scope>runtime</scope>
             </dependency>
 
             <!-- Web Services -->


### PR DESCRIPTION
Cxf dependency required in SSA and DOD environment to find addressing schema path locally. PD service was affected in those environments.
