### PR TITLE
Conn 1852

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandler.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandler.java
@@ -26,10 +26,10 @@
  */
 package gov.hhs.fha.nhinc.callback.cxf;
 
+import gov.hhs.fha.nhinc.callback.SamlConstants;
 import gov.hhs.fha.nhinc.callback.opensaml.CallbackMapProperties;
 import gov.hhs.fha.nhinc.callback.opensaml.CallbackProperties;
 import gov.hhs.fha.nhinc.callback.opensaml.HOKSAMLAssertionBuilder;
-import gov.hhs.fha.nhinc.callback.SamlConstants;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.properties.PropertyAccessor;
@@ -159,8 +159,8 @@ public class CXFSAMLCallbackHandler implements CallbackHandler {
                 resource = (String) message.get(Message.ENDPOINT_ADDRESS);
             }
         } catch (final Exception e) {
-            LOG.warn("Unable to get resource: {}", e.getLocalizedMessage());
-            LOG.trace("Get resource exception: {}", e.getLocalizedMessage(), e);
+            // LOG.warn("Unable to get resource: {}", e.getLocalizedMessage());
+            LOG.error("Get resource exception: {}", e.getLocalizedMessage(), e);
         }
         return resource;
     }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandler.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandler.java
@@ -159,7 +159,6 @@ public class CXFSAMLCallbackHandler implements CallbackHandler {
                 resource = (String) message.get(Message.ENDPOINT_ADDRESS);
             }
         } catch (final Exception e) {
-            // LOG.warn("Unable to get resource: {}", e.getLocalizedMessage());
             LOG.error("Get resource exception: {}", e.getLocalizedMessage(), e);
         }
         return resource;

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
@@ -236,7 +236,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
         try {
             name = new LdapName(userName);
         } catch (final Exception e) {
-            LOG.trace("Exception checking DN: {}", e.getLocalizedMessage(), e);
+            LOG.error("Exception checking DN: {}", e.getLocalizedMessage(), e);
         }
         return name != null;
     }
@@ -533,7 +533,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
         statements = OpenSAML2ComponentBuilder.getInstance().createEvidenceStatements(accessConstentValues,
             evidenceInstanceAccessConsentValues, NHIN_NS);
 
-        LOG.trace("SamlCallbackHandler.createEvidenceStatements() -- End");
+        LOG.debug("SamlCallbackHandler.createEvidenceStatements() -- End");
         return statements;
     }
 
@@ -677,7 +677,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
             statements = OpenSAML2ComponentBuilder.getInstance().createHomeCommunitAttributeStatement(
                 appendPrefixHomeCommunityID(communityId));
         } else {
-            LOG.debug("Home Community ID is missing");
+            LOG.warn("Home Community ID is missing");
         }
 
         return statements;
@@ -704,7 +704,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
 
             statements.addAll(OpenSAML2ComponentBuilder.getInstance().createAttributeStatement(Arrays.asList(attribute)));
         } else {
-            LOG.debug("patient id is missing");
+            LOG.warn("patient id is missing");
         }
         return statements;
 
@@ -729,7 +729,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
 
             statements.addAll(OpenSAML2ComponentBuilder.getInstance().createAttributeStatement(Arrays.asList(attribute)));
         } else {
-            LOG.debug("npi is missing");
+            LOG.warn("npi is missing");
         }
         return statements;
 
@@ -746,7 +746,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
                 NhincConstants.GATEWAY_PROPERTY_FILE, NhincConstants.ENABLE_CONDITIONS_DEFAULT_VALUE);
             return !conditionsDefaultValueEnabled.equals(Boolean.FALSE);
         } catch (final PropertyAccessException pae) {
-            LOG.trace("Property not found exception: {}", pae.getLocalizedMessage(), pae);
+            LOG.error("Property not found exception: {}", pae.getLocalizedMessage(), pae);
         }
         return Boolean.TRUE;
     }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/saml/extraction/SamlTokenCreator.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/saml/extraction/SamlTokenCreator.java
