### PR TITLE
CONN-1214 honor the value of the evidence issuer from entity message

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
@@ -103,8 +103,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
             final X509Certificate certificate = certificateManager.getDefaultCertificate();
             final PublicKey publicKey = certificateManager.getDefaultPublicKey();
             final PrivateKey privateKey = certificateManager.getDefaultPrivateKey();
-            Assertion assertion;
-            assertion = OpenSAML2ComponentBuilder.getInstance().createAssertion();
+            Assertion assertion = OpenSAML2ComponentBuilder.getInstance().createAssertion();
 
             // create the assertion id
             // Per GATEWAY-847 the id attribute should not be allowed to start
@@ -183,7 +182,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
 
         if (!(StringUtils.isNotBlank(sIssuer) && checkDistinguishedName(sIssuer))) {
             if (certificate != null) {
-                sIssuer = certificate.getIssuerDN().getName();
+                sIssuer = certificate.getSubjectDN().getName();
             } else {
                 sIssuer = NhincConstants.SAML_DEFAULT_ISSUER_NAME;
             }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
@@ -100,6 +100,9 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
         LOG.debug("SamlCallbackHandler.createHOKSAMLAssertion20()");
         Element signedAssertion = null;
         try {
+            final X509Certificate certificate = certificateManager.getDefaultCertificate();
+            final PublicKey publicKey = certificateManager.getDefaultPublicKey();
+            final PrivateKey privateKey = certificateManager.getDefaultPrivateKey();
             Assertion assertion;
             assertion = OpenSAML2ComponentBuilder.getInstance().createAssertion();
 
@@ -119,24 +122,18 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
             assertion.setIssueInstant(issueInstant);
 
             // set issuer
-            assertion.setIssuer(createIssuer(properties));
-
-            final X509Certificate certificate = certificateManager.getDefaultCertificate();
-            final PublicKey publicKey = certificateManager.getDefaultPublicKey();
+            assertion.setIssuer(createIssuer(properties, certificate));
 
             // set subject
-            final Subject subject = createSubject(properties, certificate, publicKey);
-            assertion.setSubject(subject);
+            assertion.setSubject(createSubject(properties, certificate, publicKey));
 
             // add conditions statement
-            final Conditions conditions = createConditions(properties);
-            assertion.setConditions(conditions);
+            assertion.setConditions(createConditions(properties));
 
             // add attribute statements
-            final Subject evidenceSubject = createEvidenceSubject(properties, certificate, publicKey);
-            assertion.getStatements().addAll(createAttributeStatements(properties, evidenceSubject));
+            assertion.getStatements().addAll(
+                createAttributeStatements(properties, createEvidenceSubject(properties, certificate, publicKey)));
 
-            final PrivateKey privateKey = certificateManager.getDefaultPrivateKey();
             // sign the message
             signedAssertion = sign(assertion, certificate, privateKey, publicKey);
         } catch (final SAMLComponentBuilderException | CertificateManagerException ex) {
@@ -176,24 +173,26 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
 
     }
 
-    protected Issuer createIssuer(final CallbackProperties properties) {
-        Issuer issuer;
-        final String format = properties.getAssertionIssuerFormat();
-        if (format != null) {
-            LOG.debug("Setting Assertion Issuer format to: {}", format);
-            final String sIssuer = properties.getIssuer();
-            LOG.debug("Setting Assertion Issuer to: {}", sIssuer);
-            if (isValidNameidFormat(format)) {
-                issuer = OpenSAML2ComponentBuilder.getInstance().createIssuer(format, sIssuer);
-            } else {
-                LOG.debug("Not in valid listing of formats: Using default issuer");
-                issuer = OpenSAML2ComponentBuilder.getInstance().createDefaultIssuer();
-            }
-        } else {
-            LOG.debug("Assertion issuer not defined: Using default issuer");
-            issuer = OpenSAML2ComponentBuilder.getInstance().createDefaultIssuer();
+    protected Issuer createIssuer(final CallbackProperties properties, final X509Certificate certificate) {
+        String format = properties.getAssertionIssuerFormat();
+        String sIssuer = properties.getIssuer();
+
+        if (!(StringUtils.isNotBlank(format) && isValidNameidFormat(format))) {
+            format = NhincConstants.AUTH_FRWK_NAME_ID_FORMAT_X509;
         }
-        return issuer;
+
+        if (!(StringUtils.isNotBlank(sIssuer) && checkDistinguishedName(sIssuer))) {
+            if (certificate != null) {
+                sIssuer = certificate.getIssuerDN().getName();
+            } else {
+                sIssuer = NhincConstants.SAML_DEFAULT_ISSUER_NAME;
+            }
+        }
+
+        LOG.debug("Setting Assertion Issuer format to: {}", format);
+        LOG.debug("Setting Assertion Issuer to: {}", sIssuer);
+
+        return OpenSAML2ComponentBuilder.getInstance().createIssuer(format, sIssuer);
     }
 
     /**

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
@@ -182,7 +182,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
 
         if (!(StringUtils.isNotBlank(sIssuer) && checkDistinguishedName(sIssuer))) {
             if (certificate != null) {
-                sIssuer = certificate.getSubjectDN().getName();
+                sIssuer = certificate.getSubjectX500Principal().getName();
             } else {
                 sIssuer = NhincConstants.SAML_DEFAULT_ISSUER_NAME;
             }

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilderTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilderTest.java
@@ -28,7 +28,9 @@ package gov.hhs.fha.nhinc.callback.opensaml;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -63,8 +65,6 @@ import java.util.Set;
 import org.apache.commons.collections.CollectionUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -153,13 +153,13 @@ public class HOKSAMLAssertionBuilderTest {
 
                     @Override
                     public void verify(final PublicKey key, final String sigProvider) throws CertificateException,
-                            NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException, SignatureException {
+                    NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException, SignatureException {
 
                     }
 
                     @Override
                     public void verify(final PublicKey key) throws CertificateException, NoSuchAlgorithmException,
-                            InvalidKeyException, NoSuchProviderException, SignatureException {
+                    InvalidKeyException, NoSuchProviderException, SignatureException {
                     }
 
                     @Override
@@ -254,7 +254,7 @@ public class HOKSAMLAssertionBuilderTest {
 
                     @Override
                     public void checkValidity(final Date date)
-                            throws CertificateExpiredException, CertificateNotYetValidException {
+                        throws CertificateExpiredException, CertificateNotYetValidException {
                     }
 
                     @Override
@@ -271,7 +271,7 @@ public class HOKSAMLAssertionBuilderTest {
     @Test
     public void testCreateAuthenticationStatement() {
         final List<AuthnStatement> authnStatement = new HOKSAMLAssertionBuilder()
-                .createAuthenicationStatements(getProperties());
+            .createAuthenicationStatements(getProperties());
         assertNotNull(authnStatement);
 
         assertFalse(authnStatement.isEmpty());
@@ -467,7 +467,7 @@ public class HOKSAMLAssertionBuilderTest {
         assertTrue(assertion.getID().startsWith("_"));
 
         assertTrue(beforeCreation.isBefore(assertion.getIssueInstant())
-                || beforeCreation.isEqual(assertion.getIssueInstant()));
+            || beforeCreation.isEqual(assertion.getIssueInstant()));
 
         final Issuer issuer = assertion.getIssuer();
         assertEquals(issuer.getFormat(), SAMLAssertionBuilder.X509_NAME_ID);
@@ -494,7 +494,7 @@ public class HOKSAMLAssertionBuilderTest {
         final DateTime conditionNotAfter = new DateTime();
         final PropertyAccessor propertyAccessor = mock(PropertyAccessor.class);
         when(propertyAccessor.getProperty(Mockito.anyString(), Mockito.anyString()))
-                .thenReturn(Boolean.TRUE.toString());
+        .thenReturn(Boolean.TRUE.toString());
 
         when(callbackProps.getAuthorizationStatementExists()).thenReturn(true);
         when(callbackProps.getEvidenceConditionNotBefore()).thenReturn(conditionNotBefore);
@@ -522,7 +522,7 @@ public class HOKSAMLAssertionBuilderTest {
         final DateTime conditionNotAfter = new DateTime();
         final PropertyAccessor propertyAccessor = mock(PropertyAccessor.class);
         when(propertyAccessor.getProperty(Mockito.anyString(), Mockito.anyString()))
-                .thenReturn(Boolean.FALSE.toString());
+        .thenReturn(Boolean.FALSE.toString());
 
         when(callbackProps.getAuthorizationStatementExists()).thenReturn(true);
         when(callbackProps.getEvidenceConditionNotAfter()).thenReturn(conditionNotAfter);
@@ -547,7 +547,7 @@ public class HOKSAMLAssertionBuilderTest {
         final DateTime conditionNotBefore = new DateTime();
         final PropertyAccessor propertyAccessor = mock(PropertyAccessor.class);
         when(propertyAccessor.getProperty(Mockito.anyString(), Mockito.anyString()))
-                .thenReturn(Boolean.FALSE.toString());
+        .thenReturn(Boolean.FALSE.toString());
 
         when(callbackProps.getAuthorizationStatementExists()).thenReturn(true);
         when(callbackProps.getEvidenceConditionNotBefore()).thenReturn(conditionNotBefore);
@@ -650,7 +650,7 @@ public class HOKSAMLAssertionBuilderTest {
 
             @Override
             public String getIssuer() {
-                return "issuer";
+                return "CN=SAML User,OU=connect,O=FHA,L=Melbourne,ST=FL,C=US";
             }
 
             @Override


### PR DESCRIPTION
Honor the value of the Issuer from the entity-message, 
for AuthorizationDecisionStatement-Issuer

for the Assertion-SamlIssuer, this behavior already there so there no need for coding.