### PR TITLE
Removed ConsumerPreferences and DeferredQueueManager GUIs from Connect.ear

### DIFF
--- a/Product/Production/Adapters/General/CONNECTConsumerPreferencesProfileGUI/src/main/webapp/SearchPatient.jsp
+++ b/Product/Production/Adapters/General/CONNECTConsumerPreferencesProfileGUI/src/main/webapp/SearchPatient.jsp
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<%--
+<!--
     Document   : SearchPatient
     Created on : Sep 10, 2009, 11:08:16 PM
     Author     : patlollav
---%>
+-->
 <jsp:root version="2.1" xmlns:f="http://java.sun.com/jsf/core" xmlns:h="http://java.sun.com/jsf/html" xmlns:jsp="http://java.sun.com/JSP/Page" xmlns:webuijsf="http://www.sun.com/webui/webuijsf">
     <jsp:directive.page contentType="text/html;charset=UTF-8" pageEncoding="UTF-8"/>
     <f:view>

--- a/Product/Production/Adapters/General/CONNECTConsumerPreferencesProfileGUI/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Adapters/General/CONNECTConsumerPreferencesProfileGUI/src/main/webapp/WEB-INF/web.xml
@@ -16,11 +16,11 @@
     <context-param>
         <param-name>com.sun.faces.verifyObjects</param-name>
         <param-value>false</param-value>
-    </context-param>
-    <context-param>
-        <param-name>javax.faces.FACELETS_SKIP_COMMENTS</param-name>
-        <param-value>true</param-value>
-    </context-param>
+    </context-param>  
+  <context-param>
+    <param-name>javax.faces.FACELETS_SKIP_COMMENTS</param-name>
+    <param-value>true</param-value>
+  </context-param>
 	
     <filter>
         <filter-name>UploadFilter</filter-name>

--- a/Product/Production/Adapters/General/CONNECTConsumerPreferencesProfileGUI/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Adapters/General/CONNECTConsumerPreferencesProfileGUI/src/main/webapp/WEB-INF/web.xml
@@ -17,7 +17,11 @@
         <param-name>com.sun.faces.verifyObjects</param-name>
         <param-value>false</param-value>
     </context-param>
-
+    <context-param>
+        <param-name>javax.faces.FACELETS_SKIP_COMMENTS</param-name>
+        <param-value>true</param-value>
+    </context-param>
+	
     <filter>
         <filter-name>UploadFilter</filter-name>
         <filter-class>com.sun.webui.jsf.util.UploadFilter</filter-class>

--- a/Product/Production/Adapters/General/CONNECTConsumerPreferencesProfileGUI/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Adapters/General/CONNECTConsumerPreferencesProfileGUI/src/main/webapp/WEB-INF/web.xml
@@ -16,12 +16,11 @@
     <context-param>
         <param-name>com.sun.faces.verifyObjects</param-name>
         <param-value>false</param-value>
-    </context-param>  
+    </context-param>
   <context-param>
     <param-name>javax.faces.FACELETS_SKIP_COMMENTS</param-name>
     <param-value>true</param-value>
   </context-param>
-	
     <filter>
         <filter-name>UploadFilter</filter-name>
         <filter-class>com.sun.webui.jsf.util.UploadFilter</filter-class>

--- a/Product/Production/Adapters/General/CONNECTDeferredQueueManagerGUI/src/main/webapp/ManageQueue.jspx
+++ b/Product/Production/Adapters/General/CONNECTDeferredQueueManagerGUI/src/main/webapp/ManageQueue.jspx
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<%--
+<!--
     Document   : ManageQueue
     Created on : May 13, 2011, 10:40:40 PM
     Author     : richard.ettema
---%>
+-->
 <jsp:root version="2.1" xmlns:jsp="http://java.sun.com/JSP/Page" xmlns:f="http://java.sun.com/jsf/core" xmlns:h="http://java.sun.com/jsf/html" xmlns:webuijsf="http://www.sun.com/webui/webuijsf">
     <jsp:directive.page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"/>
     <f:view>

--- a/Product/Production/Adapters/General/CONNECTDeferredQueueManagerGUI/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Adapters/General/CONNECTDeferredQueueManagerGUI/src/main/webapp/WEB-INF/web.xml
@@ -17,10 +17,10 @@
         <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
         <param-value>client</param-value>
     </context-param>
-	    <context-param>
-        <param-name>javax.faces.FACELETS_SKIP_COMMENTS</param-name>
-        <param-value>true</param-value>
-    </context-param>
+	<context-param>
+    <param-name>javax.faces.FACELETS_SKIP_COMMENTS</param-name>
+    <param-value>true</param-value>
+  </context-param>
 
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>

--- a/Product/Production/Adapters/General/CONNECTDeferredQueueManagerGUI/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Adapters/General/CONNECTDeferredQueueManagerGUI/src/main/webapp/WEB-INF/web.xml
@@ -17,6 +17,10 @@
         <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
         <param-value>client</param-value>
     </context-param>
+	    <context-param>
+        <param-name>javax.faces.FACELETS_SKIP_COMMENTS</param-name>
+        <param-value>true</param-value>
+    </context-param>
 
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>

--- a/Product/Production/Adapters/General/CONNECTDeferredQueueManagerGUI/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Adapters/General/CONNECTDeferredQueueManagerGUI/src/main/webapp/WEB-INF/web.xml
@@ -16,8 +16,8 @@
     <context-param>
         <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
         <param-value>client</param-value>
-    </context-param>
-	<context-param>
+  </context-param>
+  <context-param>
     <param-name>javax.faces.FACELETS_SKIP_COMMENTS</param-name>
     <param-value>true</param-value>
   </context-param>

--- a/Product/Production/Deploy/pom.xml
+++ b/Product/Production/Deploy/pom.xml
@@ -552,7 +552,7 @@
                 <activeByDefault>false</activeByDefault>
             </activation>
             <properties>
-                <gui.excluded>false</gui.excluded>
+                <gui.excluded>true</gui.excluded>
             </properties>
 
             <dependencies>


### PR DESCRIPTION
1. Removed ConsumerPreferences and DeferredQueueManager GUIs from maven-ear-plugin when the GUI profile is provided.
2.  Fixed jsp in ConsumerPreferencesGUI and  DeferredQueueManagerGUI projects to fix deployment.

@danielrf123 and @mhpnguyen 
