### PR TITLE
Fixed input length for Requestor/UserID, MessageID and RelatesTo

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/auditLog.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/auditLog.xhtml
@@ -71,7 +71,7 @@
                                                         </div>
                                                         <div class="form-group col-xs-4">
                                                             <h:outputLabel for="userid" class="col-lg-4 control-label" id="labelUserId" value="Requester/User:" />
-                                                            <p:inputText styleClass="col-lg-8 form-control" value="#{auditSearchBean.userId}" id="userId" maxlength="20" required="false" />
+                                                            <p:inputText styleClass="col-lg-8 form-control" value="#{auditSearchBean.userId}" id="userId" maxlength="100" required="false" />
                                                         </div>
                                                     </div>
 
@@ -94,11 +94,11 @@
                                                     <div class="row">
                                                         <div class="form-group col-xs-4">
                                                             <h:outputLabel for="messageid" class="col-lg-4 control-label" id="labelMessageId" value="Message ID:" />
-                                                            <p:inputText styleClass="col-lg-8 form-control" value="#{auditSearchBean.messageId}" style="/*height:32px;width:200px*/" id="messageId" maxlength="50" required="false" />
+                                                            <p:inputText styleClass="col-lg-8 form-control" value="#{auditSearchBean.messageId}" style="/*height:32px;width:200px*/" id="messageId" maxlength="100" required="false" />
                                                         </div>
                                                         <div class="form-group col-xs-4">
                                                             <h:outputLabel for="relatesto" class="col-lg-4 control-label" id="labelRelatesTo" value="Relates To:" />
-                                                            <p:inputText styleClass="col-lg-8 form-control" value="#{auditSearchBean.relatesTo}" style="/*height:32px;width:200px*/" id="relatesTo" maxlength="50" required="false" />
+                                                            <p:inputText styleClass="col-lg-8 form-control" value="#{auditSearchBean.relatesTo}" style="/*height:32px;width:200px*/" id="relatesTo" maxlength="100" required="false" />
                                                         </div>
                                                     </div>
 


### PR DESCRIPTION
UserId, MessageID and RelatesTo  search fields on AdminGUI now match with the corresponding database column length in AuditRepository table.

@mhpnguyen and @danielrf123 
