### PR TITLE
FHAC-846 Fix DQ passthrough auditing to be consistent

### DIFF
--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/outbound/PassthroughOutboundDocQuery.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/outbound/PassthroughOutboundDocQuery.java
@@ -92,10 +92,11 @@ public class PassthroughOutboundDocQuery implements OutboundDocQuery {
         AdhocQueryResponse response;
 
         try {
+            auditRequest(request, assertion, target);
             OutboundDocQueryOrchestratable orchestratable = new OutboundDocQueryOrchestratable(delegate, null,
                 assertion, NhincConstants.DOC_QUERY_SERVICE_NAME, target, request);
             response = delegate.process(orchestratable).getResponse();
-            auditRequest(request, assertion, target);
+
         } catch (Exception ex) {
             String errorMsg = "Error from target homeId = " + targetCommunityID + ". " + ex.getMessage();
             response = MessageGeneratorUtils.getInstance().createRepositoryErrorResponse(errorMsg);


### PR DESCRIPTION
For Query for Documents service, audit logging sequence is changed in order to fix the Time Out issue. While testing for QD 15-20 times, I observed that Time Out issue for X12 Real time service twice in 15-20 time cycle, but I was not able to re-create the same issue every time.

PR Review: @alameluchidambaram @mhpnguyen 
