### PR TITLE
Fix for java.util.ConcurrentModificationException

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/connectmgr/ConnectionManagerCache.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/connectmgr/ConnectionManagerCache.java
@@ -297,8 +297,8 @@ public class ConnectionManagerCache implements ConnectionManager {
             if (NullChecker.isNotNullish(homeCommunityId)) {
                 BusinessEntity oExistingEntity = helper.extractBusinessEntity(allEntities, homeCommunityId);
                 if (oExistingEntity != null) {
-                    helper.mergeBusinessEntityServices(oExistingEntity, uddiEntity);
-                    helper.replaceBusinessEntity(allEntities, oExistingEntity);
+                    helper.replaceBusinessEntity(allEntities, helper.mergeBusinessEntityServices(
+                        oExistingEntity, uddiEntity));
                 } else {
                     allEntities.add(uddiEntity);
                 }
@@ -345,7 +345,7 @@ public class ConnectionManagerCache implements ConnectionManager {
         }
 
         if ((oInternalEntity != null) && (oUDDIEntity != null)) {
-            helper.mergeBusinessEntityServices(oInternalEntity, oUDDIEntity);
+            oInternalEntity = helper.mergeBusinessEntityServices(oInternalEntity, oUDDIEntity);
         } else if (oUDDIEntity != null) {
             return oUDDIEntity;
         }
@@ -468,8 +468,7 @@ public class ConnectionManagerCache implements ConnectionManager {
         // Merge local and remote
         BusinessEntity oCombinedEntity;
         if ((internalBusinessEntity != null) && (uddiEntity != null)) {
-            helper.mergeBusinessEntityServices(internalBusinessEntity, uddiEntity);
-            oCombinedEntity = internalBusinessEntity;
+            oCombinedEntity = helper.mergeBusinessEntityServices(internalBusinessEntity, uddiEntity);
         } else if (internalBusinessEntity != null) {
             oCombinedEntity = internalBusinessEntity;
         } else if (uddiEntity != null) {
@@ -876,8 +875,8 @@ public class ConnectionManagerCache implements ConnectionManager {
                 if (!StringUtils.isEmpty(userSpecVersion)) {
                     final UDDI_SPEC_VERSION version = UDDI_SPEC_VERSION.fromString(userSpecVersion);
                     LOG.debug(
-                            "Attempting to look up URL by home communinity id:{}, and service name: {}, and version {}",
-                            homeCommunityId, serviceName, version.toString());
+                        "Attempting to look up URL by home communinity id:{}, and service name: {}, and version {}",
+                        homeCommunityId, serviceName, version.toString());
                     sEndpointURL = getEndpointURLByServiceNameSpecVersion(homeCommunityId, serviceName, version);
                 } else {
                     LOG.debug("Retrieve endpoint from service Name {}", serviceName);

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/connectmgr/ConnectionManagerCacheHelper.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/connectmgr/ConnectionManagerCacheHelper.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import org.uddi.api_v3.BindingTemplate;
 import org.uddi.api_v3.BusinessEntity;
 import org.uddi.api_v3.BusinessService;
+import org.uddi.api_v3.BusinessServices;
 import org.uddi.api_v3.KeyedReference;
 
 public class ConnectionManagerCacheHelper {
@@ -61,10 +62,24 @@ public class ConnectionManagerCacheHelper {
         }
         for (BusinessService uddiService : uddiEntity.getBusinessServices().getBusinessService()) {
             if (!internalServiceNames.containsKey(uddiService.getServiceKey())) {
-                internalEntity.getBusinessServices().getBusinessService().add(uddiService);
+                internalServiceNames.put(uddiService.getServiceKey(), uddiService);
             }
         }
-        return internalEntity;
+        BusinessEntity mergedEntity = new BusinessEntity();
+        List<BusinessService> mergedList = new ArrayList<>(internalServiceNames.values());
+        BusinessServices mergedServices = new BusinessServices();
+        mergedServices.getBusinessService().addAll(mergedList);
+        mergedEntity.setBusinessServices(mergedServices);
+        mergedEntity.setBusinessKey(internalEntity.getBusinessKey());
+        mergedEntity.setCategoryBag(internalEntity.getCategoryBag());
+        mergedEntity.setContacts(internalEntity.getContacts());
+        mergedEntity.setDiscoveryURLs(internalEntity.getDiscoveryURLs());
+        mergedEntity.setIdentifierBag(internalEntity.getIdentifierBag());
+        mergedEntity.getName().addAll(internalEntity.getName());
+        mergedEntity.getDescription().addAll(internalEntity.getDescription());
+        mergedEntity.getSignature().addAll(internalEntity.getSignature());
+
+        return mergedEntity;
     }
 
     public String getCommunityId(BusinessEntity businessEntity) {


### PR DESCRIPTION
1. ConnectionManagerCacheHelper: Modified mergeBusinessEntityServices() method to create and return a new BusinessEntity that holds merged enteries of both internatConnectionInfo and UddiConnectionInfo.
2. ConnectionManagerCache: Modified getAllBusinessEntities(), getBusinessEntity(), getBusinessEntityByHCID and getBusinessEntityByServiceName() to use the return value from ConnectionManagerCacheHelper's mergeBusinessEntityServices() method.

@christophermay07 
