### PR TITLE
CONN-1770 Update Merlin trust store location property

### DIFF
--- a/Product/Production/Common/Properties/src/main/resources/truststore.properties
+++ b/Product/Production/Common/Properties/src/main/resources/truststore.properties
@@ -1,4 +1,4 @@
 org.apache.ws.security.crypto.provider=org.apache.ws.security.components.crypto.Merlin
 org.apache.ws.security.crypto.merlin.keystore.type=jks
 org.apache.ws.security.crypto.merlin.keystore.password=changeit
-org.apache.ws.security.crypto.merlin.file=cacerts.jks
+org.apache.ws.security.crypto.merlin.truststore.file=cacerts.jks


### PR DESCRIPTION
In truststore.properties, updated:
org.apache.ws.security.crypto.merlin.file=cacerts.jks
to
org.apache.ws.security.crypto.merlin.truststore.file=cacerts.jks