### PR TITLE
Deactivate glassfish and generate wildfly EAR by default.

### DIFF
--- a/Product/Production/Deploy/pom.xml
+++ b/Product/Production/Deploy/pom.xml
@@ -10,11 +10,10 @@
     <name>CONNECT Deployment</name>
     <packaging>pom</packaging>
     <modelVersion>4.0.0</modelVersion>
-
-    <modules>
-        <module>glassfish</module>
-    </modules>
-
+		<modules>
+             <module>jboss7</module>
+         </modules>
+    
     <reporting>
         <plugins>
             <plugin>
@@ -824,12 +823,15 @@
             </modules>
         </profile>
 
-        <!-- JBoss 7 -->
-        <profile>
-            <id>jboss7</id>
-            <modules>
-                <module>jboss7</module>
-            </modules>
-        </profile>
-    </profiles>
+        <!-- Glassfish -->
+     	<profile>
+            <id>glassfish</id>
+			<activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+			<modules>
+				<module>glassfish</module>
+			</modules>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
When Connect builds the binaries (EAR), the system generate glassfish ear by default. Since we don't official support glassfish, we want the system to generate wildfly (jboss) ear by default unless users explicitly define glassfish profile.
@mhpnguyen and @TabassumJafri can you please review?
