### PR TITLE
FHAC-813: Removed unnecessary synchronized blocks

### DIFF
--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyWebServiceSecuredImpl.java
@@ -59,25 +59,20 @@ public class AuditRepositoryProxyWebServiceSecuredImpl implements AuditRepositor
 
         if (request.getAuditMessage() == null) {
             LOG.error("Audit Request Message is null");
-            synchronized (result) {
-                return result;
-            }
+            return result;
         }
         try {
             String url = oProxyHelper.getUrlLocalHomeCommunity(NhincConstants.AUDIT_REPO_SECURE_SERVICE_NAME);
 
             if (NullChecker.isNotNullish(url)) {
-
                 ServicePortDescriptor<AuditRepositoryManagerSecuredPortType> portDescriptor
                     = new AuditRepositorySecuredServicePortDescriptor();
 
                 CONNECTClient<AuditRepositoryManagerSecuredPortType> client = CONNECTCXFClientFactory.getInstance()
                     .getCONNECTClientSecured(portDescriptor, url, assertion);
 
-                synchronized (result) {
-                    result = (AcknowledgementType) client.invokePort(AuditRepositoryManagerSecuredPortType.class,
-                        invokeMethodName, createLogSecureEventRequestType(request));
-                }
+                result = (AcknowledgementType) client.invokePort(AuditRepositoryManagerSecuredPortType.class,
+                    invokeMethodName, createLogSecureEventRequestType(request));
             }
         } catch (Exception e) {
             LOG.error("Failed to call the web service({}). An unexpected exception occurred. Exception: {}",

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/proxy/AuditRepositoryProxyWebServiceUnsecuredImpl.java
@@ -56,27 +56,21 @@ public class AuditRepositoryProxyWebServiceUnsecuredImpl implements AuditReposit
 
         if (request.getAuditMessage() == null) {
             LOG.error("Audit Request Message is null.");
-            synchronized (result) {
-                return result;
-            }
+            return result;
         }
 
         try {
             String url = oProxyHelper.getUrlLocalHomeCommunity(NhincConstants.AUDIT_REPO_SERVICE_NAME);
 
             if (NullChecker.isNotNullish(url)) {
-
                 ServicePortDescriptor<AuditRepositoryManagerPortType> portDescriptor
                     = new AuditRepositoryUnsecuredServicePortDescriptor();
 
                 CONNECTClient<AuditRepositoryManagerPortType> client = CONNECTCXFClientFactory.getInstance()
                     .getCONNECTClientUnsecured(portDescriptor, url, assertion);
 
-                synchronized (result) {
-                    result = (AcknowledgementType) client.invokePort(AuditRepositoryManagerPortType.class,
-                        invokeMethodName, request);
-                }
-
+                result = (AcknowledgementType) client.invokePort(AuditRepositoryManagerPortType.class,
+                    invokeMethodName, request);
             }
         } catch (Exception e) {
             LOG.error("Failed to call the web service ({}).  An unexpected exception occurred. Exception: {}",


### PR DESCRIPTION
 Removed unnecessary synchronized blocks, since "result" was changed to a local method parameter
