### PR TITLE
FHAC-929: Fixed remaining SonarQube critical issues in Direct.

### DIFF
--- a/Product/Production/Gateway/Direct/src/main/java/gov/hhs/fha/nhinc/direct/DirectSenderServiceImpl.java
+++ b/Product/Production/Gateway/Direct/src/main/java/gov/hhs/fha/nhinc/direct/DirectSenderServiceImpl.java
@@ -26,6 +26,7 @@
  */
 package gov.hhs.fha.nhinc.direct;
 
+import java.util.Arrays;
 import javax.mail.MessagingException;
 import javax.mail.Session;
 import javax.mail.internet.InternetAddress;
@@ -60,7 +61,7 @@ public class DirectSenderServiceImpl extends DirectAdapterEntity implements Dire
             }
             MimeMultipart mpart = new MimeMultipart();
             MimeBodyPart bp = new MimeBodyPart();
-            bp.setText(message.getContent().toString());
+            bp.setText(Arrays.toString(message.getContent()));
             // add message body
             mpart.addBodyPart(bp);
             mimeMessage.setContent(mpart);
@@ -68,7 +69,7 @@ public class DirectSenderServiceImpl extends DirectAdapterEntity implements Dire
             mimeMessage.setSubject(message.getSubject());
             getDirectSender().sendOutboundDirect(mimeMessage);
         } catch (MessagingException ex) {
-            LOG.error(ex.getLocalizedMessage(),ex);
+            LOG.error(ex.getLocalizedMessage(), ex);
         }
         LOG.debug("-- End DirectSenderServiceImpl.sendOutboundDirect() --");
     }

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/messagemonitoring/domain/MonitoredMessage.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/messagemonitoring/domain/MonitoredMessage.java
@@ -46,12 +46,27 @@ public class MonitoredMessage implements java.io.Serializable {
     private String status;
     private Date createtime;
     private Date updatetime;
-    private Set monitoredmessagenotifications = new HashSet(0);
+    private transient Set monitoredmessagenotifications = new HashSet(0);
 
     public MonitoredMessage() {
+        // Default constructor
     }
 
-    public MonitoredMessage(String senderemailid, String subject, String messageid, String recipients, Boolean deliveryrequested, String status, Date createtime, Date updatetime, Set monitoredmessagenotifications) {
+    /**
+     *
+     * @param senderemailid
+     * @param subject
+     * @param messageid
+     * @param recipients
+     * @param deliveryrequested
+     * @param status
+     * @param createtime
+     * @param updatetime
+     * @param monitoredmessagenotifications
+     */
+    public MonitoredMessage(String senderemailid, String subject, String messageid, String recipients,
+            Boolean deliveryrequested, String status, Date createtime, Date updatetime,
+            Set monitoredmessagenotifications) {
         this.senderemailid = senderemailid;
         this.subject = subject;
         this.messageid = messageid;
@@ -64,7 +79,7 @@ public class MonitoredMessage implements java.io.Serializable {
     }
 
     public Long getId() {
-        return this.id;
+        return id;
     }
 
     public void setId(Long id) {
@@ -72,7 +87,7 @@ public class MonitoredMessage implements java.io.Serializable {
     }
 
     public String getSenderemailid() {
-        return this.senderemailid;
+        return senderemailid;
     }
 
     public void setSenderemailid(String senderemailid) {
@@ -80,7 +95,7 @@ public class MonitoredMessage implements java.io.Serializable {
     }
 
     public String getSubject() {
-        return this.subject;
+        return subject;
     }
 
     public void setSubject(String subject) {
@@ -88,7 +103,7 @@ public class MonitoredMessage implements java.io.Serializable {
     }
 
     public String getMessageid() {
-        return this.messageid;
+        return messageid;
     }
 
     public void setMessageid(String messageid) {
@@ -96,7 +111,7 @@ public class MonitoredMessage implements java.io.Serializable {
     }
 
     public String getRecipients() {
-        return this.recipients;
+        return recipients;
     }
 
     public void setRecipients(String recipients) {
@@ -104,7 +119,7 @@ public class MonitoredMessage implements java.io.Serializable {
     }
 
     public Boolean getDeliveryrequested() {
-        return this.deliveryrequested;
+        return deliveryrequested;
     }
 
     public void setDeliveryrequested(Boolean deliveryrequested) {
@@ -112,7 +127,7 @@ public class MonitoredMessage implements java.io.Serializable {
     }
 
     public String getStatus() {
-        return this.status;
+        return status;
     }
 
     public void setStatus(String status) {
@@ -120,7 +135,7 @@ public class MonitoredMessage implements java.io.Serializable {
     }
 
     public Date getCreatetime() {
-        return this.createtime;
+        return createtime;
     }
 
     public void setCreatetime(Date createtime) {
@@ -128,7 +143,7 @@ public class MonitoredMessage implements java.io.Serializable {
     }
 
     public Date getUpdatetime() {
-        return this.updatetime;
+        return updatetime;
     }
 
     public void setUpdatetime(Date updatetime) {
@@ -136,7 +151,7 @@ public class MonitoredMessage implements java.io.Serializable {
     }
 
     public Set getMonitoredmessagenotifications() {
-        return this.monitoredmessagenotifications;
+        return monitoredmessagenotifications;
     }
 
     public void setMonitoredmessagenotifications(Set monitoredmessagenotifications) {

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/xdr/SoapEdgeContext.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/xdr/SoapEdgeContext.java
@@ -52,42 +52,89 @@ public interface SoapEdgeContext {
     public static final String DIRECT_TO = "DIRECT_TO";
     public static final String DIRECT_METADATA_LEVEL = "DIRECT_METADATA_LEVEL";
 
-    public static final String[] PropertyKeys = { MESSAGE_ID, REMOTE_HOST, ENDPOINT, TO, THIS_HOST, PAT_ID, SUBSET_ID,
-            P_ID, ACTION, RELATES_TO, REPLY_TO, FROM, DIRECT_FROM, DIRECT_TO, DIRECT_METADATA_LEVEL };
-
-
+    /**
+     * @return ImmutableMap<String, String>
+     */
     public ImmutableMap<String, String> getAuditableValues();
 
+    /**
+     * @return String
+     */
     public String getMessageId();
 
+    /**
+     * @param messageId
+     */
     public void setMessageId(String messageId);
 
+    /**
+     * @return String
+     */
     public String getRemoteHost();
 
+    /**
+     * @param remoteHost
+     */
     public void setRemoteHost(String remoteHost);
 
+    /**
+     * @return String
+     */
     public String getEndpoint();
 
+    /**
+     * @param endpoint
+     */
     public void setEndpoint(String endpoint);
 
+    /**
+     * @return String
+     */
     public String getTo();
 
+    /**
+     * @param to
+     */
     public void setTo(String to);
 
+    /**
+     * @return String
+     */
     public String getThisHost();
 
+    /**
+     * @param thisHost
+     */
     public void setThisHost(String thisHost);
 
+    /**
+     * @return String
+     */
     public String getPatId();
 
+    /**
+     * @param patId
+     */
     public void setPatId(String patId);
 
+    /**
+     * @return String
+     */
     public String getSubsetId();
 
-    public void SubsetId(String subsetId);
+    /**
+     * @param subsetId
+     */
+    public void subsetId(String subsetId);
 
+    /**
+     * @return
+     */
     public String getPid();
 
+    /**
+     * @param pid
+     */
     public void setPid(String pid);
 
     /**
@@ -126,12 +173,12 @@ public interface SoapEdgeContext {
     public void setDirectMetaDataLevel(String textContentFromChildNode);
 
     /**
-     * @return
+     * @return String
      */
     public String getDirectTo();
 
     /**
-     * @return
+     * @return String
      */
     public String getDirectFrom();
 }

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/xdr/SoapEdgeContextMapImpl.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/xdr/SoapEdgeContextMapImpl.java
@@ -40,6 +40,9 @@ public class SoapEdgeContextMapImpl implements SoapEdgeContext {
     /** The properties. */
     Map<String, String> properties = null;
 
+    private static final String[] PropertyKeys = { MESSAGE_ID, REMOTE_HOST, ENDPOINT, TO, THIS_HOST, PAT_ID, SUBSET_ID,
+            P_ID, ACTION, RELATES_TO, REPLY_TO, FROM, DIRECT_FROM, DIRECT_TO, DIRECT_METADATA_LEVEL };
+
     /**
      * Instantiates a new soap edge headers properties impl.
      */
@@ -56,7 +59,7 @@ public class SoapEdgeContextMapImpl implements SoapEdgeContext {
     public ImmutableMap<String, String> getAuditableValues() {
         ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<>();
 
-        for (String s : SoapEdgeContext.PropertyKeys) {
+        for (String s : PropertyKeys) {
             String value = properties.get(s);
             if (StringUtils.isNotBlank(value)) {
                 builder.put(s, value);
@@ -201,7 +204,7 @@ public class SoapEdgeContextMapImpl implements SoapEdgeContext {
      * @see gov.hhs.fha.nhinc.direct.xdr.audit.SoapEdgeHeaders#SubsetId(java.lang.String)
      */
     @Override
-    public void SubsetId(String subsetId) {
+    public void subsetId(String subsetId) {
         properties.put(SoapEdgeContext.SUBSET_ID, subsetId);
     }
 
@@ -225,7 +228,9 @@ public class SoapEdgeContextMapImpl implements SoapEdgeContext {
         properties.put(SoapEdgeContext.P_ID, pid);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     *
      * @see gov.hhs.fha.nhinc.direct.xdr.SoapEdgeHeaders#setAction(java.lang.String)
      */
     @Override
@@ -233,7 +238,9 @@ public class SoapEdgeContextMapImpl implements SoapEdgeContext {
         properties.put(SoapEdgeContext.ACTION, action);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     *
      * @see gov.hhs.fha.nhinc.direct.xdr.SoapEdgeHeaders#setRelatesTo(java.lang.String)
      */
     @Override
@@ -241,7 +248,9 @@ public class SoapEdgeContextMapImpl implements SoapEdgeContext {
         properties.put(SoapEdgeContext.RELATES_TO, relatesTo);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     *
      * @see gov.hhs.fha.nhinc.direct.xdr.SoapEdgeHeaders#setReplyTo(java.lang.String)
      */
     @Override
@@ -249,7 +258,9 @@ public class SoapEdgeContextMapImpl implements SoapEdgeContext {
         properties.put(SoapEdgeContext.REPLY_TO, replyTo);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     *
      * @see gov.hhs.fha.nhinc.direct.xdr.SoapEdgeHeaders#setFrom(java.lang.String)
      */
     @Override
@@ -257,7 +268,9 @@ public class SoapEdgeContextMapImpl implements SoapEdgeContext {
         properties.put(SoapEdgeContext.FROM, from);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     *
      * @see gov.hhs.fha.nhinc.direct.xdr.SoapEdgeHeaders#setDirectFrom(java.lang.String)
      */
     @Override
@@ -265,7 +278,9 @@ public class SoapEdgeContextMapImpl implements SoapEdgeContext {
         properties.put(SoapEdgeContext.DIRECT_FROM, directFrom);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     *
      * @see gov.hhs.fha.nhinc.direct.xdr.SoapEdgeHeaders#setDirectTo(java.lang.String)
      */
     @Override
@@ -273,7 +288,9 @@ public class SoapEdgeContextMapImpl implements SoapEdgeContext {
         properties.put(SoapEdgeContext.DIRECT_TO, directTo);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     *
      * @see gov.hhs.fha.nhinc.direct.xdr.SoapEdgeHeaders#setDirectMetaDataLevel(java.lang.String)
      */
     @Override
@@ -281,7 +298,9 @@ public class SoapEdgeContextMapImpl implements SoapEdgeContext {
         properties.put(SoapEdgeContext.DIRECT_METADATA_LEVEL, directMetadataLevel);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     *
      * @see gov.hhs.fha.nhinc.direct.xdr.SoapEdgeContext#getDirectTo()
      */
     @Override
@@ -289,7 +308,9 @@ public class SoapEdgeContextMapImpl implements SoapEdgeContext {
         return properties.get(SoapEdgeContext.DIRECT_TO);
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     *
      * @see gov.hhs.fha.nhinc.direct.xdr.SoapEdgeContext#getDirectFrom()
      */
     @Override

--- a/Product/Production/Services/DirectCore/src/test/java/gov/hhs/fha/nhinc/direct/DirectAdapterSpringTest.java
+++ b/Product/Production/Services/DirectCore/src/test/java/gov/hhs/fha/nhinc/direct/DirectAdapterSpringTest.java
@@ -27,10 +27,11 @@
 package gov.hhs.fha.nhinc.direct;
 
 import static gov.hhs.fha.nhinc.direct.DirectUnitTestUtil.removeSmtpAgentConfig;
-import gov.hhs.fha.nhinc.mail.MailReceiver;
-import org.junit.AfterClass;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
+import gov.hhs.fha.nhinc.mail.MailReceiver;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -115,7 +116,10 @@ public class DirectAdapterSpringTest {
     @Test
     @Ignore
     public void canRunScheduledTaskEveryOneSec() throws InterruptedException {
-        Thread.sleep(DirectUnitTestUtil.WAIT_TIME_FOR_MAIL_HANDLER);
+        /*
+         * NOTE: Add Thread.sleep(DirectUnitTestUtil.WAIT_TIME_FOR_MAIL_HANDLER) right below this comment when running
+         * this test method.
+         */
 
         int internalInvocations = intMailReceiver.getHandlerInvocations();
         int externalInvocations = extMailReceiver.getHandlerInvocations();


### PR DESCRIPTION
Issues fixed: 
1. static final arrays should be "private" - **SoapEdgeContext.java**
2. Fields in a "Serializable" class should either be transient or serializable\* - **MonitoredMessage.java**
3. "hashCode" and "toString" should not be called on array instances - **DirectSenderServiceImpl.java**
4. Mutable fields should not be "public static" - **SoapEdgeContext.java**
5. "Thread.sleep" should not be used in tests - **DirectAdapterSpringTest.java**

@TabassumJafri @mhpnguyen can you please review?
