### PR TITLE
FHAC-862: Removed Direct artifactId conflict

### DIFF
--- a/Product/SoapUI_Test/RegressionSuite/Direct/AutomatedDirectTesting/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Direct/AutomatedDirectTesting/pom.xml
@@ -2,7 +2,7 @@
 
     <parent>
         <groupId>org.connectopensource</groupId>
-        <artifactId>Direct</artifactId>
+        <artifactId>DirectRegressionTests</artifactId>
         <version>4.6.0-SNAPSHOT</version>
     </parent>
 

--- a/Product/SoapUI_Test/RegressionSuite/Direct/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Direct/pom.xml
@@ -6,7 +6,7 @@
         <version>4.6.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>Direct</artifactId>
+    <artifactId>DirectRegressionTests</artifactId>
     <name>Maven 3 soapUI Direct Regression Tests</name>
     <packaging>pom</packaging>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Renamed the Maven artifactId for Direct's RegressionSuite parent POM to avoid conflict in artifact definitions.
