### PR TITLE
Fix deployment issue for weblogic 12.2.1.2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.{js}]
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+# 2 space indentation
+[*.xml]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/Product/Production/Deploy/weblogic/src/main/application/META-INF/weblogic-application.xml
+++ b/Product/Production/Deploy/weblogic/src/main/application/META-INF/weblogic-application.xml
@@ -35,6 +35,7 @@
         <package-name>schemaorg_apache_xmlbeans.system.sXMLTOOLS.*</package-name>
     </prefer-application-packages>
     <prefer-application-resources>
+        <resource-name>*.xml</resource-name>
         <resource-name>javax.faces.*</resource-name>
         <resource-name>com.sun.faces.*</resource-name>
         <resource-name>com.bea.faces.*</resource-name>
@@ -43,4 +44,3 @@
         <resource-name>org/slf4j/impl/StaticLoggerBinder.class</resource-name>
     </prefer-application-resources>
 </weblogic-application>
-


### PR DESCRIPTION
- Force weblogic to load xml configuration from application instead of from system.  

- Upload editorconfig to standardize text editor (eg notepad++).  please see http://editorconfig.org/ for more information.

