### PR TITLE
FHAC-1074: Add features to DocumentBuilderFactory to get passed XXE attacks

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/config/ConfigurationManager.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/config/ConfigurationManager.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.DOMException;
@@ -94,19 +95,19 @@ public class ConfigurationManager {
         try {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 
-            final String FEATURE = "http://xml.org/sax/features/external-general-entities";
-            dbf.setFeature(FEATURE, false);
+            final String feature = "http://xml.org/sax/features/external-general-entities";
+            dbf.setFeature(feature, false);
 
             // For Xerces 2
-            final String FEATURE_2 = "http://apache.org/xml/features/disallow-doctype-decl";
-            dbf.setFeature(FEATURE_2, true);
+            final String feature2 = "http://apache.org/xml/features/disallow-doctype-decl";
+            dbf.setFeature(feature2, true);
 
-            final String FEATURE_3 = "http://xml.org/sax/features/external-parameter-entities";
-            dbf.setFeature(FEATURE_3, false);
+            final String feature3 = "http://xml.org/sax/features/external-parameter-entities";
+            dbf.setFeature(feature3, false);
 
             // Disable external DTDs
-            final String FEATURE_4 = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
-            dbf.setFeature(FEATURE_4, false);
+            final String feature4 = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+            dbf.setFeature(feature4, false);
 
             DocumentBuilder db = dbf.newDocumentBuilder();
 
@@ -167,10 +168,9 @@ public class ConfigurationManager {
                 }
             }
 
-            if (result == null) {
-                if (config.getDefaultDuration() >= 0 && config.getDefaultUnits().length() > 0) {
-                    result = new Expiration("", config.getDefaultUnits(), config.getDefaultDuration());
-                }
+            if (result == null && config.getDefaultDuration() >= 0
+                    && StringUtils.isNotEmpty(config.getDefaultUnits())) {
+                result = new Expiration("", config.getDefaultUnits(), config.getDefaultDuration());
             }
 
         }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/config/ConfigurationManager.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/patientcorrelation/nhinc/config/ConfigurationManager.java
@@ -101,6 +101,13 @@ public class ConfigurationManager {
             final String FEATURE_2 = "http://apache.org/xml/features/disallow-doctype-decl";
             dbf.setFeature(FEATURE_2, true);
 
+            final String FEATURE_3 = "http://xml.org/sax/features/external-parameter-entities";
+            dbf.setFeature(FEATURE_3, false);
+
+            // Disable external DTDs
+            final String FEATURE_4 = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+            dbf.setFeature(FEATURE_4, false);
+
             DocumentBuilder db = dbf.newDocumentBuilder();
 
             Document doc = db.parse(file);

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/component/ConfigurationManager.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/component/ConfigurationManager.java
@@ -80,19 +80,19 @@ public class ConfigurationManager {
         try {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 
-            final String FEATURE = "http://xml.org/sax/features/external-general-entities";
-            dbf.setFeature(FEATURE, false);
+            final String feature = "http://xml.org/sax/features/external-general-entities";
+            dbf.setFeature(feature, false);
 
             // For Xerces 2
-            final String FEATURE_2 = "http://apache.org/xml/features/disallow-doctype-decl";
-            dbf.setFeature(FEATURE_2, true);
+            final String feature2 = "http://apache.org/xml/features/disallow-doctype-decl";
+            dbf.setFeature(feature2, true);
 
-            final String FEATURE_3 = "http://xml.org/sax/features/external-parameter-entities";
-            dbf.setFeature(FEATURE_3, false);
+            final String feature3 = "http://xml.org/sax/features/external-parameter-entities";
+            dbf.setFeature(feature3, false);
 
             // Disable external DTDs
-            final String FEATURE_4 = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
-            dbf.setFeature(FEATURE_4, false);
+            final String feature4 = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+            dbf.setFeature(feature4, false);
 
             DocumentBuilder db = dbf.newDocumentBuilder();
             Document doc = db.parse(file);
@@ -122,16 +122,16 @@ public class ConfigurationManager {
             Node node = channels.getChildNodes().item(s);
             if (node.getNodeType() == Node.ELEMENT_NODE) {
                 Element element = (Element) node;
-                System.out.println(element.getNodeName());
-                if (element.getNodeName().equalsIgnoreCase("RoutingConfig")) {
+
+                if ("RoutingConfig".equalsIgnoreCase(element.getNodeName())) {
                     RoutingConfig item = new RoutingConfig();
                     for (int x = 0; x < element.getChildNodes().getLength(); x++) {
                         String nodeName = element.getChildNodes().item(x).getNodeName();
                         String nodeValue = element.getChildNodes().item(x).getTextContent();
 
-                        if (nodeName.equalsIgnoreCase("Recipient")) {
+                        if ("Recipient".equalsIgnoreCase(nodeName)) {
                             item.setRecepient(nodeValue);
-                        } else if (nodeName.equalsIgnoreCase("Bean")) {
+                        } else if ("Bean".equalsIgnoreCase(nodeName)) {
                             item.setBean(nodeValue);
                         }
                     }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/component/ConfigurationManager.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/component/ConfigurationManager.java
@@ -83,9 +83,16 @@ public class ConfigurationManager {
             final String FEATURE = "http://xml.org/sax/features/external-general-entities";
             dbf.setFeature(FEATURE, false);
 
-            //For Xerces 2
+            // For Xerces 2
             final String FEATURE_2 = "http://apache.org/xml/features/disallow-doctype-decl";
             dbf.setFeature(FEATURE_2, true);
+
+            final String FEATURE_3 = "http://xml.org/sax/features/external-parameter-entities";
+            dbf.setFeature(FEATURE_3, false);
+
+            // Disable external DTDs
+            final String FEATURE_4 = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+            dbf.setFeature(FEATURE_4, false);
 
             DocumentBuilder db = dbf.newDocumentBuilder();
             Document doc = db.parse(file);


### PR DESCRIPTION
Done for fixing the XML External Entity issues found in Fortify.  If they are still detected in the scan, then I'll add a justification to the Fortify Scan Documentation.

@mhpnguyen @TabassumJafri please review.
