### PR TITLE
FHAC-1002: Fix regression suite and mvn command line

### DIFF
--- a/Product/SoapUI_Test/RegressionSuite/Passthru/DocQueryRetrieveSelfTest/DocQueryRetrieveSelfTest-soapui-project.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/DocQueryRetrieveSelfTest/DocQueryRetrieveSelfTest-soapui-project.xml
@@ -8078,7 +8078,7 @@ assert docCount.toInteger() == 0;</scriptText>
       </con:testStep>
       <con:properties/>
       <con:reportParameters/>
-      <con:tearDownScript>FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
+      <con:tearDownScript>FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase disabled="true" failOnError="true" failTestCaseOnErrors="true" id="30aca504-5f48-472f-818f-772029eaab39" keepSession="false" maxResults="0" name="3.5.1.UT.2 - Too Many Results" searchProperties="true">
       <con:settings/>
@@ -8403,7 +8403,7 @@ assert docCount.toInteger() == 20;</scriptText>
         </con:property>
       </con:properties>
       <con:reportParameters/>
-      <con:tearDownScript>FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
+      <con:tearDownScript>FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase disabled="true" failOnError="true" failTestCaseOnErrors="true" id="8a054cf4-1ea4-4731-947f-0319b21908dd" keepSession="false" maxResults="0" name="11.3.2.UT.4 - Multiple Doc unique community ID multiple set" searchProperties="true">
       <con:settings/>
@@ -8775,7 +8775,7 @@ assert documentContent != "";</scriptText>
         </con:property>
       </con:properties>
       <con:reportParameters/>
-      <con:tearDownScript>FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
+      <con:tearDownScript>FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:properties/>
     <con:reportParameters/>

--- a/Product/SoapUI_Test/RegressionSuite/Passthru/DocQueryRetrieveSelfTest/DocQueryRetrieveSelfTest-soapui-project.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Passthru/DocQueryRetrieveSelfTest/DocQueryRetrieveSelfTest-soapui-project.xml
@@ -8078,7 +8078,8 @@ assert docCount.toInteger() == 0;</scriptText>
       </con:testStep>
       <con:properties/>
       <con:reportParameters/>
-      <con:tearDownScript>FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
+      <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);</con:setupScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase disabled="true" failOnError="true" failTestCaseOnErrors="true" id="30aca504-5f48-472f-818f-772029eaab39" keepSession="false" maxResults="0" name="3.5.1.UT.2 - Too Many Results" searchProperties="true">
       <con:settings/>
@@ -8403,7 +8404,8 @@ assert docCount.toInteger() == 20;</scriptText>
         </con:property>
       </con:properties>
       <con:reportParameters/>
-      <con:tearDownScript>FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
+      <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);</con:setupScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase disabled="true" failOnError="true" failTestCaseOnErrors="true" id="8a054cf4-1ea4-4731-947f-0319b21908dd" keepSession="false" maxResults="0" name="11.3.2.UT.4 - Multiple Doc unique community ID multiple set" searchProperties="true">
       <con:settings/>
@@ -8775,7 +8777,8 @@ assert documentContent != "";</scriptText>
         </con:property>
       </con:properties>
       <con:reportParameters/>
-      <con:tearDownScript>FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
+      <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);</con:setupScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:properties/>
     <con:reportParameters/>