@@ -152,13 +152,11 @@ public class SamlTokenCreator {
      * @param assertion
      */
     private static void extractHomeCommunity(Map<String, Object> requestContext, AssertionType assertion) {
-        if (assertion.getHomeCommunity() != null) {
-            if (NullChecker.isNotNullish(assertion.getHomeCommunity().getHomeCommunityId())) {
-                requestContext.put(SamlConstants.HOME_COM_PROP, assertion.getHomeCommunity().getHomeCommunityId());
-            }
-
+        if (assertion.getHomeCommunity() != null
+            && NullChecker.isNotNullish(assertion.getHomeCommunity().getHomeCommunityId())) {
+            requestContext.put(SamlConstants.HOME_COM_PROP, assertion.getHomeCommunity().getHomeCommunityId());
         } else {
-            LOG.error("Error: samlSendOperation input assertion Home Community is null");
+            LOG.warn("samlSendOperation input assertion Home Community is null");
         }
     }
 
@@ -194,14 +192,14 @@ public class SamlTokenCreator {
                 requestContext.put(SamlConstants.SAMLCONDITIONS_NOT_BEFORE_PROP,
                     assertion.getSamlConditions().getNotBefore());
             } else {
-                LOG.warn("Error: samlSendOperation input assertion condition notBefore is null");
+                LOG.warn("samlSendOperation input assertion condition notBefore is null");
             }
 
             if (NullChecker.isNotNullish(assertion.getSamlConditions().getNotOnOrAfter())) {
                 requestContext.put(SamlConstants.SAMLCONDITIONS_NOT_AFTER_PROP,
                     assertion.getSamlConditions().getNotOnOrAfter());
             } else {
-                LOG.warn("Error: samlSendOperation input assertion condition notOnOrAfter is null");
+                LOG.warn("samlSendOperation input assertion condition notOnOrAfter is null");
             }
         }
     }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/saml/extraction/SamlTokenCreator.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/saml/extraction/SamlTokenCreator.java
@@ -75,76 +75,11 @@ public class SamlTokenCreator {
                 requestContext.put(NhincConstants.ATTRIBUTE_NAME_NPI, NPI);
             }
             extractSubjectConfirmation(requestContext, assertion);
-            UserType userInfo = assertion.getUserInfo();
-            if (userInfo != null) {
-                if (NullChecker.isNotNullish(userInfo.getUserName())) {
-                    requestContext.put(SamlConstants.USER_NAME_PROP, userInfo.getUserName());
-                }
-                HomeCommunityType org = userInfo.getOrg();
-                if (org != null) {
-                    String name = org.getName();
-                    if (NullChecker.isNotNullish(name)) {
-                        requestContext.put(SamlConstants.USER_ORG_PROP, name);
-                    }
-                    if (NullChecker.isNotNullish(org.getHomeCommunityId())) {
-                        requestContext.put(SamlConstants.USER_ORG_ID_PROP, org.getHomeCommunityId());
-                    }
-                } else {
-                    LOG.error("Error: samlSendOperation input assertion user org is null");
-                }
-                if (userInfo.getRoleCoded() != null) {
-                    if (NullChecker.isNotNullish(userInfo.getRoleCoded().getCode())) {
-                        requestContext.put(SamlConstants.USER_CODE_PROP, userInfo.getRoleCoded().getCode());
-                    }
-                    requestContext.put(SamlConstants.USER_SYST_PROP, SamlConstants.USER_SYST_ATTR);
-                    requestContext.put(SamlConstants.USER_SYST_NAME_PROP, SamlConstants.USER_SYST_NAME_ATTR);
-                    if (NullChecker.isNotNullish(userInfo.getRoleCoded().getDisplayName())) {
-                        requestContext.put(SamlConstants.USER_DISPLAY_PROP, userInfo.getRoleCoded().getDisplayName());
-                    }
-                } else {
-                    LOG.error("Error: samlSendOperation input assertion user info role is null");
-                }
-                if (userInfo.getPersonName() != null) {
-                    if (NullChecker.isNotNullish(userInfo.getPersonName().getGivenName())) {
-                        requestContext.put(SamlConstants.USER_FIRST_PROP, userInfo.getPersonName().getGivenName());
-                    }
-                    if (NullChecker.isNotNullish(userInfo.getPersonName().getSecondNameOrInitials())) {
-                        requestContext.put(SamlConstants.USER_MIDDLE_PROP,
-                            userInfo.getPersonName().getSecondNameOrInitials());
-                    }
-                    if (NullChecker.isNotNullish(userInfo.getPersonName().getFamilyName())) {
-                        requestContext.put(SamlConstants.USER_LAST_PROP, userInfo.getPersonName().getFamilyName());
-                    }
-                } else {
-                    LOG.error("Error: samlSendOperation input assertion user person name is null");
-                }
-            } else {
-                LOG.error("Error: samlSendOperation input assertion user info is null");
-            }
+            extractUserInfo(requestContext, assertion);
 
