### PR TITLE
FHAC-996: Regression clean-up for EntityPolicyEngineTest

### DIFF
--- a/Product/SoapUI_Test/RegressionSuite/Standard/EntityPolicyEngineTest/EntityPolicyEngineTest-soapui-project.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/EntityPolicyEngineTest/EntityPolicyEngineTest-soapui-project.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<con:soapui-project abortOnError="false" name="EntityPolicyEngineTest" resourceRoot="${projectDir}" runType="SEQUENTIAL" soapui-version="5.1.2" activeEnvironment="Default" id="9a64ffb4-b156-4b9d-a4cb-da753fd4dbff" xmlns:con="http://eviware.com/soapui/config">
+<con:soapui-project abortOnError="false" name="EntityPolicyEngineTest" resourceRoot="${projectDir}" runType="SEQUENTIAL" soapui-version="4.5.1" activeEnvironment="Default" id="9a64ffb4-b156-4b9d-a4cb-da753fd4dbff" xmlns:con="http://eviware.com/soapui/config">
   <con:settings/>
   <con:interface anonymous="optional" bindingName="{urn:gov:hhs:fha:nhinc:entitydocquery}EntityDocQueryBindingSoap" definition="../../../target/wsdl/EntityDocQuery.wsdl" name="EntityDocQueryBindingSoap" soapVersion="1_2" type="wsdl" wsaVersion="NONE" xsi:type="con:WsdlInterface" id="3ace40bd-8e9f-498d-90bc-08cb9df8e1a6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <con:settings/>
@@ -44,24 +44,12 @@
       <con:testStep name="ModifyInterrnalConnectionInfo" type="groovy" id="cf63398a-478b-48aa-a219-d9dda77ff966">
         <con:settings/>
         <con:config>
-          <script>import nhinc.FileUtils;
-def groovyUtils = new com.eviware.soapui.support.GroovyUtils( context );
-def destConfigFileLocation = context.findProperty("GatewayPropDir");
-def NHINGatewayHost = context.findProperty("NHINGatewayHost");
+          <script>def destConfigFileLocation = context.findProperty("GatewayPropDir");
 def mockHost = context.findProperty("MockHost");
 def mockPEURL = "http://" + mockHost + ":18088/mockPolicyEngine";
 def InitiatingHCID = context.findProperty( "LocalHCID" );
 
 nhinc.FileUtils.createOrUpdateConnection("internalConnectionInfo.xml", destConfigFileLocation, InitiatingHCID, "policyengineservice", mockPEURL, "LEVEL_a0", log)</script>
-        </con:config>
-      </con:testStep>
-      <con:testStep name="Generate patient ID for Doc Query" type="groovy" id="c311e339-3352-4c51-9d7e-513e47c56bbf">
-        <con:settings/>
-        <con:config>
-          <script>def localAA = context.findProperty('LocalAA')
-def dqPatientID = context.findProperty('DQPatientID')
-
-context.testCase.setPropertyValue('FullPatientID', "'${dqPatientID}^^^&amp;amp;${localAA}&amp;amp;ISO'");</script>
         </con:config>
       </con:testStep>
       <con:testStep name="Clear Correlation Table &amp; Add Correlation" type="groovy" id="1094642f-c71f-401b-b1a2-edf35401dc13">
@@ -371,19 +359,19 @@ declare namespace ns18='urn:gov:hhs:fha:nhinc:common:nhinccommonadapter';
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2014-03-31T14:07:42Z</con:value>
+          <con:value>2016-05-12T18:37:13Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2014-03-31T14:17:42Z</con:value>
+          <con:value>2016-05-12T18:47:13Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>03/31/2014 14:07:42</con:value>
+          <con:value>05/12/2016 18:37:13</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2014-04-30T00:00:00Z</con:value>
+          <con:value>2016-06-11T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>FullPatientID</con:name>
@@ -398,10 +386,7 @@ declare namespace ns18='urn:gov:hhs:fha:nhinc:common:nhinccommonadapter';
       <con:testStep name="ModifyInterrnalConnectionInfo" type="groovy" id="d5c3de19-57a5-43b3-8e7d-9b34dcfa8a07">
         <con:settings/>
         <con:config>
