### PR TITLE
FHAC-1034: CONNECTAdminGUI should include the javax.persistence packa…ge as a 'prefer-application-package'

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/WEB-INF/weblogic.xml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/WEB-INF/weblogic.xml
@@ -30,6 +30,7 @@
             <package-name>com.sun.faces.*</package-name> 
             <package-name>com.bea.faces.*</package-name>
             <package-name>javax.wsdl.*</package-name>
+            <package-name>javax.persistence.*</package-name>
         </wls:prefer-application-packages>
         <wls:prefer-application-resources> 
             <resource-name>javax.faces.*</resource-name> 


### PR DESCRIPTION
CONNECTAdminGUI cannot be opened after the updates for the sessionFactory done in PR #1290.  Added javax.persistence package to prefer-application-package so that the classes in it will be loaded from JPA 2.1 library included in the CONNECTADminGUI.war.

@mhpnguyen and @TabassumJafri and @sailajaa (optional) can you please review.
