### PR TITLE
add default constructor since spring bean can not instantiate without it

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/hibernate/LoginServiceImpl.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/hibernate/LoginServiceImpl.java
@@ -72,6 +72,13 @@ public class LoginServiceImpl implements LoginService {
     LoginServiceImpl(UserLoginDAO userLoginDao) {
         userLoginDAO = userLoginDao;
     }
+    
+    /**
+     * Default constructor
+     */
+    public LoginServiceImpl() {
+      //Spring can not instantiate without default constructor
+    }
 
     /*
      * (non-Javadoc)


### PR DESCRIPTION
Spring can not instantiate bean classs without default constructor.  Create default constructor without default.
@TabassumJafri , @danielrf123 : can you please review this?
