### PR TITLE
FHAC-1363: Fix ValidationSuite Tests fail when offline

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/resources/META-INF/jax-ws-catalog.xml
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/resources/META-INF/jax-ws-catalog.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
+    <rewriteSystem systemIdStartString="http://www.w3.org/2006/03/addressing" rewritePrefix="classpath:/schemas/www.w3.org/2005/08/addressing"/>
+    <rewriteSystem systemIdStartString="http://www.w3.org/2005/08/addressing" rewritePrefix="classpath:/schemas/www.w3.org/2005/08/addressing"/>
+</catalog>

--- a/Product/Production/Deploy/jboss7/pom.xml
+++ b/Product/Production/Deploy/jboss7/pom.xml
@@ -103,7 +103,7 @@
                         lib/not-yet*,
                         lib/servlet-api*,lib/stax-api*,lib/spring-webmvc*,lib/spring-jms*,lib/spring-messaging*,
                         lib/velocity*,
-                        lib/xml-apis*,lib/xmlbeans*,lib/xmlpull*,lib/xml-resolver*,lib/xmltooling*,lib/xpp3*,lib/xstream*
+                        lib/xml-apis*,lib/xmlbeans*,lib/xmlpull*,lib/xmltooling*,lib/xpp3*,lib/xstream*
                     </packagingExcludes>
                     <!-- Explode all archives on server (extremely time-consuming) -->
                     <!--includeLibInApplicationXml>true</includeLibInApplicationXml-->

--- a/Product/Production/Deploy/was/pom.xml
+++ b/Product/Production/Deploy/was/pom.xml
@@ -129,7 +129,6 @@
             lib/velocity*,
             lib/xercesImpl-2.10.0.jar,
             lib/xml-apis-*,
-            lib/xml-resolver-1.2.jar,
             lib/xmlbeans-2.6.0.jar,
             lib/xmlpull-1.1.3.1.jar,
             lib/xpp3_min-1.1.4c.jar,

--- a/Product/Production/Deploy/weblogic/pom.xml
+++ b/Product/Production/Deploy/weblogic/pom.xml
@@ -115,7 +115,7 @@
             lib/not-yet*,
             lib/servlet-api*,lib/stax-api*,lib/spring-webmvc*,lib/spring-jms*,lib/spring-messaging*,
             lib/velocity*,
-            lib/xml-apis*,lib/xmlbeans*,lib/xmlpull*,lib/xml-resolver*,lib/xmltooling*,lib/xpp3*,lib/xstream*
+            lib/xml-apis*,lib/xmlbeans*,lib/xmlpull*,lib/xmltooling*,lib/xpp3*,lib/xstream*
           </packagingExcludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
When internet cuts off,  CONNECt is unable to download ws-addr.xsd from public which cause ValidationSuite Tests fail.  The jax-ws-catalog.xml will allow CXF to reroute the public url to local schema when offline.  This also requires xmlresolver.jar to parse jax-ws-catalog.xml.
@TabassumJafri , @sjarral112: Can you please review?