### PR TITLE
Fixed Large Payload file lock

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/largefile/LargeFileDataSource.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/largefile/LargeFileDataSource.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2009-2016, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.largefile;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import javax.activation.FileDataSource;
+
+/**
+ *
+ * @author tjafri
+ */
+public class LargeFileDataSource extends FileDataSource {
+
+    private InputStream is;
+    private OutputStream os;
+
+    public LargeFileDataSource(File file) {
+        super(file);
+    }
+
+    public LargeFileDataSource(String name) {
+        super(name);
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        if (is == null) {
+            is = super.getInputStream();
+        }
+        return is;
+    }
+
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        if (os == null) {
+            os = super.getOutputStream();
+        }
+        return os;
+    }
+}

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/largefile/LargeFileUtils.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/largefile/LargeFileUtils.java
@@ -39,7 +39,6 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import javax.activation.DataHandler;
 import org.apache.cxf.attachment.ByteDataSource;
 import org.slf4j.Logger;
@@ -71,10 +70,10 @@ public class LargeFileUtils {
     public boolean isParsePayloadAsFileLocationEnabled() {
         try {
             return PropertyAccessor.getInstance().getPropertyBoolean(NhincConstants.GATEWAY_PROPERTY_FILE,
-                    NhincConstants.PARSE_PAYLOAD_AS_FILE_URI_OUTBOUND);
+                NhincConstants.PARSE_PAYLOAD_AS_FILE_URI_OUTBOUND);
         } catch (PropertyAccessException pae) {
             LOG.error("Failed to determine if payload should be parsed as a file location.  Will assume false: {}",
-                    pae.getLocalizedMessage(), pae);
+                pae.getLocalizedMessage(), pae);
         }
 
         return false;
@@ -88,10 +87,10 @@ public class LargeFileUtils {
     public boolean isSavePayloadToFileEnabled() {
         try {
             return PropertyAccessor.getInstance().getPropertyBoolean(NhincConstants.GATEWAY_PROPERTY_FILE,
-                    NhincConstants.SAVE_PAYLOAD_TO_FILE_INBOUND);
+                NhincConstants.SAVE_PAYLOAD_TO_FILE_INBOUND);
         } catch (PropertyAccessException pae) {
             LOG.error("Failed to determine if payload should be saved to a file location.  Will assume false: {}",
-                    pae.getLocalizedMessage(), pae);
+                pae.getLocalizedMessage(), pae);
         }
 
         return false;
@@ -203,23 +202,11 @@ public class LargeFileUtils {
     public DataHandler convertToDataHandler(File file) throws IOException {
         if (!file.exists()) {
             throw new IOException(
-                    "Payload file location points to does not exists.  Please ensure that the file path is base64 encoded. "
-                            + file.getAbsolutePath());
+                "Payload file location points to does not exists.  Please ensure that the file path is base64 encoded. "
+                + file.getAbsolutePath());
         }
-
-        URI fileURI = file.toURI();
-        URL fileURL = null;
-
-        if (fileURI != null) {
-            fileURL = fileURI.toURL();
-        }
-
-        // Not nested to cover the cases where a) URI is null b) URI is not null, but URL is null
-        if (fileURL == null) {
-            throw new IOException("Could not get URL for : " + file.getAbsolutePath());
-        }
-
-        return new DataHandler(fileURL);
+        LargeFileDataSource fds = new LargeFileDataSource(file);
+        return new DataHandler(fds);
     }
 
     /**
@@ -316,10 +303,10 @@ public class LargeFileUtils {
     protected String getPayloadSaveDirectory() {
         try {
             return PropertyAccessor.getInstance().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE,
-                    NhincConstants.PAYLOAD_SAVE_DIRECTORY);
+                NhincConstants.PAYLOAD_SAVE_DIRECTORY);
         } catch (PropertyAccessException pae) {
             LOG.error("Failed to determine payload save directory.  Is {} set in gateway.properties?",
-                    NhincConstants.PAYLOAD_SAVE_DIRECTORY, pae.getLocalizedMessage(), pae);
+                NhincConstants.PAYLOAD_SAVE_DIRECTORY, pae.getLocalizedMessage(), pae);
         }
 
         return null;

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/genericbatch/common/nhin/proxy/AbstractNhinX12BatchProxy.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/genericbatch/common/nhin/proxy/AbstractNhinX12BatchProxy.java
@@ -96,6 +96,8 @@ public abstract class AbstractNhinX12BatchProxy implements NhinX12BatchProxy {
         } catch (Exception ex) {
             LOG.error("Error calling batchSubmitTransaction: {}", ex.getLocalizedMessage(), ex);
             return X12EntityExceptionBuilder.getInstance().createWebServiceErrorResponse(msg, ex.getMessage());
+        } finally {
+            X12LargePayloadUtils.releaseFileLock(msg);
         }
         return response;
     }

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/utils/X12LargePayloadUtils.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/utils/X12LargePayloadUtils.java
@@ -136,4 +136,16 @@ public class X12LargePayloadUtils {
             }
         }
     }
+
+    public static void releaseFileLock(COREEnvelopeBatchSubmission request) {
+        if (FILE_UTILS.isParsePayloadAsFileLocationEnabled()) {
+            try {
+                if (request.getPayload() != null) {
+                    FILE_UTILS.closeStreamWithoutException(request.getPayload().getDataSource().getInputStream());
+                }
+            } catch (IOException e) {
+                LOG.info("Unable to release File lock", e);
+            }
+        }
+    }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/DocSubmissionUtils.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/DocSubmissionUtils.java
@@ -87,12 +87,14 @@ public class DocSubmissionUtils {
         }
         return passThroughModeEnabled;
     }
+
     /**
      * set user spec version if target doesn't have it
+     *
      * @param targets NhinTargetCommunitiesType
      * @param version service spec version
      */
