### PR TITLE
FHAC 1496- Revert XSLTransformHelper and update release note.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+## CONNECT 5.0 Release
+### Summary
+
+The 5.0 release includes a major web stack upgrade (CXF from 2.7.3 to 3.1.9), adding customizable HTTP headers to outgoing NwHIN requests, adding a time stamp to the eHealth Exchange UDDI, an audit.properties file editor, configurable TLS versions for UDDI updates, and code updates to allow CONNECT to be compiled with JDK 1.8. Support for CONNECT has been extended to JBoss EAP 7 with JBoss AS 7.1.1 no longer being officially supported by the FHA CONNECT team.
+For more information refer to the [Release Notes](https://connectopensource.atlassian.net/wiki/x/ll4BBw).
+
 ## CONNECT 4.7 Release
 ### Summary
 

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/util/XSLTransformHelper.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/util/XSLTransformHelper.java
@@ -26,7 +26,6 @@
  */
 package gov.hhs.fha.nhinc.admingui.util;
 
-import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import javax.xml.XMLConstants;
@@ -47,22 +46,18 @@ public class XSLTransformHelper {
 
     private static final Logger LOG = LoggerFactory.getLogger(XSLTransformHelper.class);
 
-    public byte[] convertXMLToHTML(final InputStream xml, final InputStream xsl) {
+    public byte[] convertXMLToHTML(InputStream xml, InputStream xsl) {
 
-        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
 
         try {
-            final TransformerFactory tFactory = TransformerFactory.newInstance();
-            tFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            TransformerFactory tFactory = TransformerFactory.newInstance();
             tFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            tFactory.setFeature(NhincConstants.FEATURE_GENERAL_ENTITIES, false);
-            tFactory.setFeature(NhincConstants.FEATURE_PARAMETER_ENTITIES, false);
-            tFactory.setFeature(NhincConstants.FEATURE_DISALLOW_DOCTYPE, true);
-            final Templates template = tFactory.newTemplates(new StreamSource(xsl));
-            final Transformer transformer = template.newTransformer();
+            Templates template = tFactory.newTemplates(new StreamSource(xsl));
+            Transformer transformer = template.newTransformer();
             transformer.transform(new StreamSource(xml), new StreamResult(output));
 
-        } catch (final TransformerException e) {
+        } catch (TransformerException e) {
             LOG.error("Exception in transforming from xml to html: {}", e.getLocalizedMessage(), e);
         }
 

--- a/Product/Production/Deploy/pom.xml
+++ b/Product/Production/Deploy/pom.xml
@@ -544,69 +544,6 @@
       </build>
     </profile>
 
-    <!-- GUI -->
-    <profile>
-      <id>GUI</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <properties>
-        <gui.excluded>true</gui.excluded>
-      </properties>
-
-      <dependencies>
-        <dependency>
-          <groupId>org.connectopensource</groupId>
-          <artifactId>CONNECTConsumerPreferencesProfileGUI</artifactId>
-          <version>${project.parent.version}</version>
-          <type>war</type>
-        </dependency>
-        <dependency>
-          <groupId>org.connectopensource</groupId>
-          <artifactId>CONNECTDeferredQueueManagerGUI</artifactId>
-          <version>${project.parent.version}</version>
-          <type>war</type>
-        </dependency>
-        <dependency>
-          <groupId>org.connectopensource</groupId>
-          <artifactId>CONNECTConsumerPreferencesProfileGUI</artifactId>
-          <version>${project.parent.version}</version>
-          <type>pom</type>
-        </dependency>
-        <dependency>
-          <groupId>org.connectopensource</groupId>
-          <artifactId>CONNECTDeferredQueueManagerGUI</artifactId>
-          <version>${project.parent.version}</version>
-          <type>pom</type>
-        </dependency>
-      </dependencies>
-
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-ear-plugin</artifactId>
-            <configuration>
-              <modules combine.children="append">
-                <webModule>
-                  <groupId>org.connectopensource</groupId>
-                  <artifactId>CONNECTConsumerPreferencesProfileGUI</artifactId>
-                  <contextRoot>/CONNECTConsumerPreferencesProfileGUI</contextRoot>
-                  <excluded>${gui.excluded}</excluded>
-                </webModule>
-                <webModule>
-                  <groupId>org.connectopensource</groupId>
-                  <artifactId>CONNECTDeferredQueueManagerGUI</artifactId>
-                  <contextRoot>/CONNECTDeferredQueueManagerGUI</contextRoot>
-                  <excluded>${gui.excluded}</excluded>
-                </webModule>
-              </modules>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
     <!-- Direct -->
     <profile>
       <id>Direct</id>

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Three primary elements make up the CONNECT solution:
 
 History
 -------
+* 5.0 released June 2017
 * 4.7 released September 2016
 * 4.6 released March 2016
 * 4.5 released July 2015


### PR DESCRIPTION
- Revert XSLTransformHelper.java since the latest xalan (2.7.2) only supports Feature Security Processing.

- Update readme.md and history.md for release 5.0.

- Remove unused GUI Profile