### PR TITLE
FHAC-823:Fix audit XSL file to load CSS for audit viewer popup to display XML elements/attributes

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/pom.xml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/pom.xml
@@ -277,7 +277,6 @@
         <dependency>
             <groupId>xalan</groupId>
             <artifactId>xalan</artifactId>
-            <version>2.7.1</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/WEB-INF/audit.xsl
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/WEB-INF/audit.xsl
@@ -13,8 +13,10 @@
     </xsl:template>
     <xsl:template name="EventIdentification">
         <h4>Event Identification:</h4>
-        <table class="table table-bordered table-condensed">
-            <tr bgcolor="#e3ebf5">
+        <table>
+            <xsl:attribute name="class">table table-bordered table-condensed</xsl:attribute>
+            <tr>
+                <xsl:attribute name="bgcolor">#e3ebf5</xsl:attribute>
                 <th>EventActionCode</th>
                 <th>EventDateTime</th>
                 <th>EventOutcomeIndicator</th>
@@ -123,8 +125,10 @@
     </xsl:template>
     <xsl:template name="ActiveParticipant">
         <h4>Active Participant:</h4>
-        <table class="table table-bordered table-condensed">
-            <tr bgcolor="#e3ebf5">
+        <table>
+	    <xsl:attribute name="class">table table-bordered table-condensed</xsl:attribute>
+	    <tr>
+                <xsl:attribute name="bgcolor">#e3ebf5</xsl:attribute>
                 <th>UserID</th>
                 <th>AlternativeUserID</th>
                 <th>UserName</th>
@@ -226,8 +230,10 @@
     </xsl:template>
     <xsl:template name="AuditSourceIdentification">
         <h4>Audit Source Identification:</h4>
-        <table class="table table-bordered table-condensed">
-            <tr bgcolor="#e3ebf5">
+        <table>
+	    <xsl:attribute name="class">table table-bordered table-condensed</xsl:attribute>
+	    <tr>
+                <xsl:attribute name="bgcolor">#e3ebf5</xsl:attribute>
                 <th>AuditEnterpriseSiteID</th>
                 <th>AuditSourceID</th>
             </tr>
@@ -259,8 +265,10 @@
     </xsl:template>
     <xsl:template name="ParticipantObjectIdentification">
         <h4>Participant Object Identification:</h4>
-        <table class="table table-bordered table-condensed">
-            <tr bgcolor="#e3ebf5">
+        <table>
+	    <xsl:attribute name="class">table table-bordered table-condensed</xsl:attribute>
+	    <tr>
+                <xsl:attribute name="bgcolor">#e3ebf5</xsl:attribute>
                 <th>ParticipantObjectID</th>
                 <th>ParticipantObjectTypeCode</th>
                 <th>ParticipantObjectTypeCodeRole</th>
@@ -385,7 +393,6 @@
                             </xsl:otherwise>
                         </xsl:choose>
                     </td>
-
                 </tr>
             </xsl:for-each>
         </table>

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/auditLog.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/auditLog.xhtml
@@ -159,7 +159,7 @@
                                                                 </p:commandButton>
                                                             </p:column>
                                                         </p:dataTable>
-                                                        <p:dialog id="auditBlobDlg" header="View Audit Message"  widgetVar="dlg1" modal="true" draggable="false" resizable="false">
+                                                        <p:dialog id="auditBlobDlg" header="View Audit Message XML Details"  widgetVar="dlg1" modal="true" draggable="false" resizable="false">
                                                             <h:outputText id="blobOutput" value="#{auditSearchBean.blobContent}" escape="false" />
                                                         </p:dialog>
                                                     </div>


### PR DESCRIPTION
1. Upgraded Xalan 2.7.1 to Xalan 2.7.2 due to OWASP findings.
2. Audit XSL file needed modification to load CSS.
