### PR TITLE
CONN-1847 Fix sonarqube flags

### DIFF
--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/mpi/adapter/component/hl7parsers/HL7DbParser201305.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/mpi/adapter/component/hl7parsers/HL7DbParser201305.java
@@ -74,6 +74,10 @@ public class HL7DbParser201305 {
      */
     public static final String SSN_ROOT_IDENTIFIER = "2.16.840.1.113883.4.1";
 
+    private HL7DbParser201305() {
+
+    }
+
     /**
      * Method to extract Gender Code from a PRPAMT201306UV02ParameterList.
      *
@@ -183,15 +187,7 @@ public class HL7DbParser201305 {
                         Serializable contentItem = iterSerialObjects.next();
 
                         if (contentItem instanceof String) {
-                            LOG.info("contentItem is string");
-                            String strValue = (String) contentItem;
-
-                            if (nameString != null) {
-                                nameString += strValue;
-                            } else {
-                                nameString = strValue;
-                            }
-                            LOG.info("nameString : {} ", nameString);
+                            nameString = hl7ParserUtils.formatNameString((String) contentItem, nameString);
                         } else if (contentItem instanceof JAXBElement) {
                             LOG.info("contentItem is JAXBElement");
 
@@ -356,16 +352,11 @@ public class HL7DbParser201305 {
                     && livingSubjectId.getValue().get(0) != null) {
                     II subjectId = livingSubjectId.getValue().get(0);
 
-                    if (subjectId.getExtension() != null && subjectId.getExtension().length() > 0
-                        && subjectId.getRoot() != null && subjectId.getRoot().length() > 0) {
+                    if (StringUtils.isNotEmpty(subjectId.getExtension())
+                        && StringUtils.isNotEmpty(subjectId.getRoot())) {
                         // Ignore SSN identifiers
                         if (!subjectId.getRoot().equals(SSN_ROOT_IDENTIFIER)) {
-                            Identifier id = new Identifier();
-                            id.setId(subjectId.getExtension());
-                            id.setOrganizationId(subjectId.getRoot());
-                            LOG.info("Created id from patient identifier [organization : {}][id : {}] ",
-                                id.getOrganizationId(), id.getId());
-                            ids.add(id);
+                            ids.add(getPatientDbIdentifier(subjectId));
                         }
                     } else {
                         LOG.info("message does not contain an id");
@@ -380,6 +371,19 @@ public class HL7DbParser201305 {
 
         LOG.trace("Exiting HL7DbParser201305.ExtractPersonIdentifiers method...");
         return ids;
+    }
+
+    /**
+     * @param subjectId
+     * @return
+     */
+    private static Identifier getPatientDbIdentifier(II subjectId) {
+        Identifier id = new Identifier();
+        id.setId(subjectId.getExtension());
+        id.setOrganizationId(subjectId.getRoot());
+        LOG.info("Created id from patient identifier [organization : {}][id : {}] ", id.getOrganizationId(),
+            id.getId());
+        return id;
     }
 
     /**
@@ -401,8 +405,8 @@ public class HL7DbParser201305 {
                     && livingSubjectId.getValue().get(0) != null) {
                     II subjectId = livingSubjectId.getValue().get(0);
 
-                    if (subjectId.getExtension() != null && subjectId.getExtension().length() > 0
-                        && subjectId.getRoot() != null && subjectId.getRoot().length() > 0) {
+                    if (StringUtils.isNotEmpty(subjectId.getExtension())
+                        && StringUtils.isNotEmpty(subjectId.getRoot())) {
                         // Look for first SSN identifier
                         if (subjectId.getRoot().equals(SSN_ROOT_IDENTIFIER)) {
                             Identifier ssnId = new Identifier();

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/mpi/adapter/component/hl7parsers/HL7DbParser201306.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/mpi/adapter/component/hl7parsers/HL7DbParser201306.java
@@ -100,6 +100,9 @@ public class HL7DbParser201306 {
     private static final String PROPERTY_FILE = "adapter";
     private static final String PROPERTY_NAME = "assigningAuthorityId";
 
+    private HL7DbParser201306() {
+
+    }
     /**
      * Method to build a PRPAIN201306UV02 from a given list of Patients and a PRPAIN201305UV02 object.
      *
@@ -348,15 +351,13 @@ public class HL7DbParser201306 {
         if (CollectionUtils.isNotEmpty(patient.getIdentifiers())
             && patient.getIdentifiers().get(0) != null) {
 
-            if (patient.getIdentifiers().get(0).getOrganizationId() != null
-                && patient.getIdentifiers().get(0).getOrganizationId().length() > 0) {
+            if (StringUtils.isNotEmpty(patient.getIdentifiers().get(0).getOrganizationId())) {
                 LOG.info(
                     "Setting Patient Id root in 201306 : {} ", patient.getIdentifiers().get(0).getOrganizationId());
                 id.setRoot(HomeCommunityMap.formatHomeCommunityId(patient.getIdentifiers().get(0).getOrganizationId()));
             }
 
-            if (patient.getIdentifiers().get(0).getId() != null
-                && patient.getIdentifiers().get(0).getId().length() > 0) {
+            if (StringUtils.isNotEmpty(patient.getIdentifiers().get(0).getId())) {
                 LOG.info("Setting Patient Id extension in 201306 : {} ", patient.getIdentifiers().get(0).getId());
                 id.setExtension(patient.getIdentifiers().get(0).getId());
             }
@@ -425,7 +426,7 @@ public class HL7DbParser201306 {
         otherIds.getClassCode().add("SD");
 
         // Set the SSN
-        if (patient.getSsn() != null && patient.getSsn().length() > 0) {
+        if (StringUtils.isNotEmpty(patient.getSsn())) {
             II ssn = new II();
             ssn.setExtension(patient.getSsn());
             ssn.setRoot("2.16.840.1.113883.4.1");
@@ -474,7 +475,7 @@ public class HL7DbParser201306 {
     private static CE createGender(Patient patient) {
         CE gender = new CE();
 
-        if (patient.getGender() != null && patient.getGender().length() > 0) {
+        if (StringUtils.isNotEmpty(patient.getGender())) {
             LOG.info("Setting Patient Gender in 201306 : {} ", patient.getGender());
             gender.setCode(patient.getGender());
         }
@@ -619,32 +620,32 @@ public class HL7DbParser201306 {
         List addrlist = result.getContent();
 
         if (add != null) {
-            if (add.getStreet1() != null && add.getStreet1().length() > 0) {
+            if (StringUtils.isNotEmpty(add.getStreet1())) {
                 AdxpExplicitStreetAddressLine street = new AdxpExplicitStreetAddressLine();
                 street.setContent(add.getStreet1());
 
                 addrlist.add(factory.createADExplicitStreetAddressLine(street));
             }
 
-            if (add.getStreet2() != null && add.getStreet2().length() > 0) {
+            if (StringUtils.isNotEmpty(add.getStreet2())) {
                 AdxpExplicitStreetAddressLine street = new AdxpExplicitStreetAddressLine();
                 street.setContent(add.getStreet2());
 
                 addrlist.add(factory.createADExplicitStreetAddressLine(street));
             }
-            if (add.getCity() != null && add.getCity().length() > 0) {
+            if (StringUtils.isNotEmpty(add.getCity())) {
                 AdxpExplicitCity city = new AdxpExplicitCity();
                 city.setContent(add.getCity());
 
                 addrlist.add(factory.createADExplicitCity(city));
             }
-            if (add.getState() != null && add.getState().length() > 0) {
+            if (StringUtils.isNotEmpty(add.getState())) {
                 AdxpExplicitState state = new AdxpExplicitState();
                 state.setContent(add.getState());
 
                 addrlist.add(factory.createADExplicitState(state));
             }
-            if (add.getPostal() != null && add.getPostal().length() > 0) {
+            if (StringUtils.isNotEmpty(add.getPostal())) {
                 AdxpExplicitPostalCode zip = new AdxpExplicitPostalCode();
                 zip.setContent(add.getPostal());
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/mpi/adapter/component/hl7parsers/HL7Parser201305.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/mpi/adapter/component/hl7parsers/HL7Parser201305.java
@@ -66,6 +66,9 @@ public class HL7Parser201305 {
     private static final Logger LOG = LoggerFactory.getLogger(HL7Parser201305.class);
     private static HL7Parser201305Utils hl7ParserUtils = HL7Parser201305Utils.getInstance();
 
+    private HL7Parser201305() {
+
+    }
     /**
      * Method to extract Gender Code from a PRPAMT201306UV02ParameterList.
      *
@@ -141,15 +144,7 @@ public class HL7Parser201305 {
                     Serializable contentItem = iterSerialObjects.next();
 
                     if (contentItem instanceof String) {
-                        LOG.info("contentItem is string");
-                        String strValue = (String) contentItem;
-
-                        if (nameString != null) {
-                            nameString += strValue;
-                        } else {
-                            nameString = strValue;
-                        }
-                        LOG.info("nameString : {} " , nameString);
+                        nameString = hl7ParserUtils.formatNameString((String) contentItem, nameString);
                     } else if (contentItem instanceof JAXBElement) {
                         LOG.info("contentItem is JAXBElement");
 
@@ -213,7 +208,7 @@ public class HL7Parser201305 {
         LOG.trace("Entering HL7Parser201305.ExtractPersonIdentifiers method...");
 
         Identifiers ids = new Identifiers();
-        Identifier id = new Identifier();
+
 
         if (CollectionUtils.isNotEmpty(params.getLivingSubjectId())
             && params.getLivingSubjectId().get(0) != null) {
@@ -225,10 +220,7 @@ public class HL7Parser201305 {
 
                 if (StringUtils.isNotEmpty(subjectId.getExtension())
                     && StringUtils.isNotEmpty(subjectId.getRoot())) {
-                    id.setId(subjectId.getExtension());
-                    id.setOrganizationId(subjectId.getRoot());
-                    LOG.info("Created id from patient identifier [organization : {}][id : {}] ",
-                        id.getOrganizationId() , id.getId());
+                    Identifier id = getMPILibIdentifier(subjectId);
                     ids.add(id);
                 } else {
                     LOG.info("message does not contain an id");
@@ -242,6 +234,19 @@ public class HL7Parser201305 {
 
         LOG.trace("Exiting HL7Parser201305.ExtractPersonIdentifiers method...");
         return ids;
+    }
+
+    /**
+     * @param subjectId
+     * @return
+     */
+    private static Identifier getMPILibIdentifier(II subjectId) {
+        Identifier id = new Identifier();
+        id.setId(subjectId.getExtension());
+        id.setOrganizationId(subjectId.getRoot());
+        LOG.info("Created id from patient identifier [organization : {}][id : {}] ", id.getOrganizationId(),
+            id.getId());
+        return id;
     }
 
     /**

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/mpi/adapter/component/hl7parsers/HL7Parser201305Utils.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/mpi/adapter/component/hl7parsers/HL7Parser201305Utils.java
@@ -142,4 +142,15 @@ public class HL7Parser201305Utils {
         return queryParamList;
     }
 
+    public String formatNameString(String strValue, String str) {
+        String nameString = str;
+        LOG.info("contentItem is string");
+        if (nameString != null) {
+            nameString += strValue;
+        } else {
+            nameString = strValue;
+        }
+        LOG.info("nameString : {} ", nameString);
+        return nameString;
+    }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/mpi/adapter/component/hl7parsers/HL7Parser201306.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/mpi/adapter/component/hl7parsers/HL7Parser201306.java
@@ -487,7 +487,7 @@ public class HL7Parser201306 {
     private static CE createGender(Patient patient) {
         CE gender = new CE();
 
-        if (patient.getGender() != null && patient.getGender().length() > 0) {
+        if (StringUtils.isNotEmpty(patient.getGender())) {
             LOG.info("Setting Patient Gender in 201306 : {} ", patient.getGender());
             gender.setCode(patient.getGender());
         }
@@ -632,32 +632,32 @@ public class HL7Parser201306 {
         List addrlist = result.getContent();
 
         if (add != null) {
-            if (add.getStreet1() != null && add.getStreet1().length() > 0) {
+            if (StringUtils.isNotEmpty(add.getStreet1())) {
                 AdxpExplicitStreetAddressLine street = new AdxpExplicitStreetAddressLine();
                 street.setContent(add.getStreet1());
 
                 addrlist.add(factory.createADExplicitStreetAddressLine(street));
             }
 
-            if (add.getStreet2() != null && add.getStreet2().length() > 0) {
+            if (StringUtils.isNotEmpty(add.getStreet2())) {
                 AdxpExplicitStreetAddressLine street = new AdxpExplicitStreetAddressLine();
                 street.setContent(add.getStreet2());
 
                 addrlist.add(factory.createADExplicitStreetAddressLine(street));
             }
-            if (add.getCity() != null && add.getCity().length() > 0) {
+            if (StringUtils.isNotEmpty(add.getCity())) {
                 AdxpExplicitCity city = new AdxpExplicitCity();
                 city.setContent(add.getCity());
 
                 addrlist.add(factory.createADExplicitCity(city));
             }
-            if (add.getState() != null && add.getState().length() > 0) {
+            if (StringUtils.isNotEmpty(add.getState())) {
                 AdxpExplicitState state = new AdxpExplicitState();
                 state.setContent(add.getState());
 
                 addrlist.add(factory.createADExplicitState(state));
             }
-            if (add.getZip() != null && add.getZip().length() > 0) {
+            if (StringUtils.isNotEmpty(add.getZip())) {
                 AdxpExplicitPostalCode zip = new AdxpExplicitPostalCode();
                 zip.setContent(add.getZip());
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/AddressDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/AddressDAO.java
@@ -27,13 +27,7 @@
 package gov.hhs.fha.nhinc.patientdb.dao;
 
 import gov.hhs.fha.nhinc.patientdb.model.Address;
-import java.util.ArrayList;
 import java.util.List;
-import org.hibernate.Criteria;
-import org.hibernate.HibernateException;
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
-import org.hibernate.criterion.Expression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -145,40 +139,7 @@ public class AddressDAO extends GenericDAOImpl<Address> {
      * @return List<Address>
      */
     public List<Address> findPatientAddresses(Long patientId) {
-        LOG.trace("AddressDAO.readPatientAddresses() - Begin");
-        List<Address> queryList = new ArrayList<>();
-        Session session = null;
-        if (patientId == null) {
-            LOG.trace("-- patientId Parameter is required for Address Query --");
-            LOG.trace("AddressDAO.readPatientAddresses() - End");
-            return queryList;
-        }
-
-        try {
-            SessionFactory sessionFactory = getSessionFactory();
-            session = sessionFactory.openSession();
-            LOG.trace("Reading Record...");
-
-            // Build the criteria
-            Criteria aCriteria = session.createCriteria(Address.class);
-            aCriteria.add(Expression.eq("patient.patientId", patientId));
-            queryList = aCriteria.list();
-        } catch (HibernateException | NullPointerException e) {
-            LOG.error("Exception during read occured due to : {}", e.getMessage(), e);
-        } finally {
-            // Flush and close session
-            if (session != null) {
-                try {
-                    session.flush();
-                    session.close();
-                } catch (HibernateException e) {
-                    LOG.error("Exception while closing the session after looking for patient address: {}",
-                        e.getMessage(), e);
-                }
-            }
-        }
-        LOG.trace("readPatientAddresses.read() - End");
-        return queryList;
+        return super.findRecords(patientId, Address.class);
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PatientDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PatientDAO.java
@@ -32,7 +32,6 @@ import gov.hhs.fha.nhinc.patientdb.model.Identifier;
 import gov.hhs.fha.nhinc.patientdb.model.Patient;
 import gov.hhs.fha.nhinc.patientdb.model.Phonenumber;
 import gov.hhs.fha.nhinc.patientdb.persistence.HibernateUtil;
-import gov.hhs.fha.nhinc.patientdb.persistence.HibernateUtilFactory;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
@@ -52,7 +51,6 @@ public class PatientDAO extends GenericDAOImpl<Patient> {
 
     private static final Logger LOG = LoggerFactory.getLogger(PatientDAO.class);
     private static PatientDAO patientDAO = new PatientDAO();
-    private HibernateUtil hibernateUtil = HibernateUtilFactory.getHibernateUtilInstance();
 
     /**
      * Constructor
@@ -146,7 +144,7 @@ public class PatientDAO extends GenericDAOImpl<Patient> {
         List<Patient> patientsList = new ArrayList<>();
 
         try {
-            session = hibernateUtil.getSessionFactory().openSession();
+            session = getSessionFactory().openSession();
 
             LOG.trace("Reading Records...");
 
@@ -440,7 +438,7 @@ public class PatientDAO extends GenericDAOImpl<Patient> {
         List<Patient> patients = new ArrayList<>();
 
         try {
-            session = hibernateUtil.getSessionFactory().openSession();
+            session = getSessionFactory().openSession();
             Query query = session.createQuery("select new Patient(p) from Patient p");
             patients = query.list();
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PersonnameDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PersonnameDAO.java
@@ -27,12 +27,7 @@
 package gov.hhs.fha.nhinc.patientdb.dao;
 
 import gov.hhs.fha.nhinc.patientdb.model.Personname;
-import gov.hhs.fha.nhinc.patientdb.persistence.HibernateUtil;
 import java.util.List;
-import org.hibernate.Criteria;
-import org.hibernate.HibernateException;
-import org.hibernate.Session;
-import org.hibernate.criterion.Expression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,9 +41,6 @@ public class PersonnameDAO extends GenericDAOImpl<Personname> {
 
     private static final Logger LOG = LoggerFactory.getLogger(PersonnameDAO.class);
     private static PersonnameDAO personnameDAO = new PersonnameDAO();
-
-    private HibernateUtil hibernateUtil = new HibernateUtil();
-
     /**
      *
      * Constructor
@@ -152,42 +144,6 @@ public class PersonnameDAO extends GenericDAOImpl<Personname> {
      * @return List<Personname>
      */
     public List<Personname> findPatientPersonnames(Long patientId) {
-        LOG.trace("PersonnameDAO.findPatientPersonnames() - Begin");
-        if (patientId == null) {
-            LOG.trace("-- patientId Parameter is required for Personname Query --");
-            LOG.trace("PersonnameDAO.findPatientPersonnames() - End");
-            return null;
-        }
-
-        Session session = null;
-        List<Personname> queryList = null;
-        try {
-            session = hibernateUtil.getSessionFactory().openSession();
-            LOG.trace("Reading Record...");
-            // Build the criteria
-            Criteria aCriteria = session.createCriteria(Personname.class);
-            aCriteria.add(Expression.eq("patient.patientId", patientId));
-            queryList = aCriteria.list();
-
-        } catch (HibernateException | NullPointerException e) {
-
-            LOG.error("Exception during read occured due to : {}", e.getMessage(), e);
-
-        } finally {
-
-            // Flush and close session
-            if (session != null) {
-                try {
-                    session.flush();
-                    session.close();
-                } catch (HibernateException e) {
-                    LOG.error("Exception while closing the session after looking for patients' names: {}",
-                        e.getMessage(), e);
-                }
-            }
-        }
-        LOG.trace("PersonnameDAO.findPatientPersonnames() - End");
-        return queryList;
+        return super.findRecords(patientId, Personname.class);
     }
-
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PhonenumberDAO.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdb/dao/PhonenumberDAO.java
@@ -28,11 +28,6 @@ package gov.hhs.fha.nhinc.patientdb.dao;
 
 import gov.hhs.fha.nhinc.patientdb.model.Phonenumber;
 import java.util.List;
-import org.hibernate.Criteria;
-import org.hibernate.HibernateException;
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
-import org.hibernate.criterion.Expression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -150,46 +145,7 @@ public class PhonenumberDAO extends GenericDAOImpl<Phonenumber> {
      * @return List<Phonenumber>
      */
     public List<Phonenumber> findPatientPhonenumbers(Long patientId) {
-
-        LOG.trace("PhonenumberDAO.findPatientPhonenumbers() - Begin");
-
-        if (patientId == null) {
-
-            LOG.trace("-- patientId Parameter is required for Phonenumber Query --");
-
-            LOG.trace("PhonenumberDAO.findPatientPhonenumbers() - End");
-
-            return null;
-
-        }
-        Session session = null;
-        List<Phonenumber> queryList = null;
-        try {
-            SessionFactory sessionFactory = getSessionFactory();
-            if (sessionFactory != null) {
-                session = sessionFactory.openSession();
-                LOG.trace("Reading Record...");
-                // Build the criteria
-                Criteria aCriteria = session.createCriteria(Phonenumber.class);
-                aCriteria.add(Expression.eq("patient.patientId", patientId));
-                queryList = aCriteria.list();
-            }
-        } catch (HibernateException | NullPointerException e) {
-            LOG.error("Exception during read occured due to : {}", e.getMessage(), e);
-        } finally {
-            // Flush and close session
-            if (session != null) {
-                try {
-                    session.flush();
-                    session.close();
-                } catch (HibernateException e) {
-                    LOG.error("Exception while closing the session after looking for patient's phone numbers: {}",
-                        e.getMessage(), e);
-                }
-            }
-        }
-        LOG.trace("PhonenumberDAO.findPatientPhonenumbers() - End");
-        return queryList;
+        return super.findRecords(patientId, Phonenumber.class);
     }
 
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/entity/proxy/EntityPatientDiscoveryProxyWebServicAbstract.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/entity/proxy/EntityPatientDiscoveryProxyWebServicAbstract.java
@@ -40,6 +40,7 @@ import gov.hhs.fha.nhinc.patientdiscovery.entity.proxy.service.EntityPatientDisc
 import gov.hhs.fha.nhinc.patientdiscovery.entity.proxy.service.EntityPatientDiscoveryServicePortDescriptor;
 import gov.hhs.fha.nhinc.webserviceproxy.WebServiceProxyHelper;
 import org.hl7.v3.PRPAIN201305UV02;
+import org.hl7.v3.RespondingGatewayPRPAIN201305UV02RequestType;
 import org.hl7.v3.RespondingGatewayPRPAIN201306UV02ResponseType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -105,8 +106,40 @@ public abstract class EntityPatientDiscoveryProxyWebServicAbstract {
         return ConnectionManagerCache.getInstance().getInternalEndpointURLByServiceName(serviceName);
     }
 
-    abstract RespondingGatewayPRPAIN201306UV02ResponseType respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 pdRequest,
-        AssertionType assertion, NhinTargetCommunitiesType targetCommunities);
+    RespondingGatewayPRPAIN201306UV02ResponseType respondingGatewayPRPAIN201305UV02(Class portType, String endpointURL,
+        PRPAIN201305UV02 pdRequest, AssertionType assertion, NhinTargetCommunitiesType targetCommunities) {
+        LOG.debug("Begin respondingGatewayPRPAIN201305UV02");
+        RespondingGatewayPRPAIN201306UV02ResponseType response = null;
+
+        try {
+            if (pdRequest == null) {
+                LOG.error("PRPAIN201305UV02 was null");
+            } else if (assertion == null) {
+                LOG.error("AssertionType was null");
+            } else if (targetCommunities == null) {
+                LOG.error("NhinTargetCommunitiesType was null");
+            } else {
+                RespondingGatewayPRPAIN201305UV02RequestType request = new RespondingGatewayPRPAIN201305UV02RequestType();
+                request.setPRPAIN201305UV02(pdRequest);
+                request.setAssertion(assertion);
+                request.setNhinTargetCommunities(targetCommunities);
+                if (portType == EntityPatientDiscoveryPortType.class) {
+                    response = (RespondingGatewayPRPAIN201306UV02ResponseType) getDiscoveryPortClient(endpointURL,
+                        assertion).invokePort(EntityPatientDiscoveryPortType.class, "respondingGatewayPRPAIN201305UV02",
+                            request);
+                } else if (portType == EntityPatientDiscoverySecuredPortType.class) {
+                    response = (RespondingGatewayPRPAIN201306UV02ResponseType) getSecuredPortClient(endpointURL,
+                        assertion).invokePort(EntityPatientDiscoverySecuredPortType.class,
+                            "respondingGatewayPRPAIN201305UV02", request);
+                }
+            }
+        } catch (Exception ex) {
+            LOG.error("Error calling respondingGatewayPRPAIN201305UV02: {} " , ex.getMessage(), ex);
+        }
+
+        LOG.debug("End respondingGatewayPRPAIN201305UV02");
+        return response;
+    }
 
     /**
      * @param url

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/entity/proxy/EntityPatientDiscoveryProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/entity/proxy/EntityPatientDiscoveryProxyWebServiceSecuredImpl.java
@@ -34,10 +34,7 @@ import gov.hhs.fha.nhinc.messaging.client.CONNECTClient;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.webserviceproxy.WebServiceProxyHelper;
 import org.hl7.v3.PRPAIN201305UV02;
-import org.hl7.v3.RespondingGatewayPRPAIN201305UV02RequestType;
 import org.hl7.v3.RespondingGatewayPRPAIN201306UV02ResponseType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -46,7 +43,6 @@ import org.slf4j.LoggerFactory;
 public class EntityPatientDiscoveryProxyWebServiceSecuredImpl extends EntityPatientDiscoveryProxyWebServicAbstract
 implements EntityPatientDiscoveryProxy {
     private String serviceName = NhincConstants.ENTITY_PATIENT_DISCOVERY_SECURED_SERVICE_NAME;
-    private static final Logger LOG = LoggerFactory.getLogger(EntityPatientDiscoveryProxyWebServiceSecuredImpl.class);
 
     protected WebServiceProxyHelper createWebServiceProxyHelper() {
         return super.getoProxyHelper();
@@ -65,31 +61,8 @@ implements EntityPatientDiscoveryProxy {
     @Override
     public RespondingGatewayPRPAIN201306UV02ResponseType respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 pdRequest,
         AssertionType assertion, NhinTargetCommunitiesType targetCommunities) {
-        LOG.debug("Begin respondingGatewayPRPAIN201305UV02");
-
-        RespondingGatewayPRPAIN201306UV02ResponseType response = null;
-        try {
-            String url = getEndpointURL();
-            if (pdRequest == null) {
-                LOG.error("PRPAIN201305UV02 was null");
-            } else if (assertion == null) {
-                LOG.error("AssertionType was null");
-            } else if (targetCommunities == null) {
-                LOG.error("NhinTargetCommunitiesType was null");
-            } else {
-                RespondingGatewayPRPAIN201305UV02RequestType request = new RespondingGatewayPRPAIN201305UV02RequestType();
-                request.setPRPAIN201305UV02(pdRequest);
-                request.setAssertion(assertion);
-                request.setNhinTargetCommunities(targetCommunities);
-                response = (RespondingGatewayPRPAIN201306UV02ResponseType) getClient(url, assertion).invokePort(
-                    EntityPatientDiscoverySecuredPortType.class, "respondingGatewayPRPAIN201305UV02", request);
-            }
-        } catch (Exception ex) {
-            LOG.error("Error calling respondingGatewayPRPAIN201305UV02: {} " , ex.getMessage(), ex);
-        }
-
-        LOG.debug("End respondingGatewayPRPAIN201305UV02");
-        return response;
+        return super.respondingGatewayPRPAIN201305UV02(EntityPatientDiscoverySecuredPortType.class, getEndpointURL(),
+            pdRequest, assertion, targetCommunities);
     }
 
     /**

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/entity/proxy/EntityPatientDiscoveryProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/entity/proxy/EntityPatientDiscoveryProxyWebServiceUnsecuredImpl.java
@@ -34,10 +34,7 @@ import gov.hhs.fha.nhinc.messaging.client.CONNECTClient;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.webserviceproxy.WebServiceProxyHelper;
 import org.hl7.v3.PRPAIN201305UV02;
-import org.hl7.v3.RespondingGatewayPRPAIN201305UV02RequestType;
 import org.hl7.v3.RespondingGatewayPRPAIN201306UV02ResponseType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -45,7 +42,6 @@ import org.slf4j.LoggerFactory;
  */
 public class EntityPatientDiscoveryProxyWebServiceUnsecuredImpl extends EntityPatientDiscoveryProxyWebServicAbstract
 implements EntityPatientDiscoveryProxy {
-    private static final Logger LOG = LoggerFactory.getLogger(EntityPatientDiscoveryProxyWebServiceUnsecuredImpl.class);
     private WebServiceProxyHelper oProxyHelper = null;
 
     public EntityPatientDiscoveryProxyWebServiceUnsecuredImpl() {
@@ -75,31 +71,7 @@ implements EntityPatientDiscoveryProxy {
     @Override
     public RespondingGatewayPRPAIN201306UV02ResponseType respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 pdRequest,
         AssertionType assertion, NhinTargetCommunitiesType targetCommunities) {
-        LOG.debug("Begin respondingGatewayPRPAIN201305UV02");
-        RespondingGatewayPRPAIN201306UV02ResponseType response = null;
-
-        try {
-            String url = getEndpointURL();
-            if (pdRequest == null) {
-                LOG.error("PRPAIN201305UV02 was null");
-            } else if (assertion == null) {
-                LOG.error("AssertionType was null");
-            } else if (targetCommunities == null) {
-                LOG.error("NhinTargetCommunitiesType was null");
-            } else {
-                RespondingGatewayPRPAIN201305UV02RequestType request = new RespondingGatewayPRPAIN201305UV02RequestType();
-                request.setPRPAIN201305UV02(pdRequest);
-                request.setAssertion(assertion);
-                request.setNhinTargetCommunities(targetCommunities);
-                response = (RespondingGatewayPRPAIN201306UV02ResponseType) getClient(url, assertion).invokePort(
-                    EntityPatientDiscoveryPortType.class, "respondingGatewayPRPAIN201305UV02", request);
-            }
-        } catch (Exception ex) {
-            LOG.error("Error calling respondingGatewayPRPAIN201305UV02: {} " , ex.getMessage(), ex);
-        }
-
-        LOG.debug("End respondingGatewayPRPAIN201305UV02");
-        return response;
+        return super.respondingGatewayPRPAIN201305UV02(EntityPatientDiscoveryPortType.class, getEndpointURL(), pdRequest, assertion, targetCommunities);
     }
 
     /**

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/entity/proxy/EntityPatientDiscoveryProxyWebServiceSecuredImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/entity/proxy/EntityPatientDiscoveryProxyWebServiceSecuredImplTest.java
@@ -26,6 +26,11 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.entity.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
 import gov.hhs.fha.nhinc.connectmgr.ConnectionManagerException;
@@ -34,17 +39,12 @@ import gov.hhs.fha.nhinc.messaging.client.CONNECTClient;
 import gov.hhs.fha.nhinc.webserviceproxy.WebServiceProxyHelper;
 import javax.xml.ws.Service;
 import org.hl7.v3.PRPAIN201305UV02;
-import org.hl7.v3.RespondingGatewayPRPAIN201305UV02RequestType;
 import org.hl7.v3.RespondingGatewayPRPAIN201306UV02ResponseType;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
 import org.jmock.integration.junit4.JUnit4Mockery;
 import org.jmock.lib.legacy.ClassImposteriser;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -89,7 +89,7 @@ public class EntityPatientDiscoveryProxyWebServiceSecuredImplTest {
     public void testInvokeConnectionManagerHappy() {
         try {
             EntityPatientDiscoveryProxyWebServiceSecuredImpl sut = new EntityPatientDiscoveryProxyWebServiceSecuredImpl() {
-               @Override
+                @Override
                 protected WebServiceProxyHelper createWebServiceProxyHelper() {
                     return mockWebServiceProxyHelper;
                 }
@@ -112,7 +112,7 @@ public class EntityPatientDiscoveryProxyWebServiceSecuredImplTest {
     @Test(expected = gov.hhs.fha.nhinc.connectmgr.ConnectionManagerException.class)
     public void testInvokeConnectionManagerException() throws ConnectionManagerException {
         EntityPatientDiscoveryProxyWebServiceSecuredImpl sut = new EntityPatientDiscoveryProxyWebServiceSecuredImpl() {
-           @Override
+            @Override
             protected WebServiceProxyHelper createWebServiceProxyHelper() {
                 return mockWebServiceProxyHelper;
             }
@@ -180,7 +180,7 @@ public class EntityPatientDiscoveryProxyWebServiceSecuredImplTest {
     public void testRespondingGatewayPRPAIN201305UV02Happy() {
         try {
             final RespondingGatewayPRPAIN201306UV02ResponseType mockResponse = context
-                    .mock(RespondingGatewayPRPAIN201306UV02ResponseType.class);
+                .mock(RespondingGatewayPRPAIN201306UV02ResponseType.class);
             context.checking(new Expectations() {
                 {
                     // TODO: Using "anything()" to match "Object..." due to JMock upgrade
@@ -193,7 +193,7 @@ public class EntityPatientDiscoveryProxyWebServiceSecuredImplTest {
 
                 @Override
                 public Object invokePort(Object portObject, Class portClass, String methodName, Object ... operationInput)
-                        throws Exception {
+                    throws Exception {
                     return null;
                 }
             };
@@ -210,12 +210,19 @@ public class EntityPatientDiscoveryProxyWebServiceSecuredImplTest {
 
                 @Override
                 protected CONNECTClient<EntityPatientDiscoverySecuredPortType> getClient(String url,
-                        AssertionType assertion) {
+                    AssertionType assertion) {
                     return mockCONNECTClient;
                 }
+
+                @Override
+                protected CONNECTClient<EntityPatientDiscoverySecuredPortType> getSecuredPortClient(String url,
+                    AssertionType assertion) {
+                    return mockCONNECTClient;
+                }
+
             };
             RespondingGatewayPRPAIN201306UV02ResponseType response = sut.respondingGatewayPRPAIN201305UV02(
-                    mockPdRequest, mockAssertion, mockTargetCommunities);
+                mockPdRequest, mockAssertion, mockTargetCommunities);
             assertNotNull("RespondingGatewayPRPAIN201306UV02ResponseType was null", response);
         } catch (Throwable t) {
             System.out.println("Error running testRespondingGatewayPRPAIN201305UV02Happy test: " + t.getMessage());
@@ -239,11 +246,11 @@ public class EntityPatientDiscoveryProxyWebServiceSecuredImplTest {
                 }
             };
             RespondingGatewayPRPAIN201306UV02ResponseType response = webProxy.respondingGatewayPRPAIN201305UV02(null,
-                    mockAssertion, mockTargetCommunities);
+                mockAssertion, mockTargetCommunities);
             assertNull("RespondingGatewayPRPAIN201306UV02ResponseType was not null", response);
         } catch (Throwable t) {
             System.out.println("Error running testRespondingGatewayPRPAIN201305UV02NullPRPAIN201305UV02 test: "
-                    + t.getMessage());
+                + t.getMessage());
             t.printStackTrace();
             fail("Error running testRespondingGatewayPRPAIN201305UV02NullPRPAIN201305UV02 test: " + t.getMessage());
         }
@@ -264,11 +271,11 @@ public class EntityPatientDiscoveryProxyWebServiceSecuredImplTest {
                 }
             };
             RespondingGatewayPRPAIN201306UV02ResponseType response = webProxy.respondingGatewayPRPAIN201305UV02(
-                    mockPdRequest, null, mockTargetCommunities);
+                mockPdRequest, null, mockTargetCommunities);
             assertNull("RespondingGatewayPRPAIN201306UV02ResponseType was not null", response);
         } catch (Throwable t) {
             System.out.println("Error running testRespondingGatewayPRPAIN201305UV02NullAssertionType test: "
-                    + t.getMessage());
+                + t.getMessage());
             t.printStackTrace();
             fail("Error running testRespondingGatewayPRPAIN201305UV02NullAssertionType test: " + t.getMessage());
         }
@@ -289,15 +296,15 @@ public class EntityPatientDiscoveryProxyWebServiceSecuredImplTest {
                 }
             };
             RespondingGatewayPRPAIN201306UV02ResponseType response = webProxy.respondingGatewayPRPAIN201305UV02(
-                    mockPdRequest, mockAssertion, null);
+                mockPdRequest, mockAssertion, null);
             assertNull("RespondingGatewayPRPAIN201306UV02ResponseType was not null", response);
         } catch (Throwable t) {
             System.out
-                    .println("Error running testRespondingGatewayPRPAIN201305UV02NullNhinTargetCommunitiesType test: "
-                            + t.getMessage());
+            .println("Error running testRespondingGatewayPRPAIN201305UV02NullNhinTargetCommunitiesType test: "
+                + t.getMessage());
             t.printStackTrace();
             fail("Error running testRespondingGatewayPRPAIN201305UV02NullNhinTargetCommunitiesType test: "
-                    + t.getMessage());
+                + t.getMessage());
         }
     }
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/entity/proxy/EntityPatientDiscoveryProxyWebServiceUnsecuredImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/entity/proxy/EntityPatientDiscoveryProxyWebServiceUnsecuredImplTest.java
@@ -26,6 +26,11 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.entity.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
 import gov.hhs.fha.nhinc.connectmgr.ConnectionManagerException;
@@ -40,10 +45,6 @@ import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
 import org.jmock.integration.junit4.JUnit4Mockery;
 import org.jmock.lib.legacy.ClassImposteriser;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -184,12 +185,12 @@ public class EntityPatientDiscoveryProxyWebServiceUnsecuredImplTest {
     public void testRespondingGatewayPRPAIN201305UV02Happy() {
         try {
             final RespondingGatewayPRPAIN201306UV02ResponseType mockResponse = context
-                    .mock(RespondingGatewayPRPAIN201306UV02ResponseType.class);
+                .mock(RespondingGatewayPRPAIN201306UV02ResponseType.class);
             context.checking(new Expectations() {
                 {
                     // TODO: Using "anything()" to match "Object..." due to JMock upgrade
                     atLeast(1).of(mockCONNECTClient).invokePort(with(any(Class.class)), with(any(String.class)),
-                            with(anything()));
+                        with(anything()));
                     will(returnValue(mockResponse));
                 }
             });
@@ -210,10 +211,17 @@ public class EntityPatientDiscoveryProxyWebServiceUnsecuredImplTest {
                 protected CONNECTClient<EntityPatientDiscoveryPortType> getClient(String url, AssertionType assertion) {
                     return mockCONNECTClient;
                 }
+
+                @Override
+                protected CONNECTClient<EntityPatientDiscoveryPortType> getDiscoveryPortClient(String url,
+                    AssertionType assertion) {
+                    return mockCONNECTClient;
+                }
+
             };
 
             RespondingGatewayPRPAIN201306UV02ResponseType response = webProxy.respondingGatewayPRPAIN201305UV02(
-                    mockPdRequest, mockAssertion, mockTargetCommunities);
+                mockPdRequest, mockAssertion, mockTargetCommunities);
             assertNotNull("RespondingGatewayPRPAIN201306UV02ResponseType was null", response);
         } catch (Throwable t) {
             System.out.println("Error running testRespondingGatewayPRPAIN201305UV02Happy test: " + t.getMessage());
@@ -238,11 +246,11 @@ public class EntityPatientDiscoveryProxyWebServiceUnsecuredImplTest {
                 }
             };
             RespondingGatewayPRPAIN201306UV02ResponseType response = webProxy.respondingGatewayPRPAIN201305UV02(null,
-                    mockAssertion, mockTargetCommunities);
+                mockAssertion, mockTargetCommunities);
             assertNull("RespondingGatewayPRPAIN201306UV02ResponseType was not null", response);
         } catch (Throwable t) {
             System.out.println("Error running testRespondingGatewayPRPAIN201305UV02NullPRPAIN201305UV02 test: "
-                    + t.getMessage());
+                + t.getMessage());
             t.printStackTrace();
             fail("Error running testRespondingGatewayPRPAIN201305UV02NullPRPAIN201305UV02 test: " + t.getMessage());
         }
@@ -264,11 +272,11 @@ public class EntityPatientDiscoveryProxyWebServiceUnsecuredImplTest {
                 }
             };
             RespondingGatewayPRPAIN201306UV02ResponseType response = webProxy.respondingGatewayPRPAIN201305UV02(
-                    mockPdRequest, null, mockTargetCommunities);
+                mockPdRequest, null, mockTargetCommunities);
             assertNull("RespondingGatewayPRPAIN201306UV02ResponseType was not null", response);
         } catch (Throwable t) {
             System.out.println("Error running testRespondingGatewayPRPAIN201305UV02NullAssertionType test: "
-                    + t.getMessage());
+                + t.getMessage());
             t.printStackTrace();
             fail("Error running testRespondingGatewayPRPAIN201305UV02NullAssertionType test: " + t.getMessage());
         }
@@ -290,15 +298,15 @@ public class EntityPatientDiscoveryProxyWebServiceUnsecuredImplTest {
                 }
             };
             RespondingGatewayPRPAIN201306UV02ResponseType response = webProxy.respondingGatewayPRPAIN201305UV02(
-                    mockPdRequest, mockAssertion, null);
+                mockPdRequest, mockAssertion, null);
             assertNull("RespondingGatewayPRPAIN201306UV02ResponseType was not null", response);
         } catch (Throwable t) {
             System.out
-                    .println("Error running testRespondingGatewayPRPAIN201305UV02NullNhinTargetCommunitiesType test: "
-                            + t.getMessage());
+            .println("Error running testRespondingGatewayPRPAIN201305UV02NullNhinTargetCommunitiesType test: "
+                + t.getMessage());
             t.printStackTrace();
             fail("Error running testRespondingGatewayPRPAIN201305UV02NullNhinTargetCommunitiesType test: "
-                    + t.getMessage());
+                + t.getMessage());
         }
     }
 


### PR DESCRIPTION
SonarQube shows some false positive issues. The following changes are not fixed as part of this PR.

Issue : duplicated blocks of code must be removed

Reason : The files handle different type of objects and it can not be refactored.
src/main/java/gov/hhs/fha/nhinc/mpi/adapter/component/hl7parsers/*
Note: Fixed this block of duplicate code in pic
![image](https://user-images.githubusercontent.com/31286842/30704360-86dddf8c-9ec0-11e7-8dd0-5978d98cd6c9.png)

Reason : Inheritance hierarchy and child classes override parent class
src/main/java/gov/hhs/fha/nhinc/patientdiscovery/aspect/*

Reason: It doesn't make sense to refactor code between a request and response objects
src/main/java/gov/hhs/fha/nhinc/patientdiscovery/entity/deferred/response/*


