### PR TITLE
Remove spring-message version range

### DIFF
--- a/Product/pom.xml
+++ b/Product/pom.xml
@@ -100,7 +100,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-messaging</artifactId>
-        <version>[4.1.9.RELEASE,)</version>
+        <version>${spring.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Remove spring-message version range since it causes an issue to retrieve "io.projectreactor:reactor-bom:pom:Bismuth-M1" artifact.
