### PR TITLE
Conn 1718 Keep-Alive and Custom HTTP Headers

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/CONNECTCXFClientFactory.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/CONNECTCXFClientFactory.java
@@ -28,7 +28,6 @@ package gov.hhs.fha.nhinc.messaging.client;
 
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.messaging.service.port.ServicePortDescriptor;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * @author akong
@@ -42,27 +41,14 @@ public class CONNECTCXFClientFactory extends CONNECTClientFactory {
     @Override
     public <T> CONNECTClient<T> getCONNECTClientSecured(ServicePortDescriptor<T> portDescriptor, String url,
             AssertionType assertion) {
-        return getCONNECTClientSecured(portDescriptor, url, assertion, null, null);
+
+        return new CONNECTCXFClientSecured<>(portDescriptor, url, assertion);
     }
 
     /**
-     * Returns a CONNECTClient configured for secured invocation. This method allows Ws-Addressing parameters to be
-     * passed for HIEM use.
-     */
-    @Override
-    public <T> CONNECTClient<T> getCONNECTClientSecured(ServicePortDescriptor<T> portDescriptor, String url,
-            AssertionType assertion, String wsAddressingTo, String subscriptionId) {
-        String wsAddressingToValue = wsAddressingTo;
-        // use the url if the wsaddressing is null or blank
-        if (StringUtils.isBlank(wsAddressingToValue)) {
-            wsAddressingToValue = url;
-        }
-        return new CONNECTCXFClientSecured<>(portDescriptor, url, assertion, wsAddressingToValue, subscriptionId);
-    }
-
-    /**
-     * Returns a CONNECTClient configured for secured invocation. This method allows the target hcid and service name to
-     * be passed to be used for purpose of/purpose for logic.
+     * Returns a CONNECTClient configured for secured invocation. This method
+     * allows the target hcid and service name to be passed to be used for
+     * purpose of/purpose for logic.
      */
     @Override
     public <T> CONNECTClient<T> getCONNECTClientSecured(ServicePortDescriptor<T> portDescriptor,

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/CONNECTCXFClientSecured.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/CONNECTCXFClientSecured.java
@@ -27,8 +27,8 @@
 package gov.hhs.fha.nhinc.messaging.client;
 
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.messaging.service.decorator.HttpHeaderServiceEndpointDecorator;
 import gov.hhs.fha.nhinc.messaging.service.decorator.SAMLServiceEndpointDecorator;
-import gov.hhs.fha.nhinc.messaging.service.decorator.cxf.SoapHeaderServiceEndPointDecorator;
 import gov.hhs.fha.nhinc.messaging.service.decorator.cxf.WsAddressingServiceEndpointDecorator;
 import gov.hhs.fha.nhinc.messaging.service.port.CachingCXFSecuredServicePortBuilder;
 import gov.hhs.fha.nhinc.messaging.service.port.ServicePortDescriptor;
@@ -43,10 +43,9 @@ public class CONNECTCXFClientSecured<T> extends CONNECTCXFClient<T> {
 
     private static final Logger LOG = LoggerFactory.getLogger(CONNECTCXFClientSecured.class);
 
-    CONNECTCXFClientSecured(ServicePortDescriptor<T> portDescriptor, String url, AssertionType assertion,
-            String wsAddressingTo, String SoapHeader) {
+    CONNECTCXFClientSecured(ServicePortDescriptor<T> portDescriptor, String url, AssertionType assertion) {
         super(portDescriptor, url, assertion, new CachingCXFSecuredServicePortBuilder<>(portDescriptor));
-        decorateEndpoint(assertion, wsAddressingTo, portDescriptor.getWSAddressingAction(), SoapHeader, null, null);
+        decorateEndpoint(assertion, url, portDescriptor.getWSAddressingAction(), null, null);
 
         serviceEndpoint.configure();
     }
@@ -54,7 +53,7 @@ public class CONNECTCXFClientSecured<T> extends CONNECTCXFClient<T> {
     CONNECTCXFClientSecured(ServicePortDescriptor<T> portDescriptor, AssertionType assertion, String url,
             String targetHomeCommunityId, String serviceName) {
         super(portDescriptor, url, assertion, new CachingCXFSecuredServicePortBuilder<>(portDescriptor));
-        decorateEndpoint(assertion, url, portDescriptor.getWSAddressingAction(), null, targetHomeCommunityId,
+        decorateEndpoint(assertion, url, portDescriptor.getWSAddressingAction(), targetHomeCommunityId,
                 serviceName);
 
         serviceEndpoint.configure();
@@ -66,12 +65,12 @@ public class CONNECTCXFClientSecured<T> extends CONNECTCXFClient<T> {
     }
 
     private void decorateEndpoint(AssertionType assertion, String wsAddressingTo, String wsAddressingActionId,
-            String subscriptionId, String targetHomeCommunityId, String serviceName) {
+            String targetHomeCommunityId, String serviceName) {
         serviceEndpoint = new SAMLServiceEndpointDecorator<>(serviceEndpoint, assertion, targetHomeCommunityId,
                 serviceName);
         serviceEndpoint = new WsAddressingServiceEndpointDecorator<>(serviceEndpoint, wsAddressingTo,
                 wsAddressingActionId, assertion);
-        serviceEndpoint = new SoapHeaderServiceEndPointDecorator<>(serviceEndpoint, subscriptionId);
+        serviceEndpoint = new HttpHeaderServiceEndpointDecorator<>(serviceEndpoint, assertion);
     }
 
     /*

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/CONNECTClientFactory.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/CONNECTClientFactory.java
@@ -37,9 +37,6 @@ public abstract class CONNECTClientFactory {
     abstract public <T> CONNECTClient<T> getCONNECTClientSecured(ServicePortDescriptor<T> portDescriptor, String url,
             AssertionType assertion);
 
-    abstract public <T> CONNECTClient<T> getCONNECTClientSecured(ServicePortDescriptor<T> portDescriptor, String url,
-            AssertionType assertion, String wsAddressing, String subscriptionId);
-
     abstract public <T> CONNECTClient<T> getCONNECTClientSecured(ServicePortDescriptor<T> portDescriptor,
             AssertionType assertion, String url, String targetHomeCommunityId, String serviceName);
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/interceptor/HttpHeaderRequestOutInterceptor.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/interceptor/HttpHeaderRequestOutInterceptor.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2009-2016, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package gov.hhs.fha.nhinc.messaging.client.interceptor;
+
+
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.AbstractPhaseInterceptor;
+import org.apache.cxf.phase.Phase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author jassmit
+ */
+public class HttpHeaderRequestOutInterceptor extends AbstractPhaseInterceptor<Message> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HttpHeaderRequestOutInterceptor.class);
+    
+    public HttpHeaderRequestOutInterceptor() {
+        super(Phase.PRE_LOGICAL);
+    }
+
+    @Override
+    public void handleMessage(Message message) throws Fault {
+        LOG.trace("Begin HttpHeaderRequestOutInterceptor");
+        Map<String, List> headers = (Map<String, List>) message.get(Message.PROTOCOL_HEADERS);
+        
+        if(headers == null) {
+            headers = new HashMap<>();
+        }
+        
+        final Map<String, String> customHttpHeaders = getCustomHttpHeaders(message);
+        
+        if(customHttpHeaders != null && !customHttpHeaders.isEmpty()) {
+            for(String key : customHttpHeaders.keySet()) {
+                String value = customHttpHeaders.get(key);
+                headers.put(key, Collections.singletonList(value));
+                LOG.debug("Adding custom CONNECT HTTP header: " , key, ", ", value);
+            }
+        }
+        
+        message.put(Message.PROTOCOL_HEADERS, headers);
+    }
+    
+    protected Map<String,String> getCustomHttpHeaders(Message message) {
+        return (HashMap<String, String>) message.get(NhincConstants.CUSTOM_HTTP_HEADERS);
+    }
+     
+}

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/interceptor/HttpHeaderRequestOutInterceptor.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/interceptor/HttpHeaderRequestOutInterceptor.java
@@ -33,7 +33,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.cxf.interceptor.Fault;
+import java.util.Map.Entry;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.phase.Phase;
@@ -53,7 +53,7 @@ public class HttpHeaderRequestOutInterceptor extends AbstractPhaseInterceptor<Me
     }
 
     @Override
-    public void handleMessage(Message message) throws Fault {
+    public void handleMessage(Message message) {
         LOG.trace("Begin HttpHeaderRequestOutInterceptor");
         Map<String, List> headers = (Map<String, List>) message.get(Message.PROTOCOL_HEADERS);
         
@@ -64,10 +64,9 @@ public class HttpHeaderRequestOutInterceptor extends AbstractPhaseInterceptor<Me
         final Map<String, String> customHttpHeaders = getCustomHttpHeaders(message);
         
         if(customHttpHeaders != null && !customHttpHeaders.isEmpty()) {
-            for(String key : customHttpHeaders.keySet()) {
-                String value = customHttpHeaders.get(key);
-                headers.put(key, Collections.singletonList(value));
-                LOG.debug("Adding custom CONNECT HTTP header: " , key, ", ", value);
+            for(Entry<String,String> entry : customHttpHeaders.entrySet()) {
+                headers.put(entry.getKey(), Collections.singletonList(entry.getValue()));
+                LOG.debug("Adding custom CONNECT HTTP header: {}, {}" , entry.getKey(), entry.getValue());
             }
         }
         

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/interceptor/HttpHeaderRequestOutInterceptor.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/interceptor/HttpHeaderRequestOutInterceptor.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import org.apache.commons.collections.MapUtils;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.phase.Phase;
@@ -63,7 +64,7 @@ public class HttpHeaderRequestOutInterceptor extends AbstractPhaseInterceptor<Me
         
         final Map<String, String> customHttpHeaders = getCustomHttpHeaders(message);
         
-        if(customHttpHeaders != null && !customHttpHeaders.isEmpty()) {
+        if(MapUtils.isNotEmpty(customHttpHeaders)) {
             for(Entry<String,String> entry : customHttpHeaders.entrySet()) {
                 headers.put(entry.getKey(), Collections.singletonList(entry.getValue()));
                 LOG.debug("Adding custom CONNECT HTTP header: {}, {}" , entry.getKey(), entry.getValue());

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/server/BaseService.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/server/BaseService.java
@@ -43,6 +43,7 @@ import java.util.Properties;
 import javax.servlet.http.HttpServletRequest;
 import javax.xml.ws.WebServiceContext;
 import javax.xml.ws.handler.MessageContext;
+import org.apache.commons.collections.MapUtils;
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.jaxws.context.WrappedMessageContext;
 import org.apache.cxf.message.Message;
@@ -90,7 +91,7 @@ public abstract class BaseService {
             if (getPropertyAccessor().getPropertyBoolean(NhincConstants.GATEWAY_PROPERTY_FILE, NhincConstants.READ_HTTP_HEADERS)) {
                 MessageContext messageContext = getMessageContext(context);
 
-                if (messageContext != null && (messageContext instanceof WrappedMessageContext)) {
+                if (messageContext instanceof WrappedMessageContext) {
                     readHttpHeaders(messageContext, assertion);
                 }
             }
@@ -201,7 +202,7 @@ public abstract class BaseService {
         Message message = ((WrappedMessageContext) messageContext).getWrappedMessage();
         if (message != null && message.get(Message.PROTOCOL_HEADERS) != null) {
             Map<String, List<String>> headers = CastUtils.cast((Map) message.get(Message.PROTOCOL_HEADERS));
-            if (headers != null && headers.keySet() != null && !headers.keySet().isEmpty()) {
+            if (MapUtils.isNotEmpty(headers)) {
                 addHeadersToAssertion(headers, assertion);
             }
         }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/server/BaseService.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/server/BaseService.java
@@ -38,6 +38,7 @@ import gov.hhs.fha.nhinc.util.HomeCommunityMap;
 import gov.hhs.fha.nhinc.wsa.WSAHeaderHelper;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 import javax.servlet.http.HttpServletRequest;
 import javax.xml.ws.WebServiceContext;
@@ -187,19 +188,23 @@ public abstract class BaseService {
         return webContextProperties;
     }
     
-    private void readHttpHeaders(MessageContext messageContext, AssertionType assertion) {
+    private static void readHttpHeaders(MessageContext messageContext, AssertionType assertion) {
         Message message = ((WrappedMessageContext) messageContext).getWrappedMessage();
         if (message != null && message.get(Message.PROTOCOL_HEADERS) != null) {
             Map<String, List<String>> headers = CastUtils.cast((Map) message.get(Message.PROTOCOL_HEADERS));
             if (headers != null && headers.keySet() != null && !headers.keySet().isEmpty()) {
-                for (String headerName : headers.keySet()) {
-                    if (!headerHelper.isStandardHeader(headerName) && !headers.get(headerName).isEmpty()) {
-                        CONNECTCustomHttpHeadersType assertionHeader = new CONNECTCustomHttpHeadersType();
-                        assertionHeader.setHeaderName(headerName);
-                        assertionHeader.setHeaderValue(headers.get(headerName).get(0));
-                        assertion.getCONNECTCustomHttpHeaders().add(assertionHeader);
-                    }
-                }
+                addHeadersToAssertion(headers, assertion);
+            }
+        }
+    }
+
+    private static void addHeadersToAssertion(Map<String, List<String>> headers, AssertionType assertion) {
+        for (Entry<String,List<String>> entry : headers.entrySet()) {
+            if (!headerHelper.isStandardHeader(entry.getKey()) && !headers.get(entry.getKey()).isEmpty()) {
+                CONNECTCustomHttpHeadersType assertionHeader = new CONNECTCustomHttpHeadersType();
+                assertionHeader.setHeaderName(entry.getKey());
+                assertionHeader.setHeaderValue(entry.getValue().get(0));
+                assertion.getCONNECTCustomHttpHeaders().add(assertionHeader);
             }
         }
     }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/server/BaseService.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/server/BaseService.java
@@ -96,7 +96,7 @@ public abstract class BaseService {
             if (assertion != null && getPropertyAccessor().getPropertyBoolean(NhincConstants.GATEWAY_PROPERTY_FILE, NhincConstants.READ_HTTP_HEADERS)) {
                 MessageContext messageContext = getMessageContext(context);
 
-                if (messageContext != null || (messageContext instanceof WrappedMessageContext)) {
+                if (messageContext != null && (messageContext instanceof WrappedMessageContext)) {
                     readHttpHeaders(messageContext, assertion);
                 }
             }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/server/HttpHeaderHelper.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/server/HttpHeaderHelper.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2009-2016, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.messaging.server;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ *
+ * @author jassmit
+ */
+public class HttpHeaderHelper {
+    
+    private static final Set<String> STANDARD_HEADERS = new HashSet<>();
+    
+    static {
+        STANDARD_HEADERS.add("Accept-Encoding".toUpperCase());
+        STANDARD_HEADERS.add("Accept-Language".toUpperCase());
+        STANDARD_HEADERS.add("Cookie".toUpperCase());
+        STANDARD_HEADERS.add("Host".toUpperCase());
+        STANDARD_HEADERS.add("User-Agent".toUpperCase());
+        STANDARD_HEADERS.add("Referer".toUpperCase());
+        STANDARD_HEADERS.add("Cache-Control".toUpperCase());
+        STANDARD_HEADERS.add("Content-Encoding".toUpperCase());
+        STANDARD_HEADERS.add("Content-Type".toUpperCase());
+        STANDARD_HEADERS.add("Content-Location".toUpperCase());
+        STANDARD_HEADERS.add("Transfer-Encoding".toUpperCase()); 
+        STANDARD_HEADERS.add("Connection".toUpperCase());
+        STANDARD_HEADERS.add("accept".toUpperCase());
+        STANDARD_HEADERS.add("server".toUpperCase());
+        STANDARD_HEADERS.add("keep-alive".toUpperCase());
+        STANDARD_HEADERS.add("pragma".toUpperCase());
+    }
+    
+    public boolean isStandardHeader(String value) {
+        return STANDARD_HEADERS.contains(value.toUpperCase());
+    }
+}

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/server/HttpHeaderHelper.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/server/HttpHeaderHelper.java
@@ -26,6 +26,7 @@
  */
 package gov.hhs.fha.nhinc.messaging.server;
 
+import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -57,6 +58,6 @@ public class HttpHeaderHelper {
     }
     
     public boolean isStandardHeader(String value) {
-        return STANDARD_HEADERS.contains(value.toUpperCase());
+        return NullChecker.isNotNullish(value) ? STANDARD_HEADERS.contains(value.toUpperCase()) : false;
     }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/HttpHeaderServiceEndpointDecorator.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/HttpHeaderServiceEndpointDecorator.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2009-2016, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.messaging.service.decorator;
+
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.CONNECTCustomHttpHeadersType;
+import gov.hhs.fha.nhinc.messaging.service.ServiceEndpoint;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.nhinclib.NullChecker;
+import gov.hhs.fha.nhinc.properties.PropertyAccessException;
+import gov.hhs.fha.nhinc.properties.PropertyAccessor;
+import java.util.HashMap;
+import java.util.Set;
+import javax.xml.ws.BindingProvider;
+import org.apache.cxf.transports.http.configuration.ConnectionType;
+import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author jassmit
+ * @param <T>
+ */
+public class HttpHeaderServiceEndpointDecorator<T> extends ServiceEndpointDecorator<T> {
+
+    private final AssertionType assertion;
+
+    private static final Logger LOG = LoggerFactory.getLogger(HttpHeaderServiceEndpointDecorator.class);
+
+    public HttpHeaderServiceEndpointDecorator(ServiceEndpoint<T> decoratedEndpoint, final AssertionType assertion) {
+        super(decoratedEndpoint);
+        this.assertion = assertion;
+    }
+
+    @Override
+    public void configure() {
+        super.configure();
+        final HTTPClientPolicy httpClientPolicy = getHTTPClientPolicy();
+        final BindingProvider bindingProvider = (BindingProvider) getPort();
+
+        //Clear http connection value.
+        httpClientPolicy.setConnection(null);
+        if (hasKeepAliveForConnection()) {
+            httpClientPolicy.setConnection(ConnectionType.KEEP_ALIVE);
+        }
+
+        bindingProvider.getRequestContext().remove(NhincConstants.CUSTOM_HTTP_HEADERS);
+        HashMap<String, String> httpHeaders = getCustomHeaders();
+
+        if (httpHeaders != null && !httpHeaders.isEmpty()) {
+            bindingProvider.getRequestContext().put(NhincConstants.CUSTOM_HTTP_HEADERS, httpHeaders);
+        }
+    }
+
+    private boolean hasKeepAliveForConnection() {
+        String keepAlive = assertion.getKeepAlive();
+        if (NullChecker.isNullish(keepAlive)) {
+            keepAlive = getKeepAliveProperty();
+        }
+
+        return NullChecker.isNotNullish(keepAlive)
+                && (keepAlive.equalsIgnoreCase("TRUE") || keepAlive.equalsIgnoreCase("T"));
+    }
+
+    private String getKeepAliveProperty() {
+        try {
+            return getPropertyAccessor().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE, NhincConstants.KEEP_ALIVE_PROP);
+        } catch (PropertyAccessException ex) {
+            LOG.warn("Unable to access property: ", NhincConstants.KEEP_ALIVE_PROP, ex);
+            return null;
+        }
+    }
+
+    private HashMap<String, String> getCustomHeaders() {
+        HashMap<String, String> customHeaders = new HashMap<>();
+        try {
+            Set<String> allPropNames = getPropertyAccessor().getPropertyNames(NhincConstants.GATEWAY_PROPERTY_FILE);
+
+            if (NullChecker.isNotNullish(allPropNames)) {
+                for (String propName : allPropNames) {
+                    if (NullChecker.isNotNullish(propName) && propName.startsWith(NhincConstants.CUSTOM_HTTP_HEADERS)) {
+                        String propValue = getPropertyAccessor().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE, propName);
+                        propName = trimPropertyName(propName);
+                        if (NullChecker.isNotNullish(propValue) && NullChecker.isNotNullish(propName)) {
+                            customHeaders.put(propName, propValue);
+                        }
+                    }
+                }
+            }
+        } catch (PropertyAccessException ex) {
+            LOG.warn("Unable to access properties for custom http headers.", ex);
+        }
+
+        if (NullChecker.isNotNullish(assertion.getCONNECTCustomHttpHeaders())) {
+            for (CONNECTCustomHttpHeadersType header : assertion.getCONNECTCustomHttpHeaders()) {
+                customHeaders.put(header.getHeaderName(), header.getHeaderValue());
+            }
+        }
+
+        return customHeaders;
+    }
+
+    protected PropertyAccessor getPropertyAccessor() {
+        return PropertyAccessor.getInstance();
+    }
+
+    private String trimPropertyName(String propName) {
+        if ((propName.length()) > (NhincConstants.CUSTOM_HTTP_HEADERS.length() + 1)) {
+            return propName.substring(NhincConstants.CUSTOM_HTTP_HEADERS.length() + 1).trim();
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/HttpHeaderServiceEndpointDecorator.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/HttpHeaderServiceEndpointDecorator.java
@@ -36,6 +36,7 @@ import gov.hhs.fha.nhinc.properties.PropertyAccessor;
 import java.util.HashMap;
 import java.util.Set;
 import javax.xml.ws.BindingProvider;
+import org.apache.commons.collections.MapUtils;
 import org.apache.cxf.transports.http.configuration.ConnectionType;
 import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
 import org.slf4j.Logger;
@@ -72,7 +73,7 @@ public class HttpHeaderServiceEndpointDecorator<T> extends ServiceEndpointDecora
         bindingProvider.getRequestContext().remove(NhincConstants.CUSTOM_HTTP_HEADERS);
         HashMap<String, String> httpHeaders = getCustomHeaders();
 
-        if (httpHeaders != null && !httpHeaders.isEmpty()) {
+        if (MapUtils.isNotEmpty(httpHeaders)) {
             bindingProvider.getRequestContext().put(NhincConstants.CUSTOM_HTTP_HEADERS, httpHeaders);
         }
     }
@@ -83,15 +84,14 @@ public class HttpHeaderServiceEndpointDecorator<T> extends ServiceEndpointDecora
             keepAlive = getKeepAliveProperty();
         }
 
-        return NullChecker.isNotNullish(keepAlive)
-                && ("TRUE".equalsIgnoreCase(keepAlive) || "T".equalsIgnoreCase(keepAlive));
+        return ("TRUE".equalsIgnoreCase(keepAlive) || "T".equalsIgnoreCase(keepAlive));
     }
 
     private String getKeepAliveProperty() {
         try {
             return getPropertyAccessor().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE, NhincConstants.KEEP_ALIVE_PROP);
         } catch (PropertyAccessException ex) {
-            LOG.warn("Unable to access property: ", NhincConstants.KEEP_ALIVE_PROP, ex);
+            LOG.warn("Unable to access property: {}", NhincConstants.KEEP_ALIVE_PROP, ex.getLocalizedMessage());
             return null;
         }
     }
@@ -105,13 +105,11 @@ public class HttpHeaderServiceEndpointDecorator<T> extends ServiceEndpointDecora
                 addPropertiesToCustomHeaders(allPropNames, customHeaders);
             }
         } catch (PropertyAccessException ex) {
-            LOG.warn("Unable to access properties for custom http headers.", ex);
+            LOG.warn("Unable to access properties for custom http headers.", ex.getLocalizedMessage());
         }
 
-        if (NullChecker.isNotNullish(assertion.getCONNECTCustomHttpHeaders())) {
-            for (CONNECTCustomHttpHeadersType header : assertion.getCONNECTCustomHttpHeaders()) {
-                customHeaders.put(header.getHeaderName(), header.getHeaderValue());
-            }
+        for (CONNECTCustomHttpHeadersType header : assertion.getCONNECTCustomHttpHeaders()) {
+            customHeaders.put(header.getHeaderName(), header.getHeaderValue());
         }
 
         return customHeaders;

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/HttpHeaderServiceEndpointDecorator.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/HttpHeaderServiceEndpointDecorator.java
@@ -84,7 +84,7 @@ public class HttpHeaderServiceEndpointDecorator<T> extends ServiceEndpointDecora
         }
 
         return NullChecker.isNotNullish(keepAlive)
-                && (keepAlive.equalsIgnoreCase("TRUE") || keepAlive.equalsIgnoreCase("T"));
+                && ("TRUE".equalsIgnoreCase(keepAlive) || "T".equalsIgnoreCase(keepAlive));
     }
 
     private String getKeepAliveProperty() {
@@ -102,15 +102,7 @@ public class HttpHeaderServiceEndpointDecorator<T> extends ServiceEndpointDecora
             Set<String> allPropNames = getPropertyAccessor().getPropertyNames(NhincConstants.GATEWAY_PROPERTY_FILE);
 
             if (NullChecker.isNotNullish(allPropNames)) {
-                for (String propName : allPropNames) {
-                    if (NullChecker.isNotNullish(propName) && propName.startsWith(NhincConstants.CUSTOM_HTTP_HEADERS)) {
-                        String propValue = getPropertyAccessor().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE, propName);
-                        propName = trimPropertyName(propName);
-                        if (NullChecker.isNotNullish(propValue) && NullChecker.isNotNullish(propName)) {
-                            customHeaders.put(propName, propValue);
-                        }
-                    }
-                }
+                addPropertiesToCustomHeaders(allPropNames, customHeaders);
             }
         } catch (PropertyAccessException ex) {
             LOG.warn("Unable to access properties for custom http headers.", ex);
@@ -125,11 +117,23 @@ public class HttpHeaderServiceEndpointDecorator<T> extends ServiceEndpointDecora
         return customHeaders;
     }
 
+    private void addPropertiesToCustomHeaders(Set<String> allPropNames, HashMap<String, String> customHeaders) throws PropertyAccessException {
+        for (String propName : allPropNames) {
+            if (NullChecker.isNotNullish(propName) && propName.startsWith(NhincConstants.CUSTOM_HTTP_HEADERS)) {
+                String propValue = getPropertyAccessor().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE, propName);
+                propName = trimPropertyName(propName);
+                if (NullChecker.isNotNullish(propValue) && NullChecker.isNotNullish(propName)) {
+                    customHeaders.put(propName, propValue);
+                }
+            }
+        }
+    }
+
     protected PropertyAccessor getPropertyAccessor() {
         return PropertyAccessor.getInstance();
     }
 
-    private String trimPropertyName(String propName) {
+    private static String trimPropertyName(String propName) {
         if ((propName.length()) > (NhincConstants.CUSTOM_HTTP_HEADERS.length() + 1)) {
             return propName.substring(NhincConstants.CUSTOM_HTTP_HEADERS.length() + 1).trim();
         } else {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsSecurityServiceEndpointDecorator.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsSecurityServiceEndpointDecorator.java
@@ -26,6 +26,7 @@
  */
 package gov.hhs.fha.nhinc.messaging.service.decorator.cxf;
 
+import gov.hhs.fha.nhinc.messaging.client.interceptor.HttpHeaderRequestOutInterceptor;
 import gov.hhs.fha.nhinc.messaging.service.ServiceEndpoint;
 import gov.hhs.fha.nhinc.messaging.service.decorator.ServiceEndpointDecorator;
 import java.util.Map;
@@ -90,6 +91,7 @@ public class WsSecurityServiceEndpointDecorator<T> extends ServiceEndpointDecora
         }
 
         client.getOutInterceptors().add(outInterceptor);
+        client.getOutInterceptors().add(new HttpHeaderRequestOutInterceptor());
     }
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
@@ -519,6 +519,10 @@ public class NhincConstants {
     public static final String PATIENT_CORR_HIBERNATE_BEAN = "patientCorrHibernateUtil";
     public static final String MSG_MONITOR_HIBERNATE_BEAN = "msgMonitorHibernateUtil";
     public static final String DIRECT_CONFIG_HIBERNATE_BEAN = "directConfigHibernateUtil";
+    
+    public static final String CUSTOM_HTTP_HEADERS = "customHttpHeaders";
+    public static final String KEEP_ALIVE_PROP = "connectionKeepAlive";
+    public static final String READ_HTTP_HEADERS = "readHttpHeaders";
 
     private NhincConstants() {
     }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/properties/PropertyAccessor.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/properties/PropertyAccessor.java
@@ -161,7 +161,7 @@ public class PropertyAccessor implements IPropertyAcessor {
      * @return An enumeration of property keys in the property file.
      * @throws PropertyAccessException This is thrown if an error occurs accessing the property.
      */
-    public synchronized final Set<String> getPropertyNames(String propertyFile) throws PropertyAccessException {
+    public synchronized Set<String> getPropertyNames(String propertyFile) throws PropertyAccessException {
         validateInput(propertyFile);
         loadPropertyFile(propertyFile);
 

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/messaging/client/CONNECTCXFClientSecuredTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/messaging/client/CONNECTCXFClientSecuredTest.java
@@ -83,19 +83,18 @@ public class CONNECTCXFClientSecuredTest {
     @Test
     public void ensureInterceptorCountIsConstant() {
         String url = "url";
-        String wsAddressingTo = "wsAddressingTo";
         AssertionType assertion = new AssertionType();
         assertion.setTransactionTimeout(-1);
 
-        CONNECTClient<TestServicePortType> client = createClient(url, assertion, wsAddressingTo);
+        CONNECTClient<TestServicePortType> client = createClient(url, assertion);
 
         Client cxfClient = ClientProxy.getClient(client.getPort());
         int numInInterceptors = cxfClient.getInInterceptors().size();
         int numOutInterceptors = cxfClient.getOutInterceptors().size();
 
-        createClient(url, assertion, wsAddressingTo);
-        createClient(url, assertion, wsAddressingTo);
-        CONNECTClient<TestServicePortType> client2 = createClient(url, assertion, wsAddressingTo);
+        createClient(url, assertion);
+        createClient(url, assertion);
+        CONNECTClient<TestServicePortType> client2 = createClient(url, assertion);
 
         Client cxfClient2 = ClientProxy.getClient(client2.getPort());
         assertEquals(numInInterceptors, cxfClient2.getInInterceptors().size());
@@ -106,7 +105,6 @@ public class CONNECTCXFClientSecuredTest {
     @Test
     public void securedClientConfiguration() {
         String url = "url";
-        String wsAddressingTo = "wsAddressingTo";
         String messageId = "urn:uuid:messageId";
         String relatesTo = "relatesTo";
         AssertionType assertion = new AssertionType();
@@ -114,7 +112,7 @@ public class CONNECTCXFClientSecuredTest {
         assertion.getRelatesToList().add(relatesTo);
         ServicePortDescriptor<TestServicePortType> portDescriptor = new TestServicePortDescriptor();
 
-        CONNECTClient<TestServicePortType> client = createClient(url, assertion, wsAddressingTo);
+        CONNECTClient<TestServicePortType> client = createClient(url, assertion);
 
         // default configuration
         timeoutTest.verifyTimeoutIsSet(client, TIMEOUT);
@@ -124,7 +122,7 @@ public class CONNECTCXFClientSecuredTest {
         // secured configuration
         samlTest.verifySAMLConfiguration(client, assertion);
         tlsTest.verifyTLSConfiguration(client);
-        addressTest.verifyAddressingProperties(client, wsAddressingTo, portDescriptor.getWSAddressingAction(),
+        addressTest.verifyAddressingProperties(client, url, portDescriptor.getWSAddressingAction(),
                 messageId, relatesTo);
         securityTest.verifyWsSecurityProperties(client);
     }
@@ -133,7 +131,6 @@ public class CONNECTCXFClientSecuredTest {
     @Test
     public void testEnableMtom() {
         String url = "url";
-        String wsAddressingTo = "wsAddressingTo";
         String messageId = "urn:uuid:messageId";
         String relatesTo = "relatesTo";
         AssertionType assertion = new AssertionType();
@@ -141,7 +138,7 @@ public class CONNECTCXFClientSecuredTest {
         assertion.getRelatesToList().add(relatesTo);
         ServicePortDescriptor<TestServicePortType> portDescriptor = new TestServicePortDescriptor();
 
-        CONNECTClient<TestServicePortType> client = createClient(url, assertion, wsAddressingTo);
+        CONNECTClient<TestServicePortType> client = createClient(url, assertion);
         client.enableMtom();
 
         // default configuration
@@ -152,7 +149,7 @@ public class CONNECTCXFClientSecuredTest {
         // secured configuration
         samlTest.verifySAMLConfiguration(client, assertion);
         tlsTest.verifyTLSConfiguration(client);
-        addressTest.verifyAddressingProperties(client, wsAddressingTo, portDescriptor.getWSAddressingAction(),
+        addressTest.verifyAddressingProperties(client, url, portDescriptor.getWSAddressingAction(),
                 messageId, relatesTo);
         securityTest.verifyWsSecurityProperties(client);
 
@@ -160,9 +157,9 @@ public class CONNECTCXFClientSecuredTest {
         mtomTest.verifyMTOMEnabled(client);
     }
 
-    private CONNECTClient<TestServicePortType> createClient(String url, AssertionType assertion, String wsAddressingTo) {
+    private CONNECTClient<TestServicePortType> createClient(String url, AssertionType assertion) {
         return CONNECTClientFactory.getInstance().getCONNECTClientSecured(new TestServicePortDescriptor(), url,
-                assertion, wsAddressingTo, null);
+                assertion);
     }
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/messaging/client/interceptor/HttpHeaderRequestOutInterceptorTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/messaging/client/interceptor/HttpHeaderRequestOutInterceptorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2009-2016, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.messaging.client.interceptor;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageImpl;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author jassmit
+ */
+public class HttpHeaderRequestOutInterceptorTest {
+    
+    public HttpHeaderRequestOutInterceptorTest() {
+    }
+    
+    @Test
+    public void testHandleMessage() {
+        Message message = new MessageImpl();
+        
+        final HashMap<String, String> customHttpHeaders = new HashMap<>();
+        String headerName = "headerName";
+        String headerValue = "headerValue";
+        customHttpHeaders.put(headerName, headerValue);
+        
+        Map<String, List> protocolHeaders = new HashMap<>();
+        List<String> connectionList = new ArrayList<>();
+        String connectionHeader = "connection";
+        String keepAliveValue = "keep-alive";
+        
+        connectionList.add(keepAliveValue);
+        protocolHeaders.put(connectionHeader, connectionList);
+        message.put(Message.PROTOCOL_HEADERS, protocolHeaders);
+        
+        HttpHeaderRequestOutInterceptor httpInterceptor = new HttpHeaderRequestOutInterceptor() {
+            @Override
+            protected Map<String,String> getCustomHttpHeaders(Message message) {
+                return customHttpHeaders;
+            }
+        };
+        httpInterceptor.handleMessage(message);
+        
+        Map<String, List> protocolHeadersResult = (Map<String, List>) message.get(Message.PROTOCOL_HEADERS);
+        
+        assertEquals(protocolHeadersResult.size(), 2);
+        assert(protocolHeadersResult.containsKey(headerName));
+        assertEquals(protocolHeadersResult.get(headerName).get(0), headerValue);
+    }
+
+}

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/messaging/server/BaseServiceTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/messaging/server/BaseServiceTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2009-2016, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.messaging.server;
+
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.CONNECTCustomHttpHeadersType;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.properties.PropertyAccessException;
+import gov.hhs.fha.nhinc.properties.PropertyAccessor;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.xml.ws.WebServiceContext;
+import javax.xml.ws.handler.MessageContext;
+import org.apache.cxf.jaxws.context.WrappedMessageContext;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ *
+ * @author jassmit
+ */
+public class BaseServiceTest {
+    
+    private static final String HEADER_NAME_1 = "headerName1";
+    private static final String HEADER_NAME_2 = "headerName2";
+    private static final String HEADER_VALUE_1 = "headerValue1";
+    private static final String HEADER_VALUE_2 = "headerValue2";
+    private static final String HEADER_NAME_CONNECTION = "connection";
+    private static final String HEADER_VALUE_CONNECTION = "keep-alive";
+    private Map<String, List<String>> happyHeaders; 
+    private Map<String, List<String>> filterHeaders;
+    
+   
+    public BaseServiceTest() {   
+    }
+    
+    @Before
+    public void setUp() {
+        happyHeaders = new HashMap<>();
+        List<String> values1 = new ArrayList<>();
+        values1.add(HEADER_VALUE_1);
+        
+        List<String> values2 = new ArrayList<>();
+        values2.add(HEADER_VALUE_2);
+        
+        List<String> connectionValues = new ArrayList<>();
+        connectionValues.add(HEADER_VALUE_CONNECTION);
+        
+        happyHeaders.put(HEADER_NAME_1, values1);
+        happyHeaders.put(HEADER_NAME_2, values2);
+        
+        filterHeaders = new HashMap<>();
+        filterHeaders.put(HEADER_NAME_1, values1);
+        filterHeaders.put(HEADER_NAME_2, values2);
+        filterHeaders.put(HEADER_NAME_CONNECTION, connectionValues);
+    }
+    
+    @After
+    public void tearDown() {
+        happyHeaders = filterHeaders = null;
+    }
+    
+    @Test
+    public void testReadHttpHeaders_ReadOff() throws PropertyAccessException {
+        final PropertyAccessor mockPropAccessor = mock(PropertyAccessor.class);
+        
+        TestService testService = new TestService() {
+            @Override
+            protected PropertyAccessor getPropertyAccessor() {
+                return mockPropAccessor;
+            }
+        };
+        
+        AssertionType resultAssertion = new AssertionType();
+        
+        when(mockPropAccessor.getPropertyBoolean(NhincConstants.GATEWAY_PROPERTY_FILE, NhincConstants.READ_HTTP_HEADERS)).thenReturn(Boolean.FALSE);
+        
+        testService.getAssertion(resultAssertion);
+        
+        List<CONNECTCustomHttpHeadersType> resultHeaders = resultAssertion.getCONNECTCustomHttpHeaders();
+        
+        assert(resultHeaders.isEmpty());
+    }
+    
+    @Test
+    public void testReadHttpHeaders_ReadsTwoValues() throws PropertyAccessException {
+        final PropertyAccessor mockPropAccessor = mock(PropertyAccessor.class);
+        final MessageImpl mockMessage = mock(MessageImpl.class);
+        final WrappedMessageContext messageContext = new WrappedMessageContext(mockMessage);
+        
+        TestService testService = new TestService() {
+            
+            @Override
+            protected PropertyAccessor getPropertyAccessor() {
+                return mockPropAccessor;
+            }
+            
+            @Override
+            protected MessageContext getMessageContext(WebServiceContext context) {
+                return messageContext;
+            }
+        };
+
+        AssertionType resultAssertion = new AssertionType();
+        
+        when(mockPropAccessor.getPropertyBoolean(NhincConstants.GATEWAY_PROPERTY_FILE, NhincConstants.READ_HTTP_HEADERS)).thenReturn(Boolean.TRUE);
+        when(mockMessage.get(Message.PROTOCOL_HEADERS)).thenReturn(happyHeaders);
+        
+        testService.getAssertion(resultAssertion);
+        
+        List<CONNECTCustomHttpHeadersType> resultHeaders = resultAssertion.getCONNECTCustomHttpHeaders();
+        assertNotNull(resultHeaders);
+        assertEquals(resultAssertion.getCONNECTCustomHttpHeaders().size(), happyHeaders.size());
+        assert(happyHeaders.keySet().contains(resultHeaders.get(0).getHeaderName()));
+        assert(happyHeaders.keySet().contains(resultHeaders.get(1).getHeaderName()));        
+    }
+    
+    @Test
+    public void testReadHttpHeaders_FilterDefaultHeader() throws PropertyAccessException {
+        final PropertyAccessor mockPropAccessor = mock(PropertyAccessor.class);
+        final MessageImpl mockMessage = mock(MessageImpl.class);
+        final WrappedMessageContext messageContext = new WrappedMessageContext(mockMessage);
+        
+        TestService testService = new TestService() {
+            
+            @Override
+            protected PropertyAccessor getPropertyAccessor() {
+                return mockPropAccessor;
+            }
+            
+            @Override
+            protected MessageContext getMessageContext(WebServiceContext context) {
+                return messageContext;
+            }
+        };
+
+        AssertionType resultAssertion = new AssertionType();
+        
+        when(mockPropAccessor.getPropertyBoolean(NhincConstants.GATEWAY_PROPERTY_FILE, NhincConstants.READ_HTTP_HEADERS)).thenReturn(Boolean.TRUE);
+        when(mockMessage.get(Message.PROTOCOL_HEADERS)).thenReturn(filterHeaders);
+        
+        testService.getAssertion(resultAssertion);
+        
+        List<CONNECTCustomHttpHeadersType> resultHeaders = resultAssertion.getCONNECTCustomHttpHeaders();
+        assertNotNull(resultHeaders);
+        assertEquals(resultAssertion.getCONNECTCustomHttpHeaders().size(), filterHeaders.size() - 1);
+        
+        boolean containsDefaultHeader = false;
+        for(CONNECTCustomHttpHeadersType header : resultHeaders) {
+            if(header.getHeaderName().equals(HEADER_NAME_CONNECTION)) {
+                containsDefaultHeader = true;
+                break;
+            }
+        }
+        
+        assertFalse(containsDefaultHeader);
+    }
+    
+    
+    class TestService extends BaseService{
+    
+        public AssertionType getAssertion(AssertionType assertion) {
+            return getAssertion(null, assertion);
+        }
+        
+    }
+
+}

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/messaging/service/decorator/HttpHeaderServiceEndpointDecoratorTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/messaging/service/decorator/HttpHeaderServiceEndpointDecoratorTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2009-2016, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.messaging.service.decorator;
+
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+import gov.hhs.fha.nhinc.common.nhinccommon.CONNECTCustomHttpHeadersType;
+import gov.hhs.fha.nhinc.messaging.client.CONNECTTestClient;
+import gov.hhs.fha.nhinc.messaging.service.ServiceEndpoint;
+import gov.hhs.fha.nhinc.messaging.service.port.TestServicePortDescriptor;
+import gov.hhs.fha.nhinc.messaging.service.port.TestServicePortType;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.properties.PropertyAccessException;
+import gov.hhs.fha.nhinc.properties.PropertyAccessor;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.xml.ws.BindingProvider;
+import org.apache.cxf.transports.http.configuration.ConnectionType;
+import org.junit.After;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Before;
+import org.junit.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ *
+ * @author jassmit
+ */
+public class HttpHeaderServiceEndpointDecoratorTest {
+
+    public HttpHeaderServiceEndpointDecoratorTest() {
+    }
+
+    @Before
+    public void setUp() {
+
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void testConfigure_WithAssertionValues() throws PropertyAccessException {
+        CONNECTTestClient<TestServicePortType> testClient = new CONNECTTestClient<>(
+                new TestServicePortDescriptor());
+
+        ServiceEndpoint<TestServicePortType> serviceEndpoint = testClient.getServiceEndpoint();
+        
+        final PropertyAccessor mockPropAccessor = mock(PropertyAccessor.class);
+
+        AssertionType assertion = new AssertionType();
+        assertion.setKeepAlive("true");
+        
+        CONNECTCustomHttpHeadersType assertionHeaders = new CONNECTCustomHttpHeadersType();
+        assertionHeaders.setHeaderName("headerName");
+        assertionHeaders.setHeaderValue("headerValue");
+        
+        assertion.getCONNECTCustomHttpHeaders().add(assertionHeaders);
+
+        HttpHeaderServiceEndpointDecorator headerDecorator = new HttpHeaderServiceEndpointDecorator(serviceEndpoint, assertion) {
+            
+            @Override
+            protected PropertyAccessor getPropertyAccessor() {
+                return mockPropAccessor;
+            }
+        };
+        
+        when(mockPropAccessor.getPropertyNames(NhincConstants.GATEWAY_PROPERTY_FILE)).thenReturn(new HashSet<String>());
+        
+        headerDecorator.configure();
+        
+        validateConfiguration(headerDecorator);
+    }
+    
+    @Test
+    public void testConfigure_WithPropertyValues() throws PropertyAccessException {
+        CONNECTTestClient<TestServicePortType> testClient = new CONNECTTestClient<>(
+                new TestServicePortDescriptor());
+
+        ServiceEndpoint<TestServicePortType> serviceEndpoint = testClient.getServiceEndpoint();
+        
+        final PropertyAccessor mockPropAccessor = mock(PropertyAccessor.class);
+
+        AssertionType assertion = new AssertionType();
+        
+        HttpHeaderServiceEndpointDecorator headerDecorator = new HttpHeaderServiceEndpointDecorator(serviceEndpoint, assertion) {
+            
+            @Override
+            protected PropertyAccessor getPropertyAccessor() {
+                return mockPropAccessor;
+            }
+        };
+        
+        final String customHeaderName = "customName";
+        final String customHeaderValue = "customValue";
+        Set<String> headerNames = new HashSet<>();
+        headerNames.add(NhincConstants.CUSTOM_HTTP_HEADERS + "." + customHeaderName);
+        
+        when(mockPropAccessor.getProperty(NhincConstants.GATEWAY_PROPERTY_FILE, NhincConstants.KEEP_ALIVE_PROP)).thenReturn("True");
+        when(mockPropAccessor.getPropertyNames(NhincConstants.GATEWAY_PROPERTY_FILE)).thenReturn(headerNames);
+        when(mockPropAccessor.getProperty(NhincConstants.GATEWAY_PROPERTY_FILE, NhincConstants.CUSTOM_HTTP_HEADERS + "." + customHeaderName)).thenReturn(customHeaderValue);
+        
+        headerDecorator.configure();
+        
+        validateConfiguration(headerDecorator);
+        BindingProvider bp = (BindingProvider) headerDecorator.getPort();
+        Map<String, List<String>> bpMap = (Map<String, List<String>>) bp.getRequestContext().get(NhincConstants.CUSTOM_HTTP_HEADERS);
+        assert(bpMap.containsKey("customName"));
+    }
+    
+    private void validateConfiguration(HttpHeaderServiceEndpointDecorator headerDecorator) {
+        assertEquals(headerDecorator.getHTTPClientPolicy().getConnection(), ConnectionType.KEEP_ALIVE);
+        
+        BindingProvider bp = (BindingProvider) headerDecorator.getPort();
+        Map<String, List<String>> bpMap = (Map<String, List<String>>) bp.getRequestContext().get(NhincConstants.CUSTOM_HTTP_HEADERS);
+        assertNotNull(bpMap);
+        assertEquals(bpMap.size(), 1);
+    }
+}

--- a/Product/Production/Common/Properties/src/main/resources/gateway.properties
+++ b/Product/Production/Common/Properties/src/main/resources/gateway.properties
@@ -124,7 +124,7 @@ connectionKeepAlive=false
 
 ! Custom HTTP headers can be created by adding properties prepended with "customHttpHeaders."
 ! Followed by the header name "=" the header value.
-! For example #customHttpHeaders.testHeader2=value2
+! For example: customHttpHeaders.testHeader2=value2
 
 !           Direct Message Monitoring properties
 !   ****These properties should be moved to DIRECT Config Service setting****

--- a/Product/Production/Common/Properties/src/main/resources/gateway.properties
+++ b/Product/Production/Common/Properties/src/main/resources/gateway.properties
@@ -116,6 +116,16 @@ CoreX12GenericBatchFutureTimeToLive=60
 # Boolean for adding the default values for SAML AuthDecision->Evidence Before and After Conditions. Default property value is true.
 enableAuthDecEvidenceConditionsDefaultValue=true
 
+# Allows for inbound custom HTTP headers to be read from inbound message and passed to the responder's adapters, default property value is false.
+readHttpHeaders=false
+
+# Sets outbound http connection value to "keep-alive", default property value is false.
+connectionKeepAlive=false
+
+! Custom HTTP headers can be created by adding properties prepended with "customHttpHeaders."
+! Followed by the header name "=" the header value.
+! For example #customHttpHeaders.testHeader2=value2
+
 !           Direct Message Monitoring properties
 !   ****These properties should be moved to DIRECT Config Service setting****
 

--- a/Product/Production/Common/Properties/src/main/resources/gateway.properties
+++ b/Product/Production/Common/Properties/src/main/resources/gateway.properties
@@ -119,7 +119,7 @@ enableAuthDecEvidenceConditionsDefaultValue=true
 # Allows for inbound custom HTTP headers to be read from inbound message and passed to the responder's adapters, default property value is false.
 readHttpHeaders=false
 
-# Sets outbound http connection value to "keep-alive", default property value is false.
+# Sets outbound http connection value to "keep-alive", default property value is false ((For True, set to True or T).
 connectionKeepAlive=false
 
 ! Custom HTTP headers can be created by adding properties prepended with "customHttpHeaders."


### PR DESCRIPTION
Allowing for adding custom HTTP headers in outbound message and for those values to be read and passed to responding adapter.