### PR TITLE
FHAC-1465: Add TLSUDDI Decorator to UDDI class

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/UDDIBaseClient.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/UDDIBaseClient.java
@@ -32,6 +32,7 @@ import gov.hhs.fha.nhinc.messaging.service.ServiceEndpoint;
 import gov.hhs.fha.nhinc.messaging.service.decorator.TimeoutServiceEndpointDecorator;
 import gov.hhs.fha.nhinc.messaging.service.decorator.URLServiceEndpointDecorator;
 import gov.hhs.fha.nhinc.messaging.service.decorator.cxf.WsAddressingServiceEndpointDecorator;
+import gov.hhs.fha.nhinc.messaging.service.decorator.cxf.TLSUDDIClientEndpointDecorator;
 import gov.hhs.fha.nhinc.messaging.service.port.CXFServicePortBuilder;
 import gov.hhs.fha.nhinc.messaging.service.port.ServicePortDescriptor;
 import gov.hhs.fha.nhinc.webserviceproxy.WebServiceProxyHelper;
@@ -54,7 +55,7 @@ public class UDDIBaseClient<T> implements CONNECTClient<T> {
         serviceEndpoint = new BaseServiceEndpoint<>(portBuilder.createPort());
         serviceEndpoint = new URLServiceEndpointDecorator<>(serviceEndpoint, url);
         serviceEndpoint = new TimeoutServiceEndpointDecorator<>(serviceEndpoint, -1);
-
+        serviceEndpoint = new TLSUDDIClientEndpointDecorator<>(serviceEndpoint);
         serviceEndpoint.configure();
 
     }


### PR DESCRIPTION
Forget to include TLSUDDI Decorator to the existing call which causes uddi to fail for configurable TLS