@@ -8899,7 +8902,7 @@ def testRunListener = [
   afterStep: { testRunner, runContext, result -> },
   beforeStep: { testRunner, runContext -> },
   beforeStep: { testRunner, runContext, testStep -> },
-  beforeRun: { testRunner, runContext -> 
+  beforeRun: { testRunner, runContext ->
     use (org.codehaus.groovy.runtime.TimeCategory) {
       def startDate = 5.minutes.ago
       def endDate = 5.minutes.from.now
@@ -8913,7 +8916,7 @@ def testRunListener = [
       runContext.testCase.setPropertyValue("sigDate", startDate.format(df))
       runContext.testCase.setPropertyValue("expireDate", expireDate.format(df))
     }
-  }   
+  }
 ] as com.eviware.soapui.model.testsuite.TestRunListener
 
 project.testSuiteList*.testCaseList.flatten()*.addTestRunListener(testRunListener)
@@ -8934,7 +8937,7 @@ com.eviware.soapui.impl.wsdl.testcase.WsdlTestRunContext.metaClass.withSql = { d
   def port = delegate.findProperty('DBPort')
   def user = delegate.findProperty('DBUser')
   def pass = delegate.findProperty('DBPass')
-  
+
   def connectString = "jdbc:mysql://${host}:${port}/${dbName}"
   def sql = groovy.sql.Sql.newInstance(connectString, user, pass, "com.mysql.jdbc.Driver");
   try {
@@ -8980,7 +8983,7 @@ com.eviware.soapui.impl.wsdl.testcase.WsdlTestRunContext.metaClass.setGatewaySta
   	config.setStandardMode();
   }
   else{
-     config.setPassthruMode();	
+     config.setPassthruMode();
   }
   server.close();
   return true;
@@ -8996,7 +8999,7 @@ com.eviware.soapui.impl.wsdl.testcase.WsdlTestRunContext.metaClass.isStandard = 
     (JMXConnector.CREDENTIALS): (String[])[username, password]
   ];
  def serverUrl = 'service:jmx:http-remoting-jmx://'+jmxHost+ ':' + jmxPort;
-   
+
   def server = JmxFactory.connect(new JmxUrl(serverUrl), env);
   def config = new GroovyMBean(server.MBeanServerConnection, 'org.connectopensource.mbeans:type=Configuration');
   //set the Gateway to Standard Mode
@@ -9024,7 +9027,7 @@ com.eviware.soapui.impl.wsdl.testcase.WsdlTestRunContext.metaClass.setGatewaySta
   	config.setStandardMode(serviceName, direction);
   }
   else{
-     config.setPassthruMode(serviceName, direction);	
+     config.setPassthruMode(serviceName, direction);
   }
   server.close();
   return true;

