### PR TITLE
FHAC-804: Fix timeout issue in PD in loopback mode

### DIFF
--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/PassthroughOutboundPatientDiscovery.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/PassthroughOutboundPatientDiscovery.java
@@ -73,13 +73,11 @@ public class PassthroughOutboundPatientDiscovery implements OutboundPatientDisco
     @Override
     public RespondingGatewayPRPAIN201306UV02ResponseType respondingGatewayPRPAIN201305UV02(
         RespondingGatewayPRPAIN201305UV02RequestType request, AssertionType assertion) {
-
+        auditRequest(request, assertion,
+                msgUtils.convertFirstToNhinTargetSystemType(request.getNhinTargetCommunities()));
         RespondingGatewayPRPAIN201306UV02ResponseType response = sendToNhin(request.getPRPAIN201305UV02(),
             MessageGeneratorUtils.getInstance().generateMessageId(assertion),
             msgUtils.convertFirstToNhinTargetSystemType(request.getNhinTargetCommunities()));
-        auidtRequest(request, assertion,
-            msgUtils.convertFirstToNhinTargetSystemType(request.getNhinTargetCommunities()));
-
         return response;
     }
 
@@ -135,7 +133,7 @@ public class PassthroughOutboundPatientDiscovery implements OutboundPatientDisco
         return (new HL7PRPA201306Transforms()).createPRPA201306ForErrors(request, errStr);
     }
 
-    private void auidtRequest(RespondingGatewayPRPAIN201305UV02RequestType request, AssertionType assertion,
+    private void auditRequest(RespondingGatewayPRPAIN201305UV02RequestType request, AssertionType assertion,
         NhinTargetSystemType target) {
         auditLogger.auditRequestMessage(request.getPRPAIN201305UV02(), assertion, target,
             NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE, null,


### PR DESCRIPTION
- Rearrange audit sequence to audit before sending out the NHIN layer.
- Correct misspelling audit method name
  Assign @christophermay07, @alameluchidambaram for peer review.