-            if (assertion.getPurposeOfDisclosureCoded() != null) {
-                if (NullChecker.isNotNullish(assertion.getPurposeOfDisclosureCoded().getCode())) {
-                    requestContext.put(SamlConstants.PURPOSE_CODE_PROP,
-                        assertion.getPurposeOfDisclosureCoded().getCode());
-                }
+            extractPurposeOfDisclosureCoded(assertion, requestContext);
+            extractHomeCommunity(requestContext, assertion);
 
-                requestContext.put(SamlConstants.PURPOSE_SYST_PROP, SamlConstants.PURPOSE_SYSTEM_ATTR);
-                requestContext.put(SamlConstants.PURPOSE_SYST_NAME_PROP, SamlConstants.PURPOSE_SYSTEMNAME_ATTR);
-                if (NullChecker.isNotNullish(assertion.getPurposeOfDisclosureCoded().getDisplayName())) {
-                    requestContext.put(SamlConstants.PURPOSE_DISPLAY_PROP,
-                        assertion.getPurposeOfDisclosureCoded().getDisplayName());
-                }
-            } else {
-                LOG.error("Error: samlSendOperation input assertion purpose coded is null");
-            }
-            if (assertion.getHomeCommunity() != null) {
-                if (NullChecker.isNotNullish(assertion.getHomeCommunity().getHomeCommunityId())) {
-                    requestContext.put(SamlConstants.HOME_COM_PROP, assertion.getHomeCommunity().getHomeCommunityId());
-                }
-
-            } else {
-                LOG.error("Error: samlSendOperation input assertion Home Community is null");
-            }
             if (CollectionUtils.isNotEmpty(assertion.getUniquePatientId())) {
                 // take first non-null item in the List as the identifier
                 for (String patId : assertion.getUniquePatientId()) {
@@ -155,140 +90,12 @@ public class SamlTokenCreator {
                 }
             }
 
-            if (assertion.getSamlIssuer() != null) {
-                if (NullChecker.isNotNullish(assertion.getSamlIssuer().getIssuer())) {
-                    requestContext.put(SamlConstants.ASSERTION_ISSUER_PROP, assertion.getSamlIssuer().getIssuer());
-                }
-                if (NullChecker.isNotNullish(assertion.getSamlIssuer().getIssuerFormat())) {
-                    requestContext.put(SamlConstants.ASSERTION_ISSUER_FORMAT_PROP,
-                        assertion.getSamlIssuer().getIssuerFormat());
-                }
-            }
+            extractSamlIssuer(requestContext, assertion);
+            extractSamlConditions(requestContext, assertion);
+            extractSamlAuthnStatement(assertion, requestContext);
+            extractSamlAuthzDecisionStatement(assertion, requestContext);
+            extractSamlIssuerAttributes(assertion, requestContext);
 
-            if (assertion.getSamlConditions() != null) {
-                if (NullChecker.isNotNullish(assertion.getSamlConditions().getNotBefore())) {
-                    requestContext.put(SamlConstants.SAMLCONDITIONS_NOT_BEFORE_PROP,
-                        assertion.getSamlConditions().getNotBefore());
-                }
-                if (NullChecker.isNotNullish(assertion.getSamlConditions().getNotOnOrAfter())) {
-                    requestContext.put(SamlConstants.SAMLCONDITIONS_NOT_AFTER_PROP,
-                        assertion.getSamlConditions().getNotOnOrAfter());
-                }
-            }
-
-            if (assertion.getSamlAuthnStatement() != null) {
-                if (NullChecker.isNotNullish(assertion.getSamlAuthnStatement().getAuthInstant())) {
-                    requestContext.put(SamlConstants.AUTHN_INSTANT_PROP,
-                        assertion.getSamlAuthnStatement().getAuthInstant());
-                }
-                if (NullChecker.isNotNullish(assertion.getSamlAuthnStatement().getSessionIndex())) {
-                    requestContext.put(SamlConstants.AUTHN_SESSION_INDEX_PROP,
-                        assertion.getSamlAuthnStatement().getSessionIndex());
-                }
-                if (NullChecker.isNotNullish(assertion.getSamlAuthnStatement().getAuthContextClassRef())) {
-                    requestContext.put(SamlConstants.AUTHN_CONTEXT_CLASS_PROP,
-                        assertion.getSamlAuthnStatement().getAuthContextClassRef());
-                }
-                if (NullChecker.isNotNullish(assertion.getSamlAuthnStatement().getSubjectLocalityAddress())) {
-                    requestContext.put(SamlConstants.SUBJECT_LOCALITY_ADDR_PROP,
-                        assertion.getSamlAuthnStatement().getSubjectLocalityAddress());
-                }
-                if (NullChecker.isNotNullish(assertion.getSamlAuthnStatement().getSubjectLocalityDNSName())) {
-                    requestContext.put(SamlConstants.SUBJECT_LOCALITY_DNS_PROP,
-                        assertion.getSamlAuthnStatement().getSubjectLocalityDNSName());
-                }
-            } else {
-                LOG.error("Error: samlSendOperation input assertion AuthnStatement is null");
-            }
-            if (assertion.getSamlAuthzDecisionStatement() != null) {
-                requestContext.put(SamlConstants.AUTHZ_STATEMENT_EXISTS_PROP, "true");
-                if (NullChecker.isNotNullish(assertion.getSamlAuthzDecisionStatement().getAction())) {
-                    requestContext.put(SamlConstants.ACTION_PROP,
-                        assertion.getSamlAuthzDecisionStatement().getAction());
-                }
-                if (NullChecker.isNotNullish(assertion.getSamlAuthzDecisionStatement().getDecision())) {
-                    requestContext.put(SamlConstants.AUTHZ_DECISION_PROP,
-                        assertion.getSamlAuthzDecisionStatement().getDecision());
-                }
-                if (assertion.getSamlAuthzDecisionStatement().getEvidence() != null
-                    && assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion() != null) {
-                    if (NullChecker
-                        .isNotNullish(assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getId())) {
-                        requestContext.put(SamlConstants.EVIDENCE_ID_PROP,
-                            assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getId());
-                    }
-                    if (NullChecker.isNotNullish(
-                        assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getIssueInstant())) {
-                        requestContext.put(SamlConstants.EVIDENCE_INSTANT_PROP,
-                            assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getIssueInstant());
-                    }
-                    if (NullChecker.isNotNullish(
-                        assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getVersion())) {
-                        requestContext.put(SamlConstants.EVIDENCE_VERSION_PROP,
-                            assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getVersion());
-                    }
-                    if (NullChecker.isNotNullish(
-                        assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getIssuer())) {
-                        requestContext.put(SamlConstants.EVIDENCE_ISSUER_PROP,
-                            assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getIssuer());
-                    }
-                    if (NullChecker.isNotNullish(
-                        assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getIssuerFormat())) {
-                        requestContext.put(SamlConstants.EVIDENCE_ISSUER_FORMAT_PROP,
-                            assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getIssuerFormat());
-                    }
-                    if (!assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getAccessConsentPolicy()
-                        .isEmpty()) {
-                        requestContext.put(SamlConstants.EVIDENCE_ACCESS_CONSENT_PROP, assertion
-                            .getSamlAuthzDecisionStatement().getEvidence().getAssertion().getAccessConsentPolicy());
-                    }
-                    if (!assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion()
-                        .getInstanceAccessConsentPolicy().isEmpty()) {
-                        requestContext.put(SamlConstants.EVIDENCE_INST_ACCESS_CONSENT_PROP,
-                            assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion()
-                            .getInstanceAccessConsentPolicy());
-                    }
-
-                    if (NullChecker.isNotNullish(
-                        assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getSubject())) {
-                        requestContext.put(SamlConstants.EVIDENCE_SUBJECT_PROP,
-                            assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getSubject());
-                    }
-
-                    if (assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion()
-                        .getConditions() != null) {
-                        if (NullChecker.isNotNullish(assertion.getSamlAuthzDecisionStatement().getEvidence()
-                            .getAssertion().getConditions().getNotBefore())) {
-                            requestContext.put(SamlConstants.EVIDENCE_CONDITION_NOT_BEFORE_PROP,
-                                assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getConditions()
-                                .getNotBefore());
-                        }
-                        if (NullChecker.isNotNullish(assertion.getSamlAuthzDecisionStatement().getEvidence()
-                            .getAssertion().getConditions().getNotOnOrAfter())) {
-                            requestContext.put(SamlConstants.EVIDENCE_CONDITION_NOT_AFTER_PROP,
-                                assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getConditions()
-                                .getNotOnOrAfter());
-                        }
-                    }
-                } else {
-                    LOG.error("Error: samlSendOperation input assertion AuthzDecisionStatement Evidence is null");
-                }
-            } else {
-                requestContext.put(SamlConstants.AUTHZ_STATEMENT_EXISTS_PROP, "false");
-                LOG.info("AuthzDecisionStatement is null.  It will not be part of the SAML Assertion");
-            }
-
-            if (assertion.getSamlIssuer() != null) {
-                if (NullChecker.isNotNullish(assertion.getSamlIssuer().getIssuer())) {
-                    requestContext.put(SamlConstants.ASSERTION_ISSUER_PROP, assertion.getSamlIssuer().getIssuer());
-                }
-                if (NullChecker.isNotNullish(assertion.getSamlIssuer().getIssuerFormat())) {
-                    requestContext.put(SamlConstants.ASSERTION_ISSUER_FORMAT_PROP,
-                        assertion.getSamlIssuer().getIssuerFormat());
-                }
-            } else {
-                LOG.debug("samlSendOperation input assertion Saml Issuer is null");
-            }
         } else {
             LOG.error("Error: samlSendOperation input assertion is null");
         }
