### PR TITLE
CONN-1768-add capability to pass all subject confirmation method

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/SamlConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/SamlConstants.java
@@ -125,6 +125,5 @@ public class SamlConstants {
     public static final String DIGEST_VALUE_TAG = "DigestValue";
     public static final String SIGNATURE_TAG = "Signature";
     public static final String SIGNATURE_VALUE_TAG = "SignatureValue";
-    public static final String SUBJECT_SENDER_VOUCHES = "senderVouches";
-    public static final String SUBJECT_BEARER = "bearer";
+    public static final String SUBJECT_CONFIRMATION = "SubjectConfirmation";
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/SamlConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/SamlConstants.java
@@ -125,4 +125,6 @@ public class SamlConstants {
     public static final String DIGEST_VALUE_TAG = "DigestValue";
     public static final String SIGNATURE_TAG = "Signature";
     public static final String SIGNATURE_VALUE_TAG = "SignatureValue";
+    public static final String SUBJECT_SENDER_VOUCHES = "senderVouches";
+    public static final String SUBJECT_BEARER = "bearer";
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackMapProperties.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackMapProperties.java
@@ -26,6 +26,8 @@
  */
 package gov.hhs.fha.nhinc.callback.opensaml;
 
+import org.apache.cxf.helpers.CastUtils;
+
 import gov.hhs.fha.nhinc.callback.SamlConstants;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants.GATEWAY_API_LEVEL;
@@ -33,6 +35,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.wss4j.common.saml.bean.SubjectConfirmationDataBean;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
@@ -519,5 +522,36 @@ public class CallbackMapProperties implements CallbackProperties {
     @Override
     public String getNPI() {
         return getNullSafeString(SamlConstants.ATTRIBUTE_NAME_NPI);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see gov.hhs.fha.nhinc.callback.opensaml.CallbackProperties#getSenderVouchesBean()
+     */
+    @Override
+    public List<SubjectConfirmationDataBean> getSenderVouchesBeans() {
+        List<Object> senderObj = getNullSafeList(SamlConstants.SUBJECT_SENDER_VOUCHES);
+        if (senderObj != null) {
+            return CastUtils.cast(senderObj, SubjectConfirmationDataBean.class);
+        } else {
+            return new ArrayList<SubjectConfirmationDataBean>();
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see gov.hhs.fha.nhinc.callback.opensaml.CallbackProperties#getBearerBean()
+     */
+    @Override
+    public List<SubjectConfirmationDataBean> getBearerBeans() {
+
+        List<Object> bearObjects = getNullSafeList(SamlConstants.SUBJECT_BEARER);
+        if (bearObjects != null) {
+            return CastUtils.cast(bearObjects, SubjectConfirmationDataBean.class);
+        } else {
+            return new ArrayList<SubjectConfirmationDataBean>();
+        }
     }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackMapProperties.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackMapProperties.java
@@ -35,7 +35,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.wss4j.common.saml.bean.SubjectConfirmationDataBean;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
@@ -527,31 +526,16 @@ public class CallbackMapProperties implements CallbackProperties {
     /*
      * (non-Javadoc)
      *
-     * @see gov.hhs.fha.nhinc.callback.opensaml.CallbackProperties#getSenderVouchesBean()
+     * @see gov.hhs.fha.nhinc.callback.opensaml.CallbackProperties#getSubjectConfirmations()
      */
     @Override
-    public List<SubjectConfirmationDataBean> getSenderVouchesBeans() {
-        List<Object> senderObj = getNullSafeList(SamlConstants.SUBJECT_SENDER_VOUCHES);
+    public List<SAMLSubjectConfirmation> getSubjectConfirmations() {
+        List<Object> senderObj = getNullSafeList(SamlConstants.SUBJECT_CONFIRMATION);
         if (senderObj != null) {
-            return CastUtils.cast(senderObj, SubjectConfirmationDataBean.class);
+            return CastUtils.cast(senderObj, SAMLSubjectConfirmation.class);
         } else {
-            return new ArrayList<SubjectConfirmationDataBean>();
+            return new ArrayList<SAMLSubjectConfirmation>();
         }
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.opensaml.CallbackProperties#getBearerBean()
-     */
-    @Override
-    public List<SubjectConfirmationDataBean> getBearerBeans() {
-
-        List<Object> bearObjects = getNullSafeList(SamlConstants.SUBJECT_BEARER);
-        if (bearObjects != null) {
-            return CastUtils.cast(bearObjects, SubjectConfirmationDataBean.class);
-        } else {
-            return new ArrayList<SubjectConfirmationDataBean>();
-        }
-    }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackProperties.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackProperties.java
@@ -26,8 +26,6 @@
  */
 package gov.hhs.fha.nhinc.callback.opensaml;
 
-import org.apache.wss4j.common.saml.bean.SubjectConfirmationDataBean;
-
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants.GATEWAY_API_LEVEL;
 import java.util.List;
 import org.joda.time.DateTime;
@@ -240,14 +238,10 @@ public interface CallbackProperties {
 
     /**
      *
-     * @return senderVouchesBean
+     * @return List of subject confirmation
      */
-    List<SubjectConfirmationDataBean> getSenderVouchesBeans();
+    List<SAMLSubjectConfirmation> getSubjectConfirmations();
 
-    /**
-     *
-     * @return bearer Bean
-     */
-    List<SubjectConfirmationDataBean> getBearerBeans();
+
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackProperties.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackProperties.java
@@ -26,6 +26,8 @@
  */
 package gov.hhs.fha.nhinc.callback.opensaml;
 
+import org.apache.wss4j.common.saml.bean.SubjectConfirmationDataBean;
+
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants.GATEWAY_API_LEVEL;
 import java.util.List;
 import org.joda.time.DateTime;
@@ -235,4 +237,17 @@ public interface CallbackProperties {
      * @return
      */
     String getUserOrganizationId();
+
+    /**
+     *
+     * @return senderVouchesBean
+     */
+    List<SubjectConfirmationDataBean> getSenderVouchesBeans();
+
+    /**
+     *
+     * @return bearer Bean
+     */
+    List<SubjectConfirmationDataBean> getBearerBeans();
+
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
@@ -48,7 +48,6 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.common.saml.SamlAssertionWrapper;
-import org.apache.wss4j.common.saml.bean.SubjectConfirmationDataBean;
 import org.joda.time.DateTime;
 import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
 import org.opensaml.core.xml.io.Marshaller;
@@ -211,22 +210,17 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
             x509Name = certificate.getSubjectDN().getName();
         }
         Subject subject = openSamlBuilder.createSubject(x509Name, publicKey);
-        // create bearer if exist
-        List<SubjectConfirmationDataBean> bearBeans = properties.getBearerBeans();
-        if (CollectionUtils.isNotEmpty(bearBeans)) {
-            for (SubjectConfirmationDataBean bear : bearBeans) {
-                SubjectConfirmation bearConfirmation = openSamlBuilder.createBearConfirmation(bear);
-                subject.getSubjectConfirmations().add(bearConfirmation);
+        //Add additional subject confirmation if exist
+        List<SAMLSubjectConfirmation> subjectConfirmations = properties.getSubjectConfirmations();
+        if (CollectionUtils.isNotEmpty(subjectConfirmations)) {
+            for (SAMLSubjectConfirmation confirmation : subjectConfirmations) {
+                SubjectConfirmation subjectConfirmation = openSamlBuilder.createSubjectConfirmation(confirmation);
+                if (subjectConfirmation != null) {
+                    subject.getSubjectConfirmations().add(openSamlBuilder.createSubjectConfirmation(confirmation));
+                }
             }
         }
-        // create voucher if exist
-        List<SubjectConfirmationDataBean> senderVouchesBeans = properties.getSenderVouchesBeans();
-        if (CollectionUtils.isNotEmpty(senderVouchesBeans)) {
-            for (SubjectConfirmationDataBean sender : senderVouchesBeans) {
-                SubjectConfirmation bearConfirmation = openSamlBuilder.createSenderVouchesConfirmation(sender);
-                subject.getSubjectConfirmations().add(bearConfirmation);
-            }
-        }
+
         return subject;
     }
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
@@ -293,17 +293,27 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
             subjectConfirmationData);
     }
 
-    public static SubjectConfirmation createSenderVouchesConfirmation(SubjectConfirmationDataBean dataBean)
+    /**
+     * Construct additional subject Confirmation for saml assertion. Since HOK(holder of key) is supported by default,
+     * we support additional sender-vouches/bearer subject confirmation
+     * @param samlSubjectConfirmation
+     * @return
+     * @throws SAMLComponentBuilderException
+     */
+    public SubjectConfirmation createSubjectConfirmation(SAMLSubjectConfirmation samlSubjectConfirmation)
         throws SAMLComponentBuilderException {
-        SubjectConfirmationData subjectConfirmData = createSubjectConfirmationData(null, dataBean);
-        return SAML2ComponentBuilder.createSubjectConfirmation(SubjectConfirmation.METHOD_SENDER_VOUCHES,
-            subjectConfirmData);
-    }
-
-    public static SubjectConfirmation createBearConfirmation(SubjectConfirmationDataBean dataBean)
-        throws SAMLComponentBuilderException {
-        SubjectConfirmationData subjectConfirmData = createSubjectConfirmationData(null, dataBean);
-        return SAML2ComponentBuilder.createSubjectConfirmation(SubjectConfirmation.METHOD_BEARER, subjectConfirmData);
+        SubjectConfirmationData subjectConfirmData = createSubjectConfirmationData(null, samlSubjectConfirmation);
+        String method = samlSubjectConfirmation.getMethod();
+        LOG.debug("Prepare to construct method {} for subject confirmation", method);
+        if (SubjectConfirmation.METHOD_SENDER_VOUCHES.equalsIgnoreCase(method)){
+            return SAML2ComponentBuilder.createSubjectConfirmation(SubjectConfirmation.METHOD_SENDER_VOUCHES,
+                subjectConfirmData);
+        }
+        if (SubjectConfirmation.METHOD_BEARER.equalsIgnoreCase(method)){
+            return SAML2ComponentBuilder.createSubjectConfirmation(SubjectConfirmation.METHOD_BEARER,
+                subjectConfirmData);
+        }
+        return null;
     }
 
     /**

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
@@ -288,10 +288,22 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
     /**
      * Returns subject Confirmation Data
      */
-    private static SubjectConfirmation createHoKConfirmation(final SubjectConfirmationData subjectConfirmationData)
-        throws SAMLComponentBuilderException {
+    private static SubjectConfirmation createHoKConfirmation(final SubjectConfirmationData subjectConfirmationData) {
         return SAML2ComponentBuilder.createSubjectConfirmation(SubjectConfirmation.METHOD_HOLDER_OF_KEY,
             subjectConfirmationData);
+    }
+
+    public static SubjectConfirmation createSenderVouchesConfirmation(SubjectConfirmationDataBean dataBean)
+        throws SAMLComponentBuilderException {
+        SubjectConfirmationData subjectConfirmData = createSubjectConfirmationData(null, dataBean);
+        return SAML2ComponentBuilder.createSubjectConfirmation(SubjectConfirmation.METHOD_SENDER_VOUCHES,
+            subjectConfirmData);
+    }
+
+    public static SubjectConfirmation createBearConfirmation(SubjectConfirmationDataBean dataBean)
+        throws SAMLComponentBuilderException {
+        SubjectConfirmationData subjectConfirmData = createSubjectConfirmationData(null, dataBean);
+        return SAML2ComponentBuilder.createSubjectConfirmation(SubjectConfirmation.METHOD_BEARER, subjectConfirmData);
     }
 
     /**
@@ -304,20 +316,19 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
      */
     private static SubjectConfirmationData createSubjectConfirmationData(final PublicKey publicKey)
         throws SAMLComponentBuilderException {
-        SubjectConfirmationData subjectConfirmationData = null;
-        try {
-            final SubjectConfirmationDataBean subjectConfirmationDataBean = new SubjectConfirmationDataBean();
-            final KeyInfoBean keyInforBean = new KeyInfoBean();
-            keyInforBean.setPublicKey(publicKey);
+        final KeyInfoBean keyInforBean = new KeyInfoBean();
+        keyInforBean.setPublicKey(publicKey);
+        return createSubjectConfirmationData(keyInforBean, new SubjectConfirmationDataBean());
+    }
 
-            subjectConfirmationData = SAML2ComponentBuilder.createSubjectConfirmationData(subjectConfirmationDataBean,
-                keyInforBean);
+    private static SubjectConfirmationData createSubjectConfirmationData(final KeyInfoBean keyInforBean,
+        final SubjectConfirmationDataBean confirDataBean) throws SAMLComponentBuilderException {
+        try {
+            return SAML2ComponentBuilder.createSubjectConfirmationData(confirDataBean, keyInforBean);
         } catch (SecurityException | WSSecurityException e) {
             LOG.error(e.getLocalizedMessage());
             throw new SAMLComponentBuilderException(e.getLocalizedMessage(), e);
         }
-
-        return subjectConfirmationData;
     }
 
     /**

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/SAMLSubjectConfirmation.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/SAMLSubjectConfirmation.java
@@ -1,0 +1,36 @@
+/**
+ *
+ */
+package gov.hhs.fha.nhinc.callback.opensaml;
+
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.wss4j.common.saml.bean.SubjectConfirmationDataBean;
+
+/**
+ * @author mpnguyen
+ *
+ */
+public class SAMLSubjectConfirmation extends SubjectConfirmationDataBean {
+    private String method;
+
+    public String getMethod() {
+        return method;
+    }
+
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+}

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/opensaml/extraction/OpenSAMLAssertionExtractorImpl.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/opensaml/extraction/OpenSAMLAssertionExtractorImpl.java
@@ -40,7 +40,7 @@ import gov.hhs.fha.nhinc.common.nhinccommon.SamlConditionsType;
 import gov.hhs.fha.nhinc.common.nhinccommon.SamlIssuerType;
 import gov.hhs.fha.nhinc.common.nhinccommon.SamlSignatureKeyInfoType;
 import gov.hhs.fha.nhinc.common.nhinccommon.SamlSignatureType;
-import gov.hhs.fha.nhinc.common.nhinccommon.SamlSubjectsType;
+import gov.hhs.fha.nhinc.common.nhinccommon.SamlSubjectConfirmationType;
 import gov.hhs.fha.nhinc.common.nhinccommon.UserType;
 import gov.hhs.fha.nhinc.cxf.extraction.SAMLExtractorDOM;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
@@ -121,32 +121,30 @@ public class OpenSAMLAssertionExtractorImpl implements SAMLExtractorDOM {
     /**
      * Extract subject multiple confirmation into assertionType
      *
-     * @param saml2Assertion
+     * @param saml2Assertion source
      * @param target
      */
-    private static void populdateSubjectConfirmation(Assertion saml2Assertion, AssertionType target) {
-        List<SamlSubjectsType> samlTargetSubjects = target.getSamlSubjects();
+    private static void populateSubjectConfirmation(Assertion saml2Assertion, AssertionType target) {
+        List<SamlSubjectConfirmationType> samlTargetSubjects = target.getSamlSubjectConfirmations();
         List<SubjectConfirmation> subjectConfirmations = saml2Assertion.getSubject().getSubjectConfirmations();
         for (SubjectConfirmation subConfirmation : subjectConfirmations) {
-            SamlSubjectsType samlSubjectTypeTarget = new SamlSubjectsType();
-            samlSubjectTypeTarget.setMethod(subConfirmation.getMethod());
+            SamlSubjectConfirmationType samlSubjConfTypeTarget = new SamlSubjectConfirmationType();
+            samlSubjConfTypeTarget.setMethod(subConfirmation.getMethod());
             SubjectConfirmationData subjectConfirmationData = subConfirmation.getSubjectConfirmationData();
             if (subjectConfirmationData != null) {
-                samlSubjectTypeTarget.setAddress(subjectConfirmationData.getAddress());
-                samlSubjectTypeTarget.setInResponseTo(subjectConfirmationData.getInResponseTo());
-                samlSubjectTypeTarget.setRecipient(subjectConfirmationData.getRecipient());
-                if (subjectConfirmationData.getNotBefore() != null || subjectConfirmationData.getNotOnOrAfter() != null) {
-                    SamlConditionsType samlConditionTarget = new SamlConditionsType();
-                    if (subjectConfirmationData.getNotBefore() != null) {
-                        samlConditionTarget.setNotBefore(subjectConfirmationData.getNotBefore().toString());
-                    }
-                    if (subjectConfirmationData.getNotOnOrAfter() != null) {
-                        samlConditionTarget.setNotOnOrAfter(subjectConfirmationData.getNotOnOrAfter().toString());
-                    }
-                    samlSubjectTypeTarget.setSubjectCondition(samlConditionTarget);
+                samlSubjConfTypeTarget.setAddress(subjectConfirmationData.getAddress());
+                samlSubjConfTypeTarget.setInResponseTo(subjectConfirmationData.getInResponseTo());
+                samlSubjConfTypeTarget.setRecipient(subjectConfirmationData.getRecipient());
+                SamlConditionsType samlConditionTarget = new SamlConditionsType();
+                if (subjectConfirmationData.getNotBefore() != null) {
+                    samlConditionTarget.setNotBefore(subjectConfirmationData.getNotBefore().toString());
                 }
+                if (subjectConfirmationData.getNotOnOrAfter() != null) {
+                    samlConditionTarget.setNotOnOrAfter(subjectConfirmationData.getNotOnOrAfter().toString());
+                }
+                samlSubjConfTypeTarget.setSubjectCondition(samlConditionTarget);
             }
-            samlTargetSubjects.add(samlSubjectTypeTarget);
+            samlTargetSubjects.add(samlSubjConfTypeTarget);
         }
     }
 
@@ -367,7 +365,7 @@ public class OpenSAMLAssertionExtractorImpl implements SAMLExtractorDOM {
             }
             target.getUserInfo().setUserName(name.getValue());
         }
-        populdateSubjectConfirmation(saml2Assertion,target);
+        populateSubjectConfirmation(saml2Assertion,target);
         LOG.debug("end populateSubject()");
     }
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/opensaml/extraction/OpenSAMLAssertionExtractorImpl.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/opensaml/extraction/OpenSAMLAssertionExtractorImpl.java
@@ -36,9 +36,11 @@ import gov.hhs.fha.nhinc.common.nhinccommon.SamlAuthzDecisionStatementEvidenceAs
 import gov.hhs.fha.nhinc.common.nhinccommon.SamlAuthzDecisionStatementEvidenceConditionsType;
 import gov.hhs.fha.nhinc.common.nhinccommon.SamlAuthzDecisionStatementEvidenceType;
 import gov.hhs.fha.nhinc.common.nhinccommon.SamlAuthzDecisionStatementType;
+import gov.hhs.fha.nhinc.common.nhinccommon.SamlConditionsType;
 import gov.hhs.fha.nhinc.common.nhinccommon.SamlIssuerType;
 import gov.hhs.fha.nhinc.common.nhinccommon.SamlSignatureKeyInfoType;
 import gov.hhs.fha.nhinc.common.nhinccommon.SamlSignatureType;
+import gov.hhs.fha.nhinc.common.nhinccommon.SamlSubjectsType;
 import gov.hhs.fha.nhinc.common.nhinccommon.UserType;
 import gov.hhs.fha.nhinc.cxf.extraction.SAMLExtractorDOM;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
@@ -65,6 +67,8 @@ import org.opensaml.saml.saml2.core.Evidence;
 import org.opensaml.saml.saml2.core.Issuer;
 import org.opensaml.saml.saml2.core.NameID;
 import org.opensaml.saml.saml2.core.Subject;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
@@ -112,6 +116,38 @@ public class OpenSAMLAssertionExtractorImpl implements SAMLExtractorDOM {
         LOG.debug("end extractSamlAssertion()");
 
         return target;
+    }
+
+    /**
+     * Extract subject multiple confirmation into assertionType
+     *
+     * @param saml2Assertion
+     * @param target
+     */
+    private static void populdateSubjectConfirmation(Assertion saml2Assertion, AssertionType target) {
+        List<SamlSubjectsType> samlTargetSubjects = target.getSamlSubjects();
+        List<SubjectConfirmation> subjectConfirmations = saml2Assertion.getSubject().getSubjectConfirmations();
+        for (SubjectConfirmation subConfirmation : subjectConfirmations) {
+            SamlSubjectsType samlSubjectTypeTarget = new SamlSubjectsType();
+            samlSubjectTypeTarget.setMethod(subConfirmation.getMethod());
+            SubjectConfirmationData subjectConfirmationData = subConfirmation.getSubjectConfirmationData();
+            if (subjectConfirmationData != null) {
+                samlSubjectTypeTarget.setAddress(subjectConfirmationData.getAddress());
+                samlSubjectTypeTarget.setInResponseTo(subjectConfirmationData.getInResponseTo());
+                samlSubjectTypeTarget.setRecipient(subjectConfirmationData.getRecipient());
+                if (subjectConfirmationData.getNotBefore() != null || subjectConfirmationData.getNotOnOrAfter() != null) {
+                    SamlConditionsType samlConditionTarget = new SamlConditionsType();
+                    if (subjectConfirmationData.getNotBefore() != null) {
+                        samlConditionTarget.setNotBefore(subjectConfirmationData.getNotBefore().toString());
+                    }
+                    if (subjectConfirmationData.getNotOnOrAfter() != null) {
+                        samlConditionTarget.setNotOnOrAfter(subjectConfirmationData.getNotOnOrAfter().toString());
+                    }
+                    samlSubjectTypeTarget.setSubjectCondition(samlConditionTarget);
+                }
+            }
+            samlTargetSubjects.add(samlSubjectTypeTarget);
+        }
     }
 
     /**
@@ -273,8 +309,8 @@ public class OpenSAMLAssertionExtractorImpl implements SAMLExtractorDOM {
 
     private static String getAttributeValue(Attribute attribute) {
         if (!CollectionUtils.isEmpty(attribute.getAttributeValues()) && attribute.getAttributeValues().get(0) != null
-                && attribute.getAttributeValues().get(0).getDOM() != null
-                && attribute.getAttributeValues().get(0).getDOM().getTextContent() != null) {
+            && attribute.getAttributeValues().get(0).getDOM() != null
+            && attribute.getAttributeValues().get(0).getDOM().getTextContent() != null) {
             return attribute.getAttributeValues().get(0).getDOM().getTextContent().trim();
         } else {
             return null;
@@ -331,7 +367,7 @@ public class OpenSAMLAssertionExtractorImpl implements SAMLExtractorDOM {
             }
             target.getUserInfo().setUserName(name.getValue());
         }
-
+        populdateSubjectConfirmation(saml2Assertion,target);
         LOG.debug("end populateSubject()");
     }
 
@@ -457,7 +493,7 @@ public class OpenSAMLAssertionExtractorImpl implements SAMLExtractorDOM {
         LOG.trace("Executing Saml2AssertionExtractor.populatePurposeOfUseAttribute...");
 
         if (!CollectionUtils.isEmpty(attribute.getAttributeValues()) && attribute.getAttributeValues().get(0) != null
-                && !CollectionUtils.isEmpty(attribute.getAttributeValues().get(0).getOrderedChildren())) {
+            && !CollectionUtils.isEmpty(attribute.getAttributeValues().get(0).getOrderedChildren())) {
 
             CeType purposeOfUse = new CeType();
             XMLObject purposeOfUseAttribute = attribute.getAttributeValues().get(0);
@@ -576,7 +612,7 @@ public class OpenSAMLAssertionExtractorImpl implements SAMLExtractorDOM {
         LOG.trace("Executing Saml2AssertionExtractor.populateSubjectRole...");
 
         if (!CollectionUtils.isEmpty(attribute.getAttributeValues()) && attribute.getAttributeValues().get(0) != null
-                && !CollectionUtils.isEmpty(attribute.getAttributeValues().get(0).getOrderedChildren())) {
+            && !CollectionUtils.isEmpty(attribute.getAttributeValues().get(0).getOrderedChildren())) {
             XMLObject subjRoleAttribute = attribute.getAttributeValues().get(0);
             XMLObject roleElement = subjRoleAttribute.getOrderedChildren().get(0);
 

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackMapPropertiesTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackMapPropertiesTest.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang.StringUtils;
+import org.apache.wss4j.common.saml.bean.SubjectConfirmationDataBean;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
@@ -157,5 +158,9 @@ public class CallbackMapPropertiesTest {
         DateTime evidenceConditionNotAfter = callbackProperties.getEvidenceConditionNotAfter();
         assertTrue(
             StringUtils.lowerCase(evidenceConditionNotAfter.toString()).contains(StringUtils.lowerCase(TEST_DATE)));
+        List<SubjectConfirmationDataBean> senderVouchesBeans = callbackProperties.getSenderVouchesBeans();
+        assertTrue(senderVouchesBeans != null);
+        List<SubjectConfirmationDataBean> bearBeans = callbackProperties.getBearerBeans();
+        assertTrue(bearBeans != null);
     }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackMapPropertiesTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackMapPropertiesTest.java
@@ -37,7 +37,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang.StringUtils;
-import org.apache.wss4j.common.saml.bean.SubjectConfirmationDataBean;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
@@ -158,9 +157,7 @@ public class CallbackMapPropertiesTest {
         DateTime evidenceConditionNotAfter = callbackProperties.getEvidenceConditionNotAfter();
         assertTrue(
             StringUtils.lowerCase(evidenceConditionNotAfter.toString()).contains(StringUtils.lowerCase(TEST_DATE)));
-        List<SubjectConfirmationDataBean> senderVouchesBeans = callbackProperties.getSenderVouchesBeans();
-        assertTrue(senderVouchesBeans != null);
-        List<SubjectConfirmationDataBean> bearBeans = callbackProperties.getBearerBeans();
-        assertTrue(bearBeans != null);
+        List<SAMLSubjectConfirmation> subjectConfirmations = callbackProperties.getSubjectConfirmations();
+        assertTrue(subjectConfirmations != null);
     }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilderTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilderTest.java
@@ -65,7 +65,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.wss4j.common.saml.bean.SubjectConfirmationDataBean;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.BeforeClass;
@@ -782,14 +781,7 @@ public class HOKSAMLAssertionBuilderTest {
             }
 
             @Override
-            public List<SubjectConfirmationDataBean> getSenderVouchesBeans() {
-                // TODO Auto-generated method stub
-                return null;
-            }
-
-            @Override
-            public List<SubjectConfirmationDataBean> getBearerBeans() {
-                // TODO Auto-generated method stub
+            public List<SAMLSubjectConfirmation> getSubjectConfirmations() {
                 return null;
             }
         };
@@ -843,24 +835,23 @@ public class HOKSAMLAssertionBuilderTest {
         final CallbackProperties callbackProps = mock(CallbackProperties.class);
         X509Certificate certificate = mock(X509Certificate.class);
         // Create subject bear
-        List<SubjectConfirmationDataBean> subjectBears = new ArrayList<>();
-        subjectBears.add(createSubjectConfirmationBean());
+        List<SAMLSubjectConfirmation> samlSubjectConfirmations = new ArrayList<>();
+        samlSubjectConfirmations.add(createSubjectConfirmationBean(SubjectConfirmation.METHOD_BEARER));
         // Create sender-vouches bean
-        List<SubjectConfirmationDataBean> subjectSV = new ArrayList<>();
-        subjectSV.add(createSubjectConfirmationBean());
+        samlSubjectConfirmations.add(createSubjectConfirmationBean(SubjectConfirmation.METHOD_SENDER_VOUCHES));
 
         when(callbackProps.getUsername()).thenReturn("junittest");
-        when(callbackProps.getBearerBeans()).thenReturn(subjectBears);
-        when(callbackProps.getSenderVouchesBeans()).thenReturn(subjectSV);
+        when(callbackProps.getSubjectConfirmations()).thenReturn(samlSubjectConfirmations);
 
         Subject subject = builder.createSubject(callbackProps, certificate, publicKey);
 
         List<SubjectConfirmation> subjectConfirmations = subject.getSubjectConfirmations();
         assertTrue(subjectConfirmations.size() == 3);
     }
-    private SubjectConfirmationDataBean createSubjectConfirmationBean(){
-        SubjectConfirmationDataBean subjectConfirmationBean = new SubjectConfirmationDataBean();
+    private SAMLSubjectConfirmation createSubjectConfirmationBean(String method){
+        SAMLSubjectConfirmation subjectConfirmationBean = new SAMLSubjectConfirmation();
         subjectConfirmationBean.setAddress("localhost");
+        subjectConfirmationBean.setMethod(method);
         return subjectConfirmationBean;
     }
 

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/opensaml/extraction/OpenSAMLAssertionExtractorImplTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/opensaml/extraction/OpenSAMLAssertionExtractorImplTest.java
@@ -31,9 +31,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
-import org.opensaml.saml.saml2.core.SubjectConfirmation;
-
-import gov.hhs.fha.nhinc.common.nhinccommon.SamlSubjectsType;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.CeType;
 import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
@@ -46,6 +43,7 @@ import gov.hhs.fha.nhinc.common.nhinccommon.SamlAuthzDecisionStatementType;
 import gov.hhs.fha.nhinc.common.nhinccommon.SamlIssuerType;
 import gov.hhs.fha.nhinc.common.nhinccommon.SamlSignatureKeyInfoType;
 import gov.hhs.fha.nhinc.common.nhinccommon.SamlSignatureType;
+import gov.hhs.fha.nhinc.common.nhinccommon.SamlSubjectConfirmationType;
 import gov.hhs.fha.nhinc.common.nhinccommon.UserType;
 import java.io.File;
 import java.net.URI;
@@ -57,6 +55,7 @@ import org.apache.wss4j.common.saml.OpenSAMLUtil;
 import org.junit.Test;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Evidence;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -106,15 +105,15 @@ public class OpenSAMLAssertionExtractorImplTest {
         verifyCeType(assertionType.getPurposeOfDisclosureCoded(), "OPERATIONS", "2.16.840.1.113883.3.18.7.1",
             "nhin-purpose", "Healthcare Operations");
         verifySignature(assertionType.getSamlSignature());
-        verifySubject(assertionType.getSamlSubjects());
+        verifySubject(assertionType.getSamlSubjectConfirmations());
     }
 
     /**
      * @param samlSubjects
      */
-    private void verifySubject(List<SamlSubjectsType> samlSubjects) {
+    private void verifySubject(List<SamlSubjectConfirmationType> samlSubjects) {
         assertEquals("subject should have HOK,SV,Bearer methods", 3, samlSubjects.size());
-        for (SamlSubjectsType subject : samlSubjects) {
+        for (SamlSubjectConfirmationType subject : samlSubjects) {
             if (SubjectConfirmation.METHOD_SENDER_VOUCHES.equalsIgnoreCase(subject.getMethod())) {
                 assertEquals("tester", subject.getInResponseTo());
                 assertEquals("127.0.0.1", subject.getAddress());

--- a/Product/Production/Common/CONNECTCoreLib/src/test/resources/testing_saml/complete_saml.xml
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/resources/testing_saml/complete_saml.xml
@@ -20,6 +20,12 @@
                 </ds:KeyInfo>
             </saml2:SubjectConfirmationData>
         </saml2:SubjectConfirmation>
+         <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:sender-vouches">
+               <saml2:SubjectConfirmationData Address="127.0.0.1" InResponseTo="tester"/>
+          </saml2:SubjectConfirmation>
+          <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+               <saml2:SubjectConfirmationData/>
+          </saml2:SubjectConfirmation>
     </saml2:Subject>
     <saml2:AuthnStatement AuthnInstant="2010-05-01T02:09:01.089Z"
         SessionIndex="123456">


### PR DESCRIPTION
Include a new feature to pass all subject confirmation method (sender-vouches/bear) from nhinc layer to adapter.
@trantang (Optional), @pvenkatakrishnan1 (Optional)