### PR TITLE
FHAC-644: Fix OrchestrationContextBuilder based on user spec

### DIFF
--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/entity/OutboundDocSubmissionDelegate.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/entity/OutboundDocSubmissionDelegate.java
@@ -59,7 +59,7 @@ public class OutboundDocSubmissionDelegate implements OutboundDelegate {
             OutboundDocSubmissionOrchestratable dsMessage = (OutboundDocSubmissionOrchestratable) message;
 
             OrchestrationContextBuilder contextBuilder = getOrchestrationContextFactory().getBuilder(
-                    dsMessage.getTarget().getHomeCommunity(), NhincConstants.NHIN_SERVICE_NAMES.DOCUMENT_SUBMISSION);
+                    dsMessage.getTarget(), NhincConstants.NHIN_SERVICE_NAMES.DOCUMENT_SUBMISSION);
 
             if (contextBuilder instanceof OutboundDocSubmissionOrchestrationContextBuilder_g0) {
                 ((OutboundDocSubmissionOrchestrationContextBuilder_g0) contextBuilder).init(message);

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/entity/deferred/request/OutboundDocSubmissionDeferredRequestDelegate.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/entity/deferred/request/OutboundDocSubmissionDeferredRequestDelegate.java
@@ -59,7 +59,7 @@ public class OutboundDocSubmissionDeferredRequestDelegate implements OutboundDel
             OutboundDocSubmissionDeferredRequestOrchestratable dsMessage = (OutboundDocSubmissionDeferredRequestOrchestratable) message;
 
             OrchestrationContextBuilder contextBuilder = getOrchestrationContextFactory().getBuilder(
-                    dsMessage.getTarget().getHomeCommunity(), NhincConstants.NHIN_SERVICE_NAMES.DOCUMENT_SUBMISSION_DEFERRED_REQUEST);
+                    dsMessage.getTarget(), NhincConstants.NHIN_SERVICE_NAMES.DOCUMENT_SUBMISSION_DEFERRED_REQUEST);
 
             if (contextBuilder instanceof OutboundDocSubmissionDeferredRequestOrchestrationContextBuilder_g0) {
                 ((OutboundDocSubmissionDeferredRequestOrchestrationContextBuilder_g0) contextBuilder).init(message);

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/entity/deferred/response/OutboundDocSubmissionDeferredResponseDelegate.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/entity/deferred/response/OutboundDocSubmissionDeferredResponseDelegate.java
@@ -59,7 +59,7 @@ public class OutboundDocSubmissionDeferredResponseDelegate implements OutboundDe
             OutboundDocSubmissionDeferredResponseOrchestratable dsMessage = (OutboundDocSubmissionDeferredResponseOrchestratable) message;
 
             OrchestrationContextBuilder contextBuilder = getOrchestrationContextFactory().getBuilder(
-                    dsMessage.getTarget().getHomeCommunity(), NhincConstants.NHIN_SERVICE_NAMES.DOCUMENT_SUBMISSION_DEFERRED_RESPONSE);
+                    dsMessage.getTarget(), NhincConstants.NHIN_SERVICE_NAMES.DOCUMENT_SUBMISSION_DEFERRED_RESPONSE);
 
             if (contextBuilder instanceof OutboundDocSubmissionDeferredResponseOrchestrationContextBuilder_g0) {
                 ((OutboundDocSubmissionDeferredResponseOrchestrationContextBuilder_g0) contextBuilder).init(message);

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/orchestration/OrchestrationContextFactory.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/orchestration/OrchestrationContextFactory.java
@@ -26,12 +26,17 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.orchestration;
 
+import org.apache.commons.lang.StringUtils;
+
 import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
+import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.connectmgr.NhinEndpointManager;
+import gov.hhs.fha.nhinc.connectmgr.UddiSpecVersionRegistry;
 import gov.hhs.fha.nhinc.docsubmission.entity.OutboundDocSubmissionFactory;
 import gov.hhs.fha.nhinc.docsubmission.entity.deferred.request.OutboundDocSubmissionDeferredRequestFactory;
 import gov.hhs.fha.nhinc.docsubmission.entity.deferred.response.OutboundDocSubmissionDeferredResponseFactory;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants.UDDI_SPEC_VERSION;
 import gov.hhs.fha.nhinc.orchestration.AbstractOrchestrationContextFactory;
 import gov.hhs.fha.nhinc.orchestration.OrchestrationContextBuilder;
 
@@ -57,6 +62,24 @@ public class OrchestrationContextFactory extends AbstractOrchestrationContextFac
         NhincConstants.GATEWAY_API_LEVEL apiLevel = nem.getApiVersion(homeCommunityType.getHomeCommunityId(),
                 serviceName);
         return getBuilder(apiLevel, serviceName);
+    }
+    /**
+     * Retrieve correct OrchestrationContextBuilder base on user spec and version
+     * @param targets NhinTargetSystemType
+     * @param serviceName NHIN_SERVICE_NAMES
+     * @return OrchestrationContextBuilder
+     */
+    public OrchestrationContextBuilder getBuilder(NhinTargetSystemType targets,
+            NhincConstants.NHIN_SERVICE_NAMES serviceName) {
+        final String userSpec = targets.getUseSpecVersion();
+        if (StringUtils.isEmpty(userSpec)) {
+            return getBuilder(targets.getHomeCommunity(), serviceName);
+        } else {
+            NhincConstants.GATEWAY_API_LEVEL apiLevel = UddiSpecVersionRegistry.getInstance().getSupportedGatewayAPI(
+                    UDDI_SPEC_VERSION.fromString(userSpec), serviceName);
+            return getBuilder(apiLevel, serviceName);
+        }
+
     }
 
     private OrchestrationContextBuilder getBuilder(NhincConstants.GATEWAY_API_LEVEL apiLevel,

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/entity/OutboundDocSubmissionDelegateTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/entity/OutboundDocSubmissionDelegateTest.java
@@ -159,7 +159,7 @@ public class OutboundDocSubmissionDelegateTest {
     private void setMockContextFactoryToReturnG0() {
         context.checking(new Expectations() {
             {
-                oneOf(mockContextFactory).getBuilder(with(any(HomeCommunityType.class)), with(equal(NhincConstants.NHIN_SERVICE_NAMES.DOCUMENT_SUBMISSION)));
+                oneOf(mockContextFactory).getBuilder(with(any(NhinTargetSystemType.class)), with(equal(NhincConstants.NHIN_SERVICE_NAMES.DOCUMENT_SUBMISSION)));
                 will(returnValue(createOutboundDocSubmissionOrchestrationContextBuilder_g0()));
             }
         });
@@ -184,7 +184,7 @@ public class OutboundDocSubmissionDelegateTest {
     private void setMockContextFactoryToReturnG1() {
         context.checking(new Expectations() {
             {
-                oneOf(mockContextFactory).getBuilder(with(any(HomeCommunityType.class)), with(equal(NhincConstants.NHIN_SERVICE_NAMES.DOCUMENT_SUBMISSION)));
+                oneOf(mockContextFactory).getBuilder(with(any(NhinTargetSystemType.class)), with(equal(NhincConstants.NHIN_SERVICE_NAMES.DOCUMENT_SUBMISSION)));
                 will(returnValue(createOutboundDocSubmissionOrchestrationContextBuilder_g1()));
             }
         });
@@ -209,7 +209,7 @@ public class OutboundDocSubmissionDelegateTest {
     private void setMockContextFactoryToReturnNull() {
         context.checking(new Expectations() {
             {
-                oneOf(mockContextFactory).getBuilder(with(any(HomeCommunityType.class)), with(equal(NhincConstants.NHIN_SERVICE_NAMES.DOCUMENT_SUBMISSION)));
+                oneOf(mockContextFactory).getBuilder(with(any(NhinTargetSystemType.class)), with(equal(NhincConstants.NHIN_SERVICE_NAMES.DOCUMENT_SUBMISSION)));
                 will(returnValue(null));
             }
         });

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/entity/deferred/request/OutboundDocSubmissionDeferredRequestDelegateTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/entity/deferred/request/OutboundDocSubmissionDeferredRequestDelegateTest.java
@@ -157,7 +157,7 @@ public class OutboundDocSubmissionDeferredRequestDelegateTest {
     private void setMockContextFactoryToReturnG0() {
         context.checking(new Expectations() {
             {
-                oneOf(mockContextFactory).getBuilder(with(any(HomeCommunityType.class)),
+                oneOf(mockContextFactory).getBuilder(with(any(NhinTargetSystemType.class)),
                         with(equal(NhincConstants.NHIN_SERVICE_NAMES.DOCUMENT_SUBMISSION_DEFERRED_REQUEST)));
                 will(returnValue(createOutboundDocSubmissionDeferredRequestOrchestrationContextBuilder_g0()));
             }
@@ -183,7 +183,7 @@ public class OutboundDocSubmissionDeferredRequestDelegateTest {
     private void setMockContextFactoryToReturnG1() {
         context.checking(new Expectations() {
             {
-                oneOf(mockContextFactory).getBuilder(with(any(HomeCommunityType.class)),
+                oneOf(mockContextFactory).getBuilder(with(any(NhinTargetSystemType.class)),
                         with(equal(NhincConstants.NHIN_SERVICE_NAMES.DOCUMENT_SUBMISSION_DEFERRED_REQUEST)));
                 will(returnValue(createOutboundDocSubmissionDeferredRequestOrchestrationContextBuilder_g1()));
             }
@@ -209,7 +209,7 @@ public class OutboundDocSubmissionDeferredRequestDelegateTest {
     private void setMockContextFactoryToReturnNull() {
         context.checking(new Expectations() {
             {
-                oneOf(mockContextFactory).getBuilder(with(any(HomeCommunityType.class)),
+                oneOf(mockContextFactory).getBuilder(with(any(NhinTargetSystemType.class)),
                         with(equal(NhincConstants.NHIN_SERVICE_NAMES.DOCUMENT_SUBMISSION_DEFERRED_REQUEST)));
                 will(returnValue(null));
             }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/entity/deferred/response/OutboundDocSubmissionDeferredResponseDelegateTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/entity/deferred/response/OutboundDocSubmissionDeferredResponseDelegateTest.java
@@ -158,7 +158,7 @@ public class OutboundDocSubmissionDeferredResponseDelegateTest {
     private void setMockContextFactoryToReturnG0() {
         context.checking(new Expectations() {
             {
-                oneOf(mockContextFactory).getBuilder(with(any(HomeCommunityType.class)),
+                oneOf(mockContextFactory).getBuilder(with(any(NhinTargetSystemType.class)),
                         with(equal(NhincConstants.NHIN_SERVICE_NAMES.DOCUMENT_SUBMISSION_DEFERRED_RESPONSE)));
                 will(returnValue(createOutboundDocSubmissionDeferredResponseOrchestrationContextBuilder_g0()));
             }
@@ -184,7 +184,7 @@ public class OutboundDocSubmissionDeferredResponseDelegateTest {
     private void setMockContextFactoryToReturnG1() {
         context.checking(new Expectations() {
             {
-                oneOf(mockContextFactory).getBuilder(with(any(HomeCommunityType.class)),
+                oneOf(mockContextFactory).getBuilder(with(any(NhinTargetSystemType.class)),
                         with(equal(NhincConstants.NHIN_SERVICE_NAMES.DOCUMENT_SUBMISSION_DEFERRED_RESPONSE)));
                 will(returnValue(createOutboundDocSubmissionDeferredResponseOrchestrationContextBuilder_g1()));
             }
@@ -210,7 +210,7 @@ public class OutboundDocSubmissionDeferredResponseDelegateTest {
     private void setMockContextFactoryToReturnNull() {
         context.checking(new Expectations() {
             {
-                oneOf(mockContextFactory).getBuilder(with(any(HomeCommunityType.class)),
+                oneOf(mockContextFactory).getBuilder(with(any(NhinTargetSystemType.class)),
                         with(equal(NhincConstants.NHIN_SERVICE_NAMES.DOCUMENT_SUBMISSION_DEFERRED_RESPONSE)));
                 will(returnValue(null));
             }

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/uddiConnectionInfo_g0.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/AuditLogging-Passthrough/uddiConnectionInfo_g0.xml
@@ -317,7 +317,7 @@
 					<bindingTemplate bindingKey="uddi:testnhincnode:DocSubmission" serviceKey="uddi:testnhincnode:DocSubmission">
                         <accessPoint useType="endPoint">https://localhost:8181/Gateway/DocumentSubmission/2_0/DocumentRepositoryXDR_Service</accessPoint>
                         <categoryBag>
-                            <keyedReference tModelKey="uddi:nhin:versionofservice" keyName="" keyValue="1.1"/>
+                            <keyedReference tModelKey="uddi:nhin:versionofservice" keyName="" keyValue="2.0"/>
                         </categoryBag>
                     </bindingTemplate>
                 </bindingTemplates>
@@ -337,7 +337,7 @@
 					<bindingTemplate bindingKey="uddi:testnhincnode:DocSubmissionDeferredReq" serviceKey="uddi:testnhincnode:DocSubmissionDeferredReq">
                         <accessPoint useType="endPoint">https://localhost:8181/Gateway/DocumentSubmission/2_0/NhinService/XDRRequest_Service</accessPoint>
                         <categoryBag>
-                            <keyedReference tModelKey="uddi:nhin:versionofservice" keyName="" keyValue="1.1"/>
+                            <keyedReference tModelKey="uddi:nhin:versionofservice" keyName="" keyValue="2.0"/>
                         </categoryBag>
                     </bindingTemplate>
                 </bindingTemplates>
@@ -357,7 +357,7 @@
                     <bindingTemplate bindingKey="uddi:testnhincnode:DocSubmissionDeferredResp" serviceKey="uddi:testnhincnode:DocSubmissionDeferredResp">
                         <accessPoint useType="endPoint">https://localhost:8181/Gateway/DocumentSubmission/2_0/NhinService/XDRResponse_Service</accessPoint>
                         <categoryBag>
-                            <keyedReference tModelKey="uddi:nhin:versionofservice" keyName="" keyValue="1.1"/>
+                            <keyedReference tModelKey="uddi:nhin:versionofservice" keyName="" keyValue="2.0"/>
                         </categoryBag>
                     </bindingTemplate>
                 </bindingTemplates>


### PR DESCRIPTION
Nightly CI job fail due to the mismatch request/response class type in webservice. This fix will allow OrachestrationContextFactory retrieves correct OrchestrationContextBuilder based on user specification.
@christophermay07 @alameluchidambaram: can you please review this?
@sailajaa : can you please review uddiConnectionInfo_g0.xml?

Thanks
