### PR TITLE
FHAC-462 Create a profile for these Manually executed SoapUI test cases

### DIFF
--- a/Product/SoapUI_Test/RegressionSuite/pom.xml
+++ b/Product/SoapUI_Test/RegressionSuite/pom.xml
@@ -12,7 +12,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <soapui.testFailIgnore>true</soapui.testFailIgnore>
+	     <soapui.testFailIgnore>true</soapui.testFailIgnore>
     </properties>
 
     <profiles>
@@ -63,10 +63,12 @@
 				 <module>Standard/Fanout-Test</module>
 				 <module>Standard/TransactionIDTest</module>
 				 <module>startEmbedded</module>
-				 <module>stopEmbedded</module> 
-				 
+				 <module>stopEmbedded</module>
+				 <module>Graveyard/LargePayloadTest</module> 
+				 <module>Utility/JMXConfigTest</module> 
 			 </modules>
 	   </profile>
+	   
     </profiles>
 
     <build>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -1,15 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <!--
-        Due to Maven limitations with plugins and multimodule reporting,
-        this POM cannot have an org.connectopensource parent module
-    -->
-	<parent>
+    <parent>
         <groupId>org.connectopensource</groupId>
         <artifactId>CONNECTSolution</artifactId>
         <version>4.7.0-SNAPSHOT</version>
     </parent>
-	
+
     <groupId>org.connectopensource</groupId>
     <artifactId>build-tools</artifactId>
     <packaging>jar</packaging>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -4,9 +4,14 @@
         Due to Maven limitations with plugins and multimodule reporting,
         this POM cannot have an org.connectopensource parent module
     -->
+	<parent>
+        <groupId>org.connectopensource</groupId>
+        <artifactId>CONNECTSolution</artifactId>
+        <version>4.7.0-SNAPSHOT</version>
+    </parent>
+	
     <groupId>org.connectopensource</groupId>
     <artifactId>build-tools</artifactId>
-    <version>4.7.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Added  below projects in manual -testing profile.

CONNECT\Product\SoapUI_Test\RegressionSuite\Graveyard\LargePayloadTest 
CONNECT\Product\SoapUI_Test\RegressionSuite\Utility\JMXConfigTest   

CONNECT\build-tools \pom.xml  missing parent information. With this change version is updating in pom.xml. of build-tools.
@mhpnguyen and @TabassumJafri can you please review?
