### PR TITLE
FHAC-642: fix DQ audit blog to populate correct spec endpoint

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/connectmgr/BaseConnctionManagerCache.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/connectmgr/BaseConnctionManagerCache.java
@@ -41,6 +41,8 @@ public class BaseConnctionManagerCache {
     protected static String HCID_1 = "1.1";
     protected static String HCID_2 = "2.2";
     protected static String HCID_3 = "3.3";
+    protected static String VERSION_OF_SERVICE_2_0 = "2.0";
+    protected static String VERSION_OF_SERVICE_3_0 = "3.0";
     protected static String QUERY_FOR_DOCUMENTS_NAME = "QueryForDocuments";
     protected static String RETRIEVE_DOCUMENTS_NAME = "RetrieveDocuments";
     protected static String DOCUMENT_SUBMISSION_NAME = "DocumentSubmission";
@@ -51,6 +53,8 @@ public class BaseConnctionManagerCache {
     protected static String QUERY_FOR_DOCUMENTS_DEFERRED_URL = "https://localhost:8181/QueryForDocumentsDeferredRequest";
     protected static String QUERY_FOR_DOCUMENTS_URL_22 = "https://server2:8181/QueryForDocuments";
     protected static String QUERY_FOR_DOCUMENTS_DEFERRED_URL_22 = "https://server2:8181/QueryForDocumentsDeferredRequest";
+    protected static String QUERY_FOR_DOCUMENTS_URL_3 = "https://server2:8181/QueryForDocuments/3_0";
+    protected static String QUERY_FOR_DOCUMENTS_URL_2 = "https://server2:8181/QueryForDocuments/2_0";
 
     protected static String FL_REGION_VALUE = "US-FL";
 

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/connectmgr/ConnectionManagerCacheTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/connectmgr/ConnectionManagerCacheTest.java
@@ -342,11 +342,14 @@ public class ConnectionManagerCacheTest extends BaseConnctionManagerCache {
     }
 
     protected NhinTargetSystemType createNhinTargetSystem_HCIDOnly() {
+        return createNhinTargetSystem_HCIDOnly(HCID_1,null);
+    }
+    protected NhinTargetSystemType createNhinTargetSystem_HCIDOnly(String hcid, String userSpec) {
         NhinTargetSystemType targetSystem = new NhinTargetSystemType();
         HomeCommunityType homeCommunity = new HomeCommunityType();
-        homeCommunity.setHomeCommunityId(HCID_1);
+        homeCommunity.setHomeCommunityId(hcid);
         targetSystem.setHomeCommunity(homeCommunity);
-
+        targetSystem.setUseSpecVersion(userSpec);
         return targetSystem;
     }
 
@@ -366,6 +369,12 @@ public class ConnectionManagerCacheTest extends BaseConnctionManagerCache {
             url = connectionManager.getEndpointURLFromNhinTarget(createNhinTargetSystem_HCIDOnly(),
                     QUERY_FOR_DOCUMENTS_NAME);
             assertTrue(url.equals(QUERY_FOR_DOCUMENTS_URL));
+            url = connectionManager.getEndpointURLFromNhinTarget(createNhinTargetSystem_HCIDOnly(HCID_2,VERSION_OF_SERVICE_2_0),
+                    QUERY_FOR_DOCUMENTS_NAME);
+            assertEquals(QUERY_FOR_DOCUMENTS_URL_2, url);
+            url = connectionManager.getEndpointURLFromNhinTarget(createNhinTargetSystem_HCIDOnly(HCID_2,VERSION_OF_SERVICE_3_0),
+                    QUERY_FOR_DOCUMENTS_NAME);
+            assertEquals(QUERY_FOR_DOCUMENTS_URL_3, url);
         } catch (Throwable t) {
             t.printStackTrace();
             fail("Error running testGetEndpointURLFromNhinTarget test: " + t.getMessage());

--- a/Product/Production/Common/CONNECTCoreLib/src/test/resources/config/ConnectionManagerCacheTest/uddiConnectionInfoTest.xml
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/resources/config/ConnectionManagerCacheTest/uddiConnectionInfoTest.xml
@@ -12,6 +12,18 @@
                             <keyedReference tModelKey="uddi:nhin:versionofservice" keyName="" keyValue="1.0"/>
                         </categoryBag>
                     </bindingTemplate>
+                     <bindingTemplate bindingKey="uddi:nhincnode:QueryForDocuments" serviceKey="uddi:testnhincnode:QueryForDocuments">
+                        <accessPoint useType="endPoint">https://server2:8181/QueryForDocuments/3_0</accessPoint>
+                        <categoryBag>
+                            <keyedReference tModelKey="uddi:nhin:versionofservice" keyName="" keyValue="3.0"/>
+                        </categoryBag>
+                    </bindingTemplate>
+                     <bindingTemplate bindingKey="uddi:nhincnode:QueryForDocuments" serviceKey="uddi:testnhincnode:QueryForDocuments">
+                        <accessPoint useType="endPoint">https://server2:8181/QueryForDocuments/2_0</accessPoint>
+                        <categoryBag>
+                            <keyedReference tModelKey="uddi:nhin:versionofservice" keyName="" keyValue="2.0"/>
+                        </categoryBag>
+                    </bindingTemplate>
                 </bindingTemplates>
                 <categoryBag>
                     <keyedReference tModelKey="uddi:nhin:standard-servicenames" keyName="QueryForDocument" keyValue="QueryForDocument"/>


### PR DESCRIPTION
Change ConnectionManagerCache to pull correct endpoint for audit purpose.
@alameluchidambaram, @TabassumJafri, @christophermay07
