### PR TITLE
FHAC-1313 fix sonar issues, add static modifier to methods

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/wss/CONNECTSignatureProcessor.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/wss/CONNECTSignatureProcessor.java
@@ -92,14 +92,14 @@ public class CONNECTSignatureProcessor extends SignatureProcessor {
         }
     }
 
-    private void inlineDigestValueIncludes(Element element, Collection<Attachment> attachments) throws IOException {
+    private static void inlineDigestValueIncludes(Element element, Collection<Attachment> attachments) throws IOException {
         NodeList digestNodes = element.getElementsByTagNameNS(SamlConstants.XML_SIGNATURE_NS,
             SamlConstants.DIGEST_VALUE_TAG);
 
         inlineIncludes(digestNodes, attachments);
     }
 
-    private void inlineSignatureValueIncludes(Element element, Collection<Attachment> attachments) throws IOException {
+    private static void inlineSignatureValueIncludes(Element element, Collection<Attachment> attachments) throws IOException {
         NodeList signatureNodes = element.getElementsByTagNameNS(SamlConstants.XML_SIGNATURE_NS,
             SamlConstants.SIGNATURE_VALUE_TAG);
 
@@ -121,7 +121,7 @@ public class CONNECTSignatureProcessor extends SignatureProcessor {
                     sigElement.setTextContent(attachmentValue);
                 } else {
                     LOG.warn(
-                        "Failed to inline signature/digest element to the header.  Cannot find reference id: " + refId);
+                        "Failed to inline signature/digest element to the header.  Cannot find reference id: {}", refId);
                 }
             }
         }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/wss/CONNECTSignatureProcessor.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/wss/CONNECTSignatureProcessor.java
@@ -64,7 +64,7 @@ public class CONNECTSignatureProcessor extends SignatureProcessor {
 
     @Override
     public List<WSSecurityEngineResult> handleToken(Element signatureElem, RequestData data, WSDocInfo wsDocInfo)
-            throws WSSecurityException {
+        throws WSSecurityException {
 
         inlineSignatureAttachments((SoapMessage) data.getMsgContext(), signatureElem);
 
@@ -88,25 +88,25 @@ public class CONNECTSignatureProcessor extends SignatureProcessor {
             inlineSignatureValueIncludes(signatureElem, attachments);
 
         } catch (IOException ioe) {
-            throw new WSSecurityException(ErrorCode.FAILURE,ioe,"Failed to inline attachments to signature.");
+            throw new WSSecurityException(ErrorCode.FAILURE, ioe, "Failed to inline attachments to signature.");
         }
     }
 
     private void inlineDigestValueIncludes(Element element, Collection<Attachment> attachments) throws IOException {
         NodeList digestNodes = element.getElementsByTagNameNS(SamlConstants.XML_SIGNATURE_NS,
-                SamlConstants.DIGEST_VALUE_TAG);
+            SamlConstants.DIGEST_VALUE_TAG);
 
         inlineIncludes(digestNodes, attachments);
     }
 
     private void inlineSignatureValueIncludes(Element element, Collection<Attachment> attachments) throws IOException {
         NodeList signatureNodes = element.getElementsByTagNameNS(SamlConstants.XML_SIGNATURE_NS,
-                SamlConstants.SIGNATURE_VALUE_TAG);
+            SamlConstants.SIGNATURE_VALUE_TAG);
 
         inlineIncludes(signatureNodes, attachments);
     }
 
-    private void inlineIncludes(NodeList signatureNodes, Collection<Attachment> attachments) throws IOException {
+    private static void inlineIncludes(NodeList signatureNodes, Collection<Attachment> attachments) throws IOException {
         for (int i = 0; i < signatureNodes.getLength(); ++i) {
             Element sigElement = (Element) signatureNodes.item(i);
 
@@ -120,14 +120,14 @@ public class CONNECTSignatureProcessor extends SignatureProcessor {
                     String attachmentValue = convertToBase64Data(attachment.get().getDataHandler());
                     sigElement.setTextContent(attachmentValue);
                 } else {
-                    LOG.warn("Failed to inline signature/digest element to the header.  Cannot find reference id: "
-                            + refId);
+                    LOG.warn(
+                        "Failed to inline signature/digest element to the header.  Cannot find reference id: " + refId);
                 }
             }
         }
     }
 
-    private Optional<Attachment> getAttachment(Collection<Attachment> attachments, String id) {
+    private static Optional<Attachment> getAttachment(Collection<Attachment> attachments, String id) {
         for (Attachment attachment : attachments) {
             if (attachment.getId().equals(id)) {
                 return Optional.of(attachment);
@@ -137,7 +137,7 @@ public class CONNECTSignatureProcessor extends SignatureProcessor {
         return Optional.absent();
     }
 
-    private boolean isIncludeElement(Element elem) {
+    private static boolean isIncludeElement(Element elem) {
         String namespace = elem.getNamespaceURI();
         String elemName = elem.getLocalName();
 
@@ -148,7 +148,7 @@ public class CONNECTSignatureProcessor extends SignatureProcessor {
         return false;
     }
 
-    private String convertToBase64Data(DataHandler dh) throws IOException {
+    private static String convertToBase64Data(DataHandler dh) throws IOException {
         byte[] attachmentBinaryData = FILE_UTILS.convertToBytes(dh);
         char[] attachmentBase64Data = Base64Coder.encode(attachmentBinaryData);
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/wss/SecurityConfigInInterceptor.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/wss/SecurityConfigInInterceptor.java
@@ -65,8 +65,7 @@ public class SecurityConfigInInterceptor extends AbstractPhaseInterceptor<Messag
             config = WSSConfig.getNewInstance();
         }
         config.setProcessor(new QName(SamlConstants.XML_SIGNATURE_NS, SamlConstants.SIGNATURE_TAG),
-                new CONNECTSignatureProcessor());
-        //msg.setContextualProperty(WSSConfig.class.getName(), config);
+            new CONNECTSignatureProcessor());
         msg.put(WSSConfig.class.getName(), config);
     }
 


### PR DESCRIPTION
Refactoring the following classes in gov.hhs.fha.nhinc.callback.cxf.wss package:
CONNECTSignatureProcessor.java
SecurityConfigInInterceptor.java  - no change to throws clause in handleMessage() method

[FHAC-13131_issuesreport_files.zip](https://github.com/CONNECT-Solution/CONNECT/files/746318/FHAC-13131_issuesreport_files.zip)

@mhpnguyen @sjarral112 @jsmith2 please review...