### PR TITLE
FHAC-1051: Added jboss-deployment-structure.xml to force the deployment to not use the JPA modules installed in Jboss 7.1.

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/pom.xml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/pom.xml
@@ -21,7 +21,6 @@
             <groupId>javax</groupId>
             <artifactId>javaee-api</artifactId>
         </dependency>
-
         <!-- CXF -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
@@ -121,12 +120,6 @@
             <artifactId>hibernate-commons-annotations</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.0-api</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-		
 
         <!-- Parsing & Code Generation -->
         <dependency>

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+			<!-- Exclude the Hibernate and persistence modules to get passed deployment error. -->
+			<module name="org.hibernate" />
+            <module name="javaee.api"/>
+            <module name="javax.persistence.api"/>
+        </exclusions>
+		<dependencies>
+			<!-- The javaee.api module needs to be added back, but should exclude the javax.persistance path. -->
+            <module name="javaee.api">
+                <imports>
+                    <exclude path="javax/persistence" />
+                </imports>
+            </module>	
+        </dependencies>
+		
+    </deployment>
+</jboss-deployment-structure>

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jboss-deployment-structure>
   <deployment>
-        <exclusions>
-            <!-- Exclude the Hibernate and persistence modules to get passed deployment error. -->
-            <module name="org.hibernate" />
-            <module name="javaee.api"/>
-            <module name="javax.persistence.api"/>
-        </exclusions>
-        <dependencies>
-            <!-- The javaee.api module needs to be added back, but should exclude the javax.persistance path. -->
-            <module name="javaee.api">
-                <imports>
-                    <exclude path="javax/persistence" />
-                </imports>
-            </module>	
-        </dependencies>	
+    <exclusions>
+      <!-- Exclude the Hibernate and persistence modules to get passed deployment error. -->
+      <module name="org.hibernate" />
+      <module name="javaee.api"/>
+      <module name="javax.persistence.api"/>
+    </exclusions>
+    <dependencies>
+      <!-- The javaee.api module needs to be added back, but should exclude the javax.persistance path. -->
+      <module name="javaee.api">
+        <imports>
+          <exclude path="javax/persistence" />
+        </imports>
+      </module>	
+    </dependencies>	
   </deployment>
 </jboss-deployment-structure>

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jboss-deployment-structure>
-   <deployment>
+  <deployment>
         <exclusions>
             <!-- Exclude the Hibernate and persistence modules to get passed deployment error. -->
             <module name="org.hibernate" />
@@ -15,5 +15,5 @@
                 </imports>
             </module>	
         </dependencies>	
-   </deployment>
+  </deployment>
 </jboss-deployment-structure>

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jboss-deployment-structure>
-    <deployment>
+   <deployment>
         <exclusions>
-			<!-- Exclude the Hibernate and persistence modules to get passed deployment error. -->
-			<module name="org.hibernate" />
+            <!-- Exclude the Hibernate and persistence modules to get passed deployment error. -->
+            <module name="org.hibernate" />
             <module name="javaee.api"/>
             <module name="javax.persistence.api"/>
         </exclusions>
-		<dependencies>
-			<!-- The javaee.api module needs to be added back, but should exclude the javax.persistance path. -->
+        <dependencies>
+            <!-- The javaee.api module needs to be added back, but should exclude the javax.persistance path. -->
             <module name="javaee.api">
                 <imports>
                     <exclude path="javax/persistence" />
                 </imports>
             </module>	
-        </dependencies>
-		
-    </deployment>
+        </dependencies>	
+   </deployment>
 </jboss-deployment-structure>


### PR DESCRIPTION
1. The new jboss-deployment-structure.xml has been added to the Web-INF folder.
2. Removed the hibernate-jpa-2.0-api dependency in ConnectAdminGUI pom.xml.

@mhpnguyen @TabassumJafri assigned to review.