--- a/Product/SoapUI_Test/RegressionSuite/Standard/DocQuerytestsforUDDI/DocQuerytestsforUDDI-soapui-project.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/DocQuerytestsforUDDI/DocQuerytestsforUDDI-soapui-project.xml
@@ -5447,6 +5447,7 @@ count(//ns6:AdhocQueryResponse[1]/ns3:RegistryObjectList[1]/ns3:ExtrinsicObject)
         </con:property>
       </con:properties>
       <con:reportParameters/>
+      <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase failOnError="true" failTestCaseOnErrors="true" id="ecb4d188-094b-4f8c-bb59-b5cf33c4e974" keepSession="false" maxResults="0" name="State Alt Path - Multiple regions and correlations" searchProperties="true">
@@ -6286,6 +6287,7 @@ count(//ns6:AdhocQueryResponse[1]/ns3:RegistryObjectList[1]/ns3:ExtrinsicObject)
         </con:property>
       </con:properties>
       <con:reportParameters/>
+      <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase disabled="true" failOnError="true" failTestCaseOnErrors="true" id="5c44df01-4f70-48d3-8930-a31ac9100e8e" keepSession="false" maxResults="0" name="HCID Happy Path - Correlation for HCID IN UDDI file/target XML" searchProperties="true">
@@ -6714,6 +6716,7 @@ count(//ns6:AdhocQueryResponse[1]/ns3:RegistryObjectList[1]/ns3:ExtrinsicObject)
         </con:property>
       </con:properties>
       <con:reportParameters/>
+      <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);</con:setupScript>
       <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase failOnError="true" failTestCaseOnErrors="true" id="7c286477-8a88-4aad-ab67-d6968f946de2" keepSession="false" maxResults="0" name="State Happy Path - Correlation for HCID not in UDDI file/target XML" searchProperties="true">

--- a/Product/SoapUI_Test/RegressionSuite/Standard/DocQuerytestsforUDDI/DocQuerytestsforUDDI-soapui-project.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/DocQuerytestsforUDDI/DocQuerytestsforUDDI-soapui-project.xml
@@ -5447,7 +5447,7 @@ count(//ns6:AdhocQueryResponse[1]/ns3:RegistryObjectList[1]/ns3:ExtrinsicObject)
         </con:property>
       </con:properties>
       <con:reportParameters/>
-      <con:tearDownScript>nhinc.FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase failOnError="true" failTestCaseOnErrors="true" id="ecb4d188-094b-4f8c-bb59-b5cf33c4e974" keepSession="false" maxResults="0" name="State Alt Path - Multiple regions and correlations" searchProperties="true">
       <con:settings/>
@@ -6286,7 +6286,7 @@ count(//ns6:AdhocQueryResponse[1]/ns3:RegistryObjectList[1]/ns3:ExtrinsicObject)
         </con:property>
       </con:properties>
       <con:reportParameters/>
-      <con:tearDownScript>nhinc.FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase disabled="true" failOnError="true" failTestCaseOnErrors="true" id="5c44df01-4f70-48d3-8930-a31ac9100e8e" keepSession="false" maxResults="0" name="HCID Happy Path - Correlation for HCID IN UDDI file/target XML" searchProperties="true">
       <con:settings/>
@@ -6714,7 +6714,7 @@ count(//ns6:AdhocQueryResponse[1]/ns3:RegistryObjectList[1]/ns3:ExtrinsicObject)
         </con:property>
       </con:properties>
       <con:reportParameters/>
-      <con:tearDownScript>nhinc.FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase failOnError="true" failTestCaseOnErrors="true" id="7c286477-8a88-4aad-ab67-d6968f946de2" keepSession="false" maxResults="0" name="State Happy Path - Correlation for HCID not in UDDI file/target XML" searchProperties="true">
       <con:settings/>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/EntityXDRTests/EntityXDRTests-soapui-project.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/EntityXDRTests/EntityXDRTests-soapui-project.xml
@@ -5860,7 +5860,7 @@ nhinc.FileUtils.CreateOrUpdateConnection(destConfigFileLocation, RemoteHCID, "se
         </con:property>
       </con:properties>
       <con:reportParameters/>
-      <con:tearDownScript>FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
+      <con:tearDownScript>FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase failOnError="true" failTestCaseOnErrors="true" id="7ab026d6-4438-498b-af6c-4e08d85df3b6" keepSession="false" maxResults="0" name="Success message from mock NHINC" searchProperties="true" disabled="true">
       <con:settings/>
@@ -6384,7 +6384,7 @@ nhinc.FileUtils.CreateOrUpdateConnection(destConfigFileLocation, LocalHCID, "moc
         </con:property>
       </con:properties>
       <con:reportParameters/>
-      <con:tearDownScript>FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
+      <con:tearDownScript>FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase failOnError="true" failTestCaseOnErrors="true" id="a83d4d4f-cf93-41e9-abf8-19e76d2bccf0" keepSession="false" maxResults="0" name="Audit Log Check" searchProperties="true" disabled="true">
       <con:settings/>
@@ -6999,7 +6999,7 @@ assert (count > 0);</script>
     </con:property>
     <con:property>
       <con:name>GatewayPropDir</con:name>
-      <con:value>c:\glassfish3\glassfish\domains\domain1\config\nhin</con:value>
+      <con:value/>
     </con:property>
   </con:properties>
   <con:afterLoadScript>def propertiesFile = new File(new File(project.path).parent, 'EntityXDRTests-soapui-project.properties')

--- a/Product/SoapUI_Test/RegressionSuite/Standard/EntityXDRTests/EntityXDRTests-soapui-project.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/EntityXDRTests/EntityXDRTests-soapui-project.xml
@@ -5860,7 +5860,8 @@ nhinc.FileUtils.CreateOrUpdateConnection(destConfigFileLocation, RemoteHCID, "se
         </con:property>
       </con:properties>
       <con:reportParameters/>
-      <con:tearDownScript>FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
+      <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);</con:setupScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase failOnError="true" failTestCaseOnErrors="true" id="7ab026d6-4438-498b-af6c-4e08d85df3b6" keepSession="false" maxResults="0" name="Success message from mock NHINC" searchProperties="true" disabled="true">
       <con:settings/>
@@ -6384,7 +6385,8 @@ nhinc.FileUtils.CreateOrUpdateConnection(destConfigFileLocation, LocalHCID, "moc
         </con:property>
       </con:properties>
       <con:reportParameters/>
-      <con:tearDownScript>FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
+      <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);</con:setupScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase failOnError="true" failTestCaseOnErrors="true" id="a83d4d4f-cf93-41e9-abf8-19e76d2bccf0" keepSession="false" maxResults="0" name="Audit Log Check" searchProperties="true" disabled="true">
       <con:settings/>

--- a/Product/SoapUI_Test/RegressionSuite/Standard/PatientCorrelation/PatientCorrelation-soapui-project.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/PatientCorrelation/PatientCorrelation-soapui-project.xml
@@ -22,7 +22,7 @@
       <con:testStep name="Clear Correlation Table" type="groovy" id="9f2fd368-72c7-4516-a803-044eec15b7f3">
         <con:settings/>
         <con:config>
-          <script>context.withSql("PatientCorrelationDB") { sql -> 
+          <script>context.withSql("PatientCorrelationDB") { sql ->
   def table = context.findProperty("PatientCorrelationTable");
 
   sql.execute("delete from " + table);
@@ -519,7 +519,7 @@
       <con:testStep name="Clear Correlation Table" type="groovy" id="abcf97c7-3f3c-4668-b3f1-cfcbfd8ee189">
         <con:settings/>
         <con:config>
-          <script>context.withSql("PatientCorrelationDB") { sql -> 
+          <script>context.withSql("PatientCorrelationDB") { sql ->
   def table = context.findProperty("PatientCorrelationTable");
 
   sql.execute("delete from " + table);
@@ -1024,7 +1024,7 @@
       <con:testStep name="Clear Correlation Table" type="groovy" id="b9ae29b0-f93f-45f8-a485-d5545cf697dd">
         <con:settings/>
         <con:config>
-          <script>context.withSql("PatientCorrelationDB") { sql -> 
+          <script>context.withSql("PatientCorrelationDB") { sql ->
   def table = context.findProperty("PatientCorrelationTable");
 
   sql.execute("delete from " + table);
@@ -1378,15 +1378,14 @@
         </con:property>
       </con:properties>
       <con:reportParameters/>
-      <con:tearDownScript>import nhinc.FileUtils;
-FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase failOnError="true" failTestCaseOnErrors="true" id="708cf740-23a5-44fb-afd3-4328b60f5f87" keepSession="false" maxResults="0" name="Simple Retrieve with multiple in repository" searchProperties="true">
       <con:settings/>
       <con:testStep name="Clear Correlation Table" type="groovy" id="a2ed7e16-3ac3-4b42-b8e9-c1d29038afc2">
         <con:settings/>
         <con:config>
-          <script>context.withSql("PatientCorrelationDB") { sql -> 
+          <script>context.withSql("PatientCorrelationDB") { sql ->
   def table = context.findProperty("PatientCorrelationTable");
 
   sql.execute("delete from " + table);
@@ -2061,15 +2060,14 @@ FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</co
         </con:property>
       </con:properties>
       <con:reportParameters/>
-      <con:tearDownScript>import nhinc.FileUtils;
-FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase failOnError="true" failTestCaseOnErrors="true" id="2ea19a05-affb-4fcc-859c-89eb8c97b68a" keepSession="false" maxResults="0" name="Multiple results" searchProperties="true">
       <con:settings/>
       <con:testStep name="Clear Correlation Table" type="groovy" id="f4aba0a3-0961-4217-87e1-8b50c4a67038">
         <con:settings/>
         <con:config>
-          <script>context.withSql("PatientCorrelationDB") { sql -> 
+          <script>context.withSql("PatientCorrelationDB") { sql ->
   def table = context.findProperty("PatientCorrelationTable");
 
   sql.execute("delete from " + table);
@@ -3162,15 +3160,14 @@ FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</co
         </con:property>
       </con:properties>
       <con:reportParameters/>
-      <con:tearDownScript>import nhinc.FileUtils;
-FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase failOnError="true" failTestCaseOnErrors="true" id="6f809e56-9c83-48e1-8d60-c03cb53b59db" keepSession="false" maxResults="0" name="Retrieve with empty repository" searchProperties="true">
       <con:settings/>
       <con:testStep name="Clear Correlation Table" type="groovy" id="4d74ff92-6fce-4a21-9cd2-72b5b5bda0a0">
         <con:settings/>
         <con:config>
-          <script>context.withSql("PatientCorrelationDB") { sql -> 
+          <script>context.withSql("PatientCorrelationDB") { sql ->
   def table = context.findProperty("PatientCorrelationTable");
 
   sql.execute("delete from " + table);
@@ -3515,15 +3512,14 @@ FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</co
         </con:property>
       </con:properties>
       <con:reportParameters/>
-      <con:tearDownScript>import nhinc.FileUtils;
-FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase failOnError="true" failTestCaseOnErrors="true" id="34355ad6-e834-45cf-9ca0-aea649e68d00" keepSession="false" maxResults="0" name="Retrieve with no results" searchProperties="true">
       <con:settings/>
       <con:testStep name="Clear Correlation Table" type="groovy" id="81835537-eeed-4f79-9a37-a0630978c78f">
         <con:settings/>
         <con:config>
-          <script>context.withSql("PatientCorrelationDB") { sql -> 
+          <script>context.withSql("PatientCorrelationDB") { sql ->
   def table = context.findProperty("PatientCorrelationTable");
 
   sql.execute("delete from " + table);
@@ -4008,8 +4004,7 @@ FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</co
         </con:property>
       </con:properties>
       <con:reportParameters/>
-      <con:tearDownScript>import nhinc.FileUtils;
-FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:properties>
       <con:property>
@@ -4098,7 +4093,7 @@ def testRunListener = [
   afterStep: { testRunner, runContext, result -> },
   beforeStep: { testRunner, runContext -> },
   beforeStep: { testRunner, runContext, testStep -> },
-  beforeRun: { testRunner, runContext -> 
+  beforeRun: { testRunner, runContext ->
     use (org.codehaus.groovy.runtime.TimeCategory) {
       def startDate = 5.minutes.ago
       def endDate = 5.minutes.from.now
@@ -4112,7 +4107,7 @@ def testRunListener = [
       runContext.testCase.setPropertyValue("sigDate", startDate.format(dfSig))
       runContext.testCase.setPropertyValue("expireDate", expireDate.format(df))
     }
-  }   
+  }
 ] as com.eviware.soapui.model.testsuite.TestRunListener
 
 project.testSuiteList*.testCaseList.flatten()*.addTestRunListener(testRunListener)

--- a/Product/SoapUI_Test/RegressionSuite/Standard/PatientCorrelation/PatientCorrelation-soapui-project.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/PatientCorrelation/PatientCorrelation-soapui-project.xml
@@ -965,7 +965,7 @@
           </con:request>
         </con:config>
       </con:testStep>
-      <con:setupScript/>
+      <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);</con:setupScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
@@ -1017,8 +1017,7 @@
         </con:property>
       </con:properties>
       <con:reportParameters/>
-      <con:tearDownScript>import nhinc.FileUtils;
-FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
+      <con:tearDownScript>nhinc.FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase failOnError="true" failTestCaseOnErrors="true" id="0cb2c0df-b008-4285-b363-e56504707a05" keepSession="false" maxResults="0" name="Simple Retrieve" searchProperties="true">
       <con:settings/>
@@ -1343,7 +1342,7 @@ FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
           </con:request>
         </con:config>
       </con:testStep>
-      <con:setupScript/>
+     <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);</con:setupScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
@@ -1380,7 +1379,7 @@ FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
       </con:properties>
       <con:reportParameters/>
       <con:tearDownScript>import nhinc.FileUtils;
-FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
+FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase failOnError="true" failTestCaseOnErrors="true" id="708cf740-23a5-44fb-afd3-4328b60f5f87" keepSession="false" maxResults="0" name="Simple Retrieve with multiple in repository" searchProperties="true">
       <con:settings/>
@@ -2010,7 +2009,7 @@ FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
           </con:request>
         </con:config>
       </con:testStep>
-      <con:setupScript/>
+       <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);</con:setupScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
@@ -2063,7 +2062,7 @@ FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
       </con:properties>
       <con:reportParameters/>
       <con:tearDownScript>import nhinc.FileUtils;
-FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
+FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase failOnError="true" failTestCaseOnErrors="true" id="2ea19a05-affb-4fcc-859c-89eb8c97b68a" keepSession="false" maxResults="0" name="Multiple results" searchProperties="true">
       <con:settings/>
@@ -3087,7 +3086,7 @@ FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
           </con:request>
         </con:config>
       </con:testStep>
-      <con:setupScript/>
+     <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);</con:setupScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
@@ -3164,7 +3163,7 @@ FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
       </con:properties>
       <con:reportParameters/>
       <con:tearDownScript>import nhinc.FileUtils;
-FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
+FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase failOnError="true" failTestCaseOnErrors="true" id="6f809e56-9c83-48e1-8d60-c03cb53b59db" keepSession="false" maxResults="0" name="Retrieve with empty repository" searchProperties="true">
       <con:settings/>
@@ -3480,7 +3479,7 @@ FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
           </con:request>
         </con:config>
       </con:testStep>
-      <con:setupScript/>
+     <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);</con:setupScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
@@ -3517,7 +3516,7 @@ FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
       </con:properties>
       <con:reportParameters/>
       <con:tearDownScript>import nhinc.FileUtils;
-FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
+FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:testCase failOnError="true" failTestCaseOnErrors="true" id="34355ad6-e834-45cf-9ca0-aea649e68d00" keepSession="false" maxResults="0" name="Retrieve with no results" searchProperties="true">
       <con:settings/>
@@ -3961,7 +3960,7 @@ FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
           </con:request>
         </con:config>
       </con:testStep>
-      <con:setupScript/>
+     <con:setupScript>nhinc.FileUtils.backupConfiguration(context.findProperty("GatewayPropDir"), log);</con:setupScript>
       <con:properties>
         <con:property>
           <con:name>startDate</con:name>
@@ -4010,7 +4009,7 @@ FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
       </con:properties>
       <con:reportParameters/>
       <con:tearDownScript>import nhinc.FileUtils;
-FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
+FileUtils.restoreConfiguration(context.findProperty("GatewayPropDir"), log);</con:tearDownScript>
     </con:testCase>
     <con:properties>
       <con:property>
@@ -4080,7 +4079,7 @@ FileUtils.restoreToMasterConfiguration(context, log);</con:tearDownScript>
     </con:property>
     <con:property>
       <con:name>GatewayPropDir</con:name>
-      <con:value>c:\glassfish3\glassfish\domains\domain1\config\nhin</con:value>
+      <con:value/>
     </con:property>
   </con:properties>
   <con:afterLoadScript>def propertiesFile = new File(new File(project.path).parent, 'PatientCorrelation-soapui-project.properties')

--- a/Product/SoapUI_Test/RegressionSuite/Standard/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/Standard/pom.xml
@@ -23,6 +23,9 @@
                     <name>regression</name>
                 </property>
             </activation>
+            <properties>
+                <properties.dir>${project.parent.parent.parent.basedir}/${wildfly.properties.dir}</properties.dir>
+            </properties>
             <modules>
                 <module>Admin-Distribution-Standard</module>
                 <module>AuditLogging-Standard</module>


### PR DESCRIPTION
- Fix mvn command line so that we don't need to pass -Dproperties.dir in command line.  We can perform regression test local with embedded server (mvn clean install -P PD,DQ,DR,DS,AD,X12 -Dregression)
- Refactor soapUI to use correct restore method instead of wrong one.
  @sailajaa @TabassumJafri : Can you please review this?
