### PR TITLE
fix restore payload element in x12 after audit

### DIFF
--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/audit/transform/X12BatchAuditTransforms.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/audit/transform/X12BatchAuditTransforms.java
@@ -27,9 +27,13 @@
 package gov.hhs.fha.nhinc.corex12.ds.audit.transform;
 
 import gov.hhs.fha.nhinc.corex12.ds.audit.X12AuditDataTransformConstants;
+
 import java.io.ByteArrayOutputStream;
+
+import javax.activation.DataHandler;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;
+
 import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeBatchSubmission;
 import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeBatchSubmissionResponse;
 import org.slf4j.Logger;
@@ -48,9 +52,10 @@ public class X12BatchAuditTransforms extends
     protected byte[] marshallToByteArrayFromRequest(COREEnvelopeBatchSubmission request) {
         byte[] bObject = null;
         if (request != null) {
+            DataHandler payloadHandler = request.getPayload();
             try {
                 ByteArrayOutputStream baOutStrm = new ByteArrayOutputStream();
-                // TODO: We set this as "" in COREX12RealTimeAuditTransforms
+                //since we don't audit payload element, set it to null.
                 request.setPayload(null);
                 Object element = new JAXBElement<>(getQname(X12AuditDataTransformConstants.CORE_X12_NAMESPACE_URI,
                     X12AuditDataTransformConstants.CORE_X12_BATCH_REQUEST_LOCALPART),
@@ -61,6 +66,7 @@ public class X12BatchAuditTransforms extends
                 LOG.error("Error while marshalling COREEnvelopeBatchSubmission Request: {}",
                     ex.getLocalizedMessage(), ex);
             }
+            request.setPayload(payloadHandler);
         }
         return bObject;
     }
@@ -69,9 +75,10 @@ public class X12BatchAuditTransforms extends
     protected byte[] marshallToByteArrayFromResponse(COREEnvelopeBatchSubmissionResponse response) {
         byte[] bObject = null;
         if (response != null) {
+            DataHandler payloadHandler = response.getPayload();
             try {
                 ByteArrayOutputStream baOutStrm = new ByteArrayOutputStream();
-                // TODO: We set this as "" in COREX12RealTimeAuditTransforms
+                //since we don't audit payload element, set it to null.
                 response.setPayload(null);
                 Object element = new JAXBElement<>(getQname(X12AuditDataTransformConstants.CORE_X12_NAMESPACE_URI,
                     X12AuditDataTransformConstants.CORE_X12_BATCH_RESPONSE_LOCALPART),
@@ -82,6 +89,7 @@ public class X12BatchAuditTransforms extends
                 LOG.error("Error while marshalling COREEnvelopeBatchSubmission Response: {}",
                     ex.getLocalizedMessage(), ex);
             }
+            response.setPayload(payloadHandler);
         }
         return bObject;
     }

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/audit/transform/X12RealTimeAuditTransforms.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/audit/transform/X12RealTimeAuditTransforms.java
@@ -27,9 +27,12 @@
 package gov.hhs.fha.nhinc.corex12.ds.audit.transform;
 
 import gov.hhs.fha.nhinc.corex12.ds.audit.X12AuditDataTransformConstants;
+
 import java.io.ByteArrayOutputStream;
+
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;
+
 import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeRealTimeRequest;
 import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeRealTimeResponse;
 import org.slf4j.Logger;
@@ -48,9 +51,9 @@ public class X12RealTimeAuditTransforms extends
     protected byte[] marshallToByteArrayFromRequest(COREEnvelopeRealTimeRequest request) {
         byte[] bObject = null;
         if (request != null) {
+            String payload = request.getPayload();
             try {
                 ByteArrayOutputStream baOutStrm = new ByteArrayOutputStream();
-                // TODO: We set this as null in COREX12BatchSubmissionAuditTransforms
                 request.setPayload("");
                 Object element = new JAXBElement<>(getQname(X12AuditDataTransformConstants.CORE_X12_NAMESPACE_URI,
                     X12AuditDataTransformConstants.CORE_X12_REQUEST_LOCALPART),
@@ -61,6 +64,7 @@ public class X12RealTimeAuditTransforms extends
                 LOG.error("Error while marshalling COREEnvelopeRealTimeRequest Request: {}",
                     ex.getLocalizedMessage(), ex);
             }
+            request.setPayload(payload);
         }
         return bObject;
     }
@@ -69,9 +73,9 @@ public class X12RealTimeAuditTransforms extends
     protected byte[] marshallToByteArrayFromResponse(COREEnvelopeRealTimeResponse response) {
         byte[] bObject = null;
         if (response != null) {
+            String payload = response.getPayload();
             try {
                 ByteArrayOutputStream baOutStrm = new ByteArrayOutputStream();
-                // TODO: We set this as null in COREX12BatchSubmissionAuditTransforms
                 response.setPayload("");
                 Object element = new JAXBElement<>(getQname(X12AuditDataTransformConstants.CORE_X12_NAMESPACE_URI,
                     X12AuditDataTransformConstants.CORE_X12_RESPONSE_LOCALPART),
@@ -82,6 +86,7 @@ public class X12RealTimeAuditTransforms extends
                 LOG.error("Error while marshalling COREEnvelopeRealTimeResponse Response: {}",
                     ex.getLocalizedMessage(), ex);
             }
+            response.setPayload(payload);
         }
         return bObject;
     }


### PR DESCRIPTION
Since we don't audit payload elememnt, we set payload element to null which causes the original value to change.  Therefore, we need to assign to a tempoary variable to hold  references and reassign after marshing.

@TabassumJafri, @danielrf123, @sailajaa(Optional); Can you please review this?
