### PR TITLE
FHAC-1419: Remove Duplicate log4j inside adminGUI module

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/resources/log4j.properties
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/resources/log4j.properties
@@ -1,8 +1,0 @@
-# Root logger option
-log4j.rootLogger=ALL, stdout
-
-# Direct log messages to stdout
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
remove log4j inside admingui.war to give CONNECT adopters configurable option to reflect their environment. 