-    public void setTargetCommunitiesVersion(NhinTargetCommunitiesType targets, UDDI_SPEC_VERSION version){
+    public void setTargetCommunitiesVersion(NhinTargetCommunitiesType targets, UDDI_SPEC_VERSION version) {
         if (targets == null) {
             targets = new ObjectFactory().createNhinTargetCommunitiesType();
         }
@@ -155,4 +157,15 @@ public class DocSubmissionUtils {
         return LargeFileUtils.getInstance();
     }
 
+    public void releaseFileLock(ProvideAndRegisterDocumentSetRequestType request) {
+        if (fileUtils.isParsePayloadAsFileLocationEnabled()) {
+            try {
+                for (Document doc : request.getDocument()) {
+                    fileUtils.closeStreamWithoutException(doc.getValue().getDataSource().getInputStream());
+                }
+            } catch (IOException e) {
+                LOG.error("Failed to release file lock.", e);
+            }
+        }
+    }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/nhin/deferred/request/proxy11/NhinDocSubmissionDeferredRequestProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/nhin/deferred/request/proxy11/NhinDocSubmissionDeferredRequestProxyWebServiceSecuredImpl.java
@@ -47,7 +47,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class NhinDocSubmissionDeferredRequestProxyWebServiceSecuredImpl implements
-        NhinDocSubmissionDeferredRequestProxy {
+    NhinDocSubmissionDeferredRequestProxy {
+
     private static final Logger LOG = LoggerFactory.getLogger(NhinDocSubmissionDeferredRequestProxyWebServiceSecuredImpl.class);
     private WebServiceProxyHelper oProxyHelper = null;
 
@@ -68,19 +69,19 @@ public class NhinDocSubmissionDeferredRequestProxyWebServiceSecuredImpl implemen
     }
 
     protected CONNECTClient<XDRDeferredRequestPortType> getCONNECTClientSecured(
-            ServicePortDescriptor<XDRDeferredRequestPortType> portDescriptor, String url, AssertionType assertion,
-                       String target, String serviceName) {
+        ServicePortDescriptor<XDRDeferredRequestPortType> portDescriptor, String url, AssertionType assertion,
+        String target, String serviceName) {
         return CONNECTClientFactory.getInstance().getCONNECTClientSecured(portDescriptor, assertion, url, target,
-                serviceName);
+            serviceName);
     }
 
     @Override
     @NwhinInvocationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
-    afterReturningBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
-    serviceType = "Document Submission Deferred Request",
-    version = "")
+        afterReturningBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
+        serviceType = "Document Submission Deferred Request",
+        version = "")
     public XDRAcknowledgementType provideAndRegisterDocumentSetBRequest11(
-            ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion, NhinTargetSystemType targetSystem) {
+        ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion, NhinTargetSystemType targetSystem) {
         LOG.debug("Begin provideAndRegisterDocumentSetBAsyncRequest");
         XDRAcknowledgementType response = null;
 
@@ -89,17 +90,17 @@ public class NhinDocSubmissionDeferredRequestProxyWebServiceSecuredImpl implemen
                 LOG.error("Message was null");
             } else {
                 String url = oProxyHelper.getUrlFromTargetSystemByGatewayAPILevel(targetSystem,
-                        NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME, GATEWAY_API_LEVEL.LEVEL_g0);
+                    NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME, GATEWAY_API_LEVEL.LEVEL_g0);
                 getDocSubmissionUtils().convertFileLocationToDataIfEnabled(request);
 
                 ServicePortDescriptor<XDRDeferredRequestPortType> portDescriptor = new NhinDocSubmissionDeferredRequestServicePortDescriptor();
                 CONNECTClient<XDRDeferredRequestPortType> client = getCONNECTClientSecured(portDescriptor, url,
-                        assertion, targetSystem.getHomeCommunity().getHomeCommunityId(),
-                        NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME );
+                    assertion, targetSystem.getHomeCommunity().getHomeCommunityId(),
+                    NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME);
                 client.enableMtom();
 
                 response = (XDRAcknowledgementType) client.invokePort(XDRDeferredRequestPortType.class,
-                        "provideAndRegisterDocumentSetBDeferredRequest", request);
+                    "provideAndRegisterDocumentSetBDeferredRequest", request);
             }
         } catch (LargePayloadException lpe) {
             LOG.error("Failed to send message.", lpe);
@@ -107,10 +108,10 @@ public class NhinDocSubmissionDeferredRequestProxyWebServiceSecuredImpl implemen
         } catch (Exception ex) {
             LOG.error("Error calling provideAndRegisterDocumentSetBDeferredRequest: " + ex.getMessage(), ex);
             response = getMessageGeneratorUtils().createRegistryErrorXDRAcknowledgementType(ex.getMessage());
+        } finally {
+            getDocSubmissionUtils().releaseFileLock(request);
         }
