### PR TITLE
FHAC-995:Regression clean-up for EntityDocRetrieveSecuredInterface Test

### DIFF
--- a/Product/SoapUI_Test/RegressionSuite/Standard/EntityDocRetrieveSecuredInterfaceTest/EntityDocRetrieveSecuredInterfaceTest-soapui-project.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/EntityDocRetrieveSecuredInterfaceTest/EntityDocRetrieveSecuredInterfaceTest-soapui-project.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<con:soapui-project abortOnError="false" name="CONN-891" resourceRoot="${projectDir}" runType="SEQUENTIAL" soapui-version="5.1.2" activeEnvironment="Default" id="769db954-d5c5-4fbf-a368-a719a8120ab3" xmlns:con="http://eviware.com/soapui/config">
+<con:soapui-project abortOnError="false" name="CONN-891" resourceRoot="${projectDir}" runType="SEQUENTIAL" soapui-version="4.5.1" activeEnvironment="Default" id="769db954-d5c5-4fbf-a368-a719a8120ab3" xmlns:con="http://eviware.com/soapui/config">
   <con:settings/>
   <con:interface anonymous="optional" bindingName="{urn:gov:hhs:fha:nhinc:entitydocretrieve}EntityDocRetrieveBindingSoap" definition="${projectDir}/../../target/wsdl/EntityDocRetrieve.wsdl" name="EntityDocRetrieveBindingSoap" soapVersion="1_2" type="wsdl" wsaVersion="NONE" xsi:type="con:WsdlInterface" id="f8cb5180-7a40-470a-9028-4b498b4b063e" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <con:settings/>
@@ -16,33 +16,6 @@
     <con:runType>SEQUENTIAL</con:runType>
     <con:testCase failOnError="true" failTestCaseOnErrors="true" id="08c7914d-69d5-40a5-951d-5774a8836aad" keepSession="false" maxResults="0" name="Document Retrieve" searchProperties="true">
       <con:settings/>
