### PR TITLE
FHAC-1372: override opensaml3 configuration for weblogic and fix ValidationSuite

### DIFF
--- a/Product/Production/Deploy/weblogic/src/main/application/META-INF/weblogic-application.xml
+++ b/Product/Production/Deploy/weblogic/src/main/application/META-INF/weblogic-application.xml
@@ -35,7 +35,12 @@
         <package-name>schemaorg_apache_xmlbeans.system.sXMLTOOLS.*</package-name>
     </prefer-application-packages>
     <prefer-application-resources>
-        <resource-name>*.xml</resource-name>
+        <resource-name>saml2-assertion-config.xml</resource-name>
+        <resource-name>saml2-metadata-config.xml</resource-name>
+        <resource-name>saml2-protocol-config.xml</resource-name>
+        <resource-name>saml1-assertion-config.xml</resource-name>
+        <resource-name>saml1-metadata-config.xml</resource-name>
+        <resource-name>saml1-protocol-config.xml</resource-name>
         <resource-name>javax.faces.*</resource-name>
         <resource-name>com.sun.faces.*</resource-name>
         <resource-name>com.bea.faces.*</resource-name>

--- a/Product/SoapUI_Test/ValidationSuite/ConnectValidation-soapui-project.xml
+++ b/Product/SoapUI_Test/ValidationSuite/ConnectValidation-soapui-project.xml
@@ -337,7 +337,7 @@
                   <urn1:translation/>
                </urn1:roleCoded>
             </urn1:userInfo>
-            <urn1:authorized>?</urn1:authorized>
+            <urn1:authorized>true</urn1:authorized>
             <!--Optional:-->
             <urn1:purposeOfDisclosureCoded>
                <urn1:code>?</urn1:code>
@@ -689,7 +689,7 @@
                   <urn1:translation/>
                </urn1:roleCoded>
             </urn1:userInfo>
-            <urn1:authorized>?</urn1:authorized>
+            <urn1:authorized>true</urn1:authorized>
             <!--Optional:-->
             <urn1:purposeOfDisclosureCoded>
                <urn1:code>?</urn1:code>

--- a/Product/SoapUI_Test/ValidationSuite/ConnectValidation-soapui-project.xml
+++ b/Product/SoapUI_Test/ValidationSuite/ConnectValidation-soapui-project.xml
@@ -2533,7 +2533,7 @@ if(passthruValue != null){
                   <urn1:translation/>
                </urn1:roleCoded>
             </urn1:userInfo>
-            <urn1:authorized>authorized</urn1:authorized>
+            <urn1:authorized>true</urn1:authorized>
             <urn1:purposeOfDisclosureCoded>
                <urn1:code>TREATMENT</urn1:code>
                <urn1:codeSystem>2.16.840.1.113883.3.18.7.1</urn1:codeSystem>
@@ -2961,7 +2961,7 @@ if(passthruValue != null){
                   <urn1:translation/>
                </urn1:roleCoded>
             </urn1:userInfo>
-            <urn1:authorized>authorized</urn1:authorized>
+            <urn1:authorized>true</urn1:authorized>
             <urn1:purposeOfDisclosureCoded>
                <urn1:code>TREATMENT</urn1:code>
                <urn1:codeSystem>2.16.840.1.113883.3.18.7.1</urn1:codeSystem>
@@ -6572,7 +6572,7 @@ if(passthruValue != null){
                   <urn1:translation/>
                </urn1:roleCoded>
             </urn1:userInfo>
-            <urn1:authorized>authorized</urn1:authorized>
+            <urn1:authorized>true</urn1:authorized>
             <urn1:purposeOfDisclosureCoded>
                <urn1:code>TREATMENT</urn1:code>
                <urn1:codeSystem>2.16.840.1.113883.3.18.7.1</urn1:codeSystem>
@@ -7000,7 +7000,7 @@ if(passthruValue != null){
                   <urn1:translation/>
                </urn1:roleCoded>
             </urn1:userInfo>
-            <urn1:authorized>authorized</urn1:authorized>
+            <urn1:authorized>true</urn1:authorized>
             <urn1:purposeOfDisclosureCoded>
                <urn1:code>TREATMENT</urn1:code>
                <urn1:codeSystem>2.16.840.1.113883.3.18.7.1</urn1:codeSystem>


### PR DESCRIPTION
* Override opensaml configuration for weblogic 12.2.1.2 and 12.1.1.
* Fix Validation Suite test cases since it has wrong value for its schema (https://github.com/CONNECT-Solution/Common-Types/blob/master/src/main/resources/schemas/nhinc/common/NhincCommon.xsd#L46)
@sovanncgi @sjarral112 @balmeeki, @TabassumJafri : can you please review it?  