-
         LOG.debug("End provideAndRegisterDocumentSetBAsyncRequest");
         return response;
     }
-
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/nhin/deferred/request/proxy20/NhinDocSubmissionDeferredRequestProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/nhin/deferred/request/proxy20/NhinDocSubmissionDeferredRequestProxyWebServiceSecuredImpl.java
@@ -47,7 +47,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class NhinDocSubmissionDeferredRequestProxyWebServiceSecuredImpl implements
-        NhinDocSubmissionDeferredRequestProxy {
+    NhinDocSubmissionDeferredRequestProxy {
+
     private static final Logger LOG = LoggerFactory.getLogger(NhinDocSubmissionDeferredRequestProxyWebServiceSecuredImpl.class);
     private WebServiceProxyHelper oProxyHelper = null;
 
@@ -68,20 +69,20 @@ public class NhinDocSubmissionDeferredRequestProxyWebServiceSecuredImpl implemen
     }
 
     protected CONNECTClient<XDRDeferredRequest20PortType> getCONNECTClientSecured(
-            ServicePortDescriptor<XDRDeferredRequest20PortType> portDescriptor, String url, AssertionType assertion,
-             String target, String serviceName) {
+        ServicePortDescriptor<XDRDeferredRequest20PortType> portDescriptor, String url, AssertionType assertion,
+        String target, String serviceName) {
 
         return CONNECTCXFClientFactory.getInstance().getCONNECTClientSecured(portDescriptor, assertion, url, target,
-                serviceName);
+            serviceName);
     }
 
     @NwhinInvocationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
-            afterReturningBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
-            serviceType = "Document Submission Deferred Request",
-            version = "")
+        afterReturningBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
+        serviceType = "Document Submission Deferred Request",
+        version = "")
     @Override
     public RegistryResponseType provideAndRegisterDocumentSetBRequest20(
-            ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion, NhinTargetSystemType targetSystem) {
+        ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion, NhinTargetSystemType targetSystem) {
         LOG.debug("Begin provideAndRegisterDocumentSetBAsyncRequest");
         RegistryResponseType response = null;
 
@@ -90,18 +91,18 @@ public class NhinDocSubmissionDeferredRequestProxyWebServiceSecuredImpl implemen
                 LOG.error("Message was null");
             } else {
                 String url = oProxyHelper.getUrlFromTargetSystemByGatewayAPILevel(targetSystem,
-                        NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME, GATEWAY_API_LEVEL.LEVEL_g1);
+                    NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME, GATEWAY_API_LEVEL.LEVEL_g1);
                 getDocSubmissionUtils().convertFileLocationToDataIfEnabled(request);
 
                 ServicePortDescriptor<XDRDeferredRequest20PortType> portDescriptor = new NhinDocSubmissionDeferredRequestServicePortDescriptor();
 
                 CONNECTClient<XDRDeferredRequest20PortType> client = getCONNECTClientSecured(portDescriptor, url,
-                        assertion, targetSystem.getHomeCommunity().getHomeCommunityId(),
-                        NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME);
+                    assertion, targetSystem.getHomeCommunity().getHomeCommunityId(),
+                    NhincConstants.NHINC_XDR_REQUEST_SERVICE_NAME);
                 client.enableMtom();
 
                 response = (RegistryResponseType) client.invokePort(XDRDeferredRequest20PortType.class,
-                        "provideAndRegisterDocumentSetBDeferredRequest", request);
+                    "provideAndRegisterDocumentSetBDeferredRequest", request);
             }
         } catch (LargePayloadException lpe) {
             LOG.error("Failed to send message.", lpe);
@@ -109,8 +110,9 @@ public class NhinDocSubmissionDeferredRequestProxyWebServiceSecuredImpl implemen
         } catch (Exception ex) {
             LOG.error("Error calling provideAndRegisterDocumentSetBDeferredRequest: " + ex.getMessage(), ex);
             response = getMessageGeneratorUtils().createRegistryErrorResponseWithAckFailure(ex.getMessage());
+        } finally {
+            getDocSubmissionUtils().releaseFileLock(request);
         }
-
         LOG.debug("End provideAndRegisterDocumentSetBAsyncRequest");
         return response;
     }


### PR DESCRIPTION
Created a Custom DataSource class that's is extended from FileDataSource. The main purpose of this class is to return the same instance of InputStream and OutputStream for a given object. User can call inputStream.close to close the underlying IinputStream. The DataHandler class is then created by providing the Custom  DataSource class and user is now able to release the file lock by calling close on the input stream. 

@mhpnguyen 