-      <con:testStep type="groovy" name="Check Passthru" id="8a91e115-1012-4c07-84ff-f9fcedd14e5c">
-        <con:settings/>
-        <con:config>
-          <script>import nhinc.FileUtils;
-def dir = context.findProperty('GatewayPropDir');
-def file = "gateway.properties";
-def passthruProp = "docretrieve.30.inbound";
-
-def passthruValue = FileUtils.readProperty(dir, file, passthruProp, log);
-log.info "Passthrough property value = ${passthruValue}";
-
-if(passthruValue != null){
-	testRunner.testCase.setPropertyValue("PassThruOn", "true");
-	FileUtils.backupFile(dir, "PolicyEngineProxyConfig.xml", log);
-	//Updating PolicyEngine for passthrough
-	def alias = 'adapterpolicyengineorchestrator';
-	def aliasName = 'adapterpolicyengineorchestratorsamljava';
-	def replaceName = 'adapterpolicyengineorchestratornoopdeny';
-	
-	FileUtils.updateSpringConfig(dir, "PolicyEngineProxyConfig.xml", alias,
-		aliasName, replaceName, log);
-	
-} else {
-	testRunner.testCase.setPropertyValue("PassThruOn", "false");
-}</script>
-        </con:config>
-      </con:testStep>
       <con:testStep name="Document Retrieve" type="request" id="13817f90-2c4c-4f39-9464-0a16c61291df">
         <con:settings/>
         <con:config xsi:type="con:RequestStep" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -54,7 +27,7 @@ if(passthruValue != null){
               <con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting>
             </con:settings>
             <con:encoding>UTF-8</con:encoding>
-            <con:endpoint>http://localhost:8080/Gateway/DocumentRetrieve/3_0/EntityServiceProxy/EntityDocRetrieveUnsecured</con:endpoint>
+            <con:endpoint>${#Project#DR_EntityEndpoint_g1}</con:endpoint>
             <con:request><![CDATA[<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:urn="urn:gov:hhs:fha:nhinc:common:nhinccommonentity" xmlns:urn1="urn:ihe:iti:xds-b:2007" xmlns:urn2="urn:gov:hhs:fha:nhinc:common:nhinccommon">
    <soap:Header/>
    <soap:Body testSuite="Entity_g1" testCase="Document Retrieve">
@@ -337,10 +310,7 @@ if(passthruValue != null){
 nhinc.FileUtils.setG1ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
 nhinc.FileUtils.copyFile(context.expand(context.testCase.testSuite.project.resourceRoot), "DocumentRetrieveProxyConfig.xml", context.findProperty('GatewayPropDir'), "DocumentRetrieveProxyConfig.xml", log);</con:setupScript>
       <con:tearDownScript>def dir = context.findProperty('GatewayPropDir');
-nhinc.FileUtils.restoreConfiguration(dir, log);
-if(context.findProperty("PassThruOn").toBoolean()){
-	nhinc.FileUtils.restoreFile(dir, "PolicyEngineProxyConfig.xml", log);
-}</con:tearDownScript>
+nhinc.FileUtils.restoreConfiguration(dir, log);</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>CorrectedRemoteHCID</con:name>
@@ -348,23 +318,19 @@ if(context.findProperty("PassThruOn").toBoolean()){
         </con:property>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2013-11-13T16:53:58Z</con:value>
+          <con:value>2016-05-13T13:59:04Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2013-11-13T17:03:58Z</con:value>
+          <con:value>2016-05-13T14:09:04Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/13/2013 16:53:58</con:value>
+          <con:value>05/13/2016 13:59:04</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2013-12-13T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>PassThruOn</con:name>
-          <con:value>true</con:value>
+          <con:value>2016-06-12T00:00:00Z</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -379,33 +345,6 @@ if(context.findProperty("PassThruOn").toBoolean()){
     <con:runType>SEQUENTIAL</con:runType>
     <con:testCase failOnError="true" failTestCaseOnErrors="true" id="3a630f37-d9fc-4fd2-bc44-bc0b04246222" keepSession="false" maxResults="0" name="Document Retrieve" searchProperties="true">
       <con:settings/>
-      <con:testStep type="groovy" name="Check Passthru" id="1803eba2-a62e-4dff-8ed6-7432a9c1173f">
-        <con:settings/>
-        <con:config>
-          <script>import nhinc.FileUtils;
-def dir = context.findProperty('GatewayPropDir');
-def file = "gateway.properties";
-def passthruProp = "docretrieve.20.inbound";
-
-def passthruValue = FileUtils.readProperty(dir, file, passthruProp, log);
-log.info "Passthrough property value = ${passthruValue}";
-
-if(passthruValue != null){
-	testRunner.testCase.setPropertyValue("PassThruOn", "true");
-	FileUtils.backupFile(dir, "PolicyEngineProxyConfig.xml", log);
-	//Updating PolicyEngine for passthrough
-	def alias = 'adapterpolicyengineorchestrator';
-	def aliasName = 'adapterpolicyengineorchestratorsamljava';
-	def replaceName = 'adapterpolicyengineorchestratornoopdeny';
-	
-	FileUtils.updateSpringConfig(dir, "PolicyEngineProxyConfig.xml", alias,
-		aliasName, replaceName, log);
-	
-} else {
-	testRunner.testCase.setPropertyValue("PassThruOn", "false");
-}</script>
-        </con:config>
-      </con:testStep>
       <con:testStep name="Document Retrieve" type="request" id="80fd20d8-9bd5-4c87-9470-0f4397ab337a">
         <con:settings/>
         <con:config xsi:type="con:RequestStep" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -417,7 +356,7 @@ if(passthruValue != null){
               <con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting>
             </con:settings>
             <con:encoding>UTF-8</con:encoding>
-            <con:endpoint>http://localhost:8080/Gateway/DocumentRetrieve/2_0/EntityServiceProxy/EntityDocRetrieveUnsecured</con:endpoint>
+            <con:endpoint>${#Project#DR_EntityEndpoint_g0}</con:endpoint>
             <con:request><![CDATA[<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:urn="urn:gov:hhs:fha:nhinc:common:nhinccommonentity" xmlns:urn1="urn:ihe:iti:xds-b:2007" xmlns:urn2="urn:gov:hhs:fha:nhinc:common:nhinccommon">
    <soap:Header/>
    <soap:Body testSuite="Entity_g0" testCase="Document Retrieve">
@@ -700,10 +639,7 @@ if(passthruValue != null){
 nhinc.FileUtils.setG0ConnectionInfo(context.expand(context.testCase.testSuite.project.resourceRoot), context.findProperty('GatewayPropDir'), log);
 nhinc.FileUtils.copyFile(context.expand(context.testCase.testSuite.project.resourceRoot), "DocumentRetrieveProxyConfig.xml", context.findProperty('GatewayPropDir'), "DocumentRetrieveProxyConfig.xml", log);</con:setupScript>
       <con:tearDownScript>def dir = context.findProperty('GatewayPropDir');
-nhinc.FileUtils.restoreConfiguration(dir, log);
-if(context.findProperty("PassThruOn").toBoolean()){
-	nhinc.FileUtils.restoreFile(dir, "PolicyEngineProxyConfig.xml", log);
-}</con:tearDownScript>
+nhinc.FileUtils.restoreConfiguration(dir, log);</con:tearDownScript>
       <con:properties>
         <con:property>
           <con:name>CorrectedRemoteHCID</con:name>
@@ -711,23 +647,19 @@ if(context.findProperty("PassThruOn").toBoolean()){
         </con:property>
         <con:property>
           <con:name>startDate</con:name>
-          <con:value>2013-11-13T16:54:24Z</con:value>
+          <con:value>2016-05-13T13:59:13Z</con:value>
         </con:property>
         <con:property>
           <con:name>endDate</con:name>
-          <con:value>2013-11-13T17:04:24Z</con:value>
+          <con:value>2016-05-13T14:09:13Z</con:value>
         </con:property>
         <con:property>
           <con:name>sigDate</con:name>
-          <con:value>11/13/2013 16:54:24</con:value>
+          <con:value>05/13/2016 13:59:13</con:value>
         </con:property>
         <con:property>
           <con:name>expireDate</con:name>
-          <con:value>2013-12-13T00:00:00Z</con:value>
-        </con:property>
-        <con:property>
-          <con:name>PassThruOn</con:name>
-          <con:value>true</con:value>
+          <con:value>2016-06-12T00:00:00Z</con:value>
         </con:property>
       </con:properties>
       <con:reportParameters/>
@@ -739,46 +671,6 @@ if(context.findProperty("PassThruOn").toBoolean()){
   </con:testSuite>
   <con:requirements/>
   <con:properties>
-    <con:property>
-      <con:name>AAMappingDB</con:name>
-      <con:value>assigningauthoritydb</con:value>
-    </con:property>
-    <con:property>
-      <con:name>AAMappingTable</con:name>
-      <con:value>aa_to_home_community_mapping</con:value>
-    </con:property>
-    <con:property>
-      <con:name>AsyncMsgDB</con:name>
-      <con:value>asyncmsgs</con:value>
-    </con:property>
-    <con:property>
-      <con:name>AsyncMsgTable</con:name>
-      <con:value>asyncmsgrepo</con:value>
-    </con:property>
-    <con:property>
-      <con:name>AuditRepoDB</con:name>
-      <con:value>auditrepo</con:value>
-    </con:property>
-    <con:property>
-      <con:name>AuditRepoTable</con:name>
-      <con:value>auditrepository</con:value>
-    </con:property>
-    <con:property>
-      <con:name>BirthTime</con:name>
-      <con:value>19630804</con:value>
-    </con:property>
-    <con:property>
-      <con:name>City</con:name>
-      <con:value>Melbourne</con:value>
-    </con:property>
-    <con:property>
-      <con:name>Country</con:name>
-      <con:value>US</con:value>
-    </con:property>
-    <con:property>
-      <con:name>DateOfSignature</con:name>
-      <con:value>20080520</con:value>
-    </con:property>
     <con:property>
       <con:name>DBHost</con:name>
       <con:value>localhost</con:value>
@@ -796,26 +688,6 @@ if(context.findProperty("PassThruOn").toBoolean()){
       <con:value>nhincuser</con:value>
     </con:property>
     <con:property>
-      <con:name>DeferredPatientDiscoveryReqMessageID</con:name>
-      <con:value>uuid:6666666666.66666.666.66</con:value>
-    </con:property>
-    <con:property>
-      <con:name>DOB</con:name>
-      <con:value>19800516</con:value>
-    </con:property>
-    <con:property>
-      <con:name>DQDocID</con:name>
-      <con:value>1.123401.55555</con:value>
-    </con:property>
-    <con:property>
-      <con:name>DQPatientID</con:name>
-      <con:value>D123401</con:value>
-    </con:property>
-    <con:property>
-      <con:name>DQPTDocID</con:name>
-      <con:value>1.123401.11111</con:value>
-    </con:property>
-    <con:property>
       <con:name>DRDocID</con:name>
       <con:value>1.123407.777777</con:value>
     </con:property>
@@ -826,10 +698,6 @@ if(context.findProperty("PassThruOn").toBoolean()){
     <con:property>
       <con:name>DynamicDQDocID</con:name>
       <con:value>103.8.9284320.020.3590.75^1266324032288</con:value>
-    </con:property>
-    <con:property>
-      <con:name>ExpirationDate</con:name>
-      <con:value>20100520</con:value>
     </con:property>
     <con:property>
       <con:name>FamilyName</con:name>
@@ -864,34 +732,6 @@ if(context.findProperty("PassThruOn").toBoolean()){
       <con:value>D123401</con:value>
     </con:property>
     <con:property>
-      <con:name>NotificationEndpoint</con:name>
-      <con:value>https://localhost:8181/Gateway/HIEM/2_0/NhinService/NotificationConsumerService/HiemNotify</con:value>
-    </con:property>
-    <con:property>
-      <con:name>NotifySubscriptionID</con:name>
-      <con:value>24085385-ef54-4aaf-b027-d5896689be24</con:value>
-    </con:property>
-    <con:property>
-      <con:name>NotifySubscriptionManagerEndpointAddress</con:name>
-      <con:value>https://localhost:8181/Gateway/HIEM/2_0/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
-    </con:property>
-    <con:property>
-      <con:name>PatientCorrelationDB</con:name>
-      <con:value>patientcorrelationdb</con:value>
-    </con:property>
-    <con:property>
-      <con:name>PatientCorrelationTable</con:name>
-      <con:value>correlatedidentifiers</con:value>
-    </con:property>
-    <con:property>
-      <con:name>project.name</con:name>
-      <con:value>EntityValidation</con:value>
-    </con:property>
-    <con:property>
-      <con:name>PurposeOfDisclosure</con:name>
-      <con:value>Mental</con:value>
-    </con:property>
-    <con:property>
       <con:name>RemoteAA</con:name>
       <con:value>2.2</con:value>
     </con:property>
@@ -908,108 +748,20 @@ if(context.findProperty("PassThruOn").toBoolean()){
       <con:value>D123401</con:value>
     </con:property>
     <con:property>
-      <con:name>SSN</con:name>
-      <con:value>123456789</con:value>
-    </con:property>
-    <con:property>
-      <con:name>State</con:name>
-      <con:value>FL</con:value>
-    </con:property>
-    <con:property>
-      <con:name>StreetAddress</con:name>
-      <con:value>123 Johnson Rd</con:value>
-    </con:property>
-    <con:property>
       <con:name>SubjectID</con:name>
       <con:value>D123401</con:value>
-    </con:property>
-    <con:property>
-      <con:name>SubscribePatientID</con:name>
-      <con:value>D123401</con:value>
-    </con:property>
-    <con:property>
-      <con:name>SubscriptionDB</con:name>
-      <con:value>subscriptionrepository</con:value>
-    </con:property>
-    <con:property>
-      <con:name>SubscriptionManagerEndpointAddress</con:name>
-      <con:value>https://localhost:8181/Gateway/HIEM/2_0/NhinService/SubscriptionManagerService/HiemUnsubscribe</con:value>
-    </con:property>
-    <con:property>
-      <con:name>SubscriptionTable</con:name>
-      <con:value>subscription</con:value>
     </con:property>
     <con:property>
       <con:name>UniquePatientId</con:name>
       <con:value>1111^^^&amp;amp;1.1&amp;amp;ISO</con:value>
     </con:property>
     <con:property>
-      <con:name>UnSubscriptionID</con:name>
-      <con:value>6deec8e7-6e6c-4269-91c2-69cb777ab8b0</con:value>
-    </con:property>
-    <con:property>
-      <con:name>ZipCode</con:name>
-      <con:value>12345</con:value>
-    </con:property>
-    <con:property>
-      <con:name>DQ_EntityEndpoint_g1</con:name>
-      <con:value>http://localhost:8080/Gateway/DocumentQuery/3_0/EntityService/EntityDocQueryUnsecured</con:value>
-    </con:property>
-    <con:property>
-      <con:name>DQ_EntityEndpoint_g0</con:name>
-      <con:value>http://localhost:8080/Gateway/DocumentQuery/2_0/EntityService/EntityDocQueryUnsecured</con:value>
-    </con:property>
-    <con:property>
-      <con:name>DS_EntityEndpoint_g1</con:name>
-      <con:value>http://localhost:8080/Gateway/DocumentSubmission/2_0/EntityService/EntityDocSubmissionUnsecured</con:value>
-    </con:property>
-    <con:property>
-      <con:name>DS_EntityEndpoint_g0</con:name>
-      <con:value>http://localhost:8080/Gateway/DocumentSubmission/1_1/EntityService/EntityDocSubmissionUnsecured</con:value>
-    </con:property>
-    <con:property>
-      <con:name>DSDefResp_EntityEndpoint_g1</con:name>
-      <con:value>http://localhost:8080/Gateway/DocumentSubmission/2_0/EntityService/EntityDocSubmissionDeferredResponseUnsecured</con:value>
-    </con:property>
-    <con:property>
-      <con:name>DSDefResp_EntityEndpoint_g0</con:name>
-      <con:value>http://localhost:8080/Gateway/DocumentSubmission/1_1/EntityService/EntityDocSubmissionDeferredResponseUnsecured</con:value>
-    </con:property>
-    <con:property>
-      <con:name>PDDefReq_EntityEndpoint</con:name>
-      <con:value>http://localhost:8080/Gateway/PatientDiscovery/1_0/EntityService/EntityPatientDiscoveryDeferredRequestUnsecured</con:value>
-    </con:property>
-    <con:property>
       <con:name>DR_EntityEndpoint_g1</con:name>
-      <con:value>http://localhost:8080/Gateway/DocumentRetrieve/3_0/EntityService/EntityDocRetrieve</con:value>
+      <con:value>http://localhost:8080/Gateway/DocumentRetrieve/3_0/EntityServiceProxy/EntityDocRetrieveUnsecured</con:value>
     </con:property>
     <con:property>
       <con:name>DR_EntityEndpoint_g0</con:name>
-      <con:value>http://localhost:8080/Gateway/DocumentRetrieve/2_0/EntityService/EntityDocRetrieve</con:value>
-    </con:property>
-    <con:property>
-      <con:name>PDDefResp_EntityEndpoint</con:name>
-      <con:value>http://localhost:8080/Gateway/PatientDiscovery/1_0/EntityService/EntityPatientDiscoveryDeferredResponseUnsecured</con:value>
-    </con:property>
-    <con:property>
-      <con:name>PD_EntityEndpoint</con:name>
-      <con:value>http://localhost:8080/Gateway/PatientDiscovery/1_0/EntityPatientDiscovery</con:value>
-    </con:property>
-    <con:property>
-      <con:name>AD_EntityEndpoint_g1</con:name>
-      <con:value>http://localhost:8080/Gateway/AdminDistribution/2_0/AdministrativeDistribution_Service</con:value>
-    </con:property>
-    <con:property>
-      <con:name>DSDefReq_EntityEndpoint_g1</con:name>
-      <con:value>http://localhost:8080/Gateway/DocumentSubmission/2_0/EntityService/EntityDocSubmissionDeferredRequestUnsecured</con:value>
-    </con:property>
-    <con:property>
-      <con:name>AD_EntityEndpoint_g0</con:name>
-      <con:value>http://localhost:8080/Gateway/AdminDistribution/1_0/AdministrativeDistribution_Service</con:value>
-    </con:property>
-    <con:property>
-      <con:name>DSDefReq_EntityEndpoint_g0</con:name>
-      <con:value>http://localhost:8080/Gateway/DocumentSubmission/1_1/EntityService/EntityDocSubmissionDeferredRequestUnsecured</con:value>
+      <con:value>http://localhost:8080/Gateway/DocumentRetrieve/2_0/EntityServiceProxy/EntityDocRetrieveUnsecured</con:value>
     </con:property>
   </con:properties>
   <con:afterLoadScript>def propertiesFilename = project.path[0..(project.path.size()-4)] + 'properties'


### PR DESCRIPTION
1. Removed "Check passthrough" which is not required step .
2. Properties clean-up.