@@ -301,6 +108,8 @@ public class SamlTokenCreator {
         // assertion.getSamlAuthzDecisionStatement().getAction()
         if (NullChecker.isNotNullish(action)) {
             requestContext.put(SamlConstants.ACTION_PROP, action);
+        } else {
+            LOG.warn("samlSendOperation input action is null");
         }
 
         if (LOG.isTraceEnabled()) {
@@ -314,6 +123,338 @@ public class SamlTokenCreator {
         LOG.trace("Exiting SamlTokenCreator.CreateRequestContext...");
         return requestContext;
 
+    }
+
+    /**
+     * @param requestContext
+     * @param assertion
+     */
+    private static void extractSamlIssuer(Map<String, Object> requestContext, AssertionType assertion) {
+        if (assertion.getSamlIssuer() != null) {
+            if (NullChecker.isNotNullish(assertion.getSamlIssuer().getIssuer())) {
+                requestContext.put(SamlConstants.ASSERTION_ISSUER_PROP, assertion.getSamlIssuer().getIssuer());
+            } else {
+                LOG.warn("samlSendOperation input assertion samlIssuer issuer is null");
+            }
+            if (NullChecker.isNotNullish(assertion.getSamlIssuer().getIssuerFormat())) {
+                requestContext.put(SamlConstants.ASSERTION_ISSUER_FORMAT_PROP,
+                    assertion.getSamlIssuer().getIssuerFormat());
+            } else {
+                LOG.warn("samlSendOperation input assertion samlIssuer issuerFormat is null");
+            }
+        } else {
+            LOG.warn("samlSendOperation input assertion samlIssuer is null");
+        }
+    }
+
+    /**
+     * @param requestContext
+     * @param assertion
+     */
+    private static void extractHomeCommunity(Map<String, Object> requestContext, AssertionType assertion) {
+        if (assertion.getHomeCommunity() != null) {
+            if (NullChecker.isNotNullish(assertion.getHomeCommunity().getHomeCommunityId())) {
+                requestContext.put(SamlConstants.HOME_COM_PROP, assertion.getHomeCommunity().getHomeCommunityId());
+            }
+
+        } else {
+            LOG.error("Error: samlSendOperation input assertion Home Community is null");
+        }
+    }
+
+    /**
+     * @param assertion
+     * @param requestContext
+     */
+    private static void extractPurposeOfDisclosureCoded(AssertionType assertion, Map<String, Object> requestContext) {
+        if (assertion.getPurposeOfDisclosureCoded() != null) {
+            if (NullChecker.isNotNullish(assertion.getPurposeOfDisclosureCoded().getCode())) {
+                requestContext.put(SamlConstants.PURPOSE_CODE_PROP,
+                    assertion.getPurposeOfDisclosureCoded().getCode());
+            }
+
+            requestContext.put(SamlConstants.PURPOSE_SYST_PROP, SamlConstants.PURPOSE_SYSTEM_ATTR);
+            requestContext.put(SamlConstants.PURPOSE_SYST_NAME_PROP, SamlConstants.PURPOSE_SYSTEMNAME_ATTR);
+            if (NullChecker.isNotNullish(assertion.getPurposeOfDisclosureCoded().getDisplayName())) {
+                requestContext.put(SamlConstants.PURPOSE_DISPLAY_PROP,
+                    assertion.getPurposeOfDisclosureCoded().getDisplayName());
+            }
+        } else {
+            LOG.error("Error: samlSendOperation input assertion purpose coded is null");
+        }
+    }
+
+    /**
+     * @param requestContext
+     * @param assertion
+     */
+    private static void extractSamlConditions(Map<String, Object> requestContext, AssertionType assertion) {
+        if (assertion.getSamlConditions() != null) {
+            if (NullChecker.isNotNullish(assertion.getSamlConditions().getNotBefore())) {
+                requestContext.put(SamlConstants.SAMLCONDITIONS_NOT_BEFORE_PROP,
+                    assertion.getSamlConditions().getNotBefore());
+            } else {
+                LOG.warn("Error: samlSendOperation input assertion condition notBefore is null");
+            }
+
+            if (NullChecker.isNotNullish(assertion.getSamlConditions().getNotOnOrAfter())) {
+                requestContext.put(SamlConstants.SAMLCONDITIONS_NOT_AFTER_PROP,
+                    assertion.getSamlConditions().getNotOnOrAfter());
+            } else {
+                LOG.warn("Error: samlSendOperation input assertion condition notOnOrAfter is null");
+            }
+        }
+    }
+
+    /**
+     * @param assertion
+     * @param requestContext
+     */
+    private static void extractSamlIssuerAttributes(AssertionType assertion, Map<String, Object> requestContext) {
+        if (assertion.getSamlIssuer() != null) {
+            if (NullChecker.isNotNullish(assertion.getSamlIssuer().getIssuer())) {
+                requestContext.put(SamlConstants.ASSERTION_ISSUER_PROP, assertion.getSamlIssuer().getIssuer());
+            }
+            if (NullChecker.isNotNullish(assertion.getSamlIssuer().getIssuerFormat())) {
+                requestContext.put(SamlConstants.ASSERTION_ISSUER_FORMAT_PROP,
+                    assertion.getSamlIssuer().getIssuerFormat());
+            }
+        } else {
+            LOG.debug("samlSendOperation input assertion Saml Issuer is null");
+        }
+    }
+
+    /**
+     * @param assertion
+     * @param requestContext
+     */
+    private static void extractSamlAuthzDecisionStatement(AssertionType assertion, Map<String, Object> requestContext) {
+        if (assertion.getSamlAuthzDecisionStatement() != null) {
+            requestContext.put(SamlConstants.AUTHZ_STATEMENT_EXISTS_PROP, "true");
+            if (NullChecker.isNotNullish(assertion.getSamlAuthzDecisionStatement().getAction())) {
+                requestContext.put(SamlConstants.ACTION_PROP,
+                    assertion.getSamlAuthzDecisionStatement().getAction());
+            } else {
+                LOG.warn("samlSendOperation input assertion AuthzDecisionStatement action is null");
+            }
+
+            if (NullChecker.isNotNullish(assertion.getSamlAuthzDecisionStatement().getDecision())) {
+                requestContext.put(SamlConstants.AUTHZ_DECISION_PROP,
+                    assertion.getSamlAuthzDecisionStatement().getDecision());
+            } else {
+                LOG.warn("samlSendOperation input assertion AuthzDecisionStatement decision is null");
+            }
+
+            if (assertion.getSamlAuthzDecisionStatement().getEvidence() != null
+                && assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion() != null) {
+                extractSamlAuthzDecisionStatementEvidenceAssertion(assertion, requestContext);
+            } else {
+                LOG.warn("samlSendOperation input assertion AuthzDecisionStatement evidence is null");
+            }
+        } else {
+            requestContext.put(SamlConstants.AUTHZ_STATEMENT_EXISTS_PROP, "false");
+            LOG.warn("samlAuthzDecisionStatement is null.  It will not be part of the SAML Assertion");
+        }
+    }
+
+    /**
+     * @param requestContext
+     * @param assertion
+     */
+    private static void extractUserInfo(Map<String, Object> requestContext, AssertionType assertion) {
+        UserType userInfo = assertion.getUserInfo();
+        if (userInfo != null) {
+            if (NullChecker.isNotNullish(userInfo.getUserName())) {
+                requestContext.put(SamlConstants.USER_NAME_PROP, userInfo.getUserName());
+            }
+            HomeCommunityType org = userInfo.getOrg();
+            if (org != null) {
+                String name = org.getName();
+                if (NullChecker.isNotNullish(name)) {
+                    requestContext.put(SamlConstants.USER_ORG_PROP, name);
+                }
+                if (NullChecker.isNotNullish(org.getHomeCommunityId())) {
+                    requestContext.put(SamlConstants.USER_ORG_ID_PROP, org.getHomeCommunityId());
+                }
+            } else {
+                LOG.error("Error: samlSendOperation input assertion user org is null");
+            }
+            if (userInfo.getRoleCoded() != null) {
+                if (NullChecker.isNotNullish(userInfo.getRoleCoded().getCode())) {
+                    requestContext.put(SamlConstants.USER_CODE_PROP, userInfo.getRoleCoded().getCode());
+                }
+                requestContext.put(SamlConstants.USER_SYST_PROP, SamlConstants.USER_SYST_ATTR);
+                requestContext.put(SamlConstants.USER_SYST_NAME_PROP, SamlConstants.USER_SYST_NAME_ATTR);
+                if (NullChecker.isNotNullish(userInfo.getRoleCoded().getDisplayName())) {
+                    requestContext.put(SamlConstants.USER_DISPLAY_PROP, userInfo.getRoleCoded().getDisplayName());
+                }
+            } else {
+                LOG.error("Error: samlSendOperation input assertion user info role is null");
+            }
+            if (userInfo.getPersonName() != null) {
+                if (NullChecker.isNotNullish(userInfo.getPersonName().getGivenName())) {
+                    requestContext.put(SamlConstants.USER_FIRST_PROP, userInfo.getPersonName().getGivenName());
+                }
+                if (NullChecker.isNotNullish(userInfo.getPersonName().getSecondNameOrInitials())) {
+                    requestContext.put(SamlConstants.USER_MIDDLE_PROP,
+                        userInfo.getPersonName().getSecondNameOrInitials());
+                }
+                if (NullChecker.isNotNullish(userInfo.getPersonName().getFamilyName())) {
+                    requestContext.put(SamlConstants.USER_LAST_PROP, userInfo.getPersonName().getFamilyName());
+                }
+            } else {
+                LOG.error("Error: samlSendOperation input assertion user person name is null");
+            }
+        } else {
+            LOG.error("Error: samlSendOperation input assertion user info is null");
+        }
+    }
+
+    /**
+     * @param assertion
+     * @param requestContext
+     */
+    private static void extractSamlAuthnStatement(AssertionType assertion, Map<String, Object> requestContext) {
+        if (assertion.getSamlAuthnStatement() != null) {
+            if (NullChecker.isNotNullish(assertion.getSamlAuthnStatement().getAuthInstant())) {
+                requestContext.put(SamlConstants.AUTHN_INSTANT_PROP,
+                    assertion.getSamlAuthnStatement().getAuthInstant());
+            } else {
+                LOG.warn("samlSendOperation input authInstant is null");
+            }
+
+            if (NullChecker.isNotNullish(assertion.getSamlAuthnStatement().getSessionIndex())) {
+                requestContext.put(SamlConstants.AUTHN_SESSION_INDEX_PROP,
+                    assertion.getSamlAuthnStatement().getSessionIndex());
+            } else {
+                LOG.warn("samlSendOperation input sessionIndex is null");
+            }
+
+            if (NullChecker.isNotNullish(assertion.getSamlAuthnStatement().getAuthContextClassRef())) {
+                requestContext.put(SamlConstants.AUTHN_CONTEXT_CLASS_PROP,
+                    assertion.getSamlAuthnStatement().getAuthContextClassRef());
+            } else {
+                LOG.warn("samlSendOperation input authContextClassRef is null");
+            }
+
+            if (NullChecker.isNotNullish(assertion.getSamlAuthnStatement().getSubjectLocalityAddress())) {
+                requestContext.put(SamlConstants.SUBJECT_LOCALITY_ADDR_PROP,
+                    assertion.getSamlAuthnStatement().getSubjectLocalityAddress());
+            } else {
+                LOG.warn("samlSendOperation input subjectLocalityAddress is null");
+            }
+
+            if (NullChecker.isNotNullish(assertion.getSamlAuthnStatement().getSubjectLocalityDNSName())) {
+                requestContext.put(SamlConstants.SUBJECT_LOCALITY_DNS_PROP,
+                    assertion.getSamlAuthnStatement().getSubjectLocalityDNSName());
+            } else {
+                LOG.warn("samlSendOperation input subjectLocalityDNSName is null");
+            }
+        } else {
+            LOG.warn("samlSendOperation input assertion samlAuthnStatement is null");
+        }
+    }
+
+    /**
+     * @param assertion
+     * @param requestContext
+     */
+    private static void extractSamlAuthzDecisionStatementEvidenceAssertion(AssertionType assertion,
+        Map<String, Object> requestContext) {
+        if (NullChecker
+            .isNotNullish(assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getId())) {
+            requestContext.put(SamlConstants.EVIDENCE_ID_PROP,
+                assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getId());
+        } else {
+            LOG.warn("samlSendOperation input assertion evidence assertion id is null");
+        }
+
+        if (NullChecker.isNotNullish(
+            assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getIssueInstant())) {
+            requestContext.put(SamlConstants.EVIDENCE_INSTANT_PROP,
+                assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getIssueInstant());
+        } else {
+            LOG.warn("samlSendOperation input assertion evidence assertion issueInstant is null");
+        }
+
+        if (NullChecker.isNotNullish(
+            assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getVersion())) {
+            requestContext.put(SamlConstants.EVIDENCE_VERSION_PROP,
+                assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getVersion());
+        } else {
+            LOG.warn("samlSendOperation input assertion evidence assertion version is null");
+        }
+
+        if (NullChecker.isNotNullish(
+            assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getIssuer())) {
+            requestContext.put(SamlConstants.EVIDENCE_ISSUER_PROP,
+                assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getIssuer());
+        } else {
+            LOG.warn("samlSendOperation input assertion evidence assertion issuer is null");
+        }
+
+        if (NullChecker.isNotNullish(
+            assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getIssuerFormat())) {
+            requestContext.put(SamlConstants.EVIDENCE_ISSUER_FORMAT_PROP,
+                assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getIssuerFormat());
+        } else {
+            LOG.warn("samlSendOperation input assertion evidence assertion issuerFormat is null");
+        }
+
+        if (CollectionUtils.isNotEmpty(
+            assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getAccessConsentPolicy())) {
+            requestContext.put(SamlConstants.EVIDENCE_ACCESS_CONSENT_PROP, assertion
+                .getSamlAuthzDecisionStatement().getEvidence().getAssertion().getAccessConsentPolicy());
+        } else {
+            LOG.warn("samlSendOperation input assertion evidence assertion accessConsentPolicy is null");
+        }
+
+        if (CollectionUtils.isNotEmpty(
+            assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getInstanceAccessConsentPolicy())) {
+            requestContext.put(SamlConstants.EVIDENCE_INST_ACCESS_CONSENT_PROP,
+                assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion()
+                .getInstanceAccessConsentPolicy());
+        } else {
+            LOG.warn("samlSendOperation input assertion evidence assertion instanceAccessConsentPolicy is null");
+        }
+
+
+        if (NullChecker.isNotNullish(
+            assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getSubject())) {
+            requestContext.put(SamlConstants.EVIDENCE_SUBJECT_PROP,
+                assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getSubject());
+        } else {
+            LOG.warn("samlSendOperation input assertion evidence assertion subject is null");
+        }
+
+        extractEvidenceAssertionConditions(assertion, requestContext);
+    }
+
+    /**
+     * @param assertion
+     * @param requestContext
+     */
+    private static void extractEvidenceAssertionConditions(AssertionType assertion,
+        Map<String, Object> requestContext) {
+        if (assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion()
+            .getConditions() != null) {
+            if (NullChecker.isNotNullish(assertion.getSamlAuthzDecisionStatement().getEvidence()
+                .getAssertion().getConditions().getNotBefore())) {
+                requestContext.put(SamlConstants.EVIDENCE_CONDITION_NOT_BEFORE_PROP,
+                    assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getConditions()
+                    .getNotBefore());
+            } else {
+                LOG.warn("samlSendOperation input assertion evidence assertion notBefore is null");
+            }
+            if (NullChecker.isNotNullish(assertion.getSamlAuthzDecisionStatement().getEvidence()
+                .getAssertion().getConditions().getNotOnOrAfter())) {
+                requestContext.put(SamlConstants.EVIDENCE_CONDITION_NOT_AFTER_PROP,
+                    assertion.getSamlAuthzDecisionStatement().getEvidence().getAssertion().getConditions()
+                    .getNotOnOrAfter());
+            } else {
+                LOG.warn("samlSendOperation input assertion evidence assertion notOnOrAfter is null");
+            }
+        }
     }
 
     private static void extractSubjectConfirmation(Map<String, Object> requestContext, AssertionType assertion) {


### PR DESCRIPTION
Inconsistent logging for missing saml attribute statements on build (some are warn others info).

Some observation:
Currently there's no null check for the child attributes of 
<urn1:homeCommunity> such as description, homeCommunityId, name 

Attributes I wasn't able to test:
message
QualifiedSubjectIdentifier
implementsSpecVersion
samlSignature
assigningAuthority
messageId
relatesToList
NhinTargetCommunity.list
NhinTargetCommunity.region
NhinTargetSystem.useSpecVersion
transactionTimeout
keepAlive
CONNECTCustomHttpHeaders