-          <script>import nhinc.FileUtils;
-def groovyUtils = new com.eviware.soapui.support.GroovyUtils( context );
-def destConfigFileLocation = context.findProperty("GatewayPropDir");
-def NHINGatewayHost = context.findProperty("NHINGatewayHost");
+          <script>def destConfigFileLocation = context.findProperty("GatewayPropDir");
 def mockHost = context.findProperty("MockHost");
 def mockPEURL = "http://" + mockHost + ":18088/mockPolicyEngine1";
 def InitiatingHCID = context.findProperty( "LocalHCID" );
@@ -732,19 +717,19 @@ declare namespace ns18='urn:gov:hhs:fha:nhinc:common:nhinccommonadapter';
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2014-03-31T14:08:43Z</con:value>
+          <con:value>2016-05-12T18:37:15Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2014-03-31T14:18:43Z</con:value>
+          <con:value>2016-05-12T18:47:15Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>03/31/2014 14:08:43</con:value>
+          <con:value>05/12/2016 18:37:15</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2014-04-30T00:00:00Z</con:value>
+          <con:value>2016-06-11T00:00:00Z</con:value>
         </con:property>
         <con:property>
           <con:name>correctedRemoteHCID</con:name>
@@ -774,14 +759,6 @@ declare namespace ns18='urn:gov:hhs:fha:nhinc:common:nhinccommonadapter';
     <con:property>
       <con:name>AQUserID</con:name>
       <con:value>mfranklin</con:value>
-    </con:property>
-    <con:property>
-      <con:name>AuditDB</con:name>
-      <con:value>auditrepo</con:value>
-    </con:property>
-    <con:property>
-      <con:name>AuditTable</con:name>
-      <con:value>auditrepository</con:value>
     </con:property>
     <con:property>
       <con:name>DBHost</con:name>
@@ -816,10 +793,6 @@ declare namespace ns18='urn:gov:hhs:fha:nhinc:common:nhinccommonadapter';
       <con:value>1</con:value>
     </con:property>
     <con:property>
-      <con:name>Endpoint-AuditLogQuery</con:name>
-      <con:value>http://localhost:8080/CONNECTAdapter/EntityAuditQuery</con:value>
-    </con:property>
-    <con:property>
       <con:name>Endpoint-DocQuery</con:name>
       <con:value>http://localhost:8080/Gateway/DocumentQuery/3_0/EntityService/EntityDocQueryUnsecured</con:value>
     </con:property>
@@ -828,36 +801,12 @@ declare namespace ns18='urn:gov:hhs:fha:nhinc:common:nhinccommonadapter';
       <con:value>http://localhost:8080/Gateway/DocumentRetrieve/2_0/EntityService/EntityDocRetrieve</con:value>
     </con:property>
     <con:property>
-      <con:name>Endpoint-Notify</con:name>
-      <con:value>http://localhost:8080/Gateway/HIEM/2_0/EntityNotificationConsumer</con:value>
-    </con:property>
-    <con:property>
-      <con:name>Endpoint-Reidentification</con:name>
-      <con:value>http://localhost:8080/CONNECTAdapter/EntitySubjectDiscovery</con:value>
-    </con:property>
-    <con:property>
-      <con:name>Endpoint-SubjectDiscovery</con:name>
-      <con:value>http://localhost:8080/CONNECTAdapter/EntitySubjectDiscovery</con:value>
-    </con:property>
-    <con:property>
-      <con:name>Endpoint-Subscribe</con:name>
-      <con:value>http://localhost:8080/Gateway/HIEM/2_0/EntityNotificationProducer</con:value>
-    </con:property>
-    <con:property>
-      <con:name>Endpoint-Unsubscribe</con:name>
-      <con:value>http://localhost:8080/Gateway/HIEM/2_0/EntitySubscriptionManager</con:value>
-    </con:property>
-    <con:property>
       <con:name>GatewayPropDir</con:name>
