### PR TITLE
FHAC-1023: Fix SonarQube blockers/major issues introduced from Hibernate upgrade.

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/async/AsyncMessageProcessHelper.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/async/AsyncMessageProcessHelper.java
@@ -28,9 +28,10 @@ package gov.hhs.fha.nhinc.async;
 
 import gov.hhs.fha.nhinc.asyncmsgs.dao.AsyncMsgRecordDao;
 import gov.hhs.fha.nhinc.asyncmsgs.model.AsyncMsgRecord;
+import gov.hhs.fha.nhinc.asyncmsgs.persistence.HibernateUtil;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
-import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
+import gov.hhs.fha.nhinc.persistence.HibernateUtilFactory;
 import gov.hhs.fha.nhinc.transform.marshallers.JAXBContextHandler;
 import gov.hhs.fha.nhinc.transform.subdisc.HL7AckTransforms;
 import gov.hhs.fha.nhinc.util.JAXBUnmarshallingUtil;
@@ -71,6 +72,8 @@ public class AsyncMessageProcessHelper {
     private static final Logger LOG = LoggerFactory.getLogger(AsyncMessageProcessHelper.class);
 
     private static HashMap<String, String> statusToDirectionMap = new HashMap<>();
+
+    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getAsyncMsgsHibernateUtil();
 
     static {
         statusToDirectionMap.put(AsyncMsgRecordDao.QUEUE_STATUS_REQSENT, AsyncMsgRecordDao.QUEUE_DIRECTION_OUTBOUND);
@@ -569,8 +572,8 @@ public class AsyncMessageProcessHelper {
 
     protected Session getSession() {
         Session session = null;
-        if (HibernateUtilFactory.getAsyncMsgsHibernateUtil() != null) {
-            session = HibernateUtilFactory.getAsyncMsgsHibernateUtil().getSessionFactory().openSession();
+        if (hibernateUtil != null) {
+            session = hibernateUtil.getSessionFactory().openSession();
         } else {
             LOG.error("Session is null");
         }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/async/AsyncMessageProcessHelper.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/async/AsyncMessageProcessHelper.java
@@ -59,6 +59,7 @@ import org.hl7.v3.RespondingGatewayPRPAIN201305UV02RequestType;
 import org.hl7.v3.RespondingGatewayPRPAIN201306UV02RequestType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.stereotype.Component;
 
 /**
@@ -73,7 +74,7 @@ public class AsyncMessageProcessHelper {
 
     private static HashMap<String, String> statusToDirectionMap = new HashMap<>();
 
-    private HibernateUtil hibernateUtil = new HibernateUtil();
+    private static HibernateUtil hibernateUtil;
 
     static {
         statusToDirectionMap.put(AsyncMsgRecordDao.QUEUE_STATUS_REQSENT, AsyncMsgRecordDao.QUEUE_DIRECTION_OUTBOUND);
@@ -398,7 +399,6 @@ public class AsyncMessageProcessHelper {
             if (session != null) {
                 session.close();
             }
-            hibernateUtil.closeSessionFactory();
         }
 
         return asyncMessage;
@@ -429,7 +429,6 @@ public class AsyncMessageProcessHelper {
             if (session != null) {
                 session.close();
             }
-            hibernateUtil.closeSessionFactory();
         }
 
         return asyncMessage;
@@ -460,7 +459,6 @@ public class AsyncMessageProcessHelper {
             if (session != null) {
                 session.close();
             }
-            hibernateUtil.closeSessionFactory();
         }
 
         return asyncMessage;
@@ -573,8 +571,7 @@ public class AsyncMessageProcessHelper {
 
     protected Session getSession() {
         Session session = null;
-        hibernateUtil.buildSessionFactory();
-        SessionFactory fact = hibernateUtil.getSessionFactory();
+        SessionFactory fact = getHibernateUtil().getSessionFactory();
         if (fact != null) {
             session = fact.openSession();
         } else {
@@ -583,4 +580,14 @@ public class AsyncMessageProcessHelper {
         return session;
     }
 
+    /**
+     * @return the HibernateUtil
+     */
+    protected static HibernateUtil getHibernateUtil() {
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+                new String[] { "classpath:CONNECT-context.xml" });
+        LOG.debug("Memory address " + context.getId());
+        hibernateUtil = context.getBean("asyncmsgsHibernateUtil", HibernateUtil.class);
+        return hibernateUtil;
+    }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/async/AsyncMessageProcessHelper.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/async/AsyncMessageProcessHelper.java
@@ -71,8 +71,6 @@ public class AsyncMessageProcessHelper {
 
     private static HashMap<String, String> statusToDirectionMap = new HashMap<>();
 
-    private static HibernateUtil hibernateUtil;
-
     static {
         statusToDirectionMap.put(AsyncMsgRecordDao.QUEUE_STATUS_REQSENT, AsyncMsgRecordDao.QUEUE_DIRECTION_OUTBOUND);
         statusToDirectionMap.put(AsyncMsgRecordDao.QUEUE_STATUS_REQSENTACK, AsyncMsgRecordDao.QUEUE_DIRECTION_OUTBOUND);
@@ -570,23 +568,13 @@ public class AsyncMessageProcessHelper {
 
     protected Session getSession() {
         Session session = null;
-        if (getHibernateUtil() != null) {
-            session = getHibernateUtil().getSessionFactory().openSession();
+        HibernateUtil util = HibernateUtilFactory.getAsyncMsgsHibernateUtil();
+        if (util != null) {
+            session = util.getSessionFactory().openSession();
         } else {
             LOG.error("Session is null");
         }
         return session;
     }
 
-    /**
-     * Get this class' HibernateUtil
-     *
-     * @return hibernateUtil
-     */
-    private static HibernateUtil getHibernateUtil() {
-        if (hibernateUtil == null) {
-            hibernateUtil = HibernateUtilFactory.getAsyncMsgsHibernateUtil();
-        }
-        return hibernateUtil;
-    }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/asyncmsgs/dao/AsyncMsgRecordDao.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/asyncmsgs/dao/AsyncMsgRecordDao.java
@@ -27,10 +27,10 @@
 package gov.hhs.fha.nhinc.asyncmsgs.dao;
 
 import gov.hhs.fha.nhinc.asyncmsgs.model.AsyncMsgRecord;
-import gov.hhs.fha.nhinc.asyncmsgs.persistence.HibernateUtil;
 import gov.hhs.fha.nhinc.common.deferredqueuemanager.QueryDeferredQueueRequestType;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
+import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
 import gov.hhs.fha.nhinc.properties.PropertyAccessException;
 import gov.hhs.fha.nhinc.properties.PropertyAccessor;
 import gov.hhs.fha.nhinc.util.format.XMLDateUtil;
@@ -42,12 +42,10 @@ import org.hibernate.Criteria;
 import org.hibernate.HibernateException;
 import org.hibernate.Query;
 import org.hibernate.Session;
-import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.hibernate.criterion.Restrictions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  *
@@ -81,22 +79,12 @@ public class AsyncMsgRecordDao {
     public static final String QUEUE_STATUS_RSPSENTACK = "RSPSENTACK";
     public static final String QUEUE_STATUS_RSPSENTERR = "RSPSENTERR";
 
-    private HibernateUtil hibernateUtil;
-
     public AsyncMsgRecordDao() {
         accessor = PropertyAccessor.getInstance();
     }
 
     public AsyncMsgRecordDao(PropertyAccessor accessor) {
         this.accessor = accessor;
-    }
-
-    private HibernateUtil getHibernateUtil() {
-        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
-                new String[] { "classpath:CONNECT-context.xml" });
-        LOG.debug("Memory address " + context.getId());
-        hibernateUtil = context.getBean("asyncmsgsHibernateUtil", HibernateUtil.class);
-        return hibernateUtil;
     }
 
     /**
@@ -677,12 +665,16 @@ public class AsyncMsgRecordDao {
         return currentTime.getTime();
     }
 
+    /**
+     * Returns a new session from AsyncMessages HibernateUtil
+     *
+     * @return
+     */
     protected Session getSession() {
-        SessionFactory fact = getHibernateUtil().getSessionFactory();
 
         Session session = null;
-        if (fact != null) {
-            session = fact.openSession();
+        if (HibernateUtilFactory.getAsyncMsgsHibernateUtil() != null) {
+            session = HibernateUtilFactory.getAsyncMsgsHibernateUtil().getSessionFactory().openSession();
         }
 
         return session;

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/asyncmsgs/dao/AsyncMsgRecordDao.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/asyncmsgs/dao/AsyncMsgRecordDao.java
@@ -27,10 +27,11 @@
 package gov.hhs.fha.nhinc.asyncmsgs.dao;
 
 import gov.hhs.fha.nhinc.asyncmsgs.model.AsyncMsgRecord;
+import gov.hhs.fha.nhinc.asyncmsgs.persistence.HibernateUtil;
 import gov.hhs.fha.nhinc.common.deferredqueuemanager.QueryDeferredQueueRequestType;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
-import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
+import gov.hhs.fha.nhinc.persistence.HibernateUtilFactory;
 import gov.hhs.fha.nhinc.properties.PropertyAccessException;
 import gov.hhs.fha.nhinc.properties.PropertyAccessor;
 import gov.hhs.fha.nhinc.util.format.XMLDateUtil;
@@ -78,6 +79,8 @@ public class AsyncMsgRecordDao {
     public static final String QUEUE_STATUS_RSPSENT = "RSPSENT";
     public static final String QUEUE_STATUS_RSPSENTACK = "RSPSENTACK";
     public static final String QUEUE_STATUS_RSPSENTERR = "RSPSENTERR";
+
+    private HibernateUtil hibernateUtil = HibernateUtilFactory.getAsyncMsgsHibernateUtil();
 
     public AsyncMsgRecordDao() {
         accessor = PropertyAccessor.getInstance();
@@ -363,7 +366,7 @@ public class AsyncMsgRecordDao {
                     criteria.add(Restrictions.le("ResponseTime", date));
                     criteriaPopulated = true;
                 }
-                if (queryCriteria.getServiceName() != null && queryCriteria.getServiceName().size() > 0) {
+                if (queryCriteria.getServiceName() != null && !queryCriteria.getServiceName().isEmpty()) {
                     criteria.add(Restrictions.in("ServiceName", queryCriteria.getServiceName()));
                     criteriaPopulated = true;
                 }
@@ -371,11 +374,11 @@ public class AsyncMsgRecordDao {
                     criteria.add(Restrictions.eq("Direction", queryCriteria.getDirection()));
                     criteriaPopulated = true;
                 }
-                if (queryCriteria.getCommunityId() != null && queryCriteria.getCommunityId().size() > 0) {
+                if (queryCriteria.getCommunityId() != null && !queryCriteria.getCommunityId().isEmpty()) {
                     criteria.add(Restrictions.in("CommunityId", queryCriteria.getCommunityId()));
                     criteriaPopulated = true;
                 }
-                if (queryCriteria.getStatus() != null && queryCriteria.getStatus().size() > 0) {
+                if (queryCriteria.getStatus() != null && !queryCriteria.getStatus().isEmpty()) {
                     criteria.add(Restrictions.in("Status", queryCriteria.getStatus()));
                     criteriaPopulated = true;
                 }
@@ -673,8 +676,8 @@ public class AsyncMsgRecordDao {
     protected Session getSession() {
 
         Session session = null;
-        if (HibernateUtilFactory.getAsyncMsgsHibernateUtil() != null) {
-            session = HibernateUtilFactory.getAsyncMsgsHibernateUtil().getSessionFactory().openSession();
+        if (hibernateUtil != null) {
+            session = hibernateUtil.getSessionFactory().openSession();
         }
 
         return session;

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/asyncmsgs/dao/AsyncMsgRecordDao.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/asyncmsgs/dao/AsyncMsgRecordDao.java
@@ -47,6 +47,7 @@ import org.hibernate.Transaction;
 import org.hibernate.criterion.Restrictions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  *
@@ -80,7 +81,7 @@ public class AsyncMsgRecordDao {
     public static final String QUEUE_STATUS_RSPSENTACK = "RSPSENTACK";
     public static final String QUEUE_STATUS_RSPSENTERR = "RSPSENTERR";
 
-    private HibernateUtil hibernateUtil = new HibernateUtil();
+    private HibernateUtil hibernateUtil;
 
     public AsyncMsgRecordDao() {
         accessor = PropertyAccessor.getInstance();
@@ -88,6 +89,14 @@ public class AsyncMsgRecordDao {
 
     public AsyncMsgRecordDao(PropertyAccessor accessor) {
         this.accessor = accessor;
+    }
+
+    private HibernateUtil getHibernateUtil() {
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+                new String[] { "classpath:CONNECT-context.xml" });
+        LOG.debug("Memory address " + context.getId());
+        hibernateUtil = context.getBean("asyncmsgsHibernateUtil", HibernateUtil.class);
+        return hibernateUtil;
     }
 
     /**
@@ -127,7 +136,6 @@ public class AsyncMsgRecordDao {
                     LOG.error("Failed to close session: {}", he.getLocalizedMessage(), he);
                 }
             }
-            hibernateUtil.closeSessionFactory();
         }
 
         return asyncMsgRecs;
@@ -170,7 +178,6 @@ public class AsyncMsgRecordDao {
                     LOG.error("Failed to close session: {}", he.getLocalizedMessage(), he);
                 }
             }
-            hibernateUtil.closeSessionFactory();
         }
 
         return asyncMsgRecs;
@@ -210,7 +217,6 @@ public class AsyncMsgRecordDao {
                     LOG.error("Failed to close session: {}", he.getLocalizedMessage(), he);
                 }
             }
-            hibernateUtil.closeSessionFactory();
         }
 
         return asyncMsgRecs;
@@ -250,7 +256,6 @@ public class AsyncMsgRecordDao {
                     LOG.error("Failed to close session: {}", he.getLocalizedMessage(), he);
                 }
             }
-            hibernateUtil.closeSessionFactory();
         }
 
         return asyncMsgRecs;
@@ -288,7 +293,6 @@ public class AsyncMsgRecordDao {
                     LOG.error("Failed to close session: {}", he.getLocalizedMessage(), he);
                 }
             }
-            hibernateUtil.closeSessionFactory();
         }
 
         return asyncMsgRecs;
@@ -327,7 +331,6 @@ public class AsyncMsgRecordDao {
                     LOG.error("Failed to close session: {}", he.getLocalizedMessage(), he);
                 }
             }
-            hibernateUtil.closeSessionFactory();
         }
 
         return asyncMsgRecs;
@@ -415,7 +418,6 @@ public class AsyncMsgRecordDao {
                     LOG.error("Failed to close session: " + he.getLocalizedMessage(), he);
                 }
             }
-            hibernateUtil.closeSessionFactory();
         }
 
         return asyncMsgRecs;
@@ -462,7 +464,6 @@ public class AsyncMsgRecordDao {
                 if (session != null) {
                     session.close();
                 }
-                hibernateUtil.closeSessionFactory();
             }
         }
 
@@ -503,7 +504,6 @@ public class AsyncMsgRecordDao {
                     LOG.error("Failed to close session: {}", he.getLocalizedMessage(), he);
                 }
             }
-            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("AsyncMsgRecordDao.save() - End");
@@ -553,7 +553,6 @@ public class AsyncMsgRecordDao {
                     LOG.error("Failed to close session: {}", he.getLocalizedMessage(), he);
                 }
             }
-            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("AsyncMsgRecordDao.save(list) - End");
@@ -592,7 +591,6 @@ public class AsyncMsgRecordDao {
                     LOG.error("Failed to close session: {}", he.getLocalizedMessage(), he);
                 }
             }
-            hibernateUtil.closeSessionFactory();
         }
         LOG.debug("Completed database record delete");
     }
@@ -680,8 +678,7 @@ public class AsyncMsgRecordDao {
     }
 
     protected Session getSession() {
-        hibernateUtil.buildSessionFactory();
-        SessionFactory fact = hibernateUtil.getSessionFactory();
+        SessionFactory fact = getHibernateUtil().getSessionFactory();
 
         Session session = null;
         if (fact != null) {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/asyncmsgs/dao/AsyncMsgRecordDao.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/asyncmsgs/dao/AsyncMsgRecordDao.java
@@ -52,6 +52,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author JHOPPESC
  */
+
 public class AsyncMsgRecordDao {
 
     private static final Logger LOG = LoggerFactory.getLogger(AsyncMsgRecordDao.class);
@@ -78,6 +79,8 @@ public class AsyncMsgRecordDao {
     public static final String QUEUE_STATUS_RSPSENT = "RSPSENT";
     public static final String QUEUE_STATUS_RSPSENTACK = "RSPSENTACK";
     public static final String QUEUE_STATUS_RSPSENTERR = "RSPSENTERR";
+
+    private HibernateUtil hibernateUtil = new HibernateUtil();
 
     public AsyncMsgRecordDao() {
         accessor = PropertyAccessor.getInstance();
@@ -124,6 +127,7 @@ public class AsyncMsgRecordDao {
                     LOG.error("Failed to close session: {}", he.getLocalizedMessage(), he);
                 }
             }
+            hibernateUtil.closeSessionFactory();
         }
 
         return asyncMsgRecs;
@@ -166,6 +170,7 @@ public class AsyncMsgRecordDao {
                     LOG.error("Failed to close session: {}", he.getLocalizedMessage(), he);
                 }
             }
+            hibernateUtil.closeSessionFactory();
         }
 
         return asyncMsgRecs;
@@ -205,6 +210,7 @@ public class AsyncMsgRecordDao {
                     LOG.error("Failed to close session: {}", he.getLocalizedMessage(), he);
                 }
             }
+            hibernateUtil.closeSessionFactory();
         }
 
         return asyncMsgRecs;
@@ -244,6 +250,7 @@ public class AsyncMsgRecordDao {
                     LOG.error("Failed to close session: {}", he.getLocalizedMessage(), he);
                 }
             }
+            hibernateUtil.closeSessionFactory();
         }
 
         return asyncMsgRecs;
@@ -281,6 +288,7 @@ public class AsyncMsgRecordDao {
                     LOG.error("Failed to close session: {}", he.getLocalizedMessage(), he);
                 }
             }
+            hibernateUtil.closeSessionFactory();
         }
 
         return asyncMsgRecs;
@@ -319,6 +327,7 @@ public class AsyncMsgRecordDao {
                     LOG.error("Failed to close session: {}", he.getLocalizedMessage(), he);
                 }
             }
+            hibernateUtil.closeSessionFactory();
         }
 
         return asyncMsgRecs;
@@ -406,6 +415,7 @@ public class AsyncMsgRecordDao {
                     LOG.error("Failed to close session: " + he.getLocalizedMessage(), he);
                 }
             }
+            hibernateUtil.closeSessionFactory();
         }
 
         return asyncMsgRecs;
@@ -452,6 +462,7 @@ public class AsyncMsgRecordDao {
                 if (session != null) {
                     session.close();
                 }
+                hibernateUtil.closeSessionFactory();
             }
         }
 
@@ -492,6 +503,7 @@ public class AsyncMsgRecordDao {
                     LOG.error("Failed to close session: {}", he.getLocalizedMessage(), he);
                 }
             }
+            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("AsyncMsgRecordDao.save() - End");
@@ -541,6 +553,7 @@ public class AsyncMsgRecordDao {
                     LOG.error("Failed to close session: {}", he.getLocalizedMessage(), he);
                 }
             }
+            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("AsyncMsgRecordDao.save(list) - End");
@@ -579,6 +592,7 @@ public class AsyncMsgRecordDao {
                     LOG.error("Failed to close session: {}", he.getLocalizedMessage(), he);
                 }
             }
+            hibernateUtil.closeSessionFactory();
         }
         LOG.debug("Completed database record delete");
     }
@@ -666,13 +680,15 @@ public class AsyncMsgRecordDao {
     }
 
     protected Session getSession() {
+        hibernateUtil.buildSessionFactory();
+        SessionFactory fact = hibernateUtil.getSessionFactory();
+
         Session session = null;
-        SessionFactory fact = HibernateUtil.getSessionFactory();
         if (fact != null) {
             session = fact.openSession();
-        } else {
-            LOG.error("Session is null");
         }
+
         return session;
     }
+
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/asyncmsgs/dao/AsyncMsgRecordDao.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/asyncmsgs/dao/AsyncMsgRecordDao.java
@@ -80,8 +80,6 @@ public class AsyncMsgRecordDao {
     public static final String QUEUE_STATUS_RSPSENTACK = "RSPSENTACK";
     public static final String QUEUE_STATUS_RSPSENTERR = "RSPSENTERR";
 
-    private HibernateUtil hibernateUtil = HibernateUtilFactory.getAsyncMsgsHibernateUtil();
-
     public AsyncMsgRecordDao() {
         accessor = PropertyAccessor.getInstance();
     }
@@ -676,6 +674,7 @@ public class AsyncMsgRecordDao {
     protected Session getSession() {
 
         Session session = null;
+        HibernateUtil hibernateUtil = HibernateUtilFactory.getAsyncMsgsHibernateUtil();
         if (hibernateUtil != null) {
             session = hibernateUtil.getSessionFactory().openSession();
         }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/asyncmsgs/persistence/HibernateUtil.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/asyncmsgs/persistence/HibernateUtil.java
@@ -35,13 +35,11 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
 
 /**
  *
  * @author JHOPPESC
  */
-@Service
 public class HibernateUtil {
 
     private SessionFactory sessionFactory;

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/common/connectionmanager/dao/AssigningAuthorityHomeCommunityMappingDAO.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/common/connectionmanager/dao/AssigningAuthorityHomeCommunityMappingDAO.java
@@ -27,7 +27,8 @@
 package gov.hhs.fha.nhinc.common.connectionmanager.dao;
 
 import gov.hhs.fha.nhinc.common.connectionmanager.model.AssigningAuthorityToHomeCommunityMapping;
-import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
+import gov.hhs.fha.nhinc.common.connectionmanager.persistence.HibernateUtil;
+import gov.hhs.fha.nhinc.persistence.HibernateUtilFactory;
 import java.util.ArrayList;
 import java.util.List;
 import org.hibernate.HibernateException;
@@ -45,6 +46,7 @@ import org.slf4j.LoggerFactory;
 public class AssigningAuthorityHomeCommunityMappingDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(AssigningAuthorityHomeCommunityMappingDAO.class);
+    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getConnManHibernateUtil();
 
     /**
      * This method retrieves and returns a AssigningAuthority for an Home Community...
@@ -110,7 +112,7 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
 
     /**
      * This method retrieves Home Community for an Assigning Authority...
-     *
+     * 
      * @param assigningAuthority
      * @return
      */
@@ -127,7 +129,7 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
                     Query namedQuery = sess.getNamedQuery("findAAByAAId");
                     namedQuery.setParameter("assigningAuthorityId", assigningAuthority);
                     List<AssigningAuthorityToHomeCommunityMapping> l = namedQuery.list();
-                    if (l != null && l.size() > 0) {
+                    if (l != null && !l.isEmpty()) {
                         homeCommunity = l.get(0).getHomeCommunityId();
                     }
                 } else {
@@ -173,7 +175,7 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
                     namedQuery.setParameter("homeCommunityId", homeCommunityId);
                     List<AssigningAuthorityToHomeCommunityMapping> l = namedQuery.list();
 
-                    if (l != null && l.size() > 0) {
+                    if (l != null && !l.isEmpty()) {
                         LOG.info("Assigning Authority and Home Community pair already present in the repository");
                     } else {
                         mappingInfo = new AssigningAuthorityToHomeCommunityMapping();
@@ -216,8 +218,8 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
      */
     protected SessionFactory getSessionFactory() {
         SessionFactory fact = null;
-        if (HibernateUtilFactory.getConnManHibernateUtil() != null) {
-            fact = HibernateUtilFactory.getConnManHibernateUtil().getSessionFactory();
+        if (hibernateUtil != null) {
+            fact = hibernateUtil.getSessionFactory();
         }
         return fact;
     }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/common/connectionmanager/dao/AssigningAuthorityHomeCommunityMappingDAO.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/common/connectionmanager/dao/AssigningAuthorityHomeCommunityMappingDAO.java
@@ -46,7 +46,6 @@ import org.slf4j.LoggerFactory;
 public class AssigningAuthorityHomeCommunityMappingDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(AssigningAuthorityHomeCommunityMappingDAO.class);
-    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getConnManHibernateUtil();
 
     /**
      * This method retrieves and returns a AssigningAuthority for an Home Community...
@@ -112,7 +111,7 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
 
     /**
      * This method retrieves Home Community for an Assigning Authority...
-     * 
+     *
      * @param assigningAuthority
      * @return
      */
@@ -218,8 +217,9 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
      */
     protected SessionFactory getSessionFactory() {
         SessionFactory fact = null;
-        if (hibernateUtil != null) {
-            fact = hibernateUtil.getSessionFactory();
+        HibernateUtil util = HibernateUtilFactory.getConnManHibernateUtil();
+        if (util != null) {
+            fact = util.getSessionFactory();
         }
         return fact;
     }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/common/connectionmanager/dao/AssigningAuthorityHomeCommunityMappingDAO.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/common/connectionmanager/dao/AssigningAuthorityHomeCommunityMappingDAO.java
@@ -37,6 +37,7 @@ import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  *
@@ -46,7 +47,7 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(AssigningAuthorityHomeCommunityMappingDAO.class);
 
-    private HibernateUtil hibernateUtil = new HibernateUtil();
+    private HibernateUtil hibernateUtil;
 
     /**
      * This method retrieves and returns a AssigningAuthority for an Home Community...
@@ -99,7 +100,6 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
                         LOG.error("Failed to close session: {}", he.getMessage(), he);
                     }
                 }
-                hibernateUtil.closeSessionFactory();
             }
         } else {
             LOG.error("Please provide a valid homeCommunityId");
@@ -144,7 +144,6 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
                         LOG.error("Failed to close session: {}", he.getMessage(), he);
                     }
                 }
-                hibernateUtil.closeSessionFactory();
             }
         } else {
             LOG.error("Enter correct assigning authority");
@@ -207,7 +206,6 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
                         LOG.error("Failed to close session: {}", he.getMessage(), he);
                     }
                 }
-                hibernateUtil.closeSessionFactory();
             }
         } else {
             LOG.error("Invalid data entered, Enter Valid data to store");
@@ -219,8 +217,14 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
     }
 
     protected SessionFactory getSessionFactory() {
-        hibernateUtil.buildSessionFactory();
-        return hibernateUtil.getSessionFactory();
+        return getHibernateUtil().getSessionFactory();
+    }
+
+    private HibernateUtil getHibernateUtil() {
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+                new String[] { "classpath:CONNECT-context.xml" });
+        hibernateUtil = context.getBean("connManHibernateUtil", HibernateUtil.class);
+        return hibernateUtil;
     }
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/common/connectionmanager/dao/AssigningAuthorityHomeCommunityMappingDAO.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/common/connectionmanager/dao/AssigningAuthorityHomeCommunityMappingDAO.java
@@ -27,7 +27,7 @@
 package gov.hhs.fha.nhinc.common.connectionmanager.dao;
 
 import gov.hhs.fha.nhinc.common.connectionmanager.model.AssigningAuthorityToHomeCommunityMapping;
-import gov.hhs.fha.nhinc.common.connectionmanager.persistence.HibernateUtil;
+import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
 import java.util.ArrayList;
 import java.util.List;
 import org.hibernate.HibernateException;
@@ -37,7 +37,6 @@ import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  *
@@ -46,8 +45,6 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 public class AssigningAuthorityHomeCommunityMappingDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(AssigningAuthorityHomeCommunityMappingDAO.class);
-
-    private HibernateUtil hibernateUtil;
 
     /**
      * This method retrieves and returns a AssigningAuthority for an Home Community...
@@ -80,8 +77,8 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
         if (homeCommunityId != null && !homeCommunityId.isEmpty()) {
             SessionFactory fact = getSessionFactory();
             try {
-                sess = fact.openSession();
-                if (sess != null) {
+                if (fact != null) {
+                    sess = fact.openSession();
                     Query namedQuery = sess.getNamedQuery("findAAByHomeCommunityId");
                     namedQuery.setParameter("homeCommunityId", homeCommunityId);
                     for (AssigningAuthorityToHomeCommunityMapping mapping : (List<AssigningAuthorityToHomeCommunityMapping>) namedQuery
@@ -125,8 +122,8 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
             Session sess = null;
             SessionFactory fact = getSessionFactory();
             try {
-                sess = fact.openSession();
-                if (sess != null) {
+                if (fact != null) {
+                    sess = fact.openSession();
                     Query namedQuery = sess.getNamedQuery("findAAByAAId");
                     namedQuery.setParameter("assigningAuthorityId", assigningAuthority);
                     List<AssigningAuthorityToHomeCommunityMapping> l = namedQuery.list();
@@ -161,8 +158,6 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
      */
     public boolean storeMapping(String homeCommunityId, String assigningAuthority) {
         LOG.debug("--Begin AssigningAuthorityHomeCommunityMappingDAO.storeAssigningAuthorityAndHomeCommunity() ---");
-        System.out.println(
-                "--Begin AssigningAuthorityHomeCommunityMappingDAO.storeAssigningAuthorityAndHomeCommunity() ---");
         boolean success = false;
         AssigningAuthorityToHomeCommunityMapping mappingInfo = null;
         Transaction trans = null;
@@ -171,8 +166,8 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
                 && !assigningAuthority.isEmpty()) {
             SessionFactory fact = getSessionFactory();
             try {
-                sess = fact.openSession();
-                if (sess != null) {
+                if (fact != null) {
+                    sess = fact.openSession();
                     Query namedQuery = sess.getNamedQuery("findAAByAAIdAndHomeCommunityId");
                     namedQuery.setParameter("assigningAuthorityId", assigningAuthority);
                     namedQuery.setParameter("homeCommunityId", homeCommunityId);
@@ -211,20 +206,20 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
             LOG.error("Invalid data entered, Enter Valid data to store");
         }
         LOG.debug("--End AssigningAuthorityHomeCommunityMappingDAO.storeAssigningAuthorityAndHomeCommunity() ---");
-        System.out.println(
-                "--End AssigningAuthorityHomeCommunityMappingDAO.storeAssigningAuthorityAndHomeCommunity() ---");
         return success;
     }
 
+    /**
+     * Returns the session factory belonging to Connection Manager HibernateUtil
+     *
+     * @return
+     */
     protected SessionFactory getSessionFactory() {
-        return getHibernateUtil().getSessionFactory();
-    }
-
-    private HibernateUtil getHibernateUtil() {
-        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
-                new String[] { "classpath:CONNECT-context.xml" });
-        hibernateUtil = context.getBean("connManHibernateUtil", HibernateUtil.class);
-        return hibernateUtil;
+        SessionFactory fact = null;
+        if (HibernateUtilFactory.getConnManHibernateUtil() != null) {
+            fact = HibernateUtilFactory.getConnManHibernateUtil().getSessionFactory();
+        }
+        return fact;
     }
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/common/connectionmanager/dao/AssigningAuthorityHomeCommunityMappingDAO.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/common/connectionmanager/dao/AssigningAuthorityHomeCommunityMappingDAO.java
@@ -46,6 +46,8 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(AssigningAuthorityHomeCommunityMappingDAO.class);
 
+    private HibernateUtil hibernateUtil = new HibernateUtil();
+
     /**
      * This method retrieves and returns a AssigningAuthority for an Home Community...
      *
@@ -75,7 +77,7 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
         Session sess = null;
         List<String> listOfAAs = new ArrayList<>();
         if (homeCommunityId != null && !homeCommunityId.isEmpty()) {
-            SessionFactory fact = HibernateUtil.getSessionFactory();
+            SessionFactory fact = getSessionFactory();
             try {
                 sess = fact.openSession();
                 if (sess != null) {
@@ -94,16 +96,17 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
                     try {
                         sess.close();
                     } catch (HibernateException he) {
-                        LOG.error("Failed to close session: " + he.getMessage(), he);
+                        LOG.error("Failed to close session: {}", he.getMessage(), he);
                     }
                 }
+                hibernateUtil.closeSessionFactory();
             }
         } else {
             LOG.error("Please provide a valid homeCommunityId");
         }
         if (LOG.isTraceEnabled()) {
             LOG.trace("-- End AssigningAuthorityHomeCommunityMappingDAO.getAssigningAuthoritiesByHomeCommunity() ---");
-            LOG.trace("getAssigningAuthoritiesByHomeCommunity - listOfAAs.size: " + listOfAAs.size());
+            LOG.trace("getAssigningAuthoritiesByHomeCommunity - listOfAAs.size: {}", listOfAAs.size());
         }
         return listOfAAs;
     }
@@ -120,7 +123,7 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
         String homeCommunity = "";
         if (assigningAuthority != null && !assigningAuthority.isEmpty()) {
             Session sess = null;
-            SessionFactory fact = HibernateUtil.getSessionFactory();
+            SessionFactory fact = getSessionFactory();
             try {
                 sess = fact.openSession();
                 if (sess != null) {
@@ -138,9 +141,10 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
                     try {
                         sess.close();
                     } catch (HibernateException he) {
-                        LOG.error("Failed to close session: " + he.getMessage(), he);
+                        LOG.error("Failed to close session: {}", he.getMessage(), he);
                     }
                 }
+                hibernateUtil.closeSessionFactory();
             }
         } else {
             LOG.error("Enter correct assigning authority");
@@ -166,7 +170,7 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
         Session sess = null;
         if (homeCommunityId != null && !homeCommunityId.isEmpty() && assigningAuthority != null
                 && !assigningAuthority.isEmpty()) {
-            SessionFactory fact = HibernateUtil.getSessionFactory();
+            SessionFactory fact = getSessionFactory();
             try {
                 sess = fact.openSession();
                 if (sess != null) {
@@ -193,16 +197,17 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
                     try {
                         trans.commit();
                     } catch (HibernateException he) {
-                        LOG.error("Failed to commit transaction: " + he.getMessage(), he);
+                        LOG.error("Failed to commit transaction: {}", he.getMessage(), he);
                     }
                 }
                 if (sess != null) {
                     try {
                         sess.close();
                     } catch (HibernateException he) {
-                        LOG.error("Failed to close session: " + he.getMessage(), he);
+                        LOG.error("Failed to close session: {}", he.getMessage(), he);
                     }
                 }
+                hibernateUtil.closeSessionFactory();
             }
         } else {
             LOG.error("Invalid data entered, Enter Valid data to store");
@@ -212,4 +217,10 @@ public class AssigningAuthorityHomeCommunityMappingDAO {
                 "--End AssigningAuthorityHomeCommunityMappingDAO.storeAssigningAuthorityAndHomeCommunity() ---");
         return success;
     }
+
+    protected SessionFactory getSessionFactory() {
+        hibernateUtil.buildSessionFactory();
+        return hibernateUtil.getSessionFactory();
+    }
+
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/docrepository/adapter/dao/DocumentDao.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/docrepository/adapter/dao/DocumentDao.java
@@ -51,7 +51,6 @@ import org.slf4j.LoggerFactory;
  */
 public class DocumentDao {
     private static final Logger LOG = LoggerFactory.getLogger(DocumentDao.class);
-    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getDocRepoHibernateUtil();
 
     /**
      * Save a document record to the database. Insert if document id is null. Update otherwise.
@@ -385,8 +384,10 @@ public class DocumentDao {
 
     protected Session getSession() {
         Session session = null;
-        SessionFactory fact = hibernateUtil.getSessionFactory();
-        if (fact != null) {
+
+        HibernateUtil util = HibernateUtilFactory.getDocRepoHibernateUtil();
+        if (util != null) {
+            SessionFactory fact = util.getSessionFactory();
             session = fact.openSession();
         } else {
             LOG.error("Session is null");

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/docrepository/adapter/dao/DocumentDao.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/docrepository/adapter/dao/DocumentDao.java
@@ -28,7 +28,7 @@ package gov.hhs.fha.nhinc.docrepository.adapter.dao;
 
 import gov.hhs.fha.nhinc.docrepository.adapter.model.Document;
 import gov.hhs.fha.nhinc.docrepository.adapter.model.DocumentQueryParams;
-import gov.hhs.fha.nhinc.docrepository.adapter.persistence.HibernateUtil;
+import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
@@ -42,7 +42,6 @@ import org.hibernate.criterion.Expression;
 import org.hibernate.criterion.Restrictions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * Data access object class for Document data
@@ -51,8 +50,6 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
  */
 public class DocumentDao {
     private static final Logger LOG = LoggerFactory.getLogger(DocumentDao.class);
-
-    private static HibernateUtil hibernateUtil;
 
     /**
      * Save a document record to the database. Insert if document id is null. Update otherwise.
@@ -386,20 +383,13 @@ public class DocumentDao {
 
     protected Session getSession() {
         Session session = null;
-        SessionFactory fact = getHibernateUtil().getSessionFactory();
+        SessionFactory fact = HibernateUtilFactory.getDocRepoHibernateUtil().getSessionFactory();
         if (fact != null) {
             session = fact.openSession();
         } else {
             LOG.error("Session is null");
         }
         return session;
-    }
-
-    private static HibernateUtil getHibernateUtil() {
-        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
-                new String[] { "classpath:CONNECT-context.xml" });
-        hibernateUtil = context.getBean("docRepoHibernateUtil", HibernateUtil.class);
-        return hibernateUtil;
     }
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/docrepository/adapter/dao/DocumentDao.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/docrepository/adapter/dao/DocumentDao.java
@@ -28,7 +28,8 @@ package gov.hhs.fha.nhinc.docrepository.adapter.dao;
 
 import gov.hhs.fha.nhinc.docrepository.adapter.model.Document;
 import gov.hhs.fha.nhinc.docrepository.adapter.model.DocumentQueryParams;
-import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
+import gov.hhs.fha.nhinc.docrepository.adapter.persistence.HibernateUtil;
+import gov.hhs.fha.nhinc.persistence.HibernateUtilFactory;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
@@ -50,6 +51,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DocumentDao {
     private static final Logger LOG = LoggerFactory.getLogger(DocumentDao.class);
+    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getDocRepoHibernateUtil();
 
     /**
      * Save a document record to the database. Insert if document id is null. Update otherwise.
@@ -383,7 +385,7 @@ public class DocumentDao {
 
     protected Session getSession() {
         Session session = null;
-        SessionFactory fact = HibernateUtilFactory.getDocRepoHibernateUtil().getSessionFactory();
+        SessionFactory fact = hibernateUtil.getSessionFactory();
         if (fact != null) {
             session = fact.openSession();
         } else {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/docrepository/adapter/dao/DocumentDao.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/docrepository/adapter/dao/DocumentDao.java
@@ -42,6 +42,7 @@ import org.hibernate.criterion.Expression;
 import org.hibernate.criterion.Restrictions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * Data access object class for Document data
@@ -51,7 +52,7 @@ import org.slf4j.LoggerFactory;
 public class DocumentDao {
     private static final Logger LOG = LoggerFactory.getLogger(DocumentDao.class);
 
-    private HibernateUtil hibernateUtil = new HibernateUtil();
+    private static HibernateUtil hibernateUtil;
 
     /**
      * Save a document record to the database. Insert if document id is null. Update otherwise.
@@ -86,7 +87,6 @@ public class DocumentDao {
                     LOG.error("Failed to close session: {}", he.getMessage(), he);
                 }
             }
-            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("Completed document save");
@@ -126,7 +126,6 @@ public class DocumentDao {
                     LOG.error("Failed to close session: {}", he.getMessage(), he);
                 }
             }
-            hibernateUtil.closeSessionFactory();
         }
         LOG.debug("Completed document delete");
     }
@@ -161,7 +160,6 @@ public class DocumentDao {
                     LOG.error("Failed to close session: {}", he.getMessage(), he);
                 }
             }
-            hibernateUtil.closeSessionFactory();
         }
         return document;
     }
@@ -197,7 +195,6 @@ public class DocumentDao {
                     LOG.error("Failed to close session: {}", he.getMessage(), he);
                 }
             }
-            hibernateUtil.closeSessionFactory();
         }
         return documents;
     }
@@ -383,21 +380,26 @@ public class DocumentDao {
                     LOG.error("Failed to close session: {}", he.getMessage(), he);
                 }
             }
-            hibernateUtil.closeSessionFactory();
         }
         return documents;
     }
 
     protected Session getSession() {
         Session session = null;
-        hibernateUtil.buildSessionFactory();
-        SessionFactory fact = hibernateUtil.getSessionFactory();
+        SessionFactory fact = getHibernateUtil().getSessionFactory();
         if (fact != null) {
             session = fact.openSession();
         } else {
             LOG.error("Session is null");
         }
         return session;
+    }
+
+    private static HibernateUtil getHibernateUtil() {
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+                new String[] { "classpath:CONNECT-context.xml" });
+        hibernateUtil = context.getBean("docRepoHibernateUtil", HibernateUtil.class);
+        return hibernateUtil;
     }
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/docrepository/adapter/dao/DocumentDao.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/docrepository/adapter/dao/DocumentDao.java
@@ -51,6 +51,8 @@ import org.slf4j.LoggerFactory;
 public class DocumentDao {
     private static final Logger LOG = LoggerFactory.getLogger(DocumentDao.class);
 
+    private HibernateUtil hibernateUtil = new HibernateUtil();
+
     /**
      * Save a document record to the database. Insert if document id is null. Update otherwise.
      *
@@ -74,16 +76,17 @@ public class DocumentDao {
                 try {
                     trans.commit();
                 } catch (HibernateException he) {
-                    LOG.error("Failed to commit transaction: " + he.getMessage(), he);
+                    LOG.error("Failed to commit transaction: {}", he.getMessage(), he);
                 }
             }
             if (sess != null) {
                 try {
                     sess.close();
                 } catch (HibernateException he) {
-                    LOG.error("Failed to close session: " + he.getMessage(), he);
+                    LOG.error("Failed to close session: {}", he.getMessage(), he);
                 }
             }
+            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("Completed document save");
@@ -113,16 +116,17 @@ public class DocumentDao {
                 try {
                     trans.commit();
                 } catch (HibernateException he) {
-                    LOG.error("Failed to commit transaction: " + he.getMessage(), he);
+                    LOG.error("Failed to commit transaction: {}", he.getMessage(), he);
                 }
             }
             if (sess != null) {
                 try {
                     sess.close();
                 } catch (HibernateException he) {
-                    LOG.error("Failed to close session: " + he.getMessage(), he);
+                    LOG.error("Failed to close session: {}", he.getMessage(), he);
                 }
             }
+            hibernateUtil.closeSessionFactory();
         }
         LOG.debug("Completed document delete");
     }
@@ -140,7 +144,7 @@ public class DocumentDao {
         try {
             sess = getSession();
             if (sess != null) {
-                document = (Document) sess.get(Document.class, documentId);
+                document = sess.get(Document.class, documentId);
             } else {
                 LOG.error("Failed to obtain a session from the sessionFactory");
             }
@@ -154,15 +158,12 @@ public class DocumentDao {
                 try {
                     sess.close();
                 } catch (HibernateException he) {
-                    LOG.error("Failed to close session: " + he.getMessage(), he);
+                    LOG.error("Failed to close session: {}", he.getMessage(), he);
                 }
             }
+            hibernateUtil.closeSessionFactory();
         }
         return document;
-    }
-
-    protected SessionFactory getSessionFactory() {
-        return HibernateUtil.getSessionFactory();
     }
 
     /**
@@ -193,9 +194,10 @@ public class DocumentDao {
                 try {
                     sess.close();
                 } catch (HibernateException he) {
-                    LOG.error("Failed to close session: " + he.getMessage(), he);
+                    LOG.error("Failed to close session: {}", he.getMessage(), he);
                 }
             }
+            hibernateUtil.closeSessionFactory();
         }
         return documents;
     }
@@ -378,16 +380,18 @@ public class DocumentDao {
                 try {
                     sess.close();
                 } catch (HibernateException he) {
-                    LOG.error("Failed to close session: " + he.getMessage(), he);
+                    LOG.error("Failed to close session: {}", he.getMessage(), he);
                 }
             }
+            hibernateUtil.closeSessionFactory();
         }
         return documents;
     }
 
     protected Session getSession() {
         Session session = null;
-        SessionFactory fact = HibernateUtil.getSessionFactory();
+        hibernateUtil.buildSessionFactory();
+        SessionFactory fact = hibernateUtil.getSessionFactory();
         if (fact != null) {
             session = fact.openSession();
         } else {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/docrepository/adapter/dao/EventCodeDao.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/docrepository/adapter/dao/EventCodeDao.java
@@ -27,7 +27,7 @@
 package gov.hhs.fha.nhinc.docrepository.adapter.dao;
 
 import gov.hhs.fha.nhinc.docrepository.adapter.model.EventCode;
-import gov.hhs.fha.nhinc.docrepository.adapter.persistence.HibernateUtil;
+import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -52,7 +52,6 @@ import org.hibernate.criterion.Subqueries;
 import org.hibernate.type.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.stereotype.Component;
 
 /**
@@ -68,24 +67,10 @@ public class EventCodeDao {
      */
     private static final Logger LOG = LoggerFactory.getLogger(EventCodeDao.class);
 
-    private HibernateUtil hibernateUtil;
-
     /**
      * The Constant EBXML_EVENT_CODE_LIST.
      */
     private static final String EBXML_EVENT_CODE_LIST = "$XDSDocumentEntryEventCodeList";
-
-    /**
-     * Gets the static HibernateUtil
-     *
-     * @return hibernateUtil
-     */
-    private HibernateUtil getHibernateUtil() {
-        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
-                new String[] { "classpath:CONNECT-context.xml" });
-        hibernateUtil = context.getBean("docRepoHibernateUtil", HibernateUtil.class);
-        return hibernateUtil;
-    }
 
     /**
      * Gets the session factory.
@@ -93,7 +78,7 @@ public class EventCodeDao {
      * @return the session factory
      */
     protected SessionFactory getSessionFactory() {
-        return getHibernateUtil().getSessionFactory();
+        return HibernateUtilFactory.getDocRepoHibernateUtil().getSessionFactory();
     }
 
     /**
@@ -173,7 +158,6 @@ public class EventCodeDao {
                     String[] alias = new String[1];
                     alias[0] = "documentid";
                     Type[] types = new Type[1];
-                    // types[0] = Hibernate.INTEGER;
                     types[0] = org.hibernate.type.StandardBasicTypes.INTEGER;
                     List<String> classCodes;
                     List<String> orValues;
@@ -398,7 +382,7 @@ public class EventCodeDao {
         String[] eventCodeList;
         String separate = "\\^\\^";
         eventCodeList = eventCodeParam.split(separate);
-        if (paramName.equalsIgnoreCase("eventCode")) {
+        if ("eventCode".equalsIgnoreCase(paramName)) {
             return eventCodeList[0];
         } else {
             return eventCodeList[1];

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/docrepository/adapter/dao/EventCodeDao.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/docrepository/adapter/dao/EventCodeDao.java
@@ -41,7 +41,6 @@ import oasis.names.tc.ebxml_regrep.xsd.rim._3.ValueListType;
 import org.hibernate.Criteria;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
-import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.DetachedCriteria;
@@ -72,27 +71,17 @@ public class EventCodeDao {
      */
     private static final String EBXML_EVENT_CODE_LIST = "$XDSDocumentEntryEventCodeList";
 
-    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getDocRepoHibernateUtil();
-
-    /**
-     * Gets the session factory.
-     *
-     * @return the session factory
-     */
-    protected SessionFactory getSessionFactory() {
-        return hibernateUtil.getSessionFactory();
-    }
-
     /**
      * Gets the session.
      *
      * @param sessionFactory the session factory
      * @return the session
      */
-    protected Session getSession(SessionFactory sessionFactory) {
+    protected Session getSession() {
         Session session = null;
-        if (sessionFactory != null) {
-            session = sessionFactory.openSession();
+        HibernateUtil util = HibernateUtilFactory.getDocRepoHibernateUtil();
+        if (util != null) {
+            session = util.getSessionFactory().openSession();
         }
         return session;
     }
@@ -106,18 +95,15 @@ public class EventCodeDao {
         Session sess = null;
         Transaction trans = null;
         try {
-            SessionFactory fact = getSessionFactory();
-            if (fact != null) {
-                sess = getSession(fact);
-                if (sess != null) {
-                    trans = sess.beginTransaction();
-                    sess.delete(eventCode);
-                } else {
-                    LOG.error("Failed to obtain a session from the sessionFactory");
-                }
+
+            sess = getSession();
+            if (sess != null) {
+                trans = sess.beginTransaction();
+                sess.delete(eventCode);
             } else {
-                LOG.error("Session factory was null");
+                LOG.error("Failed to obtain a session from the sessionFactory");
             }
+
         } finally {
             if (trans != null) {
                 try {
@@ -149,7 +135,7 @@ public class EventCodeDao {
         List<String> eventCodeSchemeList = new ArrayList<>();
         Session sess = null;
         try {
-            sess = getSession(getSessionFactory());
+            sess = getSession();
 
             if (sess != null) {
                 Criteria criteria = sess.createCriteria(EventCode.class);

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/docrepository/adapter/dao/EventCodeDao.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/docrepository/adapter/dao/EventCodeDao.java
@@ -52,6 +52,7 @@ import org.hibernate.criterion.Subqueries;
 import org.hibernate.type.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.stereotype.Component;
 
 /**
@@ -67,7 +68,7 @@ public class EventCodeDao {
      */
     private static final Logger LOG = LoggerFactory.getLogger(EventCodeDao.class);
 
-    private HibernateUtil hibernateUtil = new HibernateUtil();
+    private HibernateUtil hibernateUtil;
 
     /**
      * The Constant EBXML_EVENT_CODE_LIST.
@@ -75,13 +76,24 @@ public class EventCodeDao {
     private static final String EBXML_EVENT_CODE_LIST = "$XDSDocumentEntryEventCodeList";
 
     /**
+     * Gets the static HibernateUtil
+     *
+     * @return hibernateUtil
+     */
+    private HibernateUtil getHibernateUtil() {
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+                new String[] { "classpath:CONNECT-context.xml" });
+        hibernateUtil = context.getBean("docRepoHibernateUtil", HibernateUtil.class);
+        return hibernateUtil;
+    }
+
+    /**
      * Gets the session factory.
      *
      * @return the session factory
      */
     protected SessionFactory getSessionFactory() {
-        hibernateUtil.buildSessionFactory();
-        return hibernateUtil.getSessionFactory();
+        return getHibernateUtil().getSessionFactory();
     }
 
     /**
@@ -134,7 +146,6 @@ public class EventCodeDao {
                     LOG.error("Failed to close session: {}", he.getMessage(), he);
                 }
             }
-            hibernateUtil.closeSessionFactory();
         }
     }
 
@@ -249,7 +260,6 @@ public class EventCodeDao {
                     LOG.error("Failed to close session: {}", he.getMessage(), he);
                 }
             }
-            hibernateUtil.closeSessionFactory();
         }
         return eventCodes;
     }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/docrepository/adapter/dao/EventCodeDao.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/docrepository/adapter/dao/EventCodeDao.java
@@ -52,18 +52,22 @@ import org.hibernate.criterion.Subqueries;
 import org.hibernate.type.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
 /**
  * Data access object class for EventCode data.
  *
  * @author Neil Webb, msw
  */
+@Component
 public class EventCodeDao {
 
     /**
      * The Constant LOG.
      */
     private static final Logger LOG = LoggerFactory.getLogger(EventCodeDao.class);
+
+    private HibernateUtil hibernateUtil = new HibernateUtil();
 
     /**
      * The Constant EBXML_EVENT_CODE_LIST.
@@ -76,7 +80,8 @@ public class EventCodeDao {
      * @return the session factory
      */
     protected SessionFactory getSessionFactory() {
-        return HibernateUtil.getSessionFactory();
+        hibernateUtil.buildSessionFactory();
+        return hibernateUtil.getSessionFactory();
     }
 
     /**
@@ -119,16 +124,17 @@ public class EventCodeDao {
                 try {
                     trans.commit();
                 } catch (HibernateException he) {
-                    LOG.error("Failed to commit transaction: " + he.getMessage(), he);
+                    LOG.error("Failed to commit transaction: {}", he.getMessage(), he);
                 }
             }
             if (sess != null) {
                 try {
                     sess.close();
                 } catch (HibernateException he) {
-                    LOG.error("Failed to close session: " + he.getMessage(), he);
+                    LOG.error("Failed to close session: {}", he.getMessage(), he);
                 }
             }
+            hibernateUtil.closeSessionFactory();
         }
     }
 
@@ -240,9 +246,10 @@ public class EventCodeDao {
                 try {
                     sess.close();
                 } catch (HibernateException he) {
-                    LOG.error("Failed to close session: " + he.getMessage(), he);
+                    LOG.error("Failed to close session: {}", he.getMessage(), he);
                 }
             }
+            hibernateUtil.closeSessionFactory();
         }
         return eventCodes;
     }
@@ -418,16 +425,17 @@ public class EventCodeDao {
                         }
                         resultCollection.add(singleValue);
                         if (LOG.isDebugEnabled()) {
-                            LOG.debug("Added single value: " + singleValue + " to query parameters");
+                            LOG.debug("Added single value: {} to query parameters", singleValue);
                         }
                     }
                 }
             } else {
                 resultCollection.add(paramFormattedString);
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("No wrapper on status - adding status: " + paramFormattedString + " to query parameters");
+                    LOG.debug("No wrapper on status - adding status: {} to query parameters", paramFormattedString);
                 }
             }
         }
     }
+
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/event/dao/DatabaseEventLoggerDao.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/event/dao/DatabaseEventLoggerDao.java
@@ -51,7 +51,6 @@ public class DatabaseEventLoggerDao {
     private static final String EVENT_TYPE_NAME = "eventName";
     private static final String EVENT_SERVICETYPE_NAME = "serviceType";
     private static final String DATE_NAME = "eventTime";
-    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getEventHibernateUtil();
 
     private static class SingletonHolder {
         public static final DatabaseEventLoggerDao INSTANCE = new DatabaseEventLoggerDao();
@@ -161,9 +160,9 @@ public class DatabaseEventLoggerDao {
 
     protected SessionFactory getSessionFactory() {
         SessionFactory fact = null;
-
-        if (hibernateUtil != null) {
-            fact = hibernateUtil.getSessionFactory();
+        HibernateUtil util = HibernateUtilFactory.getEventHibernateUtil();
+        if (util != null) {
+            fact = util.getSessionFactory();
         }
         return fact;
     }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/event/dao/DatabaseEventLoggerDao.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/event/dao/DatabaseEventLoggerDao.java
@@ -27,7 +27,8 @@
 package gov.hhs.fha.nhinc.event.dao;
 
 import gov.hhs.fha.nhinc.event.model.DatabaseEvent;
-import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
+import gov.hhs.fha.nhinc.event.persistence.HibernateUtil;
+import gov.hhs.fha.nhinc.persistence.HibernateUtilFactory;
 import java.util.ArrayList;
 import java.util.List;
 import org.hibernate.HibernateException;
@@ -39,12 +40,10 @@ import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
 
 /**
  * Data Access Object which logs events in the database.
  */
-@Service
 public class DatabaseEventLoggerDao {
 
     private static final Logger LOG = LoggerFactory.getLogger(DatabaseEventLoggerDao.class);
@@ -52,12 +51,13 @@ public class DatabaseEventLoggerDao {
     private static final String EVENT_TYPE_NAME = "eventName";
     private static final String EVENT_SERVICETYPE_NAME = "serviceType";
     private static final String DATE_NAME = "eventTime";
+    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getEventHibernateUtil();
 
     private static class SingletonHolder {
+        public static final DatabaseEventLoggerDao INSTANCE = new DatabaseEventLoggerDao();
+
         private SingletonHolder() {
         }
-
-        public static final DatabaseEventLoggerDao INSTANCE = new DatabaseEventLoggerDao();
     }
 
     /**
@@ -162,8 +162,8 @@ public class DatabaseEventLoggerDao {
     protected SessionFactory getSessionFactory() {
         SessionFactory fact = null;
 
-        if (HibernateUtilFactory.getEventHibernateUtil() != null) {
-            fact = HibernateUtilFactory.getEventHibernateUtil().getSessionFactory();
+        if (hibernateUtil != null) {
+            fact = hibernateUtil.getSessionFactory();
         }
         return fact;
     }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/event/persistence/HibernateUtil.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/event/persistence/HibernateUtil.java
@@ -35,6 +35,7 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  *
@@ -45,6 +46,8 @@ public class HibernateUtil {
 
     private SessionFactory sessionFactory;
     private static final Logger LOG = LoggerFactory.getLogger(HibernateUtil.class);
+
+    private static HibernateUtil hibernateUtil;
 
     /**
      * Method returns an instance of Hibernate SessionFactory.
@@ -96,5 +99,14 @@ public class HibernateUtil {
         }
 
         return result;
+    }
+
+    public static HibernateUtil getHibernateUtil() {
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+                new String[] { "classpath:CONNECT-context.xml" });
+        if (hibernateUtil == null) {
+            hibernateUtil = context.getBean("eventHibernateUtil", HibernateUtil.class);
+        }
+        return hibernateUtil;
     }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/event/persistence/HibernateUtil.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/event/persistence/HibernateUtil.java
@@ -65,11 +65,9 @@ public class HibernateUtil {
                 sessionFactory = new Configuration().configure()
                         .buildSessionFactory(new StandardServiceRegistryBuilder().configure(getConfigFile()).build());
             }
-        } catch (HibernateException he) {
+        } catch (ExceptionInInitializerError he) {
             // Make sure you log the exception, as it might be swallowed
-            LOG.error("Initial SessionFactory creation failed." + he, he.getCause());
-            LOG.error("Initial SessionFactory creation failed." + he);
-            throw new ExceptionInInitializerError(he);
+            LOG.error("Initial SessionFactory creation failed. {}", he, he.getCause());
         }
     }
 
@@ -77,9 +75,11 @@ public class HibernateUtil {
      * Method closes the Hibernate SessionFactory
      */
     public void closeSessionFactory() {
+        LOG.info("Closing sessionFactory in HibernateUtil");
         try {
             if (sessionFactory != null && !sessionFactory.isClosed()) {
                 sessionFactory.close();
+                LOG.info("Successfully closed sessionFactory in event.persistence.HibernateUtil");
             }
         } catch (HibernateException he) {
             LOG.error("Error while closing the sessionFactory: {}", he.getLocalizedMessage(), he);

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/event/persistence/HibernateUtil.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/event/persistence/HibernateUtil.java
@@ -43,14 +43,28 @@ import org.slf4j.LoggerFactory;
  */
 public class HibernateUtil {
 
-    private static final SessionFactory SESSION_FACTORY;
+    private SessionFactory sessionFactory;
     private static final Logger LOG = LoggerFactory.getLogger(HibernateUtil.class);
 
-    static {
+    /**
+     * Method returns an instance of Hibernate SessionFactory.
+     *
+     * @return SessionFactory The Hibernate Session Factory
+     */
+    public SessionFactory getSessionFactory() {
+        return sessionFactory;
+    }
+
+    /**
+     * Method builds the Hibernate SessionFactory.
+     */
+    public void buildSessionFactory() {
         try {
             // Create the SessionFactory from hibernate.cfg.xml
-            SESSION_FACTORY = new Configuration().configure()
-                    .buildSessionFactory(new StandardServiceRegistryBuilder().configure(getConfigFile()).build());
+            if (sessionFactory == null || sessionFactory.isClosed()) {
+                sessionFactory = new Configuration().configure()
+                        .buildSessionFactory(new StandardServiceRegistryBuilder().configure(getConfigFile()).build());
+            }
         } catch (HibernateException he) {
             // Make sure you log the exception, as it might be swallowed
             LOG.error("Initial SessionFactory creation failed." + he, he.getCause());
@@ -60,12 +74,16 @@ public class HibernateUtil {
     }
 
     /**
-     * Method returns an instance of Hibernate SessionFactory.
-     *
-     * @return SessionFactory The Hibernate Session Factory
+     * Method closes the Hibernate SessionFactory
      */
-    public static SessionFactory getSessionFactory() {
-        return SESSION_FACTORY;
+    public void closeSessionFactory() {
+        try {
+            if (sessionFactory != null && !sessionFactory.isClosed()) {
+                sessionFactory.close();
+            }
+        } catch (HibernateException he) {
+            LOG.error("Error while closing the sessionFactory: {}", he.getLocalizedMessage(), he);
+        }
     }
 
     private static File getConfigFile() {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/logging/transaction/dao/TransactionDAO.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/logging/transaction/dao/TransactionDAO.java
@@ -29,6 +29,7 @@ package gov.hhs.fha.nhinc.logging.transaction.dao;
 import gov.hhs.fha.nhinc.logging.transaction.model.TransactionRepo;
 import gov.hhs.fha.nhinc.logging.transaction.persistance.HibernateUtil;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
+import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
 import java.util.List;
 import org.hibernate.HibernateException;
 import org.hibernate.Query;
@@ -37,7 +38,6 @@ import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.stereotype.Service;
 
 /**
@@ -68,16 +68,7 @@ public class TransactionDAO {
      */
     public static TransactionDAO getInstance() {
         LOG.debug("getTransactionDAOInstance()...");
-        ClassPathXmlApplicationContext context = SingletonHolder.INSTANCE_CONTEXT;
-        LOG.debug("Memory address " + context.getId());
-        hibernateUtil = context.getBean("txHibernateUtil", HibernateUtil.class);
-
         return INSTANCE;
-    }
-
-    private static class SingletonHolder {
-        public static final ClassPathXmlApplicationContext INSTANCE_CONTEXT = new ClassPathXmlApplicationContext(
-                new String[] { "classpath:CONNECT-context.xml" });
     }
 
     /**
@@ -95,7 +86,7 @@ public class TransactionDAO {
 
         if (transactionRepo != null) {
             try {
-                final SessionFactory sessionFactory = getTxHibernateUtil().getSessionFactory();
+                final SessionFactory sessionFactory = getSessionFactory();
                 session = sessionFactory.openSession();
                 tx = session.beginTransaction();
                 LOG.info("Inserting Record...");
@@ -135,7 +126,7 @@ public class TransactionDAO {
         Session session = null;
 
         try {
-            final SessionFactory sessionFactory = getTxHibernateUtil().getSessionFactory();
+            final SessionFactory sessionFactory = getSessionFactory();
             session = sessionFactory.openSession();
 
             if (LOG.isDebugEnabled()) {
@@ -169,6 +160,15 @@ public class TransactionDAO {
         if (tx != null) {
             tx.rollback();
         }
+    }
+
+    /**
+     * Protected method that gets the SingletonHolder's sessionFactory.
+     *
+     * @return sessionFactory
+     */
+    protected static SessionFactory getSessionFactory() {
+        return HibernateUtilFactory.getTransactionHibernateUtil().getSessionFactory();
     }
 
     /**

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/logging/transaction/dao/TransactionDAO.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/logging/transaction/dao/TransactionDAO.java
@@ -29,7 +29,7 @@ package gov.hhs.fha.nhinc.logging.transaction.dao;
 import gov.hhs.fha.nhinc.logging.transaction.model.TransactionRepo;
 import gov.hhs.fha.nhinc.logging.transaction.persistance.HibernateUtil;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
-import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
+import gov.hhs.fha.nhinc.persistence.HibernateUtilFactory;
 import java.util.List;
 import org.hibernate.HibernateException;
 import org.hibernate.Query;
@@ -38,7 +38,6 @@ import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
 
 /**
  * TransactionDAO provides methods to query and update the transrepo database.
@@ -46,13 +45,12 @@ import org.springframework.stereotype.Service;
  * @author jasonasmith
  *
  */
-@Service
 public class TransactionDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(TransactionDAO.class);
     private static final TransactionDAO INSTANCE = new TransactionDAO();
 
-    private static HibernateUtil hibernateUtil;
+    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getTransactionHibernateUtil();
 
     /**
      * The constructor.
@@ -168,13 +166,7 @@ public class TransactionDAO {
      * @return sessionFactory
      */
     protected static SessionFactory getSessionFactory() {
-        return HibernateUtilFactory.getTransactionHibernateUtil().getSessionFactory();
+        return hibernateUtil.getSessionFactory();
     }
 
-    /**
-     * @return the HibernateUtil
-     */
-    protected HibernateUtil getTxHibernateUtil() {
-        return hibernateUtil;
-    }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/logging/transaction/dao/TransactionDAO.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/logging/transaction/dao/TransactionDAO.java
@@ -49,6 +49,8 @@ public class TransactionDAO {
     private static final Logger LOG = LoggerFactory.getLogger(TransactionDAO.class);
     private static final TransactionDAO INSTANCE = new TransactionDAO();
 
+    private static HibernateUtil hibernateUtil = new HibernateUtil();
+
     /**
      * The constructor.
      */
@@ -63,6 +65,7 @@ public class TransactionDAO {
      */
     public static TransactionDAO getInstance() {
         LOG.debug("getTransactionDAOInstance()...");
+        hibernateUtil = new HibernateUtil();
         return INSTANCE;
     }
 
@@ -81,7 +84,7 @@ public class TransactionDAO {
 
         if (transactionRepo != null) {
             try {
-                final SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+                final SessionFactory sessionFactory = getSessionFactory();
                 session = sessionFactory.openSession();
                 tx = session.beginTransaction();
                 LOG.info("Inserting Record...");
@@ -96,6 +99,7 @@ public class TransactionDAO {
                 LOG.error("Exception during insertion caused by :" + e.getMessage(), e);
             } finally {
                 closeSession(session);
+                hibernateUtil.closeSessionFactory();
             }
         }
         LOG.debug("TransactionDAO.insertIntoTransactionRepo() - End");
@@ -121,7 +125,7 @@ public class TransactionDAO {
         Session session = null;
 
         try {
-            final SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+            final SessionFactory sessionFactory = getSessionFactory();
             session = sessionFactory.openSession();
 
             if (LOG.isDebugEnabled()) {
@@ -155,6 +159,11 @@ public class TransactionDAO {
         if (tx != null) {
             tx.rollback();
         }
+    }
+
+    protected SessionFactory getSessionFactory() {
+        hibernateUtil.buildSessionFactory();
+        return hibernateUtil.getSessionFactory();
     }
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/logging/transaction/dao/TransactionDAO.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/logging/transaction/dao/TransactionDAO.java
@@ -50,8 +50,6 @@ public class TransactionDAO {
     private static final Logger LOG = LoggerFactory.getLogger(TransactionDAO.class);
     private static final TransactionDAO INSTANCE = new TransactionDAO();
 
-    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getTransactionHibernateUtil();
-
     /**
      * The constructor.
      */
@@ -166,7 +164,12 @@ public class TransactionDAO {
      * @return sessionFactory
      */
     protected static SessionFactory getSessionFactory() {
-        return hibernateUtil.getSessionFactory();
+        SessionFactory fact = null;
+        HibernateUtil util = HibernateUtilFactory.getTransactionHibernateUtil();
+        if (util != null) {
+            fact = util.getSessionFactory();
+        }
+        return fact;
     }
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/logging/transaction/persistance/HibernateUtil.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/logging/transaction/persistance/HibernateUtil.java
@@ -36,7 +36,6 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  *
@@ -47,8 +46,6 @@ public class HibernateUtil {
 
     private SessionFactory sessionFactory;
     private static final Logger LOG = LoggerFactory.getLogger(HibernateUtil.class);
-
-    private static HibernateUtil hibernateUtil;
 
     /**
      * Method builds the Hibernate SessionFactory.
@@ -103,12 +100,4 @@ public class HibernateUtil {
         return result;
     }
 
-    public static HibernateUtil getHibernateUtil() {
-        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
-                new String[] { "classpath:CONNECT-context.xml" });
-        if (hibernateUtil == null) {
-            hibernateUtil = context.getBean("txHibernateUtil", HibernateUtil.class);
-        }
-        return hibernateUtil;
-    }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/logging/transaction/persistance/HibernateUtil.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/logging/transaction/persistance/HibernateUtil.java
@@ -36,6 +36,7 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  *
@@ -46,6 +47,8 @@ public class HibernateUtil {
 
     private SessionFactory sessionFactory;
     private static final Logger LOG = LoggerFactory.getLogger(HibernateUtil.class);
+
+    private static HibernateUtil hibernateUtil;
 
     /**
      * Method builds the Hibernate SessionFactory.
@@ -98,5 +101,14 @@ public class HibernateUtil {
         }
 
         return result;
+    }
+
+    public static HibernateUtil getHibernateUtil() {
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+                new String[] { "classpath:CONNECT-context.xml" });
+        if (hibernateUtil == null) {
+            hibernateUtil = context.getBean("txHibernateUtil", HibernateUtil.class);
+        }
+        return hibernateUtil;
     }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/logging/transaction/persistance/HibernateUtil.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/logging/transaction/persistance/HibernateUtil.java
@@ -30,6 +30,7 @@ import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.properties.HibernateAccessor;
 import gov.hhs.fha.nhinc.properties.PropertyAccessException;
 import java.io.File;
+import org.hibernate.HibernateException;
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
@@ -43,18 +44,36 @@ import org.slf4j.LoggerFactory;
  */
 public class HibernateUtil {
 
-    private static final SessionFactory SESSION_FACTORY;
+    private SessionFactory sessionFactory;
     private static final Logger LOG = LoggerFactory.getLogger(HibernateUtil.class);
 
-    static {
+    /**
+     * Method builds the Hibernate SessionFactory.
+     */
+    public void buildSessionFactory() {
         try {
             // Create the SessionFactory from hibernate.cfg.xml
-            SESSION_FACTORY = new Configuration().configure()
-                    .buildSessionFactory(new StandardServiceRegistryBuilder().configure(getConfigFile()).build());
+            if (sessionFactory == null || sessionFactory.isClosed()) {
+                sessionFactory = new Configuration().configure()
+                        .buildSessionFactory(new StandardServiceRegistryBuilder().configure(getConfigFile()).build());
+            }
         } catch (ExceptionInInitializerError ex) {
             // Make sure you log the exception, as it might be swallowed
-            LOG.error("Initial SessionFactory creation failed." + ex, ex.getCause());
+            LOG.error("Initial SessionFactory creation failed. {}", ex.getLocalizedMessage(), ex);
             throw ex;
+        }
+    }
+
+    /**
+     * Method closes the Hibernate SessionFactory
+     */
+    public void closeSessionFactory() {
+        try {
+            if (sessionFactory != null && !sessionFactory.isClosed()) {
+                sessionFactory.close();
+            }
+        } catch (HibernateException he) {
+            LOG.error("Failed to close sessionFactory. {}", he.getLocalizedMessage(), he);
         }
     }
 
@@ -63,8 +82,8 @@ public class HibernateUtil {
      *
      * @return SessionFactory The Hibernate Session Factory
      */
-    public static SessionFactory getSessionFactory() {
-        return SESSION_FACTORY;
+    public SessionFactory getSessionFactory() {
+        return sessionFactory;
     }
 
     private static File getConfigFile() {
@@ -73,7 +92,7 @@ public class HibernateUtil {
         try {
             result = HibernateAccessor.getInstance().getHibernateFile(NhincConstants.HIBERNATE_TRANSREPO_REPOSITORY);
         } catch (PropertyAccessException ex) {
-            LOG.error("Unable to load " + NhincConstants.HIBERNATE_TRANSREPO_REPOSITORY + " " + ex.getMessage(), ex);
+            LOG.error("Unable to load {} {}", NhincConstants.HIBERNATE_TRANSREPO_REPOSITORY, ex.getMessage(), ex);
         }
 
         return result;

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/logging/transaction/persistance/HibernateUtil.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/logging/transaction/persistance/HibernateUtil.java
@@ -50,6 +50,7 @@ public class HibernateUtil {
     /**
      * Method builds the Hibernate SessionFactory.
      */
+
     public void buildSessionFactory() {
         try {
             // Create the SessionFactory from hibernate.cfg.xml
@@ -70,6 +71,7 @@ public class HibernateUtil {
     public void closeSessionFactory() {
         try {
             if (sessionFactory != null && !sessionFactory.isClosed()) {
+                LOG.info("About to close sessionfactory in transaction.persistence.HibernateUtil");
                 sessionFactory.close();
             }
         } catch (HibernateException he) {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
@@ -42,6 +42,7 @@ public class NhincConstants {
 
         LEVEL_g0, LEVEL_g1
     }
+
     public static final String HCID_PREFIX = "urn:oid:";
 
     public static enum ADAPTER_API_LEVEL {
@@ -78,24 +79,25 @@ public class NhincConstants {
     public static enum NHIN_SERVICE_NAMES {
 
         PATIENT_DISCOVERY(PATIENT_DISCOVERY_SERVICE_NAME), PATIENT_DISCOVERY_DEFERRED_REQUEST(
-            PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME), PATIENT_DISCOVERY_DEFERRED_RESPONSE(
-            PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME),
-        DOCUMENT_QUERY(DOC_QUERY_SERVICE_NAME),
-        DOCUMENT_RETRIEVE(DOC_RETRIEVE_SERVICE_NAME),
-        DOCUMENT_SUBMISSION(NHINC_XDR_SERVICE_NAME), DOCUMENT_SUBMISSION_DEFERRED_REQUEST(
-            NHINC_XDR_REQUEST_SERVICE_NAME), DOCUMENT_SUBMISSION_DEFERRED_RESPONSE(NHINC_XDR_RESPONSE_SERVICE_NAME),
-        ADMINISTRATIVE_DISTRIBUTION(NHIN_ADMIN_DIST_SERVICE_NAME),
-        CORE_X12DS_REALTIME(CORE_X12DS_REALTIME_SERVICE_NAME),
-        CORE_X12DS_GENERICBATCH_REQUEST(CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME),
-        CORE_X12DS_GENERICBATCH_RESPONSE(CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME);
+                PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME), PATIENT_DISCOVERY_DEFERRED_RESPONSE(
+                        PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME), DOCUMENT_QUERY(
+                                DOC_QUERY_SERVICE_NAME), DOCUMENT_RETRIEVE(
+                                        DOC_RETRIEVE_SERVICE_NAME), DOCUMENT_SUBMISSION(
+                                                NHINC_XDR_SERVICE_NAME), DOCUMENT_SUBMISSION_DEFERRED_REQUEST(
+                                                        NHINC_XDR_REQUEST_SERVICE_NAME), DOCUMENT_SUBMISSION_DEFERRED_RESPONSE(
+                                                                NHINC_XDR_RESPONSE_SERVICE_NAME), ADMINISTRATIVE_DISTRIBUTION(
+                                                                        NHIN_ADMIN_DIST_SERVICE_NAME), CORE_X12DS_REALTIME(
+                                                                                CORE_X12DS_REALTIME_SERVICE_NAME), CORE_X12DS_GENERICBATCH_REQUEST(
+                                                                                        CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME), CORE_X12DS_GENERICBATCH_RESPONSE(
+                                                                                                CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME);
         private String UDDIServiceName = null;
 
         NHIN_SERVICE_NAMES(String value) {
-            this.UDDIServiceName = value;
+            UDDIServiceName = value;
         }
 
         public String getUDDIServiceName() {
-            return this.UDDIServiceName;
+            return UDDIServiceName;
         }
 
         public static NHIN_SERVICE_NAMES fromValueString(String valueString) {
@@ -153,7 +155,7 @@ public class NhincConstants {
     public static final String TIMESTAMP_TIME_TO_LIVE = "TimeStampTimeToLive";
     public static final String TIMESTAMP_STRICT = "TimeStampStrict";
     public static final String TIMESTAMP_FUTURE_TIME_TO_LIVE = "FutureTimeToLive";
-    //X12 Generic Batch Specific Timestamp validator values
+    // X12 Generic Batch Specific Timestamp validator values
     public static final String X12_GENERIC_BATCH_TIMESTAMP_TIME_TO_LIVE = "CoreX12GenericBatchTimeStampTimeToLive";
     public static final String X12_GENERIC_BATCH_TIMESTAMP_STRICT = "CoreX12GenericBatchTimeStampStrict";
     public static final String X12_GENERIC_BATCH_TIMESTAMP_FUTURE_TIME_TO_LIVE = "CoreX12GenericBatchFutureTimeToLive";
@@ -312,7 +314,7 @@ public class NhincConstants {
     // Adapter Component MPI constants
     public static final String ADAPTER_COMPONENT_MPI_SERVICE_NAME = "adaptercomponentmpiservice";
     public static final String ADAPTER_COMPONENT_MPI_SECURED_SERVICE_NAME = "adaptercomponentmpisecuredservice";
-    //Adapter Audit Query Service Name
+    // Adapter Audit Query Service Name
     public static final String ADAPTER_AUDIT_QUERY_LOG_SERVICE_NAME = "auditquerylog";
     // SOAP Headers
     public static final String HTTP_REQUEST_ATTRIBUTE_SOAPMESSAGE = "SoapMessage";
@@ -459,10 +461,10 @@ public class NhincConstants {
     // AdminGUI constants
     public static final String ADMIN_GUI_PROXY_CONFIG_FILE_NAME = "AdminGUIProxyConfig.xml";
 
-    //Adapter properties for retrieving X12 RealTime payload
+    // Adapter properties for retrieving X12 RealTime payload
     public static final String CORE_X12DS_RT_DYNAMIC_DOC_FILE = "x12.realtime.doc.file";
 
-    //DocumentQueryTransform Constants
+    // DocumentQueryTransform Constants
     public static final String EBXML_DOCENTRY_PATIENT_ID = "$XDSDocumentEntryPatientId";
     // Hibernate Config Files
     public static final String HIBERNATE_AUDIT_REPOSITORY = "auditrepo.hibernate.cfg.xml";
@@ -487,26 +489,35 @@ public class NhincConstants {
     public static final String JMX_PATIENT_DISCOVERY_10_BEAN_NAME = "org.connectopensource.mbeans:type=PatientDiscovery10WebServices";
     // Standard Format for parsing String into Date
     public static final String DATE_PARSE_FORMAT = "yyyyMMddHHmmss";
-    //Document Type property for UClient
+    // Document Type property for UClient
     public static final String DOCUMENT_TYPE_PROPERTY_FILE = "documentTypes";
 
-    //AuditRepository EJB Core Module name
+    // AuditRepository EJB Core Module name
     public static final String EJB_CORE_MODULE_NAME = "AuditRepositoryCore";
-    //AuditRepository EJB Bean name
+    // AuditRepository EJB Bean name
     public static final String AUDIT_LOGGER_EJB_BEAN_NAME = "AuditEJBLoggerImpl";
     /* -- End Document Retrieve deferred Service Name -- */
 
-    //ReplyTo Header value for Nwhin Outbound messages
+    // ReplyTo Header value for Nwhin Outbound messages
     public static final String WSA_REPLY_TO = "http://www.w3.org/2005/08/addressing/anonymous";
-    //ReplyTo key value to be retrieved from cxf message Inbound Headers
+    // ReplyTo key value to be retrieved from cxf message Inbound Headers
     public static final String INBOUND_REPLY_TO = "ReplyTo";
-    //ReplyTo Header to be retrieved from cxf Inbound messages
+    // ReplyTo Header to be retrieved from cxf Inbound messages
     public static final String INBOUND_REPLY_TO_HEADER = "javax.xml.ws.addressing.context.inbound";
 
     // audit logging properties file name
     public static final String AUDIT_LOGGING_PROPERTY_FILE = "audit";
     public static final String LOG_TO_DATABASE = "LogToDatabase";
     public static final String LOG_TO_FILE = "LogToFile";
+
+    // Hibernate bean names
+    public static final String TRANSACTION_HIBERNATE_BEAN = "txHibernateUtil";
+    public static final String EVENT_HIBERNATE_BEAN = "eventHibernateUtil";
+    public static final String ASYNC_MSG_HIBERNATE_BEAN = "asyncmsgsHibernateUtil";
+    public static final String CONNECTION_HIBERNATE_BEAN = "connManHibernateUtil";
+    public static final String DOCREPO_HIBERNATE_BEAN = "docRepoHibernateUtil";
+    public static final String PATIENT_CORR_HIBERNATE_BEAN = "patientCorrHibernateUtil";
+    public static final String MSG_MONITOR_HIBERNATE_BEAN = "msgMonitorHibernateUtil";
 
     private NhincConstants() {
     }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/CorrelatedIdentifiersDaoImpl.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/CorrelatedIdentifiersDaoImpl.java
@@ -40,13 +40,15 @@ public class CorrelatedIdentifiersDaoImpl implements CorrelatedIdentifiersDao {
     @Override
     public List<QualifiedPatientIdentifier> retrievePatientCorrelation(
             QualifiedPatientIdentifier qualifiedPatientIdentifier, List<String> includeOnlyAssigningAuthorities) {
-        return Retriever.retrievePatientCorrelation(qualifiedPatientIdentifier, includeOnlyAssigningAuthorities);
+        Retriever retriever = new Retriever();
+        return retriever.retrievePatientCorrelation(qualifiedPatientIdentifier, includeOnlyAssigningAuthorities);
     }
 
     @Override
     public List<QualifiedPatientIdentifier> retrievePatientCorrelation(
             QualifiedPatientIdentifier qualifiedPatientIdentifier) {
-        return Retriever.retrievePatientCorrelation(qualifiedPatientIdentifier);
+        Retriever retriever = new Retriever();
+        return retriever.retrievePatientCorrelation(qualifiedPatientIdentifier);
     }
 
     @Override

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/CorrelatedIdentifiersDaoImpl.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/CorrelatedIdentifiersDaoImpl.java
@@ -40,15 +40,13 @@ public class CorrelatedIdentifiersDaoImpl implements CorrelatedIdentifiersDao {
     @Override
     public List<QualifiedPatientIdentifier> retrievePatientCorrelation(
             QualifiedPatientIdentifier qualifiedPatientIdentifier, List<String> includeOnlyAssigningAuthorities) {
-        Retriever retriever = new Retriever();
-        return retriever.retrievePatientCorrelation(qualifiedPatientIdentifier, includeOnlyAssigningAuthorities);
+        return Retriever.retrievePatientCorrelation(qualifiedPatientIdentifier, includeOnlyAssigningAuthorities);
     }
 
     @Override
     public List<QualifiedPatientIdentifier> retrievePatientCorrelation(
             QualifiedPatientIdentifier qualifiedPatientIdentifier) {
-        Retriever retriever = new Retriever();
-        return retriever.retrievePatientCorrelation(qualifiedPatientIdentifier);
+        return Retriever.retrievePatientCorrelation(qualifiedPatientIdentifier);
     }
 
     @Override

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/PDDeferredCorrelationDao.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/PDDeferredCorrelationDao.java
@@ -47,7 +47,6 @@ import org.slf4j.LoggerFactory;
 public class PDDeferredCorrelationDao {
 
     private static final Logger LOG = LoggerFactory.getLogger(PDDeferredCorrelationDao.class);
-    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientCorrHibernateUtil();
 
     /**
      * Query by Message Id. This should return only one record.
@@ -190,10 +189,10 @@ public class PDDeferredCorrelationDao {
      */
     protected SessionFactory getSessionFactory() {
         SessionFactory fact = null;
-        if (hibernateUtil != null) {
-            fact = hibernateUtil.getSessionFactory();
+        HibernateUtil util = HibernateUtilFactory.getPatientCorrHibernateUtil();
+        if (util != null) {
+            fact = util.getSessionFactory();
         }
         return fact;
     }
-
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/PDDeferredCorrelationDao.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/PDDeferredCorrelationDao.java
@@ -27,7 +27,8 @@
 package gov.hhs.fha.nhinc.patientcorrelation.nhinc.dao;
 
 import gov.hhs.fha.nhinc.patientcorrelation.nhinc.model.PDDeferredCorrelation;
-import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
+import gov.hhs.fha.nhinc.patientcorrelation.nhinc.persistence.HibernateUtil;
+import gov.hhs.fha.nhinc.persistence.HibernateUtilFactory;
 import java.util.Date;
 import java.util.List;
 import org.hibernate.HibernateException;
@@ -46,6 +47,7 @@ import org.slf4j.LoggerFactory;
 public class PDDeferredCorrelationDao {
 
     private static final Logger LOG = LoggerFactory.getLogger(PDDeferredCorrelationDao.class);
+    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientCorrHibernateUtil();
 
     /**
      * Query by Message Id. This should return only one record.
@@ -188,8 +190,8 @@ public class PDDeferredCorrelationDao {
      */
     protected SessionFactory getSessionFactory() {
         SessionFactory fact = null;
-        if (HibernateUtilFactory.getPatientCorrHibernateUtil() != null) {
-            fact = HibernateUtilFactory.getPatientCorrHibernateUtil().getSessionFactory();
+        if (hibernateUtil != null) {
+            fact = hibernateUtil.getSessionFactory();
         }
         return fact;
     }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/PDDeferredCorrelationDao.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/PDDeferredCorrelationDao.java
@@ -47,6 +47,8 @@ public class PDDeferredCorrelationDao {
 
     private static final Logger LOG = LoggerFactory.getLogger(PDDeferredCorrelationDao.class);
 
+    private HibernateUtil hibernateUtil = new HibernateUtil();
+
     /**
      * Query by Message Id. This should return only one record.
      *
@@ -61,7 +63,8 @@ public class PDDeferredCorrelationDao {
         II patientId = null;
 
         try {
-            SessionFactory fact = HibernateUtil.getSessionFactory();
+            hibernateUtil.buildSessionFactory();
+            SessionFactory fact = hibernateUtil.getSessionFactory();
             if (fact != null) {
                 sess = fact.openSession();
                 if (sess != null) {
@@ -84,13 +87,14 @@ public class PDDeferredCorrelationDao {
                 try {
                     sess.close();
                 } catch (HibernateException he) {
-                    LOG.error("Failed to close session: " + he.getMessage(), he);
+                    LOG.error("Failed to close session: {}", he.getMessage(), he);
                 }
             }
+            hibernateUtil.closeSessionFactory();
         }
 
         if (pdCorrelations == null || pdCorrelations.size() != 1) {
-            LOG.error("Failed to find a unique patient id with the given message id " + messageId);
+            LOG.error("Failed to find a unique patient id with the given message id {}", messageId);
         } else {
             PDDeferredCorrelation pdCorrelation = pdCorrelations.get(0);
             patientId = new II();
@@ -139,7 +143,8 @@ public class PDDeferredCorrelationDao {
         Session sess = null;
         Transaction trans = null;
         try {
-            SessionFactory fact = HibernateUtil.getSessionFactory();
+            hibernateUtil.buildSessionFactory();
+            SessionFactory fact = hibernateUtil.getSessionFactory();
             if (fact != null) {
                 sess = fact.openSession();
                 if (sess != null) {
@@ -166,16 +171,17 @@ public class PDDeferredCorrelationDao {
                 try {
                     trans.commit();
                 } catch (HibernateException he) {
-                    LOG.error("Failed to commit transaction: " + he.getMessage(), he);
+                    LOG.error("Failed to commit transaction: {}", he.getMessage(), he);
                 }
             }
             if (sess != null) {
                 try {
                     sess.close();
                 } catch (HibernateException he) {
-                    LOG.error("Failed to close session: " + he.getMessage(), he);
+                    LOG.error("Failed to close session: {}", he.getMessage(), he);
                 }
             }
+            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("PDDeferredCorrelationDao.save() - End");

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/PDDeferredCorrelationDao.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/PDDeferredCorrelationDao.java
@@ -27,7 +27,7 @@
 package gov.hhs.fha.nhinc.patientcorrelation.nhinc.dao;
 
 import gov.hhs.fha.nhinc.patientcorrelation.nhinc.model.PDDeferredCorrelation;
-import gov.hhs.fha.nhinc.patientcorrelation.nhinc.persistence.HibernateUtil;
+import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
 import java.util.Date;
 import java.util.List;
 import org.hibernate.HibernateException;
@@ -38,7 +38,6 @@ import org.hibernate.Transaction;
 import org.hl7.v3.II;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  *
@@ -47,8 +46,6 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 public class PDDeferredCorrelationDao {
 
     private static final Logger LOG = LoggerFactory.getLogger(PDDeferredCorrelationDao.class);
-
-    private HibernateUtil hibernateUtil;
 
     /**
      * Query by Message Id. This should return only one record.
@@ -64,7 +61,7 @@ public class PDDeferredCorrelationDao {
         II patientId = null;
 
         try {
-            SessionFactory fact = getHibernateUtil().getSessionFactory();
+            SessionFactory fact = getSessionFactory();
             if (fact != null) {
                 sess = fact.openSession();
                 if (sess != null) {
@@ -90,7 +87,6 @@ public class PDDeferredCorrelationDao {
                     LOG.error("Failed to close session: {}", he.getMessage(), he);
                 }
             }
-            hibernateUtil.closeSessionFactory();
         }
 
         if (pdCorrelations == null || pdCorrelations.size() != 1) {
@@ -143,7 +139,7 @@ public class PDDeferredCorrelationDao {
         Session sess = null;
         Transaction trans = null;
         try {
-            SessionFactory fact = getHibernateUtil().getSessionFactory();
+            SessionFactory fact = getSessionFactory();
             if (fact != null) {
                 sess = fact.openSession();
                 if (sess != null) {
@@ -185,12 +181,17 @@ public class PDDeferredCorrelationDao {
         LOG.debug("PDDeferredCorrelationDao.save() - End");
     }
 
-    private HibernateUtil getHibernateUtil() {
-        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
-                new String[] { "classpath:CONNECT-context.xml" });
-        LOG.debug("Memory address " + context.getId());
-        hibernateUtil = context.getBean("patientCorrHibernateUtil", HibernateUtil.class);
-        return hibernateUtil;
+    /**
+     * Gets the session factory belonging to Patient Correlation HibernateUtil
+     *
+     * @return sessionFactory
+     */
+    protected SessionFactory getSessionFactory() {
+        SessionFactory fact = null;
+        if (HibernateUtilFactory.getPatientCorrHibernateUtil() != null) {
+            fact = HibernateUtilFactory.getPatientCorrHibernateUtil().getSessionFactory();
+        }
+        return fact;
     }
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/PDDeferredCorrelationDao.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/PDDeferredCorrelationDao.java
@@ -38,6 +38,7 @@ import org.hibernate.Transaction;
 import org.hl7.v3.II;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  *
@@ -47,7 +48,7 @@ public class PDDeferredCorrelationDao {
 
     private static final Logger LOG = LoggerFactory.getLogger(PDDeferredCorrelationDao.class);
 
-    private HibernateUtil hibernateUtil = new HibernateUtil();
+    private HibernateUtil hibernateUtil;
 
     /**
      * Query by Message Id. This should return only one record.
@@ -63,8 +64,7 @@ public class PDDeferredCorrelationDao {
         II patientId = null;
 
         try {
-            hibernateUtil.buildSessionFactory();
-            SessionFactory fact = hibernateUtil.getSessionFactory();
+            SessionFactory fact = getHibernateUtil().getSessionFactory();
             if (fact != null) {
                 sess = fact.openSession();
                 if (sess != null) {
@@ -143,8 +143,7 @@ public class PDDeferredCorrelationDao {
         Session sess = null;
         Transaction trans = null;
         try {
-            hibernateUtil.buildSessionFactory();
-            SessionFactory fact = hibernateUtil.getSessionFactory();
+            SessionFactory fact = getHibernateUtil().getSessionFactory();
             if (fact != null) {
                 sess = fact.openSession();
                 if (sess != null) {
@@ -181,10 +180,17 @@ public class PDDeferredCorrelationDao {
                     LOG.error("Failed to close session: {}", he.getMessage(), he);
                 }
             }
-            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("PDDeferredCorrelationDao.save() - End");
+    }
+
+    private HibernateUtil getHibernateUtil() {
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+                new String[] { "classpath:CONNECT-context.xml" });
+        LOG.debug("Memory address " + context.getId());
+        hibernateUtil = context.getBean("patientCorrHibernateUtil", HibernateUtil.class);
+        return hibernateUtil;
     }
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/Retriever.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/Retriever.java
@@ -49,7 +49,6 @@ import org.slf4j.LoggerFactory;
 public class Retriever {
 
     private static final Logger LOG = LoggerFactory.getLogger(Retriever.class);
-    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientCorrHibernateUtil();
 
     public static List<QualifiedPatientIdentifier> retrievePatientCorrelation(
             QualifiedPatientIdentifier qualifiedPatientIdentifier, List<String> includeOnlyAssigningAuthorities) {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/Retriever.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/Retriever.java
@@ -40,6 +40,7 @@ import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Expression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  *
@@ -49,7 +50,7 @@ public class Retriever {
 
     private static final Logger LOG = LoggerFactory.getLogger(Retriever.class);
 
-    private HibernateUtil hibernateUtil = new HibernateUtil();
+    private HibernateUtil hibernateUtil;
 
     public List<QualifiedPatientIdentifier> retrievePatientCorrelation(
             QualifiedPatientIdentifier qualifiedPatientIdentifier, List<String> includeOnlyAssigningAuthorities) {
@@ -230,8 +231,7 @@ public class Retriever {
         List<CorrelatedIdentifiers> result = null;
 
         try {
-            hibernateUtil.buildSessionFactory();
-            fact = hibernateUtil.getSessionFactory();
+            fact = getHibernateUtil().getSessionFactory();
             sess = fact.openSession();
 
             Criteria criteria;
@@ -304,4 +304,12 @@ public class Retriever {
 
         return modifiedResult;
     }
+
+    protected HibernateUtil getHibernateUtil() {
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+                new String[] { "classpath:CONNECT-context.xml" });
+        hibernateUtil = context.getBean("patientCorrHibernateUtil", HibernateUtil.class);
+        return hibernateUtil;
+    }
+
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/Retriever.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/Retriever.java
@@ -29,7 +29,6 @@ package gov.hhs.fha.nhinc.patientcorrelation.nhinc.dao;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import gov.hhs.fha.nhinc.patientcorrelation.nhinc.model.CorrelatedIdentifiers;
 import gov.hhs.fha.nhinc.patientcorrelation.nhinc.model.QualifiedPatientIdentifier;
-import gov.hhs.fha.nhinc.patientcorrelation.nhinc.persistence.HibernateUtil;
 import gov.hhs.fha.nhinc.persistence.HibernateUtilFactory;
 import java.util.ArrayList;
 import java.util.Date;

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/Retriever.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/Retriever.java
@@ -49,7 +49,9 @@ public class Retriever {
 
     private static final Logger LOG = LoggerFactory.getLogger(Retriever.class);
 
-    public static List<QualifiedPatientIdentifier> retrievePatientCorrelation(
+    private HibernateUtil hibernateUtil = new HibernateUtil();
+
+    public List<QualifiedPatientIdentifier> retrievePatientCorrelation(
             QualifiedPatientIdentifier qualifiedPatientIdentifier, List<String> includeOnlyAssigningAuthorities) {
         List<QualifiedPatientIdentifier> qualifiedPatientIdentifiers = retrievePatientCorrelation(
                 qualifiedPatientIdentifier);
@@ -59,7 +61,7 @@ public class Retriever {
         return qualifiedPatientIdentifiers;
     }
 
-    private static List<QualifiedPatientIdentifier> filterByIncludeList(
+    private List<QualifiedPatientIdentifier> filterByIncludeList(
             List<QualifiedPatientIdentifier> qualifiedPatientIdentifiers,
             List<String> includeOnlyAssigningAuthorities) {
         List<QualifiedPatientIdentifier> filteredQualifiedPatientIdentifiers;
@@ -90,7 +92,7 @@ public class Retriever {
         return found;
     }
 
-    public static List<QualifiedPatientIdentifier> retrievePatientCorrelation(
+    public List<QualifiedPatientIdentifier> retrievePatientCorrelation(
             QualifiedPatientIdentifier qualifiedPatientIdentifier) {
         LOG.debug("-- Begin CorrelatedIdentifiersDao.retrieveAllPatientCorrelation() ---");
 
@@ -166,7 +168,7 @@ public class Retriever {
         return list1;
     }
 
-    public static boolean doesCorrelationExist(CorrelatedIdentifiers correlatedIdentifers) {
+    public boolean doesCorrelationExist(CorrelatedIdentifiers correlatedIdentifers) {
         boolean exists;
 
         CorrelatedIdentifiers criteria;
@@ -191,7 +193,7 @@ public class Retriever {
         return exists;
     }
 
-    public static CorrelatedIdentifiers retrieveSinglePatientCorrelation(CorrelatedIdentifiers correlatedIdentifers) {
+    public CorrelatedIdentifiers retrieveSinglePatientCorrelation(CorrelatedIdentifiers correlatedIdentifers) {
         List<CorrelatedIdentifiers> resultSet;
         CorrelatedIdentifiers result = new CorrelatedIdentifiers();
 
@@ -222,14 +224,14 @@ public class Retriever {
 
     }
 
-    private static List<CorrelatedIdentifiers> retrievePatientCorrelation(CorrelatedIdentifiers correlatedIdentifers) {
+    private List<CorrelatedIdentifiers> retrievePatientCorrelation(CorrelatedIdentifiers correlatedIdentifers) {
         SessionFactory fact;
         Session sess = null;
         List<CorrelatedIdentifiers> result = null;
-        // List<CorrelatedIdentifiers> modifiedResult = null;
 
         try {
-            fact = HibernateUtil.getSessionFactory();
+            hibernateUtil.buildSessionFactory();
+            fact = hibernateUtil.getSessionFactory();
             sess = fact.openSession();
 
             Criteria criteria;
@@ -270,11 +272,6 @@ public class Retriever {
             }
         }
 
-        // only non-expired patient correlation records will be returned.
-        // expired correlation records will be removed from the datebase.
-        // modifiedResult = removeExpiredCorrelations(result);
-
-        // return modifiedResult;
         return result;
     }
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/Retriever.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/Retriever.java
@@ -29,7 +29,8 @@ package gov.hhs.fha.nhinc.patientcorrelation.nhinc.dao;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import gov.hhs.fha.nhinc.patientcorrelation.nhinc.model.CorrelatedIdentifiers;
 import gov.hhs.fha.nhinc.patientcorrelation.nhinc.model.QualifiedPatientIdentifier;
-import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
+import gov.hhs.fha.nhinc.patientcorrelation.nhinc.persistence.HibernateUtil;
+import gov.hhs.fha.nhinc.persistence.HibernateUtilFactory;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -48,6 +49,7 @@ import org.slf4j.LoggerFactory;
 public class Retriever {
 
     private static final Logger LOG = LoggerFactory.getLogger(Retriever.class);
+    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientCorrHibernateUtil();
 
     public static List<QualifiedPatientIdentifier> retrievePatientCorrelation(
             QualifiedPatientIdentifier qualifiedPatientIdentifier, List<String> includeOnlyAssigningAuthorities) {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/Retriever.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/Retriever.java
@@ -29,7 +29,7 @@ package gov.hhs.fha.nhinc.patientcorrelation.nhinc.dao;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import gov.hhs.fha.nhinc.patientcorrelation.nhinc.model.CorrelatedIdentifiers;
 import gov.hhs.fha.nhinc.patientcorrelation.nhinc.model.QualifiedPatientIdentifier;
-import gov.hhs.fha.nhinc.patientcorrelation.nhinc.persistence.HibernateUtil;
+import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -40,7 +40,6 @@ import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Expression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  *
@@ -50,9 +49,7 @@ public class Retriever {
 
     private static final Logger LOG = LoggerFactory.getLogger(Retriever.class);
 
-    private HibernateUtil hibernateUtil;
-
-    public List<QualifiedPatientIdentifier> retrievePatientCorrelation(
+    public static List<QualifiedPatientIdentifier> retrievePatientCorrelation(
             QualifiedPatientIdentifier qualifiedPatientIdentifier, List<String> includeOnlyAssigningAuthorities) {
         List<QualifiedPatientIdentifier> qualifiedPatientIdentifiers = retrievePatientCorrelation(
                 qualifiedPatientIdentifier);
@@ -62,7 +59,7 @@ public class Retriever {
         return qualifiedPatientIdentifiers;
     }
 
-    private List<QualifiedPatientIdentifier> filterByIncludeList(
+    private static List<QualifiedPatientIdentifier> filterByIncludeList(
             List<QualifiedPatientIdentifier> qualifiedPatientIdentifiers,
             List<String> includeOnlyAssigningAuthorities) {
         List<QualifiedPatientIdentifier> filteredQualifiedPatientIdentifiers;
@@ -93,7 +90,7 @@ public class Retriever {
         return found;
     }
 
-    public List<QualifiedPatientIdentifier> retrievePatientCorrelation(
+    public static List<QualifiedPatientIdentifier> retrievePatientCorrelation(
             QualifiedPatientIdentifier qualifiedPatientIdentifier) {
         LOG.debug("-- Begin CorrelatedIdentifiersDao.retrieveAllPatientCorrelation() ---");
 
@@ -169,7 +166,7 @@ public class Retriever {
         return list1;
     }
 
-    public boolean doesCorrelationExist(CorrelatedIdentifiers correlatedIdentifers) {
+    public static boolean doesCorrelationExist(CorrelatedIdentifiers correlatedIdentifers) {
         boolean exists;
 
         CorrelatedIdentifiers criteria;
@@ -194,7 +191,7 @@ public class Retriever {
         return exists;
     }
 
-    public CorrelatedIdentifiers retrieveSinglePatientCorrelation(CorrelatedIdentifiers correlatedIdentifers) {
+    public static CorrelatedIdentifiers retrieveSinglePatientCorrelation(CorrelatedIdentifiers correlatedIdentifers) {
         List<CorrelatedIdentifiers> resultSet;
         CorrelatedIdentifiers result = new CorrelatedIdentifiers();
 
@@ -225,13 +222,13 @@ public class Retriever {
 
     }
 
-    private List<CorrelatedIdentifiers> retrievePatientCorrelation(CorrelatedIdentifiers correlatedIdentifers) {
+    private static List<CorrelatedIdentifiers> retrievePatientCorrelation(CorrelatedIdentifiers correlatedIdentifers) {
         SessionFactory fact;
         Session sess = null;
         List<CorrelatedIdentifiers> result = null;
 
         try {
-            fact = getHibernateUtil().getSessionFactory();
+            fact = HibernateUtilFactory.getPatientCorrHibernateUtil().getSessionFactory();
             sess = fact.openSession();
 
             Criteria criteria;
@@ -303,13 +300,6 @@ public class Retriever {
         }
 
         return modifiedResult;
-    }
-
-    protected HibernateUtil getHibernateUtil() {
-        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
-                new String[] { "classpath:CONNECT-context.xml" });
-        hibernateUtil = context.getBean("patientCorrHibernateUtil", HibernateUtil.class);
-        return hibernateUtil;
     }
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/Storer.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/Storer.java
@@ -44,7 +44,6 @@ import org.slf4j.LoggerFactory;
 public class Storer {
 
     private static final Logger LOG = LoggerFactory.getLogger(Storer.class);
-    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientCorrHibernateUtil();
 
     public static void addPatientCorrelation(CorrelatedIdentifiers correlatedIdentifers) {
         LOG.info("patient correlation add requested");
@@ -199,7 +198,7 @@ public class Storer {
     }
 
     protected static HibernateUtil getHibernateUtil() {
-        return hibernateUtil;
+        return HibernateUtilFactory.getPatientCorrHibernateUtil();
     }
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/Storer.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/Storer.java
@@ -28,6 +28,7 @@ package gov.hhs.fha.nhinc.patientcorrelation.nhinc.dao;
 
 import gov.hhs.fha.nhinc.patientcorrelation.nhinc.model.CorrelatedIdentifiers;
 import gov.hhs.fha.nhinc.patientcorrelation.nhinc.persistence.HibernateUtil;
+import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
 import org.hibernate.HibernateException;
 import org.hibernate.Query;
 import org.hibernate.Session;
@@ -35,7 +36,6 @@ import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  *
@@ -45,12 +45,9 @@ public class Storer {
 
     private static final Logger LOG = LoggerFactory.getLogger(Storer.class);
 
-    private static HibernateUtil hibernateUtil;
-
     public static void addPatientCorrelation(CorrelatedIdentifiers correlatedIdentifers) {
         LOG.info("patient correlation add requested");
-        Retriever retriever = new Retriever();
-        if (!retriever.doesCorrelationExist(correlatedIdentifers)) {
+        if (!Retriever.doesCorrelationExist(correlatedIdentifers)) {
             localAddPatientCorrelation(correlatedIdentifers);
         } else if (correlatedIdentifers.getCorrelationExpirationDate() != null) {
             LOG.info("updating expiration date");
@@ -65,8 +62,8 @@ public class Storer {
         SessionFactory fact = null;
         Session sess = null;
         Transaction trans = null;
-        Retriever retriever = new Retriever();
-        CorrelatedIdentifiers singleRecord = retriever.retrieveSinglePatientCorrelation(correlatedIdentifers);
+
+        CorrelatedIdentifiers singleRecord = Retriever.retrieveSinglePatientCorrelation(correlatedIdentifers);
 
         singleRecord.setCorrelationExpirationDate(correlatedIdentifers.getCorrelationExpirationDate());
 
@@ -104,7 +101,6 @@ public class Storer {
         SessionFactory fact = null;
         Session sess = null;
         Transaction trans = null;
-        HibernateUtil hibernateUtil = new HibernateUtil();
 
         try {
             fact = getHibernateUtil().getSessionFactory();
@@ -202,10 +198,7 @@ public class Storer {
     }
 
     protected static HibernateUtil getHibernateUtil() {
-        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
-                new String[] { "classpath:CONNECT-context.xml" });
-        hibernateUtil = context.getBean("patientCorrHibernateUtil", HibernateUtil.class);
-        return hibernateUtil;
+        return HibernateUtilFactory.getPatientCorrHibernateUtil();
     }
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/Storer.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/Storer.java
@@ -28,7 +28,7 @@ package gov.hhs.fha.nhinc.patientcorrelation.nhinc.dao;
 
 import gov.hhs.fha.nhinc.patientcorrelation.nhinc.model.CorrelatedIdentifiers;
 import gov.hhs.fha.nhinc.patientcorrelation.nhinc.persistence.HibernateUtil;
-import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
+import gov.hhs.fha.nhinc.persistence.HibernateUtilFactory;
 import org.hibernate.HibernateException;
 import org.hibernate.Query;
 import org.hibernate.Session;
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 public class Storer {
 
     private static final Logger LOG = LoggerFactory.getLogger(Storer.class);
+    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientCorrHibernateUtil();
 
     public static void addPatientCorrelation(CorrelatedIdentifiers correlatedIdentifers) {
         LOG.info("patient correlation add requested");
@@ -198,7 +199,7 @@ public class Storer {
     }
 
     protected static HibernateUtil getHibernateUtil() {
-        return HibernateUtilFactory.getPatientCorrHibernateUtil();
+        return hibernateUtil;
     }
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/Storer.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/dao/Storer.java
@@ -46,7 +46,8 @@ public class Storer {
 
     public static void addPatientCorrelation(CorrelatedIdentifiers correlatedIdentifers) {
         LOG.info("patient correlation add requested");
-        if (!Retriever.doesCorrelationExist(correlatedIdentifers)) {
+        Retriever retriever = new Retriever();
+        if (!retriever.doesCorrelationExist(correlatedIdentifers)) {
             localAddPatientCorrelation(correlatedIdentifers);
         } else if (correlatedIdentifers.getCorrelationExpirationDate() != null) {
             LOG.info("updating expiration date");
@@ -58,14 +59,18 @@ public class Storer {
 
     private static void localUpdatePatientCorrelation(CorrelatedIdentifiers correlatedIdentifers) {
         LOG.debug("-- Begin CorrelatedIdentifiersDao.localUpdatePatientCorrelation() ---");
+        SessionFactory fact = null;
         Session sess = null;
         Transaction trans = null;
-        CorrelatedIdentifiers singleRecord = Retriever.retrieveSinglePatientCorrelation(correlatedIdentifers);
+        Retriever retriever = new Retriever();
+        HibernateUtil hibernateUtil = new HibernateUtil();
+        CorrelatedIdentifiers singleRecord = retriever.retrieveSinglePatientCorrelation(correlatedIdentifers);
 
         singleRecord.setCorrelationExpirationDate(correlatedIdentifers.getCorrelationExpirationDate());
 
         try {
-            SessionFactory fact = HibernateUtil.getSessionFactory();
+            hibernateUtil.buildSessionFactory();
+            fact = hibernateUtil.getSessionFactory();
             if (fact != null) {
                 sess = fact.openSession();
                 trans = sess.beginTransaction();
@@ -78,27 +83,32 @@ public class Storer {
                 try {
                     trans.commit();
                 } catch (HibernateException he) {
-                    LOG.error("Failed to commit transaction: " + he.getMessage(), he);
+                    LOG.error("Failed to commit transaction: {}", he.getMessage(), he);
                 }
             }
             if (sess != null) {
                 try {
                     sess.close();
                 } catch (HibernateException he) {
-                    LOG.error("Failed to close session: " + he.getMessage(), he);
+                    LOG.error("Failed to close session: {}", he.getMessage(), he);
                 }
             }
+            hibernateUtil.closeSessionFactory();
+
         }
         LOG.debug("-- End CorrelatedIdentifiersDao.localUpdatePatientCorrelation() ---");
     }
 
     private static void localAddPatientCorrelation(CorrelatedIdentifiers correlatedIdentifers) {
         LOG.debug("-- Begin CorrelatedIdentifiersDao.addPatientCorrelation() ---");
+        SessionFactory fact = null;
         Session sess = null;
         Transaction trans = null;
+        HibernateUtil hibernateUtil = new HibernateUtil();
 
         try {
-            SessionFactory fact = HibernateUtil.getSessionFactory();
+            hibernateUtil.buildSessionFactory();
+            fact = hibernateUtil.getSessionFactory();
             if (fact != null) {
                 sess = fact.openSession();
                 trans = sess.beginTransaction();
@@ -111,24 +121,28 @@ public class Storer {
                 try {
                     trans.commit();
                 } catch (HibernateException he) {
-                    LOG.error("Failed to commit transaction: " + he.getMessage(), he);
+                    LOG.error("Failed to commit transaction: {}", he.getMessage(), he);
                 }
             }
             if (sess != null) {
                 try {
                     sess.close();
                 } catch (HibernateException he) {
-                    LOG.error("Failed to close session: " + he.getMessage(), he);
+                    LOG.error("Failed to close session: {}", he.getMessage(), he);
                 }
             }
+
+            hibernateUtil.closeSessionFactory();
         }
         LOG.debug("-- End CorrelatedIdentifiersDao.addPatientCorrelation() ---");
     }
 
     public static void removePatientCorrelation(CorrelatedIdentifiers correlatedIdentifers) {
         LOG.debug("-- Begin CorrelatedIdentifiersDao.removePatientCorrelation() ---");
+        SessionFactory fact = null;
         Session sess = null;
         Transaction trans = null;
+        HibernateUtil hibernateUtil = new HibernateUtil();
 
         String deleteCorrelatedIdentifiersSQL = "delete from correlatedidentifiers "
                 + "where ((PatientAssigningAuthorityId = :patientAssigningAuthority " + "and PatientId= :patientId "
@@ -145,9 +159,9 @@ public class Storer {
         String paramCorrelatedPatientAssignAuthId = correlatedIdentifers.getCorrelatedPatientAssigningAuthorityId();
         String paramCorrelatedPatientId = correlatedIdentifers.getCorrelatedPatientId();
         try {
-            SessionFactory fact = HibernateUtil.getSessionFactory();
+            hibernateUtil.buildSessionFactory();
+            fact = hibernateUtil.getSessionFactory();
             if (fact != null) {
-                System.out.println("Factory Created...");
                 sess = fact.openSession();
                 if (sess != null) {
                     trans = sess.beginTransaction();
@@ -176,17 +190,21 @@ public class Storer {
                 try {
                     trans.rollback();
                 } catch (HibernateException he) {
-                    LOG.error("Failed to commit transaction: " + he.getMessage(), he);
+                    LOG.error("Failed to commit transaction: {}", he.getMessage(), he);
                 }
             }
             if (sess != null) {
                 try {
                     sess.close();
                 } catch (HibernateException he) {
-                    LOG.error("Failed to close session: " + he.getMessage(), he);
+                    LOG.error("Failed to close session: {}", he.getMessage(), he);
                 }
             }
+
+            hibernateUtil.closeSessionFactory();
+
         }
         LOG.debug("-- End CorrelatedIdentifiersDao.removePatientCorrelation() ---");
     }
+
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/persistence/HibernateUtil.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/persistence/HibernateUtil.java
@@ -43,18 +43,35 @@ import org.slf4j.LoggerFactory;
  */
 public class HibernateUtil {
 
-    private static final SessionFactory sessionFactory;
+    private SessionFactory sessionFactory;
     private static final Logger LOG = LoggerFactory.getLogger(HibernateUtil.class);
 
-    static {
+    /**
+     * Method builds the Hibernate SessionFactory.
+     */
+    public void buildSessionFactory() {
         try {
             // Create the SessionFactory from hibernate.cfg.xml
-            sessionFactory = new Configuration().configure()
-                    .buildSessionFactory(new StandardServiceRegistryBuilder().configure(getConfigFile()).build());
+            if (sessionFactory == null || sessionFactory.isClosed()) {
+                sessionFactory = new Configuration().configure()
+                        .buildSessionFactory(new StandardServiceRegistryBuilder().configure(getConfigFile()).build());
+            }
         } catch (HibernateException he) {
             // Make sure you log the exception, as it might be swallowed
-            LOG.error("Initial SessionFactory creation failed." + he);
-            throw new ExceptionInInitializerError(he);
+            LOG.error("Initial SessionFactory creation failed. {}", he.getLocalizedMessage(), he);
+        }
+    }
+
+    /**
+     * Method closes the Hibernate SessionFactory
+     */
+    public void closeSessionFactory() {
+        try {
+            if (sessionFactory != null && !sessionFactory.isClosed()) {
+                sessionFactory.close();
+            }
+        } catch (HibernateException e) {
+            LOG.error("Initial SessionFactory creation failed. {}", e.getLocalizedMessage(), e);
         }
     }
 
@@ -63,7 +80,7 @@ public class HibernateUtil {
      *
      * @return SessionFactory
      */
-    public static SessionFactory getSessionFactory() {
+    public SessionFactory getSessionFactory() {
         return sessionFactory;
     }
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/persistence/HibernateUtilFactory.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/persistence/HibernateUtilFactory.java
@@ -18,6 +18,15 @@ public class HibernateUtilFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(HibernateUtilFactory.class);
 
+    // HibernateUtil members for the utility classes belonging to CoreLib
+    private static gov.hhs.fha.nhinc.logging.transaction.persistance.HibernateUtil transactionHibernateUtil;
+    private static gov.hhs.fha.nhinc.event.persistence.HibernateUtil eventHibernateUtil;
+    private static gov.hhs.fha.nhinc.asyncmsgs.persistence.HibernateUtil asyncMsgsHibernateUtil;
+    private static gov.hhs.fha.nhinc.common.connectionmanager.persistence.HibernateUtil connManHibernateUtil;
+    private static gov.hhs.fha.nhinc.docrepository.adapter.persistence.HibernateUtil docRepoHibernateUtil;
+    private static gov.hhs.fha.nhinc.patientcorrelation.nhinc.persistence.HibernateUtil patientCorrHibernateUtil;
+    private static gov.hhs.fha.nhinc.direct.messagemonitoring.persistence.HibernateUtil msgMonitorHibernateUtil;
+
     /**
      * Private constructor to hide the public one.
      */
@@ -49,16 +58,22 @@ public class HibernateUtilFactory {
         ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
 
         LOG.debug("Memory address transactionHibernateUtil {}", context.getId());
-        return context.getBean(NhincConstants.TRANSACTION_HIBERNATE_BEAN,
-                gov.hhs.fha.nhinc.logging.transaction.persistance.HibernateUtil.class);
+        if (transactionHibernateUtil == null) {
+            transactionHibernateUtil = context.getBean(NhincConstants.TRANSACTION_HIBERNATE_BEAN,
+                    gov.hhs.fha.nhinc.logging.transaction.persistance.HibernateUtil.class);
+        }
+        return transactionHibernateUtil;
     }
 
     public static gov.hhs.fha.nhinc.event.persistence.HibernateUtil getEventHibernateUtil() {
         ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
 
         LOG.debug("Memory address eventHibernateUtil {}", context.getId());
-        return context.getBean(NhincConstants.EVENT_HIBERNATE_BEAN,
-                gov.hhs.fha.nhinc.event.persistence.HibernateUtil.class);
+        if (eventHibernateUtil == null) {
+            eventHibernateUtil = context.getBean(NhincConstants.EVENT_HIBERNATE_BEAN,
+                    gov.hhs.fha.nhinc.event.persistence.HibernateUtil.class);
+        }
+        return eventHibernateUtil;
     }
 
     /**
@@ -68,8 +83,13 @@ public class HibernateUtilFactory {
         ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
 
         LOG.debug("Memory address in getAsyncMsgsHibernateUtil {}", context.getId());
-        return context.getBean(NhincConstants.ASYNC_MSG_HIBERNATE_BEAN,
-                gov.hhs.fha.nhinc.asyncmsgs.persistence.HibernateUtil.class);
+
+        if (asyncMsgsHibernateUtil == null) {
+            asyncMsgsHibernateUtil = context.getBean(NhincConstants.ASYNC_MSG_HIBERNATE_BEAN,
+                    gov.hhs.fha.nhinc.asyncmsgs.persistence.HibernateUtil.class);
+        }
+
+        return asyncMsgsHibernateUtil;
     }
 
     /**
@@ -81,8 +101,12 @@ public class HibernateUtilFactory {
         ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
 
         LOG.debug("Memory address getConnManHibernateUtil {}", context.getId());
-        return context.getBean(NhincConstants.CONNECTION_HIBERNATE_BEAN,
-                gov.hhs.fha.nhinc.common.connectionmanager.persistence.HibernateUtil.class);
+
+        if (connManHibernateUtil == null) {
+            connManHibernateUtil = context.getBean(NhincConstants.CONNECTION_HIBERNATE_BEAN,
+                    gov.hhs.fha.nhinc.common.connectionmanager.persistence.HibernateUtil.class);
+        }
+        return connManHibernateUtil;
     }
 
     /**
@@ -94,8 +118,11 @@ public class HibernateUtilFactory {
         ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
 
         LOG.debug("Memory address getDocRepoHibernateUtil {}", context.getId());
-        return context.getBean(NhincConstants.DOCREPO_HIBERNATE_BEAN,
-                gov.hhs.fha.nhinc.docrepository.adapter.persistence.HibernateUtil.class);
+        if (docRepoHibernateUtil == null) {
+            docRepoHibernateUtil = context.getBean(NhincConstants.DOCREPO_HIBERNATE_BEAN,
+                    gov.hhs.fha.nhinc.docrepository.adapter.persistence.HibernateUtil.class);
+        }
+        return docRepoHibernateUtil;
     }
 
     /**
@@ -107,8 +134,11 @@ public class HibernateUtilFactory {
         ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
 
         LOG.debug("Memory address getPatientCorrHibernateUtil {}", context.getId());
-        return context.getBean(NhincConstants.PATIENT_CORR_HIBERNATE_BEAN,
-                gov.hhs.fha.nhinc.patientcorrelation.nhinc.persistence.HibernateUtil.class);
+        if (patientCorrHibernateUtil == null) {
+            patientCorrHibernateUtil = context.getBean(NhincConstants.PATIENT_CORR_HIBERNATE_BEAN,
+                    gov.hhs.fha.nhinc.patientcorrelation.nhinc.persistence.HibernateUtil.class);
+        }
+        return patientCorrHibernateUtil;
     }
 
     /**
@@ -120,8 +150,11 @@ public class HibernateUtilFactory {
         ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
 
         LOG.debug("Memory address geMsgMonitorHibernateUtil {}", context.getId());
-        return context.getBean(NhincConstants.MSG_MONITOR_HIBERNATE_BEAN,
-                gov.hhs.fha.nhinc.direct.messagemonitoring.persistence.HibernateUtil.class);
+        if (msgMonitorHibernateUtil == null) {
+            msgMonitorHibernateUtil = context.getBean(NhincConstants.MSG_MONITOR_HIBERNATE_BEAN,
+                    gov.hhs.fha.nhinc.direct.messagemonitoring.persistence.HibernateUtil.class);
+        }
+        return msgMonitorHibernateUtil;
     }
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/persistence/HibernateUtilFactory.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/persistence/HibernateUtilFactory.java
@@ -1,7 +1,7 @@
 /**
  *
  */
-package gov.hhs.fha.nhinc.properties;
+package gov.hhs.fha.nhinc.persistence;
 
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import org.slf4j.Logger;
@@ -33,11 +33,11 @@ public class HibernateUtilFactory {
      */
     private static class ClassPathSingleton {
 
-        private ClassPathSingleton() {
-        }
-
         public static final ClassPathXmlApplicationContext CONTEXT = new ClassPathXmlApplicationContext(
                 new String[] { "classpath:CONNECT-context.xml" });
+
+        private ClassPathSingleton() {
+        }
     }
 
     /**
@@ -49,20 +49,16 @@ public class HibernateUtilFactory {
         ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
 
         LOG.debug("Memory address transactionHibernateUtil {}", context.getId());
-        gov.hhs.fha.nhinc.logging.transaction.persistance.HibernateUtil hibernateUtil = context.getBean(
-                NhincConstants.TRANSACTION_HIBERNATE_BEAN,
+        return context.getBean(NhincConstants.TRANSACTION_HIBERNATE_BEAN,
                 gov.hhs.fha.nhinc.logging.transaction.persistance.HibernateUtil.class);
-        return hibernateUtil;
     }
 
     public static gov.hhs.fha.nhinc.event.persistence.HibernateUtil getEventHibernateUtil() {
         ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
 
         LOG.debug("Memory address eventHibernateUtil {}", context.getId());
-        gov.hhs.fha.nhinc.event.persistence.HibernateUtil hibernateUtil = context
-                .getBean(NhincConstants.EVENT_HIBERNATE_BEAN, gov.hhs.fha.nhinc.event.persistence.HibernateUtil.class);
-
-        return hibernateUtil;
+        return context.getBean(NhincConstants.EVENT_HIBERNATE_BEAN,
+                gov.hhs.fha.nhinc.event.persistence.HibernateUtil.class);
     }
 
     /**
@@ -71,11 +67,9 @@ public class HibernateUtilFactory {
     public static gov.hhs.fha.nhinc.asyncmsgs.persistence.HibernateUtil getAsyncMsgsHibernateUtil() {
         ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
 
-        LOG.debug("Memory address in getAsyncMsgsHibernateUtil, ", context.getId());
-        gov.hhs.fha.nhinc.asyncmsgs.persistence.HibernateUtil hibernateUtil = context.getBean(
-                NhincConstants.ASYNC_MSG_HIBERNATE_BEAN, gov.hhs.fha.nhinc.asyncmsgs.persistence.HibernateUtil.class);
-
-        return hibernateUtil;
+        LOG.debug("Memory address in getAsyncMsgsHibernateUtil {}", context.getId());
+        return context.getBean(NhincConstants.ASYNC_MSG_HIBERNATE_BEAN,
+                gov.hhs.fha.nhinc.asyncmsgs.persistence.HibernateUtil.class);
     }
 
     /**
@@ -87,11 +81,8 @@ public class HibernateUtilFactory {
         ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
 
         LOG.debug("Memory address getConnManHibernateUtil {}", context.getId());
-        gov.hhs.fha.nhinc.common.connectionmanager.persistence.HibernateUtil hibernateUtil = context.getBean(
-                NhincConstants.CONNECTION_HIBERNATE_BEAN,
+        return context.getBean(NhincConstants.CONNECTION_HIBERNATE_BEAN,
                 gov.hhs.fha.nhinc.common.connectionmanager.persistence.HibernateUtil.class);
-
-        return hibernateUtil;
     }
 
     /**
@@ -103,11 +94,8 @@ public class HibernateUtilFactory {
         ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
 
         LOG.debug("Memory address getDocRepoHibernateUtil {}", context.getId());
-        gov.hhs.fha.nhinc.docrepository.adapter.persistence.HibernateUtil hibernateUtil = context.getBean(
-                NhincConstants.DOCREPO_HIBERNATE_BEAN,
+        return context.getBean(NhincConstants.DOCREPO_HIBERNATE_BEAN,
                 gov.hhs.fha.nhinc.docrepository.adapter.persistence.HibernateUtil.class);
-
-        return hibernateUtil;
     }
 
     /**
@@ -119,11 +107,8 @@ public class HibernateUtilFactory {
         ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
 
         LOG.debug("Memory address getPatientCorrHibernateUtil {}", context.getId());
-        gov.hhs.fha.nhinc.patientcorrelation.nhinc.persistence.HibernateUtil hibernateUtil = context.getBean(
-                NhincConstants.PATIENT_CORR_HIBERNATE_BEAN,
+        return context.getBean(NhincConstants.PATIENT_CORR_HIBERNATE_BEAN,
                 gov.hhs.fha.nhinc.patientcorrelation.nhinc.persistence.HibernateUtil.class);
-
-        return hibernateUtil;
     }
 
     /**
@@ -135,11 +120,8 @@ public class HibernateUtilFactory {
         ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
 
         LOG.debug("Memory address geMsgMonitorHibernateUtil {}", context.getId());
-        gov.hhs.fha.nhinc.direct.messagemonitoring.persistence.HibernateUtil hibernateUtil = context.getBean(
-                NhincConstants.MSG_MONITOR_HIBERNATE_BEAN,
+        return context.getBean(NhincConstants.MSG_MONITOR_HIBERNATE_BEAN,
                 gov.hhs.fha.nhinc.direct.messagemonitoring.persistence.HibernateUtil.class);
-
-        return hibernateUtil;
     }
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/properties/HibernateUtilFactory.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/properties/HibernateUtilFactory.java
@@ -1,0 +1,145 @@
+/**
+ *
+ */
+package gov.hhs.fha.nhinc.properties;
+
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+/**
+ * @author drfernan
+ *
+ *         Factory class to load and retrieve beans defined for HibernateUtil utility classes.
+ *
+ */
+public class HibernateUtilFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HibernateUtilFactory.class);
+
+    /**
+     * Private constructor to hide the public one.
+     */
+    private HibernateUtilFactory() {
+
+    }
+
+    /**
+     * Singleton class that holds the ClassPathXmlApplicationContext
+     *
+     * @author drfernan
+     *
+     */
+    private static class ClassPathSingleton {
+
+        private ClassPathSingleton() {
+        }
+
+        public static final ClassPathXmlApplicationContext CONTEXT = new ClassPathXmlApplicationContext(
+                new String[] { "classpath:CONNECT-context.xml" });
+    }
+
+    /**
+     * Method that returns the Transaction HibernateUtil
+     *
+     * @return
+     */
+    public static gov.hhs.fha.nhinc.logging.transaction.persistance.HibernateUtil getTransactionHibernateUtil() {
+        ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
+
+        LOG.debug("Memory address transactionHibernateUtil {}", context.getId());
+        gov.hhs.fha.nhinc.logging.transaction.persistance.HibernateUtil hibernateUtil = context.getBean(
+                NhincConstants.TRANSACTION_HIBERNATE_BEAN,
+                gov.hhs.fha.nhinc.logging.transaction.persistance.HibernateUtil.class);
+        return hibernateUtil;
+    }
+
+    public static gov.hhs.fha.nhinc.event.persistence.HibernateUtil getEventHibernateUtil() {
+        ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
+
+        LOG.debug("Memory address eventHibernateUtil {}", context.getId());
+        gov.hhs.fha.nhinc.event.persistence.HibernateUtil hibernateUtil = context
+                .getBean(NhincConstants.EVENT_HIBERNATE_BEAN, gov.hhs.fha.nhinc.event.persistence.HibernateUtil.class);
+
+        return hibernateUtil;
+    }
+
+    /**
+     * Method that returns the Asynchronous Message HibernateUtil
+     */
+    public static gov.hhs.fha.nhinc.asyncmsgs.persistence.HibernateUtil getAsyncMsgsHibernateUtil() {
+        ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
+
+        LOG.debug("Memory address in getAsyncMsgsHibernateUtil, ", context.getId());
+        gov.hhs.fha.nhinc.asyncmsgs.persistence.HibernateUtil hibernateUtil = context.getBean(
+                NhincConstants.ASYNC_MSG_HIBERNATE_BEAN, gov.hhs.fha.nhinc.asyncmsgs.persistence.HibernateUtil.class);
+
+        return hibernateUtil;
+    }
+
+    /**
+     * Method that returns the Connection Manager HibernateUtil
+     *
+     * @return
+     */
+    public static gov.hhs.fha.nhinc.common.connectionmanager.persistence.HibernateUtil getConnManHibernateUtil() {
+        ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
+
+        LOG.debug("Memory address getConnManHibernateUtil {}", context.getId());
+        gov.hhs.fha.nhinc.common.connectionmanager.persistence.HibernateUtil hibernateUtil = context.getBean(
+                NhincConstants.CONNECTION_HIBERNATE_BEAN,
+                gov.hhs.fha.nhinc.common.connectionmanager.persistence.HibernateUtil.class);
+
+        return hibernateUtil;
+    }
+
+    /**
+     * Method that returns the Document Repository HibernateUtil
+     *
+     * @return
+     */
+    public static gov.hhs.fha.nhinc.docrepository.adapter.persistence.HibernateUtil getDocRepoHibernateUtil() {
+        ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
+
+        LOG.debug("Memory address getDocRepoHibernateUtil {}", context.getId());
+        gov.hhs.fha.nhinc.docrepository.adapter.persistence.HibernateUtil hibernateUtil = context.getBean(
+                NhincConstants.DOCREPO_HIBERNATE_BEAN,
+                gov.hhs.fha.nhinc.docrepository.adapter.persistence.HibernateUtil.class);
+
+        return hibernateUtil;
+    }
+
+    /**
+     * Method that returns the Patient Correlation HibernateUtil.
+     *
+     * @return
+     */
+    public static gov.hhs.fha.nhinc.patientcorrelation.nhinc.persistence.HibernateUtil getPatientCorrHibernateUtil() {
+        ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
+
+        LOG.debug("Memory address getPatientCorrHibernateUtil {}", context.getId());
+        gov.hhs.fha.nhinc.patientcorrelation.nhinc.persistence.HibernateUtil hibernateUtil = context.getBean(
+                NhincConstants.PATIENT_CORR_HIBERNATE_BEAN,
+                gov.hhs.fha.nhinc.patientcorrelation.nhinc.persistence.HibernateUtil.class);
+
+        return hibernateUtil;
+    }
+
+    /**
+     * Method that returns the Message monitoring HibernateUtil.
+     *
+     * @return
+     */
+    public static gov.hhs.fha.nhinc.direct.messagemonitoring.persistence.HibernateUtil getMsgMonitorHibernateUtil() {
+        ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
+
+        LOG.debug("Memory address geMsgMonitorHibernateUtil {}", context.getId());
+        gov.hhs.fha.nhinc.direct.messagemonitoring.persistence.HibernateUtil hibernateUtil = context.getBean(
+                NhincConstants.MSG_MONITOR_HIBERNATE_BEAN,
+                gov.hhs.fha.nhinc.direct.messagemonitoring.persistence.HibernateUtil.class);
+
+        return hibernateUtil;
+    }
+
+}

--- a/Product/Production/Common/CONNECTCoreLib/src/main/resources/CONNECT-context.xml
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/resources/CONNECT-context.xml
@@ -37,6 +37,6 @@
         init-method="buildSessionFactory" destroy-method="closeSessionFactory"/>   
 
     <bean name="msgMonitorHibernateUtil" class="gov.hhs.fha.nhinc.direct.messagemonitoring.persistence.HibernateUtil" 
-        init-method="buildSessionFactory" destroy-method="closeSessionFactory"/>  
+        init-method="buildSessionFactory" destroy-method="closeSessionFactory" lazy-init="true"/>  
 
 </beans>

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/docrepository/adapter/dao/EventCodeDaoTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/docrepository/adapter/dao/EventCodeDaoTest.java
@@ -38,7 +38,6 @@ import java.util.List;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.SlotType1;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
-import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,26 +58,17 @@ public class EventCodeDaoTest {
     /** The event code dao. */
     private EventCodeDao eventCodeDao;
 
-    /** The session factory. */
-    private SessionFactory sessionFactory;
-
     /**
      * Sets the up.
      */
     @Before
     public void setUp() {
         transaction = mock(Transaction.class);
-        sessionFactory = mock(SessionFactory.class);
 
         eventCodeDao = new EventCodeDao() {
             @Override
-            protected Session getSession(SessionFactory sessionFactory) {
+            protected Session getSession() {
                 return session;
-            }
-
-            @Override
-            protected SessionFactory getSessionFactory() {
-                return sessionFactory;
             }
 
             @Override

--- a/Product/Production/Gateway/CONNECTGatewayWeb/src/main/java/gov/hhs/fha/nhinc/gateway/servlet/InitServlet.java
+++ b/Product/Production/Gateway/CONNECTGatewayWeb/src/main/java/gov/hhs/fha/nhinc/gateway/servlet/InitServlet.java
@@ -60,11 +60,13 @@ public class InitServlet extends HttpServlet {
     public void init(ServletConfig config) throws ServletException {
         super.init(config);
         executor = Executors.newFixedThreadPool(ExecutorServiceHelper.getInstance().getExecutorPoolSize());
-        largeJobExecutor = Executors.newFixedThreadPool(ExecutorServiceHelper.getInstance()
-            .getLargeJobExecutorPoolSize());
-        //Initialize HibernateUtil when CONNECTGatewayWeb is initialized required for AuditRepo JavaImpl EJB calls.
-        //Do not Remove this ...
-        HibernateUtil.getSessionFactory();
+        largeJobExecutor = Executors
+                .newFixedThreadPool(ExecutorServiceHelper.getInstance().getLargeJobExecutorPoolSize());
+        // Initialize HibernateUtil when CONNECTGatewayWeb is initialized required for AuditRepo JavaImpl EJB calls.
+        // Do not Remove this ...
+
+        HibernateUtil hibernateUtil = new HibernateUtil();
+        hibernateUtil.buildSessionFactory();
         // register event loggers as observers...
         EventLoggerFactory.getInstance().registerLoggers();
     }
@@ -84,14 +86,14 @@ public class InitServlet extends HttpServlet {
             try {
                 executor.shutdown();
             } catch (Exception e) {
-                LOG.error("Error while shutdown of ExecutorService: " + e.getLocalizedMessage(), e);
+                LOG.error("Error while shutdown of ExecutorService: {}", e.getLocalizedMessage(), e);
             }
         }
         if (largeJobExecutor != null) {
             try {
                 largeJobExecutor.shutdown();
             } catch (Exception e) {
-                LOG.error("Error while shutdown of ExecutorService: " + e.getLocalizedMessage(), e);
+                LOG.error("Error while shutdown of ExecutorService: {}", e.getLocalizedMessage(), e);
             }
         }
     }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAO.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAO.java
@@ -51,6 +51,8 @@ public class AuditRepositoryDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(AuditRepositoryDAO.class);
 
+    private HibernateUtil hibernateUtil = new HibernateUtil();
+
     /**
      * Constructor
      */
@@ -87,7 +89,7 @@ public class AuditRepositoryDAO {
                 if (tx != null) {
                     tx.rollback();
                 }
-                LOG.error("Error during insertion caused by :" + e.getLocalizedMessage(), e);
+                LOG.error("Error during insertion caused by : {}", e.getLocalizedMessage(), e);
             } finally {
                 closeSession(session);
             }
@@ -140,7 +142,7 @@ public class AuditRepositoryDAO {
 
             queryList = aCriteria.list();
         } catch (final HibernateException e) {
-            LOG.error("Exception in AuditLog.get() occurred due to :" + e.getLocalizedMessage(), e);
+            LOG.error("Exception in AuditLog.get() occurred due to : {}", e.getLocalizedMessage(), e);
         } finally {
             closeSession(session);
         }
@@ -180,7 +182,7 @@ public class AuditRepositoryDAO {
             // if no criteria is passed then it will search full database with above mentioned columns in the result
             queryList = queryCriteria.list();
         } catch (final HibernateException e) {
-            LOG.error("Exception in AuditLog.get() occurred due to :" + e.getLocalizedMessage(), e);
+            LOG.error("Exception in AuditLog.get() occurred due to : {}", e.getLocalizedMessage(), e);
         } finally {
             closeSession(session);
         }
@@ -238,7 +240,7 @@ public class AuditRepositoryDAO {
             queryList = queryCriteria.list();
 
         } catch (final HibernateException e) {
-            LOG.error("Exception in AuditLog.get() occurred due to :" + e.getLocalizedMessage(), e);
+            LOG.error("Exception in AuditLog.get() occurred due to : {}", e.getLocalizedMessage(), e);
         } finally {
             closeSession(session);
         }
@@ -266,7 +268,7 @@ public class AuditRepositoryDAO {
 
             message = (Blob) queryCriteria.uniqueResult();
         } catch (final HibernateException e) {
-            LOG.error("Exception in AuditLog.get() occurred due to :" + e.getLocalizedMessage(), e);
+            LOG.error("Exception in AuditLog.get() occurred due to : {}", e.getLocalizedMessage(), e);
         } finally {
             closeSession(session);
         }
@@ -284,6 +286,7 @@ public class AuditRepositoryDAO {
         if (session != null) {
             session.close();
         }
+        hibernateUtil.closeSessionFactory();
     }
 
     /**
@@ -291,6 +294,8 @@ public class AuditRepositoryDAO {
      * @return Hibernate session
      */
     protected Session getSession() {
-        return HibernateUtil.getSessionFactory().openSession();
+        hibernateUtil.buildSessionFactory();
+        return hibernateUtil.getSessionFactory().openSession();
     }
+
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAO.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAO.java
@@ -41,6 +41,7 @@ import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * AuditRepositoryDAO Class provides methods to query and update Audit Data to/from MySQL Database using Hibernate
@@ -51,7 +52,7 @@ public class AuditRepositoryDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(AuditRepositoryDAO.class);
 
-    private HibernateUtil hibernateUtil = new HibernateUtil();
+    private HibernateUtil hibernateUtil;
 
     /**
      * Constructor
@@ -286,7 +287,6 @@ public class AuditRepositoryDAO {
         if (session != null) {
             session.close();
         }
-        hibernateUtil.closeSessionFactory();
     }
 
     /**
@@ -294,8 +294,19 @@ public class AuditRepositoryDAO {
      * @return Hibernate session
      */
     protected Session getSession() {
-        hibernateUtil.buildSessionFactory();
-        return hibernateUtil.getSessionFactory().openSession();
+        return getHibernateUtil().getSessionFactory().openSession();
+    }
+
+    /**
+     * Load HibernateUtil bean.
+     *
+     * @return hibernateUtil
+     */
+    protected HibernateUtil getHibernateUtil() {
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+                new String[] { "classpath:spring-beans.xml" });
+        hibernateUtil = context.getBean("auditRepoHibernateUtil", HibernateUtil.class);
+        return hibernateUtil;
     }
 
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAO.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/AuditRepositoryDAO.java
@@ -53,8 +53,6 @@ public class AuditRepositoryDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(AuditRepositoryDAO.class);
 
-    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getAuditRepoHibernateUtil();
-
     /**
      * Constructor
      */
@@ -305,6 +303,7 @@ public class AuditRepositoryDAO {
      */
     protected Session getSession() {
         Session session = null;
+        HibernateUtil hibernateUtil = HibernateUtilFactory.getAuditRepoHibernateUtil();
 
         if (hibernateUtil != null) {
             session = hibernateUtil.getSessionFactory().openSession();

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/util/HibernateUtil.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/util/HibernateUtil.java
@@ -44,22 +44,41 @@ import org.slf4j.LoggerFactory;
  */
 public class HibernateUtil {
 
-    private static final SessionFactory sessionFactory;
+    private SessionFactory sessionFactory;
     private static final Logger LOG = LoggerFactory.getLogger(HibernateUtil.class);
 
-    static {
+    /**
+     * Method builds the Hibernate SessionFactory.
+     */
+    public void buildSessionFactory() {
         try {
             // Create the SessionFactory from hibernate.cfg.xml
             LOG.debug("Building the session factory in HibernateUtil in AuditRepositoryCore");
-            sessionFactory = new Configuration().configure()
-                    .buildSessionFactory(new StandardServiceRegistryBuilder().configure(getConfigFile()).build());
+            if (sessionFactory == null || sessionFactory.isClosed()) {
+                sessionFactory = new Configuration().configure()
+                        .buildSessionFactory(new StandardServiceRegistryBuilder().configure(getConfigFile()).build());
+            }
         } catch (HibernateException ex) {
             // Make sure you log the exception, as it might be swallowed
-            LOG.error("Initial SessionFactory creation failed." + ex.getLocalizedMessage(), ex);
+            LOG.error("Initial SessionFactory creation failed. {}", ex.getLocalizedMessage(), ex);
             throw new ExceptionInInitializerError(ex);
         } catch (Exception ex) {
             LOG.error("Error in building sessionFactory. {}", ex.getLocalizedMessage(), ex);
             throw new ExceptionInInitializerError(ex);
+        }
+    }
+
+    /**
+     * Method closes the Hibernate SessionFactory
+     */
+
+    public void closeSessionFactory() {
+        try {
+            if (sessionFactory != null && !sessionFactory.isClosed()) {
+                sessionFactory.close();
+            }
+        } catch (HibernateException e) {
+            LOG.error("Error in closing sessionFactory. {}", e.getLocalizedMessage(), e);
         }
     }
 
@@ -82,7 +101,7 @@ public class HibernateUtil {
      *
      * @return SessionFactory
      */
-    public static SessionFactory getSessionFactory() {
+    public SessionFactory getSessionFactory() {
         return sessionFactory;
     }
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/util/HibernateUtil.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/util/HibernateUtil.java
@@ -73,6 +73,7 @@ public class HibernateUtil {
      */
 
     public void closeSessionFactory() {
+        LOG.info("Closing the sessionFactory in HibernateUtil");
         try {
             if (sessionFactory != null && !sessionFactory.isClosed()) {
                 sessionFactory.close();

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/util/HibernateUtilFactory.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/util/HibernateUtilFactory.java
@@ -1,0 +1,58 @@
+/**
+ *
+ */
+package gov.hhs.fha.nhinc.auditrepository.hibernate.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+/**
+ * @author drfernan
+ *
+ *         Factory class to load the AuditRepositoryCore spring configuration.
+ *
+ */
+public class HibernateUtilFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HibernateUtilFactory.class);
+
+    private static final String AUDIT_REPO_HIBERNATE = "auditRepoHibernateUtil";
+
+    /**
+     * Private constructor to hide the public one.
+     */
+    private HibernateUtilFactory() {
+
+    }
+
+    /**
+     * Private class that holds that loads the spring-beans.xml into the Classpath application context.
+     *
+     * @author drfernan
+     *
+     */
+    private static class ClassPathSingleton {
+
+        private ClassPathSingleton() {
+        }
+
+        public static final ClassPathXmlApplicationContext CONTEXT = new ClassPathXmlApplicationContext(
+                new String[] { "classpath:spring-beans.xml" });
+    }
+
+    /**
+     * Method that returns the Audit Repository HibernateUtil.
+     *
+     * @return
+     */
+    public static HibernateUtil getAuditRepoHibernateUtil() {
+        ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
+
+        LOG.debug("Memory address getAuditRepoHibernateUtil {}", context.getId());
+        gov.hhs.fha.nhinc.auditrepository.hibernate.util.HibernateUtil hibernateUtil = context
+                .getBean(AUDIT_REPO_HIBERNATE, gov.hhs.fha.nhinc.auditrepository.hibernate.util.HibernateUtil.class);
+        return hibernateUtil;
+    }
+
+}

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/util/HibernateUtilFactory.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/util/HibernateUtilFactory.java
@@ -19,6 +19,8 @@ public class HibernateUtilFactory {
 
     private static final String AUDIT_REPO_HIBERNATE = "auditRepoHibernateUtil";
 
+    private static HibernateUtil hibernateUtil;
+
     /**
      * Private constructor to hide the public one.
      */
@@ -50,8 +52,11 @@ public class HibernateUtilFactory {
         ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
 
         LOG.debug("Memory address getAuditRepoHibernateUtil {}", context.getId());
-        return context.getBean(AUDIT_REPO_HIBERNATE,
-                gov.hhs.fha.nhinc.auditrepository.hibernate.util.HibernateUtil.class);
+        if (hibernateUtil == null) {
+            hibernateUtil = context.getBean(AUDIT_REPO_HIBERNATE,
+                    gov.hhs.fha.nhinc.auditrepository.hibernate.util.HibernateUtil.class);
+        }
+        return hibernateUtil;
     }
 
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/util/HibernateUtilFactory.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/hibernate/util/HibernateUtilFactory.java
@@ -34,11 +34,11 @@ public class HibernateUtilFactory {
      */
     private static class ClassPathSingleton {
 
-        private ClassPathSingleton() {
-        }
-
         public static final ClassPathXmlApplicationContext CONTEXT = new ClassPathXmlApplicationContext(
                 new String[] { "classpath:spring-beans.xml" });
+
+        private ClassPathSingleton() {
+        }
     }
 
     /**
@@ -50,9 +50,8 @@ public class HibernateUtilFactory {
         ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
 
         LOG.debug("Memory address getAuditRepoHibernateUtil {}", context.getId());
-        gov.hhs.fha.nhinc.auditrepository.hibernate.util.HibernateUtil hibernateUtil = context
-                .getBean(AUDIT_REPO_HIBERNATE, gov.hhs.fha.nhinc.auditrepository.hibernate.util.HibernateUtil.class);
-        return hibernateUtil;
+        return context.getBean(AUDIT_REPO_HIBERNATE,
+                gov.hhs.fha.nhinc.auditrepository.hibernate.util.HibernateUtil.class);
     }
 
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditDBStoreImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditDBStoreImpl.java
@@ -59,6 +59,8 @@ public class AuditDBStoreImpl implements AuditStore {
     private static final Logger LOG = LoggerFactory.getLogger(AuditDBStoreImpl.class);
     private static final AuditRepositoryDAO auditLogDao = new AuditRepositoryDAO();
 
+    private HibernateUtil hibernateUtil = new HibernateUtil();
+
     @Override
     public boolean saveAuditRecord(LogEventSecureRequestType request, AssertionType assertion) {
         List<AuditRepositoryRecord> auditRecList = new ArrayList<>();
@@ -102,9 +104,10 @@ public class AuditDBStoreImpl implements AuditStore {
             baOutStrm.close();
             marshaller.marshal(oJaxbElement, baOutStrm);
             byte[] buffer = baOutStrm.toByteArray();
-            eventMessage = HibernateUtil.getSessionFactory().openSession().getLobHelper().createBlob(buffer);
+            hibernateUtil.buildSessionFactory();
+            eventMessage = hibernateUtil.getSessionFactory().openSession().getLobHelper().createBlob(buffer);
         } catch (JAXBException | IOException e) {
-            LOG.error("Exception during Blob conversion :" + e.getLocalizedMessage(), e);
+            LOG.error("Exception during Blob conversion : {}", e.getLocalizedMessage(), e);
         }
         return eventMessage;
     }
@@ -123,4 +126,5 @@ public class AuditDBStoreImpl implements AuditStore {
         LOG.info("eventDate -> " + eventDate);
         return eventDate;
     }
+
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditDBStoreImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditDBStoreImpl.java
@@ -31,6 +31,7 @@ import com.services.nhinc.schema.auditmessage.ObjectFactory;
 import gov.hhs.fha.nhinc.auditrepository.hibernate.AuditRepositoryDAO;
 import gov.hhs.fha.nhinc.auditrepository.hibernate.AuditRepositoryRecord;
 import gov.hhs.fha.nhinc.auditrepository.hibernate.util.HibernateUtil;
+import gov.hhs.fha.nhinc.auditrepository.hibernate.util.HibernateUtilFactory;
 import gov.hhs.fha.nhinc.common.auditlog.LogEventSecureRequestType;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.transform.marshallers.JAXBContextHandler;
@@ -49,7 +50,6 @@ import javax.xml.bind.Marshaller;
 import javax.xml.datatype.XMLGregorianCalendar;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  *
@@ -59,8 +59,6 @@ public class AuditDBStoreImpl implements AuditStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(AuditDBStoreImpl.class);
     private static final AuditRepositoryDAO auditLogDao = new AuditRepositoryDAO();
-
-    private HibernateUtil hibernateUtil;
 
     @Override
     public boolean saveAuditRecord(LogEventSecureRequestType request, AssertionType assertion) {
@@ -132,11 +130,8 @@ public class AuditDBStoreImpl implements AuditStore {
      *
      * @return hibernateUtil
      */
-    private HibernateUtil getHibernateUtil() {
-        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
-                new String[] { "classpath:spring-beans.xml" });
-        hibernateUtil = context.getBean("auditRepoHibernateUtil", HibernateUtil.class);
-        return hibernateUtil;
+    private static HibernateUtil getHibernateUtil() {
+        return HibernateUtilFactory.getAuditRepoHibernateUtil();
     }
 
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditDBStoreImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditDBStoreImpl.java
@@ -59,6 +59,7 @@ public class AuditDBStoreImpl implements AuditStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(AuditDBStoreImpl.class);
     private static final AuditRepositoryDAO auditLogDao = new AuditRepositoryDAO();
+    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getAuditRepoHibernateUtil();
 
     @Override
     public boolean saveAuditRecord(LogEventSecureRequestType request, AssertionType assertion) {
@@ -131,7 +132,7 @@ public class AuditDBStoreImpl implements AuditStore {
      * @return hibernateUtil
      */
     private static HibernateUtil getHibernateUtil() {
-        return HibernateUtilFactory.getAuditRepoHibernateUtil();
+        return hibernateUtil;
     }
 
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditDBStoreImpl.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditDBStoreImpl.java
@@ -59,7 +59,6 @@ public class AuditDBStoreImpl implements AuditStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(AuditDBStoreImpl.class);
     private static final AuditRepositoryDAO auditLogDao = new AuditRepositoryDAO();
-    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getAuditRepoHibernateUtil();
 
     @Override
     public boolean saveAuditRecord(LogEventSecureRequestType request, AssertionType assertion) {
@@ -132,7 +131,7 @@ public class AuditDBStoreImpl implements AuditStore {
      * @return hibernateUtil
      */
     private static HibernateUtil getHibernateUtil() {
-        return hibernateUtil;
+        return HibernateUtilFactory.getAuditRepoHibernateUtil();
     }
 
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/resources/spring-beans.xml
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/resources/spring-beans.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+    http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+    http://www.springframework.org/schema/context
+    http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+
+   <context:annotation-config/>
+   <context:component-scan base-package="gov.hhs.fha.nhinc"/>
+
+   <!-- Definition for HibernateUtil bean-->
+   <bean id="auditRepoHibernateUtil" class="gov.hhs.fha.nhinc.auditrepository.hibernate.util.HibernateUtil"
+            init-method="buildSessionFactory" destroy-method="closeSessionFactory"/>            
+                        
+</beans>

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditRetrieveDBTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditquerylog/nhinc/proxy/AuditRetrieveDBTest.java
@@ -158,6 +158,10 @@ public class AuditRetrieveDBTest {
 
     private List<AuditRepositoryRecord> createAuditRepositoryRecord() {
         List<AuditRepositoryRecord> list = new ArrayList<>();
+
+        HibernateUtil hibernateUtil = new HibernateUtil();
+        hibernateUtil.buildSessionFactory();
+
         AuditRepositoryRecord dbRec = new AuditRepositoryRecord();
         dbRec.setDirection(DIRECTION);
         dbRec.setRemoteHcid(REMOTE_HCID);
@@ -169,7 +173,7 @@ public class AuditRetrieveDBTest {
         dbRec.setEventTimestamp(EVENT_TIMESTAMP);
         // dbRec.setMessage(Hibernate.createBlob(AUDIT_MESSAGE.getBytes()));
         dbRec.setMessage(
-                HibernateUtil.getSessionFactory().openSession().getLobHelper().createBlob(AUDIT_MESSAGE.getBytes()));
+                hibernateUtil.getSessionFactory().openSession().getLobHelper().createBlob(AUDIT_MESSAGE.getBytes()));
         list.add(dbRec);
         return list;
     }
@@ -181,10 +185,11 @@ public class AuditRetrieveDBTest {
             try {
                 return DatatypeFactory.newInstance().newXMLGregorianCalendar(gregorianCalendar);
             } catch (DatatypeConfigurationException ex) {
-                LOG.error("Unable to convert date: " + ex.getLocalizedMessage(), ex);
+                LOG.error("Unable to convert date: {}", ex.getLocalizedMessage(), ex);
                 return null;
             }
         }
         return null;
     }
+
 }

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectAdapterFactory.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectAdapterFactory.java
@@ -28,11 +28,11 @@ package gov.hhs.fha.nhinc.direct;
 
 import gov.hhs.fha.nhinc.event.EventLoggerFactory;
 import gov.hhs.fha.nhinc.mail.ManageTaskScheduler;
+import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
 import gov.hhs.fha.nhinc.proxy.ComponentProxyFactory;
 import org.nhindirect.gateway.smtp.GatewayState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * Direct Client Factory responsible for {@link DirectAdapter}.
@@ -53,12 +53,12 @@ public class DirectAdapterFactory extends DirectAdapterEntity {
          * DO NOT remove either of the following two lines of code until this issue is resolved.
          */
 
-        gov.hhs.fha.nhinc.event.persistence.HibernateUtil eventHibernateUtil = new gov.hhs.fha.nhinc.event.persistence.HibernateUtil();
-        eventHibernateUtil.buildSessionFactory();
+        gov.hhs.fha.nhinc.event.persistence.HibernateUtil eventHibernateUtil = HibernateUtilFactory
+                .getEventHibernateUtil();
 
-        gov.hhs.fha.nhinc.direct.messagemonitoring.persistence.HibernateUtil messageHibernateUtil = new gov.hhs.fha.nhinc.direct.messagemonitoring.persistence.HibernateUtil();
-        messageHibernateUtil.buildSessionFactory();
-        
+        gov.hhs.fha.nhinc.direct.messagemonitoring.persistence.HibernateUtil messageHibernateUtil = HibernateUtilFactory
+                .getMsgMonitorHibernateUtil();
+
         LOG.trace("Registering event Loggers");
         EventLoggerFactory.getInstance().registerLoggers();
         LOG.trace("Registering handlers...");

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectAdapterFactory.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectAdapterFactory.java
@@ -32,6 +32,7 @@ import gov.hhs.fha.nhinc.proxy.ComponentProxyFactory;
 import org.nhindirect.gateway.smtp.GatewayState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * Direct Client Factory responsible for {@link DirectAdapter}.
@@ -51,12 +52,13 @@ public class DirectAdapterFactory extends DirectAdapterEntity {
          * Persistence; initializing both when the Direct Servlet is initialized as a workaround. <br/>
          * DO NOT remove either of the following two lines of code until this issue is resolved.
          */
+
         gov.hhs.fha.nhinc.event.persistence.HibernateUtil eventHibernateUtil = new gov.hhs.fha.nhinc.event.persistence.HibernateUtil();
         eventHibernateUtil.buildSessionFactory();
 
         gov.hhs.fha.nhinc.direct.messagemonitoring.persistence.HibernateUtil messageHibernateUtil = new gov.hhs.fha.nhinc.direct.messagemonitoring.persistence.HibernateUtil();
         messageHibernateUtil.buildSessionFactory();
-
+        
         LOG.trace("Registering event Loggers");
         EventLoggerFactory.getInstance().registerLoggers();
         LOG.trace("Registering handlers...");

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectAdapterFactory.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectAdapterFactory.java
@@ -28,7 +28,7 @@ package gov.hhs.fha.nhinc.direct;
 
 import gov.hhs.fha.nhinc.event.EventLoggerFactory;
 import gov.hhs.fha.nhinc.mail.ManageTaskScheduler;
-import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
+import gov.hhs.fha.nhinc.persistence.HibernateUtilFactory;
 import gov.hhs.fha.nhinc.proxy.ComponentProxyFactory;
 import org.nhindirect.gateway.smtp.GatewayState;
 import org.slf4j.Logger;

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/messagemonitoring/dao/impl/MessageMonitoringDAOImpl.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/messagemonitoring/dao/impl/MessageMonitoringDAOImpl.java
@@ -31,6 +31,7 @@ import gov.hhs.fha.nhinc.direct.messagemonitoring.dao.MessageMonitoringDAOExcept
 import gov.hhs.fha.nhinc.direct.messagemonitoring.domain.MonitoredMessage;
 import gov.hhs.fha.nhinc.direct.messagemonitoring.domain.MonitoredMessageNotification;
 import gov.hhs.fha.nhinc.direct.messagemonitoring.persistence.HibernateUtil;
+import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
 import java.util.ArrayList;
 import java.util.List;
 import org.hibernate.HibernateException;
@@ -39,7 +40,6 @@ import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * Class provides MessageMonitoringDb database interface services
@@ -50,16 +50,12 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(MessageMonitoringDAOImpl.class);
 
-    private HibernateUtil hibernateUtil;
-
     private static class SingletonHolder {
 
         private SingletonHolder() {
         }
 
         public static final MessageMonitoringDAO INSTANCE = new MessageMonitoringDAOImpl();
-        public static final ClassPathXmlApplicationContext INSTANCE_CONTEXT = new ClassPathXmlApplicationContext(
-                new String[] { "classpath:spring-beans.xml" });
     }
 
     /**
@@ -73,9 +69,7 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
     }
 
     protected HibernateUtil getHibernateUtil() {
-        ClassPathXmlApplicationContext context = SingletonHolder.INSTANCE_CONTEXT;
-        hibernateUtil = context.getBean("msgMonitorHibernateUtil", HibernateUtil.class);
-        return hibernateUtil;
+        return HibernateUtilFactory.getMsgMonitorHibernateUtil();
     }
 
     /**
@@ -96,9 +90,11 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
         try {
             LOG.debug("Inside addOutgoingMessage()");
             session = getSession();
-            tx = session.beginTransaction();
-            session.persist(trackMessage);
-            tx.commit();
+            if (session != null) {
+                tx = session.beginTransaction();
+                session.persist(trackMessage);
+                tx.commit();
+            }
 
         } catch (final HibernateException e) {
             result = false;
@@ -130,9 +126,11 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
         try {
             LOG.debug("Inside addOutgoingMessage()");
             session = getSession();
-            tx = session.beginTransaction();
-            session.update(trackMessage);
-            tx.commit();
+            if (session != null) {
+                tx = session.beginTransaction();
+                session.update(trackMessage);
+                tx.commit();
+            }
         } catch (final HibernateException e) {
             result = false;
             transactionRollback(tx);
@@ -162,9 +160,11 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
         try {
             LOG.debug("Inside addOutgoingMessage()");
             session = getSession();
-            tx = session.beginTransaction();
-            session.update(trackMessageNotification);
-            tx.commit();
+            if (session != null) {
+                tx = session.beginTransaction();
+                session.update(trackMessageNotification);
+                tx.commit();
+            }
         } catch (final HibernateException e) {
             result = false;
             transactionRollback(tx);
@@ -193,9 +193,11 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
         try {
             LOG.debug("Inside addOutgoingMessage()");
             session = getSession();
-            tx = session.beginTransaction();
-            session.delete(trackMessage);
-            tx.commit();
+            if (session != null) {
+                tx = session.beginTransaction();
+                session.delete(trackMessage);
+                tx.commit();
+            }
         } catch (final HibernateException e) {
             result = false;
             transactionRollback(tx);
@@ -219,7 +221,9 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
         try {
             LOG.debug("Inside addOutgoingMessage()");
             session = getSession();
-            pendingList = session.createCriteria(MonitoredMessage.class).list();
+            if (session != null) {
+                pendingList = session.createCriteria(MonitoredMessage.class).list();
+            }
         } catch (final HibernateException e) {
             LOG.error("Exception during insertion caused by : {}", e.getMessage(), e);
         } finally {

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/messagemonitoring/dao/impl/MessageMonitoringDAOImpl.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/messagemonitoring/dao/impl/MessageMonitoringDAOImpl.java
@@ -50,8 +50,6 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(MessageMonitoringDAOImpl.class);
 
-    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getMsgMonitorHibernateUtil();
-
     private static class SingletonHolder {
         public static final MessageMonitoringDAO INSTANCE = new MessageMonitoringDAOImpl();
 
@@ -67,10 +65,6 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
     public static MessageMonitoringDAO getInstance() {
         LOG.debug("getInstance()...");
         return SingletonHolder.INSTANCE;
-    }
-
-    protected HibernateUtil getHibernateUtil() {
-        return hibernateUtil;
     }
 
     /**
@@ -267,7 +261,8 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
      */
     protected Session getSession() {
         Session session = null;
-        SessionFactory fact = getHibernateUtil().getSessionFactory();
+        HibernateUtil util = HibernateUtilFactory.getMsgMonitorHibernateUtil();
+        SessionFactory fact = util.getSessionFactory();
         if (fact != null) {
             session = fact.openSession();
         } else {

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/messagemonitoring/dao/impl/MessageMonitoringDAOImpl.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/messagemonitoring/dao/impl/MessageMonitoringDAOImpl.java
@@ -31,7 +31,7 @@ import gov.hhs.fha.nhinc.direct.messagemonitoring.dao.MessageMonitoringDAOExcept
 import gov.hhs.fha.nhinc.direct.messagemonitoring.domain.MonitoredMessage;
 import gov.hhs.fha.nhinc.direct.messagemonitoring.domain.MonitoredMessageNotification;
 import gov.hhs.fha.nhinc.direct.messagemonitoring.persistence.HibernateUtil;
-import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
+import gov.hhs.fha.nhinc.persistence.HibernateUtilFactory;
 import java.util.ArrayList;
 import java.util.List;
 import org.hibernate.HibernateException;
@@ -50,12 +50,13 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(MessageMonitoringDAOImpl.class);
 
+    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getMsgMonitorHibernateUtil();
+
     private static class SingletonHolder {
+        public static final MessageMonitoringDAO INSTANCE = new MessageMonitoringDAOImpl();
 
         private SingletonHolder() {
         }
-
-        public static final MessageMonitoringDAO INSTANCE = new MessageMonitoringDAOImpl();
     }
 
     /**
@@ -69,7 +70,7 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
     }
 
     protected HibernateUtil getHibernateUtil() {
-        return HibernateUtilFactory.getMsgMonitorHibernateUtil();
+        return hibernateUtil;
     }
 
     /**

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/messagemonitoring/dao/impl/MessageMonitoringDAOImpl.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/messagemonitoring/dao/impl/MessageMonitoringDAOImpl.java
@@ -49,6 +49,8 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(MessageMonitoringDAOImpl.class);
 
+    private HibernateUtil hibernateUtil = new HibernateUtil();
+
     private static class SingletonHolder {
 
         public static final MessageMonitoringDAO INSTANCE = new MessageMonitoringDAOImpl();
@@ -226,6 +228,7 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
         if (session != null) {
             session.close();
         }
+        hibernateUtil.closeSessionFactory();
     }
 
     /**
@@ -249,7 +252,8 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
      */
     protected Session getSession() {
         Session session = null;
-        final SessionFactory fact = HibernateUtil.getSessionFactory();
+        hibernateUtil.buildSessionFactory();
+        SessionFactory fact = hibernateUtil.getSessionFactory();
         if (fact != null) {
             session = fact.openSession();
         } else {
@@ -257,4 +261,5 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
         }
         return session;
     }
+
 }

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/mail/ManageTaskScheduler.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/mail/ManageTaskScheduler.java
@@ -57,11 +57,14 @@ public class ManageTaskScheduler {
      */
     public void init() throws Exception {
         LOG.info("Inside init method -->TaskScheduler Instance:" + scheduler);
-        //Initialize the HibernateUtil within the appserver context
-        if (HibernateUtil.getSessionFactory() != null) {
-            LOG.info("Inside init method --> HibernateUtil.getSessionFactory()..getClass().getName():" + HibernateUtil.getSessionFactory().getClass().getName());
+        // Initialize the HibernateUtil within the appserver context
+        HibernateUtil hibernateUtil = new HibernateUtil();
+        hibernateUtil.buildSessionFactory();
+        if (hibernateUtil.getSessionFactory() != null) {
+            LOG.info("Inside init method --> HibernateUtil.getSessionFactory()..getClass().getName(): {}",
+                    hibernateUtil.getSessionFactory().getClass().getName());
         } else {
-            LOG.info("Inside init method --> HibernateUtil.getSessionFactory():" + HibernateUtil.getSessionFactory());
+            LOG.info("Inside init method --> HibernateUtil.getSessionFactory(): {}", hibernateUtil.getSessionFactory());
         }
     }
 
@@ -70,9 +73,8 @@ public class ManageTaskScheduler {
      *
      */
     public void clean() {
-        System.out.println("Inside clean method -->TaskScheduler Instance:" + scheduler);
         LOG.info("Inside clean method -->TaskScheduler Instance:" + scheduler);
-        //shutdown the scheduler thread if its running
+        // shutdown the scheduler thread if its running
         if (scheduler != null) {
             scheduler.shutdown();
         }

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/mail/ManageTaskScheduler.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/mail/ManageTaskScheduler.java
@@ -26,7 +26,6 @@
  */
 package gov.hhs.fha.nhinc.mail;
 
-import gov.hhs.fha.nhinc.event.persistence.HibernateUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -58,14 +57,18 @@ public class ManageTaskScheduler {
     public void init() throws Exception {
         LOG.info("Inside init method -->TaskScheduler Instance:" + scheduler);
         // Initialize the HibernateUtil within the appserver context
-        HibernateUtil hibernateUtil = new HibernateUtil();
-        hibernateUtil.buildSessionFactory();
-        if (hibernateUtil.getSessionFactory() != null) {
-            LOG.info("Inside init method --> HibernateUtil.getSessionFactory()..getClass().getName(): {}",
-                    hibernateUtil.getSessionFactory().getClass().getName());
-        } else {
-            LOG.info("Inside init method --> HibernateUtil.getSessionFactory(): {}", hibernateUtil.getSessionFactory());
-        }
+
+        /* This bean is commented out in spring configuration. Removing it from init method. */
+        // ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+        // new String[] { "classpath:spring-beans.xml" });
+        // HibernateUtil hibernateUtil = context.getBean("msgMonitorHibernateUtil", HibernateUtil.class);
+        //
+        // if (hibernateUtil.getSessionFactory() != null) {
+        // LOG.info("Inside init method --> HibernateUtil.getSessionFactory()..getClass().getName(): {}",
+        // hibernateUtil.getSessionFactory().getClass().getName());
+        // } else {
+        // LOG.info("Inside init method --> HibernateUtil.getSessionFactory(): {}", hibernateUtil.getSessionFactory());
+        // }
     }
 
     /**

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/mail/ManageTaskScheduler.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/mail/ManageTaskScheduler.java
@@ -27,7 +27,7 @@
 package gov.hhs.fha.nhinc.mail;
 
 import gov.hhs.fha.nhinc.event.persistence.HibernateUtil;
-import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
+import gov.hhs.fha.nhinc.persistence.HibernateUtilFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/mail/ManageTaskScheduler.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/mail/ManageTaskScheduler.java
@@ -26,6 +26,8 @@
  */
 package gov.hhs.fha.nhinc.mail;
 
+import gov.hhs.fha.nhinc.event.persistence.HibernateUtil;
+import gov.hhs.fha.nhinc.properties.HibernateUtilFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -57,18 +59,13 @@ public class ManageTaskScheduler {
     public void init() throws Exception {
         LOG.info("Inside init method -->TaskScheduler Instance:" + scheduler);
         // Initialize the HibernateUtil within the appserver context
-
-        /* This bean is commented out in spring configuration. Removing it from init method. */
-        // ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
-        // new String[] { "classpath:spring-beans.xml" });
-        // HibernateUtil hibernateUtil = context.getBean("msgMonitorHibernateUtil", HibernateUtil.class);
-        //
-        // if (hibernateUtil.getSessionFactory() != null) {
-        // LOG.info("Inside init method --> HibernateUtil.getSessionFactory()..getClass().getName(): {}",
-        // hibernateUtil.getSessionFactory().getClass().getName());
-        // } else {
-        // LOG.info("Inside init method --> HibernateUtil.getSessionFactory(): {}", hibernateUtil.getSessionFactory());
-        // }
+        HibernateUtil hibernateUtil = HibernateUtilFactory.getEventHibernateUtil();
+        if (hibernateUtil.getSessionFactory() != null) {
+            LOG.info("Inside init method --> HibernateUtil.getSessionFactory()..getClass().getName(): {}",
+                    hibernateUtil.getSessionFactory().getClass().getName());
+        } else {
+            LOG.info("Inside init method --> HibernateUtil.getSessionFactory(): {}", hibernateUtil.getSessionFactory());
+        }
     }
 
     /**

--- a/Product/Production/Services/DirectCore/src/main/resources/spring-beans.xml
+++ b/Product/Production/Services/DirectCore/src/main/resources/spring-beans.xml
@@ -15,27 +15,10 @@
 
     <context:annotation-config />
     <context:component-scan base-package="gov.hhs.fha.nhinc"/>
-
-    <bean name="eventfactory" class="gov.hhs.fha.nhinc.event.EventFactoryFactoryBean" />
-
-    <bean name="txHibernateUtil" class="gov.hhs.fha.nhinc.logging.transaction.persistance.HibernateUtil" 
-        init-method="buildSessionFactory" destroy-method="closeSessionFactory"/>
     
     <bean name="eventHibernateUtil" class="gov.hhs.fha.nhinc.event.persistence.HibernateUtil" 
         init-method="buildSessionFactory" destroy-method="closeSessionFactory"/>
         
-    <bean name="asyncmsgsHibernateUtil" class="gov.hhs.fha.nhinc.asyncmsgs.persistence.HibernateUtil" 
-        init-method="buildSessionFactory" destroy-method="closeSessionFactory"/>    
-
-    <bean name="connManHibernateUtil" class="gov.hhs.fha.nhinc.common.connectionmanager.persistence.HibernateUtil" 
-        init-method="buildSessionFactory" destroy-method="closeSessionFactory"/>    
-
-    <bean name="docRepoHibernateUtil" class="gov.hhs.fha.nhinc.docrepository.adapter.persistence.HibernateUtil" 
-        init-method="buildSessionFactory" destroy-method="closeSessionFactory"/>   
-
-    <bean name="patientCorrHibernateUtil" class="gov.hhs.fha.nhinc.patientcorrelation.nhinc.persistence.HibernateUtil" 
-        init-method="buildSessionFactory" destroy-method="closeSessionFactory"/>   
-
     <bean name="msgMonitorHibernateUtil" class="gov.hhs.fha.nhinc.direct.messagemonitoring.persistence.HibernateUtil" 
         init-method="buildSessionFactory" destroy-method="closeSessionFactory"/>  
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/AddressDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/AddressDAO.java
@@ -48,6 +48,8 @@ public class AddressDAO {
     private static final Logger LOG = LoggerFactory.getLogger(AddressDAO.class);
     private static AddressDAO addressDAO = new AddressDAO();
 
+    private HibernateUtil hibernateUtil = new HibernateUtil();
+
     /**
      * Constructor.
      */
@@ -88,7 +90,7 @@ public class AddressDAO {
 
             try {
 
-                SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+                SessionFactory sessionFactory = getSessionFactory();
 
                 session = sessionFactory.openSession();
 
@@ -112,7 +114,7 @@ public class AddressDAO {
 
                 }
 
-                LOG.error("Exception during insertion caused by :" + e.getMessage(), e);
+                LOG.error("Exception during insertion caused by : {}", e.getMessage(), e);
 
             } finally {
 
@@ -122,7 +124,7 @@ public class AddressDAO {
                     session.close();
 
                 }
-
+                hibernateUtil.closeSessionFactory();
             }
 
         }
@@ -165,7 +167,7 @@ public class AddressDAO {
 
         try {
 
-            SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+            SessionFactory sessionFactory = getSessionFactory();
 
             session = sessionFactory.openSession();
 
@@ -186,7 +188,7 @@ public class AddressDAO {
 
         } catch (Exception e) {
 
-            LOG.error("Exception during read occured due to :" + e.getMessage(), e);
+            LOG.error("Exception during read occured due to : {}", e.getMessage(), e);
 
         } finally {
 
@@ -199,6 +201,7 @@ public class AddressDAO {
 
             }
 
+            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("AddressDAO.read() - End");
@@ -229,7 +232,7 @@ public class AddressDAO {
 
             try {
 
-                SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+                SessionFactory sessionFactory = getSessionFactory();
 
                 session = sessionFactory.openSession();
 
@@ -253,7 +256,7 @@ public class AddressDAO {
 
                 }
 
-                LOG.error("Exception during update caused by :" + e.getMessage(), e);
+                LOG.error("Exception during update caused by : {}", e.getMessage(), e);
 
             } finally {
 
@@ -264,6 +267,7 @@ public class AddressDAO {
 
                 }
 
+                hibernateUtil.closeSessionFactory();
             }
 
         }
@@ -288,7 +292,7 @@ public class AddressDAO {
 
         try {
 
-            SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+            SessionFactory sessionFactory = getSessionFactory();
 
             session = sessionFactory.openSession();
 
@@ -299,7 +303,7 @@ public class AddressDAO {
 
         } catch (Exception e) {
 
-            LOG.error("Exception during delete occured due to :" + e.getMessage(), e);
+            LOG.error("Exception during delete occured due to : {}", e.getMessage(), e);
 
         } finally {
 
@@ -312,6 +316,7 @@ public class AddressDAO {
 
             }
 
+            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("AddressDAO.delete() - End");
@@ -351,7 +356,7 @@ public class AddressDAO {
 
         try {
 
-            SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+            SessionFactory sessionFactory = getSessionFactory();
 
             session = sessionFactory.openSession();
 
@@ -366,7 +371,7 @@ public class AddressDAO {
 
         } catch (Exception e) {
 
-            LOG.error("Exception during read occured due to :" + e.getMessage(), e);
+            LOG.error("Exception during read occured due to : {}", e.getMessage(), e);
 
         } finally {
 
@@ -379,12 +384,18 @@ public class AddressDAO {
 
             }
 
+            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("readPatientAddresses.read() - End");
 
         return queryList;
 
+    }
+
+    protected SessionFactory getSessionFactory() {
+        hibernateUtil.buildSessionFactory();
+        return hibernateUtil.getSessionFactory();
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/AddressDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/AddressDAO.java
@@ -29,6 +29,7 @@ package gov.hhs.fha.nhinc.patientdb.dao;
 import gov.hhs.fha.nhinc.patientdb.model.Address;
 import gov.hhs.fha.nhinc.patientdb.persistence.HibernateUtil;
 import gov.hhs.fha.nhinc.patientdb.persistence.HibernateUtilFactory;
+import java.util.ArrayList;
 import java.util.List;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
@@ -48,6 +49,7 @@ public class AddressDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(AddressDAO.class);
     private static AddressDAO addressDAO = new AddressDAO();
+    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
 
     /**
      * Constructor.
@@ -178,7 +180,7 @@ public class AddressDAO {
 
             queryList = aCriteria.list();
 
-            if (queryList != null && queryList.size() > 0) {
+            if (queryList != null && !queryList.isEmpty()) {
 
                 foundRecord = queryList.get(0);
 
@@ -332,19 +334,17 @@ public class AddressDAO {
 
         LOG.debug("AddressDAO.readPatientAddresses() - Begin");
 
+        List<Address> queryList = new ArrayList<>();
+        Session session = null;
+
         if (patientId == null) {
 
             LOG.info("-- patientId Parameter is required for Address Query --");
 
             LOG.debug("AddressDAO.readPatientAddresses() - End");
 
-            return null;
-
+            return queryList;
         }
-
-        Session session = null;
-
-        List<Address> queryList = null;
 
         try {
 
@@ -385,7 +385,6 @@ public class AddressDAO {
     }
 
     protected SessionFactory getSessionFactory() {
-        HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
         SessionFactory fact = null;
         if (hibernateUtil != null) {
             fact = hibernateUtil.getSessionFactory();

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/AddressDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/AddressDAO.java
@@ -36,6 +36,7 @@ import org.hibernate.Transaction;
 import org.hibernate.criterion.Expression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  *
@@ -48,7 +49,7 @@ public class AddressDAO {
     private static final Logger LOG = LoggerFactory.getLogger(AddressDAO.class);
     private static AddressDAO addressDAO = new AddressDAO();
 
-    private HibernateUtil hibernateUtil = new HibernateUtil();
+    private HibernateUtil hibernateUtil;
 
     /**
      * Constructor.
@@ -65,6 +66,18 @@ public class AddressDAO {
     public static AddressDAO getAddressDAOInstance() {
         LOG.debug("getAddressDAOInstance()..");
         return addressDAO;
+    }
+
+    /**
+     * Load HibernateUtil bean.
+     *
+     * @return hibernateUtil
+     */
+    protected HibernateUtil getHibernateUtil() {
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+                new String[] { "classpath:spring-beans.xml" });
+        hibernateUtil = context.getBean("patientDbHibernateUtil", HibernateUtil.class);
+        return hibernateUtil;
     }
 
     // =========================
@@ -124,7 +137,6 @@ public class AddressDAO {
                     session.close();
 
                 }
-                hibernateUtil.closeSessionFactory();
             }
 
         }
@@ -200,8 +212,6 @@ public class AddressDAO {
                 session.close();
 
             }
-
-            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("AddressDAO.read() - End");
@@ -266,8 +276,6 @@ public class AddressDAO {
                     session.close();
 
                 }
-
-                hibernateUtil.closeSessionFactory();
             }
 
         }
@@ -315,8 +323,6 @@ public class AddressDAO {
                 session.close();
 
             }
-
-            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("AddressDAO.delete() - End");
@@ -383,8 +389,6 @@ public class AddressDAO {
                 session.close();
 
             }
-
-            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("readPatientAddresses.read() - End");
@@ -394,8 +398,7 @@ public class AddressDAO {
     }
 
     protected SessionFactory getSessionFactory() {
-        hibernateUtil.buildSessionFactory();
-        return hibernateUtil.getSessionFactory();
+        return getHibernateUtil().getSessionFactory();
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/AddressDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/AddressDAO.java
@@ -28,6 +28,7 @@ package gov.hhs.fha.nhinc.patientdb.dao;
 
 import gov.hhs.fha.nhinc.patientdb.model.Address;
 import gov.hhs.fha.nhinc.patientdb.persistence.HibernateUtil;
+import gov.hhs.fha.nhinc.patientdb.persistence.HibernateUtilFactory;
 import java.util.List;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
@@ -36,7 +37,6 @@ import org.hibernate.Transaction;
 import org.hibernate.criterion.Expression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  *
@@ -48,8 +48,6 @@ public class AddressDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(AddressDAO.class);
     private static AddressDAO addressDAO = new AddressDAO();
-
-    private HibernateUtil hibernateUtil;
 
     /**
      * Constructor.
@@ -66,18 +64,6 @@ public class AddressDAO {
     public static AddressDAO getAddressDAOInstance() {
         LOG.debug("getAddressDAOInstance()..");
         return addressDAO;
-    }
-
-    /**
-     * Load HibernateUtil bean.
-     *
-     * @return hibernateUtil
-     */
-    protected HibernateUtil getHibernateUtil() {
-        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
-                new String[] { "classpath:spring-beans.xml" });
-        hibernateUtil = context.getBean("patientDbHibernateUtil", HibernateUtil.class);
-        return hibernateUtil;
     }
 
     // =========================
@@ -389,6 +375,7 @@ public class AddressDAO {
                 session.close();
 
             }
+
         }
 
         LOG.debug("readPatientAddresses.read() - End");
@@ -398,7 +385,12 @@ public class AddressDAO {
     }
 
     protected SessionFactory getSessionFactory() {
-        return getHibernateUtil().getSessionFactory();
+        HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
+        SessionFactory fact = null;
+        if (hibernateUtil != null) {
+            fact = hibernateUtil.getSessionFactory();
+        }
+        return fact;
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/AddressDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/AddressDAO.java
@@ -49,7 +49,6 @@ public class AddressDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(AddressDAO.class);
     private static AddressDAO addressDAO = new AddressDAO();
-    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
 
     /**
      * Constructor.
@@ -386,8 +385,9 @@ public class AddressDAO {
 
     protected SessionFactory getSessionFactory() {
         SessionFactory fact = null;
-        if (hibernateUtil != null) {
-            fact = hibernateUtil.getSessionFactory();
+        HibernateUtil util = HibernateUtilFactory.getPatientDiscHibernateUtil();
+        if (util != null) {
+            fact = util.getSessionFactory();
         }
         return fact;
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/IdentifierDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/IdentifierDAO.java
@@ -50,8 +50,6 @@ public class IdentifierDAO {
 
     private static IdentifierDAO identifierDAO = new IdentifierDAO();
 
-    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
-
     /**
      *
      * Constructor
@@ -340,8 +338,9 @@ public class IdentifierDAO {
      */
     protected SessionFactory getSessionFactory() {
         SessionFactory fact = null;
-        if (hibernateUtil != null) {
-            fact = hibernateUtil.getSessionFactory();
+        HibernateUtil util = HibernateUtilFactory.getPatientDiscHibernateUtil();
+        if (util != null) {
+            fact = util.getSessionFactory();
         }
         return fact;
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/IdentifierDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/IdentifierDAO.java
@@ -49,6 +49,8 @@ public class IdentifierDAO {
 
     private static IdentifierDAO identifierDAO = new IdentifierDAO();
 
+    private HibernateUtil hibernateUtil = new HibernateUtil();
+
     /**
      *
      * Constructor
@@ -100,7 +102,7 @@ public class IdentifierDAO {
 
             try {
 
-                SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+                SessionFactory sessionFactory = hibernateUtil.getSessionFactory();
 
                 session = sessionFactory.openSession();
 
@@ -124,7 +126,7 @@ public class IdentifierDAO {
 
                 }
 
-                LOG.error("Exception during insertion caused by :" + e.getMessage(), e);
+                LOG.error("Exception during insertion caused by : {}", e.getMessage(), e);
 
             } finally {
 
@@ -177,7 +179,7 @@ public class IdentifierDAO {
 
         try {
 
-            SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+            SessionFactory sessionFactory = hibernateUtil.getSessionFactory();
 
             session = sessionFactory.openSession();
 
@@ -198,7 +200,7 @@ public class IdentifierDAO {
 
         } catch (Exception e) {
 
-            LOG.error("Exception during read occured due to :" + e.getMessage(), e);
+            LOG.error("Exception during read occured due to : {}", e.getMessage(), e);
 
         } finally {
 
@@ -241,7 +243,7 @@ public class IdentifierDAO {
 
             try {
 
-                SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+                SessionFactory sessionFactory = hibernateUtil.getSessionFactory();
 
                 session = sessionFactory.openSession();
 
@@ -265,7 +267,7 @@ public class IdentifierDAO {
 
                 }
 
-                LOG.error("Exception during update caused by :" + e.getMessage(), e);
+                LOG.error("Exception during update caused by : {}", e.getMessage(), e);
 
             } finally {
 
@@ -300,7 +302,7 @@ public class IdentifierDAO {
 
         try {
 
-            SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+            SessionFactory sessionFactory = hibernateUtil.getSessionFactory();
 
             session = sessionFactory.openSession();
 
@@ -311,7 +313,7 @@ public class IdentifierDAO {
 
         } catch (Exception e) {
 
-            LOG.error("Exception during delete occured due to :" + e.getMessage(), e);
+            LOG.error("Exception during delete occured due to : {}", e.getMessage(), e);
 
         } finally {
 
@@ -330,4 +332,8 @@ public class IdentifierDAO {
 
     }
 
+    protected SessionFactory getSessionFactory() {
+        hibernateUtil.buildSessionFactory();
+        return hibernateUtil.getSessionFactory();
+    }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/IdentifierDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/IdentifierDAO.java
@@ -28,6 +28,7 @@ package gov.hhs.fha.nhinc.patientdb.dao;
 
 import gov.hhs.fha.nhinc.patientdb.model.Identifier;
 import gov.hhs.fha.nhinc.patientdb.persistence.HibernateUtil;
+import gov.hhs.fha.nhinc.patientdb.persistence.HibernateUtilFactory;
 import java.util.List;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
@@ -36,7 +37,6 @@ import org.hibernate.Transaction;
 import org.hibernate.criterion.Expression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  *
@@ -49,8 +49,6 @@ public class IdentifierDAO {
     private static final Logger LOG = LoggerFactory.getLogger(IdentifierDAO.class);
 
     private static IdentifierDAO identifierDAO = new IdentifierDAO();
-
-    private HibernateUtil hibernateUtil;
 
     /**
      *
@@ -74,18 +72,6 @@ public class IdentifierDAO {
 
         return identifierDAO;
 
-    }
-
-    /**
-     * Load HibernateUtil bean.
-     *
-     * @return hibernateUtil
-     */
-    protected HibernateUtil getHibernateUtil() {
-        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
-                new String[] { "classpath:spring-beans.xml" });
-        hibernateUtil = context.getBean("patientDbHibernateUtil", HibernateUtil.class);
-        return hibernateUtil;
     }
 
     // =========================
@@ -115,7 +101,7 @@ public class IdentifierDAO {
 
             try {
 
-                SessionFactory sessionFactory = getHibernateUtil().getSessionFactory();
+                SessionFactory sessionFactory = getSessionFactory();
 
                 session = sessionFactory.openSession();
 
@@ -192,7 +178,7 @@ public class IdentifierDAO {
 
         try {
 
-            SessionFactory sessionFactory = getHibernateUtil().getSessionFactory();
+            SessionFactory sessionFactory = getSessionFactory();
 
             session = sessionFactory.openSession();
 
@@ -256,7 +242,7 @@ public class IdentifierDAO {
 
             try {
 
-                SessionFactory sessionFactory = getHibernateUtil().getSessionFactory();
+                SessionFactory sessionFactory = getSessionFactory();
 
                 session = sessionFactory.openSession();
 
@@ -315,7 +301,7 @@ public class IdentifierDAO {
 
         try {
 
-            SessionFactory sessionFactory = getHibernateUtil().getSessionFactory();
+            SessionFactory sessionFactory = getSessionFactory();
 
             session = sessionFactory.openSession();
 
@@ -343,6 +329,20 @@ public class IdentifierDAO {
 
         LOG.debug("IdentifierDAO.delete() - End");
 
+    }
+
+    /**
+     * Returns the sessionFactory belonging to PatientDiscovery HibernateUtil
+     *
+     * @return
+     */
+    protected SessionFactory getSessionFactory() {
+        HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
+        SessionFactory fact = null;
+        if (hibernateUtil != null) {
+            fact = hibernateUtil.getSessionFactory();
+        }
+        return fact;
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/IdentifierDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/IdentifierDAO.java
@@ -36,6 +36,7 @@ import org.hibernate.Transaction;
 import org.hibernate.criterion.Expression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  *
@@ -49,7 +50,7 @@ public class IdentifierDAO {
 
     private static IdentifierDAO identifierDAO = new IdentifierDAO();
 
-    private HibernateUtil hibernateUtil = new HibernateUtil();
+    private HibernateUtil hibernateUtil;
 
     /**
      *
@@ -73,6 +74,18 @@ public class IdentifierDAO {
 
         return identifierDAO;
 
+    }
+
+    /**
+     * Load HibernateUtil bean.
+     *
+     * @return hibernateUtil
+     */
+    protected HibernateUtil getHibernateUtil() {
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+                new String[] { "classpath:spring-beans.xml" });
+        hibernateUtil = context.getBean("patientDbHibernateUtil", HibernateUtil.class);
+        return hibernateUtil;
     }
 
     // =========================
@@ -102,7 +115,7 @@ public class IdentifierDAO {
 
             try {
 
-                SessionFactory sessionFactory = hibernateUtil.getSessionFactory();
+                SessionFactory sessionFactory = getHibernateUtil().getSessionFactory();
 
                 session = sessionFactory.openSession();
 
@@ -179,7 +192,7 @@ public class IdentifierDAO {
 
         try {
 
-            SessionFactory sessionFactory = hibernateUtil.getSessionFactory();
+            SessionFactory sessionFactory = getHibernateUtil().getSessionFactory();
 
             session = sessionFactory.openSession();
 
@@ -243,7 +256,7 @@ public class IdentifierDAO {
 
             try {
 
-                SessionFactory sessionFactory = hibernateUtil.getSessionFactory();
+                SessionFactory sessionFactory = getHibernateUtil().getSessionFactory();
 
                 session = sessionFactory.openSession();
 
@@ -302,7 +315,7 @@ public class IdentifierDAO {
 
         try {
 
-            SessionFactory sessionFactory = hibernateUtil.getSessionFactory();
+            SessionFactory sessionFactory = getHibernateUtil().getSessionFactory();
 
             session = sessionFactory.openSession();
 
@@ -332,8 +345,4 @@ public class IdentifierDAO {
 
     }
 
-    protected SessionFactory getSessionFactory() {
-        hibernateUtil.buildSessionFactory();
-        return hibernateUtil.getSessionFactory();
-    }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/IdentifierDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/IdentifierDAO.java
@@ -50,6 +50,8 @@ public class IdentifierDAO {
 
     private static IdentifierDAO identifierDAO = new IdentifierDAO();
 
+    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
+
     /**
      *
      * Constructor
@@ -191,7 +193,7 @@ public class IdentifierDAO {
 
             queryList = aCriteria.list();
 
-            if (queryList != null && queryList.size() > 0) {
+            if (queryList != null && !queryList.isEmpty()) {
 
                 foundRecord = queryList.get(0);
 
@@ -337,7 +339,6 @@ public class IdentifierDAO {
      * @return
      */
     protected SessionFactory getSessionFactory() {
-        HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
         SessionFactory fact = null;
         if (hibernateUtil != null) {
             fact = hibernateUtil.getSessionFactory();

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PatientDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PatientDAO.java
@@ -32,6 +32,7 @@ import gov.hhs.fha.nhinc.patientdb.model.Identifier;
 import gov.hhs.fha.nhinc.patientdb.model.Patient;
 import gov.hhs.fha.nhinc.patientdb.model.Phonenumber;
 import gov.hhs.fha.nhinc.patientdb.persistence.HibernateUtil;
+import gov.hhs.fha.nhinc.patientdb.persistence.HibernateUtilFactory;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,7 +45,6 @@ import org.hibernate.criterion.Expression;
 import org.hibernate.type.StandardBasicTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * PatientDAO Class provides methods to query and update Patient Data to/from MySQL Database using Hibernate
@@ -55,8 +55,6 @@ public class PatientDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(PatientDAO.class);
     private static PatientDAO patientDAO = new PatientDAO();
-
-    private HibernateUtil hibernateUtil;
 
     /**
      * Constructor
@@ -73,18 +71,6 @@ public class PatientDAO {
     public static PatientDAO getPatientDAOInstance() {
         LOG.debug("getPatientDAOInstance()..");
         return patientDAO;
-    }
-
-    /**
-     * Load HibernateUtil bean.
-     *
-     * @return hibernateUtil
-     */
-    protected HibernateUtil getHibernateUtil() {
-        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
-                new String[] { "classpath:spring-beans.xml" });
-        hibernateUtil = context.getBean("patientDbHibernateUtil", HibernateUtil.class);
-        return hibernateUtil;
     }
 
     // =========================
@@ -286,7 +272,7 @@ public class PatientDAO {
             }
 
             // Build the select with query criteria
-            StringBuffer sqlSelect = new StringBuffer(
+            StringBuilder sqlSelect = new StringBuilder(
                     "SELECT DISTINCT p.patientId, p.dateOfBirth, p.gender, p.ssn, i.id, i.organizationid");
             sqlSelect.append(" FROM patientdb.patient p");
             sqlSelect.append(" INNER JOIN patientdb.identifier i ON p.patientId = i.patientId");
@@ -298,7 +284,7 @@ public class PatientDAO {
                 sqlSelect.append(" INNER JOIN patientdb.phonenumber h ON p.patientId = h.patientId");
             }
 
-            StringBuffer criteriaString = new StringBuffer("");
+            StringBuilder criteriaString = new StringBuilder("");
             if (NullChecker.isNotNullish(gender)) {
                 if (criteriaString.length() > 0) {
                     criteriaString.append(" AND");
@@ -541,8 +527,18 @@ public class PatientDAO {
         return patientsList;
     }
 
+    /**
+     * Returns the sessionFactory belonging to PatientDiscovery HibernateUtil
+     *
+     * @return
+     */
     protected SessionFactory getSessionFactory() {
-        return getHibernateUtil().getSessionFactory();
+        HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
+        SessionFactory fact = null;
+        if (hibernateUtil != null) {
+            fact = hibernateUtil.getSessionFactory();
+        }
+        return fact;
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PatientDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PatientDAO.java
@@ -55,7 +55,6 @@ public class PatientDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(PatientDAO.class);
     private static PatientDAO patientDAO = new PatientDAO();
-    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
 
     /**
      * Constructor
@@ -535,6 +534,7 @@ public class PatientDAO {
      */
     protected SessionFactory getSessionFactory() {
         SessionFactory fact = null;
+        HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
         if (hibernateUtil != null) {
             fact = hibernateUtil.getSessionFactory();
         }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PatientDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PatientDAO.java
@@ -44,6 +44,7 @@ import org.hibernate.criterion.Expression;
 import org.hibernate.type.StandardBasicTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * PatientDAO Class provides methods to query and update Patient Data to/from MySQL Database using Hibernate
@@ -55,7 +56,7 @@ public class PatientDAO {
     private static final Logger LOG = LoggerFactory.getLogger(PatientDAO.class);
     private static PatientDAO patientDAO = new PatientDAO();
 
-    private HibernateUtil hibernateUtil = new HibernateUtil();
+    private HibernateUtil hibernateUtil;
 
     /**
      * Constructor
@@ -72,6 +73,18 @@ public class PatientDAO {
     public static PatientDAO getPatientDAOInstance() {
         LOG.debug("getPatientDAOInstance()..");
         return patientDAO;
+    }
+
+    /**
+     * Load HibernateUtil bean.
+     *
+     * @return hibernateUtil
+     */
+    protected HibernateUtil getHibernateUtil() {
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+                new String[] { "classpath:spring-beans.xml" });
+        hibernateUtil = context.getBean("patientDbHibernateUtil", HibernateUtil.class);
+        return hibernateUtil;
     }
 
     // =========================
@@ -111,7 +124,6 @@ public class PatientDAO {
                 if (session != null) {
                     session.close();
                 }
-                hibernateUtil.closeSessionFactory();
             }
         }
         LOG.debug("PatientDAO.create() - End");
@@ -159,7 +171,6 @@ public class PatientDAO {
                 session.flush();
                 session.close();
             }
-            hibernateUtil.closeSessionFactory();
         }
         LOG.debug("PatientDAO.read() - End");
         return foundRecord;
@@ -199,7 +210,6 @@ public class PatientDAO {
                 if (session != null) {
                     session.close();
                 }
-                hibernateUtil.closeSessionFactory();
             }
         }
         LOG.debug("PatientDAO.update() - End");
@@ -230,7 +240,6 @@ public class PatientDAO {
                 session.flush();
                 session.close();
             }
-            hibernateUtil.closeSessionFactory();
         }
         LOG.debug("PatientDAO.delete() - End");
     }
@@ -527,15 +536,13 @@ public class PatientDAO {
                 session.flush();
                 session.close();
             }
-            hibernateUtil.closeSessionFactory();
         }
         LOG.debug("PatientDAO.findPatients() - End");
         return patientsList;
     }
 
     protected SessionFactory getSessionFactory() {
-        hibernateUtil.buildSessionFactory();
-        return hibernateUtil.getSessionFactory();
+        return getHibernateUtil().getSessionFactory();
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PatientDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PatientDAO.java
@@ -55,6 +55,7 @@ public class PatientDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(PatientDAO.class);
     private static PatientDAO patientDAO = new PatientDAO();
+    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
 
     /**
      * Constructor
@@ -146,7 +147,7 @@ public class PatientDAO {
 
             queryList = aCriteria.list();
 
-            if (queryList != null && queryList.size() > 0) {
+            if (queryList != null && !queryList.isEmpty()) {
                 foundRecord = queryList.get(0);
             }
         } catch (Exception e) {
@@ -263,11 +264,11 @@ public class PatientDAO {
             String suffix = patient.getPersonnames().get(0).getSuffix();
 
             Address address = new Address();
-            if (patient.getAddresses() != null && patient.getAddresses().size() > 0) {
+            if (patient.getAddresses() != null && !patient.getAddresses().isEmpty()) {
                 address = patient.getAddresses().get(0);
             }
             Phonenumber phonenumber = new Phonenumber();
-            if (patient.getPhonenumbers() != null && patient.getPhonenumbers().size() > 0) {
+            if (patient.getPhonenumbers() != null && !patient.getPhonenumbers().isEmpty()) {
                 phonenumber = patient.getPhonenumbers().get(0);
             }
 
@@ -469,7 +470,7 @@ public class PatientDAO {
 
             List<Object[]> result = sqlQuery.list();
 
-            if (result != null && result.size() > 0) {
+            if (result != null && !result.isEmpty()) {
                 Long[] patientIdArray = new Long[result.size()];
                 Timestamp[] dateOfBirthArray = new Timestamp[result.size()];
                 String[] genderArray = new String[result.size()];
@@ -533,7 +534,6 @@ public class PatientDAO {
      * @return
      */
     protected SessionFactory getSessionFactory() {
-        HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
         SessionFactory fact = null;
         if (hibernateUtil != null) {
             fact = hibernateUtil.getSessionFactory();

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PersonnameDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PersonnameDAO.java
@@ -28,6 +28,7 @@ package gov.hhs.fha.nhinc.patientdb.dao;
 
 import gov.hhs.fha.nhinc.patientdb.model.Personname;
 import gov.hhs.fha.nhinc.patientdb.persistence.HibernateUtil;
+import gov.hhs.fha.nhinc.patientdb.persistence.HibernateUtilFactory;
 import java.util.List;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
@@ -36,7 +37,6 @@ import org.hibernate.Transaction;
 import org.hibernate.criterion.Expression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  *
@@ -49,8 +49,6 @@ public class PersonnameDAO {
     private static final Logger LOG = LoggerFactory.getLogger(PersonnameDAO.class);
 
     private static PersonnameDAO personnameDAO = new PersonnameDAO();
-
-    private HibernateUtil hibernateUtil;
 
     /**
      *
@@ -74,18 +72,6 @@ public class PersonnameDAO {
 
         return personnameDAO;
 
-    }
-
-    /**
-     * Load HibernateUtil bean.
-     *
-     * @return hibernateUtil
-     */
-    protected HibernateUtil getHibernateUtil() {
-        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
-                new String[] { "classpath:spring-beans.xml" });
-        hibernateUtil = context.getBean("patientDbHibernateUtil", HibernateUtil.class);
-        return hibernateUtil;
     }
 
     // =========================
@@ -409,8 +395,18 @@ public class PersonnameDAO {
 
     }
 
+    /**
+     * Returns the sessionFactory belonging to PatientDiscovery HibernateUtil
+     *
+     * @return
+     */
     protected SessionFactory getSessionFactory() {
-        return getHibernateUtil().getSessionFactory();
+        HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
+        SessionFactory fact = null;
+        if (hibernateUtil != null) {
+            fact = hibernateUtil.getSessionFactory();
+        }
+        return fact;
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PersonnameDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PersonnameDAO.java
@@ -50,6 +50,8 @@ public class PersonnameDAO {
 
     private static PersonnameDAO personnameDAO = new PersonnameDAO();
 
+    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
+
     /**
      *
      * Constructor
@@ -190,7 +192,7 @@ public class PersonnameDAO {
 
             queryList = aCriteria.list();
 
-            if (queryList != null && queryList.size() > 0) {
+            if (queryList != null && !queryList.isEmpty()) {
 
                 foundRecord = queryList.get(0);
 
@@ -401,7 +403,6 @@ public class PersonnameDAO {
      * @return
      */
     protected SessionFactory getSessionFactory() {
-        HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
         SessionFactory fact = null;
         if (hibernateUtil != null) {
             fact = hibernateUtil.getSessionFactory();

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PersonnameDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PersonnameDAO.java
@@ -49,6 +49,8 @@ public class PersonnameDAO {
 
     private static PersonnameDAO personnameDAO = new PersonnameDAO();
 
+    private HibernateUtil hibernateUtil = new HibernateUtil();
+
     /**
      *
      * Constructor
@@ -100,7 +102,7 @@ public class PersonnameDAO {
 
             try {
 
-                SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+                SessionFactory sessionFactory = getSessionFactory();
 
                 session = sessionFactory.openSession();
 
@@ -124,7 +126,7 @@ public class PersonnameDAO {
 
                 }
 
-                LOG.error("Exception during insertion caused by :" + e.getMessage(), e);
+                LOG.error("Exception during insertion caused by : {}", e.getMessage(), e);
 
             } finally {
 
@@ -134,7 +136,7 @@ public class PersonnameDAO {
                     session.close();
 
                 }
-
+                hibernateUtil.closeSessionFactory();
             }
 
         }
@@ -177,7 +179,7 @@ public class PersonnameDAO {
 
         try {
 
-            SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+            SessionFactory sessionFactory = getSessionFactory();
 
             session = sessionFactory.openSession();
 
@@ -198,7 +200,7 @@ public class PersonnameDAO {
 
         } catch (Exception e) {
 
-            LOG.error("Exception during read occured due to :" + e.getMessage(), e);
+            LOG.error("Exception during read occured due to : {}", e.getMessage(), e);
 
         } finally {
 
@@ -210,7 +212,7 @@ public class PersonnameDAO {
                 session.close();
 
             }
-
+            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("PersonnameDAO.read() - End");
@@ -241,7 +243,7 @@ public class PersonnameDAO {
 
             try {
 
-                SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+                SessionFactory sessionFactory = getSessionFactory();
 
                 session = sessionFactory.openSession();
 
@@ -265,7 +267,7 @@ public class PersonnameDAO {
 
                 }
 
-                LOG.error("Exception during update caused by :" + e.getMessage(), e);
+                LOG.error("Exception during update caused by : {}", e.getMessage(), e);
 
             } finally {
 
@@ -275,7 +277,7 @@ public class PersonnameDAO {
                     session.close();
 
                 }
-
+                hibernateUtil.closeSessionFactory();
             }
 
         }
@@ -300,7 +302,7 @@ public class PersonnameDAO {
 
         try {
 
-            SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+            SessionFactory sessionFactory = getSessionFactory();
 
             session = sessionFactory.openSession();
 
@@ -311,7 +313,7 @@ public class PersonnameDAO {
 
         } catch (Exception e) {
 
-            LOG.error("Exception during delete occured due to :" + e.getMessage(), e);
+            LOG.error("Exception during delete occured due to : {}", e.getMessage(), e);
 
         } finally {
 
@@ -323,7 +325,7 @@ public class PersonnameDAO {
                 session.close();
 
             }
-
+            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("PersonnameDAO.delete() - End");
@@ -363,7 +365,7 @@ public class PersonnameDAO {
 
         try {
 
-            SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+            SessionFactory sessionFactory = getSessionFactory();
 
             session = sessionFactory.openSession();
 
@@ -378,7 +380,7 @@ public class PersonnameDAO {
 
         } catch (Exception e) {
 
-            LOG.error("Exception during read occured due to :" + e.getMessage(), e);
+            LOG.error("Exception during read occured due to : {}", e.getMessage(), e);
 
         } finally {
 
@@ -390,13 +392,18 @@ public class PersonnameDAO {
                 session.close();
 
             }
-
+            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("PersonnameDAO.findPatientPersonnames() - End");
 
         return queryList;
 
+    }
+
+    protected SessionFactory getSessionFactory() {
+        hibernateUtil.buildSessionFactory();
+        return hibernateUtil.getSessionFactory();
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PersonnameDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PersonnameDAO.java
@@ -50,8 +50,6 @@ public class PersonnameDAO {
 
     private static PersonnameDAO personnameDAO = new PersonnameDAO();
 
-    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
-
     /**
      *
      * Constructor
@@ -404,6 +402,7 @@ public class PersonnameDAO {
      */
     protected SessionFactory getSessionFactory() {
         SessionFactory fact = null;
+        HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
         if (hibernateUtil != null) {
             fact = hibernateUtil.getSessionFactory();
         }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PersonnameDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PersonnameDAO.java
@@ -36,6 +36,7 @@ import org.hibernate.Transaction;
 import org.hibernate.criterion.Expression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  *
@@ -49,7 +50,7 @@ public class PersonnameDAO {
 
     private static PersonnameDAO personnameDAO = new PersonnameDAO();
 
-    private HibernateUtil hibernateUtil = new HibernateUtil();
+    private HibernateUtil hibernateUtil;
 
     /**
      *
@@ -73,6 +74,18 @@ public class PersonnameDAO {
 
         return personnameDAO;
 
+    }
+
+    /**
+     * Load HibernateUtil bean.
+     *
+     * @return hibernateUtil
+     */
+    protected HibernateUtil getHibernateUtil() {
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+                new String[] { "classpath:spring-beans.xml" });
+        hibernateUtil = context.getBean("patientDbHibernateUtil", HibernateUtil.class);
+        return hibernateUtil;
     }
 
     // =========================
@@ -136,7 +149,6 @@ public class PersonnameDAO {
                     session.close();
 
                 }
-                hibernateUtil.closeSessionFactory();
             }
 
         }
@@ -212,7 +224,6 @@ public class PersonnameDAO {
                 session.close();
 
             }
-            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("PersonnameDAO.read() - End");
@@ -277,7 +288,6 @@ public class PersonnameDAO {
                     session.close();
 
                 }
-                hibernateUtil.closeSessionFactory();
             }
 
         }
@@ -325,7 +335,6 @@ public class PersonnameDAO {
                 session.close();
 
             }
-            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("PersonnameDAO.delete() - End");
@@ -392,7 +401,6 @@ public class PersonnameDAO {
                 session.close();
 
             }
-            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("PersonnameDAO.findPatientPersonnames() - End");
@@ -402,8 +410,7 @@ public class PersonnameDAO {
     }
 
     protected SessionFactory getSessionFactory() {
-        hibernateUtil.buildSessionFactory();
-        return hibernateUtil.getSessionFactory();
+        return getHibernateUtil().getSessionFactory();
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PhonenumberDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PhonenumberDAO.java
@@ -49,6 +49,8 @@ public class PhonenumberDAO {
 
     private static PhonenumberDAO phonenumberDAO = new PhonenumberDAO();
 
+    private HibernateUtil hibernateUtil = new HibernateUtil();
+
     /**
      *
      * Constructor
@@ -100,7 +102,7 @@ public class PhonenumberDAO {
 
             try {
 
-                SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+                SessionFactory sessionFactory = getSessionFactory();
 
                 session = sessionFactory.openSession();
 
@@ -124,7 +126,7 @@ public class PhonenumberDAO {
 
                 }
 
-                LOG.error("Exception during insertion caused by :" + e.getMessage(), e);
+                LOG.error("Exception during insertion caused by : {}", e.getMessage(), e);
 
             } finally {
 
@@ -134,7 +136,7 @@ public class PhonenumberDAO {
                     session.close();
 
                 }
-
+                hibernateUtil.closeSessionFactory();
             }
 
         }
@@ -177,7 +179,7 @@ public class PhonenumberDAO {
 
         try {
 
-            SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+            SessionFactory sessionFactory = getSessionFactory();
 
             session = sessionFactory.openSession();
 
@@ -198,7 +200,7 @@ public class PhonenumberDAO {
 
         } catch (Exception e) {
 
-            LOG.error("Exception during read occured due to :" + e.getMessage(), e);
+            LOG.error("Exception during read occured due to : {}", e.getMessage(), e);
 
         } finally {
 
@@ -210,7 +212,7 @@ public class PhonenumberDAO {
                 session.close();
 
             }
-
+            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("PhonenumberDAO.read() - End");
@@ -241,7 +243,7 @@ public class PhonenumberDAO {
 
             try {
 
-                SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+                SessionFactory sessionFactory = getSessionFactory();
 
                 session = sessionFactory.openSession();
 
@@ -265,7 +267,7 @@ public class PhonenumberDAO {
 
                 }
 
-                LOG.error("Exception during update caused by :" + e.getMessage(), e);
+                LOG.error("Exception during update caused by : {}", e.getMessage(), e);
 
             } finally {
 
@@ -275,7 +277,7 @@ public class PhonenumberDAO {
                     session.close();
 
                 }
-
+                hibernateUtil.closeSessionFactory();
             }
 
         }
@@ -300,7 +302,7 @@ public class PhonenumberDAO {
 
         try {
 
-            SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+            SessionFactory sessionFactory = getSessionFactory();
 
             session = sessionFactory.openSession();
 
@@ -311,7 +313,7 @@ public class PhonenumberDAO {
 
         } catch (Exception e) {
 
-            LOG.error("Exception during delete occured due to :" + e.getMessage(), e);
+            LOG.error("Exception during delete occured due to : {}", e.getMessage(), e);
 
         } finally {
 
@@ -323,7 +325,7 @@ public class PhonenumberDAO {
                 session.close();
 
             }
-
+            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("PhonenumberDAO.delete() - End");
@@ -363,7 +365,7 @@ public class PhonenumberDAO {
 
         try {
 
-            SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+            SessionFactory sessionFactory = getSessionFactory();
 
             session = sessionFactory.openSession();
 
@@ -378,7 +380,7 @@ public class PhonenumberDAO {
 
         } catch (Exception e) {
 
-            LOG.error("Exception during read occured due to :" + e.getMessage(), e);
+            LOG.error("Exception during read occured due to : {}", e.getMessage(), e);
 
         } finally {
 
@@ -390,13 +392,18 @@ public class PhonenumberDAO {
                 session.close();
 
             }
-
+            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("PhonenumberDAO.findPatientPhonenumbers() - End");
 
         return queryList;
 
+    }
+
+    protected SessionFactory getSessionFactory() {
+        hibernateUtil.buildSessionFactory();
+        return hibernateUtil.getSessionFactory();
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PhonenumberDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PhonenumberDAO.java
@@ -50,8 +50,6 @@ public class PhonenumberDAO {
 
     private static PhonenumberDAO phonenumberDAO = new PhonenumberDAO();
 
-    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
-
     /**
      *
      * Constructor
@@ -410,6 +408,7 @@ public class PhonenumberDAO {
      */
     protected SessionFactory getSessionFactory() {
         SessionFactory fact = null;
+        HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
         if (hibernateUtil != null) {
             fact = hibernateUtil.getSessionFactory();
         }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PhonenumberDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PhonenumberDAO.java
@@ -50,6 +50,8 @@ public class PhonenumberDAO {
 
     private static PhonenumberDAO phonenumberDAO = new PhonenumberDAO();
 
+    private static HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
+
     /**
      *
      * Constructor
@@ -407,7 +409,6 @@ public class PhonenumberDAO {
      * @return
      */
     protected SessionFactory getSessionFactory() {
-        HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
         SessionFactory fact = null;
         if (hibernateUtil != null) {
             fact = hibernateUtil.getSessionFactory();

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PhonenumberDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PhonenumberDAO.java
@@ -28,6 +28,7 @@ package gov.hhs.fha.nhinc.patientdb.dao;
 
 import gov.hhs.fha.nhinc.patientdb.model.Phonenumber;
 import gov.hhs.fha.nhinc.patientdb.persistence.HibernateUtil;
+import gov.hhs.fha.nhinc.patientdb.persistence.HibernateUtilFactory;
 import java.util.List;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
@@ -36,7 +37,6 @@ import org.hibernate.Transaction;
 import org.hibernate.criterion.Expression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  *
@@ -49,8 +49,6 @@ public class PhonenumberDAO {
     private static final Logger LOG = LoggerFactory.getLogger(PhonenumberDAO.class);
 
     private static PhonenumberDAO phonenumberDAO = new PhonenumberDAO();
-
-    private HibernateUtil hibernateUtil;
 
     /**
      *
@@ -76,18 +74,6 @@ public class PhonenumberDAO {
 
     }
 
-    /**
-     * Load HibernateUtil bean.
-     *
-     * @return hibernateUtil
-     */
-    protected HibernateUtil getHibernateUtil() {
-        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
-                new String[] { "classpath:spring-beans.xml" });
-        hibernateUtil = context.getBean("patientDbHibernateUtil", HibernateUtil.class);
-        return hibernateUtil;
-    }
-
     // =========================
     // Standard CRUD DML Methods
     // =========================
@@ -107,11 +93,11 @@ public class PhonenumberDAO {
 
         Session session = null;
 
-        Transaction tx = null;
-
         boolean result = true;
 
         if (phonenumberRecord != null) {
+
+            Transaction tx = null;
 
             try {
 
@@ -193,21 +179,23 @@ public class PhonenumberDAO {
 
             SessionFactory sessionFactory = getSessionFactory();
 
-            session = sessionFactory.openSession();
+            if (sessionFactory != null) {
+                session = sessionFactory.openSession();
 
-            LOG.info("Reading Record...");
+                LOG.info("Reading Record...");
 
-            // Build the criteria
-            Criteria aCriteria = session.createCriteria(Phonenumber.class);
+                // Build the criteria
+                Criteria aCriteria = session.createCriteria(Phonenumber.class);
 
-            aCriteria.add(Expression.eq("id", id));
+                aCriteria.add(Expression.eq("id", id));
 
-            queryList = aCriteria.list();
+                queryList = aCriteria.list();
 
-            if (queryList != null && queryList.size() > 0) {
+                if (queryList != null && !queryList.isEmpty()) {
 
-                foundRecord = queryList.get(0);
+                    foundRecord = queryList.get(0);
 
+                }
             }
 
         } catch (Exception e) {
@@ -246,11 +234,11 @@ public class PhonenumberDAO {
 
         Session session = null;
 
-        Transaction tx = null;
-
         boolean result = true;
 
         if (phonenumberRecord != null) {
+
+            Transaction tx = null;
 
             try {
 
@@ -314,12 +302,14 @@ public class PhonenumberDAO {
 
             SessionFactory sessionFactory = getSessionFactory();
 
-            session = sessionFactory.openSession();
+            if (sessionFactory != null) {
+                session = sessionFactory.openSession();
 
-            LOG.info("Deleting Record...");
+                LOG.info("Deleting Record...");
 
-            // Delete the Phonenumber record
-            session.delete(phonenumberRecord);
+                // Delete the Phonenumber record
+                session.delete(phonenumberRecord);
+            }
 
         } catch (Exception e) {
 
@@ -376,17 +366,19 @@ public class PhonenumberDAO {
 
             SessionFactory sessionFactory = getSessionFactory();
 
-            session = sessionFactory.openSession();
+            if (sessionFactory != null) {
+                session = sessionFactory.openSession();
 
-            LOG.info("Reading Record...");
+                LOG.info("Reading Record...");
 
-            // Build the criteria
-            Criteria aCriteria = session.createCriteria(Phonenumber.class);
+                // Build the criteria
+                Criteria aCriteria = session.createCriteria(Phonenumber.class);
 
-            aCriteria.add(Expression.eq("patient.patientId", patientId));
+                aCriteria.add(Expression.eq("patient.patientId", patientId));
 
-            queryList = aCriteria.list();
+                queryList = aCriteria.list();
 
+            }
         } catch (Exception e) {
 
             LOG.error("Exception during read occured due to : {}", e.getMessage(), e);
@@ -409,8 +401,18 @@ public class PhonenumberDAO {
 
     }
 
+    /**
+     * Returns the sessionFactory belonging to PatientDiscovery HibernateUtil
+     *
+     * @return
+     */
     protected SessionFactory getSessionFactory() {
-        return getHibernateUtil().getSessionFactory();
+        HibernateUtil hibernateUtil = HibernateUtilFactory.getPatientDiscHibernateUtil();
+        SessionFactory fact = null;
+        if (hibernateUtil != null) {
+            fact = hibernateUtil.getSessionFactory();
+        }
+        return fact;
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PhonenumberDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PhonenumberDAO.java
@@ -36,6 +36,7 @@ import org.hibernate.Transaction;
 import org.hibernate.criterion.Expression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  *
@@ -49,7 +50,7 @@ public class PhonenumberDAO {
 
     private static PhonenumberDAO phonenumberDAO = new PhonenumberDAO();
 
-    private HibernateUtil hibernateUtil = new HibernateUtil();
+    private HibernateUtil hibernateUtil;
 
     /**
      *
@@ -73,6 +74,18 @@ public class PhonenumberDAO {
 
         return phonenumberDAO;
 
+    }
+
+    /**
+     * Load HibernateUtil bean.
+     *
+     * @return hibernateUtil
+     */
+    protected HibernateUtil getHibernateUtil() {
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+                new String[] { "classpath:spring-beans.xml" });
+        hibernateUtil = context.getBean("patientDbHibernateUtil", HibernateUtil.class);
+        return hibernateUtil;
     }
 
     // =========================
@@ -136,7 +149,6 @@ public class PhonenumberDAO {
                     session.close();
 
                 }
-                hibernateUtil.closeSessionFactory();
             }
 
         }
@@ -212,7 +224,6 @@ public class PhonenumberDAO {
                 session.close();
 
             }
-            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("PhonenumberDAO.read() - End");
@@ -277,7 +288,6 @@ public class PhonenumberDAO {
                     session.close();
 
                 }
-                hibernateUtil.closeSessionFactory();
             }
 
         }
@@ -325,7 +335,6 @@ public class PhonenumberDAO {
                 session.close();
 
             }
-            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("PhonenumberDAO.delete() - End");
@@ -392,7 +401,6 @@ public class PhonenumberDAO {
                 session.close();
 
             }
-            hibernateUtil.closeSessionFactory();
         }
 
         LOG.debug("PhonenumberDAO.findPatientPhonenumbers() - End");
@@ -402,8 +410,7 @@ public class PhonenumberDAO {
     }
 
     protected SessionFactory getSessionFactory() {
-        hibernateUtil.buildSessionFactory();
-        return hibernateUtil.getSessionFactory();
+        return getHibernateUtil().getSessionFactory();
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/persistence/HibernateUtil.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/persistence/HibernateUtil.java
@@ -66,6 +66,7 @@ public class HibernateUtil {
      * Method closes the Hibernate SessionFactory
      */
     public void closeSessionFactory() {
+        LOG.info("Closing sessionFactory in HibernateUtil");
         try {
             if (sessionFactory != null && !sessionFactory.isClosed()) {
                 sessionFactory.close();

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/persistence/HibernateUtil.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/persistence/HibernateUtil.java
@@ -42,18 +42,36 @@ import org.slf4j.LoggerFactory;
  */
 public class HibernateUtil {
 
-    private static final SessionFactory sessionFactory;
+    private SessionFactory sessionFactory;
     private static final Logger LOG = LoggerFactory.getLogger(HibernateUtil.class);
 
-    static {
+    /**
+     * Create the SessionFactory
+     */
+    public void buildSessionFactory() {
         try {
             // Create the SessionFactory from hibernate.cfg.xml
-            sessionFactory = new Configuration().configure()
-                    .buildSessionFactory(new StandardServiceRegistryBuilder().configure(getConfigFile()).build());
+            if (sessionFactory == null || sessionFactory.isClosed()) {
+                sessionFactory = new Configuration().configure()
+                        .buildSessionFactory(new StandardServiceRegistryBuilder().configure(getConfigFile()).build());
+            }
         } catch (HibernateException he) {
             // Make sure you log the exception, as it might be swallowed
-            LOG.error("Initial SessionFactory creation failed." + he);
+            LOG.error("Initial SessionFactory creation failed. {}", he);
             throw new ExceptionInInitializerError(he);
+        }
+    }
+
+    /**
+     * Method closes the Hibernate SessionFactory
+     */
+    public void closeSessionFactory() {
+        try {
+            if (sessionFactory != null && !sessionFactory.isClosed()) {
+                sessionFactory.close();
+            }
+        } catch (HibernateException he) {
+            LOG.error("Error during closing the sessionFactory: {}", he.getLocalizedMessage(), he);
         }
     }
 
@@ -62,7 +80,7 @@ public class HibernateUtil {
      *
      * @return SessionFactory
      */
-    public static SessionFactory getSessionFactory() {
+    public SessionFactory getSessionFactory() {
         return sessionFactory;
     }
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/persistence/HibernateUtilFactory.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/persistence/HibernateUtilFactory.java
@@ -1,0 +1,54 @@
+/**
+ *
+ */
+package gov.hhs.fha.nhinc.patientdb.persistence;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+/**
+ * @author drfernan
+ *
+ */
+public class HibernateUtilFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HibernateUtilFactory.class);
+    private static final String PATIENT_DISCOVERY_HIBERNATE = "patientDbHibernateUtil";
+
+    /**
+     * Private constructor to hide the public one.
+     */
+    private HibernateUtilFactory() {
+
+    }
+
+    /**
+     * Private class that loads the spring-beans.xml into the classpath application context.
+     *
+     * @author drfernan
+     *
+     */
+    private static class ClassPathSingleton {
+
+        private ClassPathSingleton() {
+        }
+
+        public static final ClassPathXmlApplicationContext CONTEXT = new ClassPathXmlApplicationContext(
+                new String[] { "classpath:spring-beans.xml" });
+    }
+
+    /**
+     * Method that retusn the Patient Discovery HibernateUtil.
+     *
+     * @return
+     */
+    public static HibernateUtil getPatientDiscHibernateUtil() {
+        ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
+
+        LOG.debug("Memory address getPatientDiscHibernateUtil {}", context.getId());
+        HibernateUtil hibernateUtil = context.getBean(PATIENT_DISCOVERY_HIBERNATE, HibernateUtil.class);
+        return hibernateUtil;
+    }
+
+}

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/persistence/HibernateUtilFactory.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/persistence/HibernateUtilFactory.java
@@ -16,12 +16,12 @@ public class HibernateUtilFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(HibernateUtilFactory.class);
     private static final String PATIENT_DISCOVERY_HIBERNATE = "patientDbHibernateUtil";
+    private static HibernateUtil hibernateUtil;
 
     /**
      * Private constructor to hide the public one.
      */
     private HibernateUtilFactory() {
-
     }
 
     /**
@@ -48,7 +48,12 @@ public class HibernateUtilFactory {
         ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
 
         LOG.debug("Memory address getPatientDiscHibernateUtil {}", context.getId());
-        return context.getBean(PATIENT_DISCOVERY_HIBERNATE, HibernateUtil.class);
+
+        if (hibernateUtil == null) {
+            hibernateUtil = context.getBean(PATIENT_DISCOVERY_HIBERNATE, HibernateUtil.class);
+        }
+
+        return hibernateUtil;
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/persistence/HibernateUtilFactory.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/persistence/HibernateUtilFactory.java
@@ -10,6 +10,7 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 /**
  * @author drfernan
  *
+ *         Factory class to load the PatientDiscoveryCore spring configuration.
  */
 public class HibernateUtilFactory {
 
@@ -31,11 +32,11 @@ public class HibernateUtilFactory {
      */
     private static class ClassPathSingleton {
 
-        private ClassPathSingleton() {
-        }
-
         public static final ClassPathXmlApplicationContext CONTEXT = new ClassPathXmlApplicationContext(
                 new String[] { "classpath:spring-beans.xml" });
+
+        private ClassPathSingleton() {
+        }
     }
 
     /**
@@ -47,8 +48,7 @@ public class HibernateUtilFactory {
         ClassPathXmlApplicationContext context = ClassPathSingleton.CONTEXT;
 
         LOG.debug("Memory address getPatientDiscHibernateUtil {}", context.getId());
-        HibernateUtil hibernateUtil = context.getBean(PATIENT_DISCOVERY_HIBERNATE, HibernateUtil.class);
-        return hibernateUtil;
+        return context.getBean(PATIENT_DISCOVERY_HIBERNATE, HibernateUtil.class);
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/resources/spring-beans.xml
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/resources/spring-beans.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:jee="http://www.springframework.org/schema/jee"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+        http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd 
+        http://www.springframework.org/schema/jee http://www.springframework.org/schema/jee/spring-jee-3.0.xsd"
+        default-autowire="byName">
+
+    <context:annotation-config />
+    <context:component-scan base-package="gov.hhs.fha.nhinc"/>
+    
+    <bean name="patientDbHibernateUtil" class="gov.hhs.fha.nhinc.patientdb.persistence.HibernateUtil" 
+        init-method="buildSessionFactory" destroy-method="closeSessionFactory"/>
+
+</beans>


### PR DESCRIPTION
1) Removed static blocks from HibernateUtil classes and have buildSessionFactory() and closeSessionFactory() be used to manage session factories.
2) HibernateUtil is no longer used as a singleton.  Have classes that call it own their own HibernateUtil.

@mhpnguyen , @TabassumJafri  can you please review.