-      <con:value>c:\glassfish3\glassfish\domains\domain1\config\nhin</con:value>
+      <con:value/>
     </con:property>
     <con:property>
       <con:name>LocalAA</con:name>
       <con:value>1.1</con:value>
-    </con:property>
-    <con:property>
-      <con:name>LocalConfigDir</con:name>
-      <con:value>C:/SelfTest/EndToEndSelfTest</con:value>
     </con:property>
     <con:property>
       <con:name>LocalHCDescription</con:name>
@@ -876,44 +825,12 @@ declare namespace ns18='urn:gov:hhs:fha:nhinc:common:nhinccommonadapter';
       <con:value>localhost</con:value>
     </con:property>
     <con:property>
-      <con:name>MPIDir</con:name>
-      <con:value>C:/Sun/AppServer/domains/domain1/config</con:value>
-    </con:property>
-    <con:property>
-      <con:name>NHINGatewayConfigDir</con:name>
-      <con:value>C:/Sun/AppServer/domains/domain1/config/nhin</con:value>
-    </con:property>
-    <con:property>
-      <con:name>NHINGatewayHost</con:name>
-      <con:value>localhost</con:value>
-    </con:property>
-    <con:property>
-      <con:name>NotificationEndpoint</con:name>
-      <con:value>https://localhost:8181/Gateway/HIEM/2_0/NhinService/NotificationConsumerService/HiemNotify</con:value>
-    </con:property>
-    <con:property>
-      <con:name>NotifySubscriptionID</con:name>
-      <con:value>-f7c1a5d:1204e50e42e:-79eb</con:value>
-    </con:property>
-    <con:property>
-      <con:name>NotifySubscriptionManagerEndpointAddress</con:name>
-      <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
-    </con:property>
-    <con:property>
       <con:name>PatientCorrelationDB</con:name>
       <con:value>patientcorrelationdb</con:value>
     </con:property>
     <con:property>
       <con:name>PatientCorrelationTable</con:name>
       <con:value>correlatedidentifiers</con:value>
-    </con:property>
-    <con:property>
-      <con:name>PseudonymAA</con:name>
-      <con:value>ABC</con:value>
-    </con:property>
-    <con:property>
-      <con:name>PseudonymPatientID</con:name>
-      <con:value>PSEUDO001</con:value>
     </con:property>
     <con:property>
       <con:name>RealAA</con:name>
@@ -938,30 +855,6 @@ declare namespace ns18='urn:gov:hhs:fha:nhinc:common:nhinccommonadapter';
     <con:property>
       <con:name>RemotePatientID</con:name>
       <con:value>D123401</con:value>
-    </con:property>
-    <con:property>
-      <con:name>SubscribePatientID</con:name>
-      <con:value>D123401</con:value>
-    </con:property>
-    <con:property>
-      <con:name>SubscriptionDB</con:name>
-      <con:value>subscriptionrepository</con:value>
-    </con:property>
-    <con:property>
-      <con:name>SubscriptionEndpoint</con:name>
-      <con:value>https://localhost:8181/Gateway/HIEM/2_0/NhinService/NotificationProducerService/HiemSubscription</con:value>
-    </con:property>
-    <con:property>
-      <con:name>SubscriptionManagerEndpointAddress</con:name>
-      <con:value>https://localhost:8181/CONNECTNhinServicesWeb/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
-    </con:property>
-    <con:property>
-      <con:name>SubscriptionTable</con:name>
-      <con:value>subscription</con:value>
-    </con:property>
-    <con:property>
-      <con:name>UnsubSubscriptionID</con:name>
-      <con:value>3e74139f-5271-4db1-98c0-88748fa3e4e3</con:value>
     </con:property>
   </con:properties>
   <con:afterLoadScript>def propertiesFilename = project.path[0..(project.path.size()-4)] + 'properties'


### PR DESCRIPTION
1. Removed deprecated test steps.
2. Removed unused properties.
3. Correct Script.
