### PR TITLE
CONN_2144: Adding required attributes to be checked during CXF callba…

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/PurposeOfForDecider.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/PurposeOfForDecider.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -27,7 +27,6 @@
 package gov.hhs.fha.nhinc.callback;
 
 import gov.hhs.fha.nhinc.callback.opensaml.CallbackProperties;
-
 import gov.hhs.fha.nhinc.callback.purposeuse.PurposeUseProxy;
 import gov.hhs.fha.nhinc.callback.purposeuse.PurposeUseProxyObjectFactory;
 import gov.hhs.fha.nhinc.connectmgr.NhinEndpointManager;
@@ -94,14 +93,8 @@ public class PurposeOfForDecider {
     }
 
     private void logPurposeDecision(Boolean purposeFor, String hcid, String serviceName) {
-        String purposeName;
-        if (purposeFor) {
-            purposeName = "PURPOSE FOR";
-        } else {
-            purposeName = "PURPOSE OF";
-        }
-
-        LOG.debug("PurposeOfForDecider decision for HCID: " + hcid + " and Service Name: " + serviceName + " is = "
-                + purposeName + ".");
+        String purposeName = purposeFor ? "PURPOSE FOR" : "PURPOSE OF";
+        LOG.debug("PurposeOfForDecider decision for HCID: {} and Service Name: {} is = {}.", hcid, serviceName,
+            purposeName);
     }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandler.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandler.java
@@ -120,7 +120,7 @@ public class CXFSAMLCallbackHandler implements CallbackHandler {
 
         LOG.trace("CXFSAMLCallbackHandler.handle end");
 
-        // throw new IllegalStateException("HCID is missing for assertion");
+
     }
 
     /**

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandler.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandler.java
@@ -33,6 +33,7 @@ import gov.hhs.fha.nhinc.callback.opensaml.HOKSAMLAssertionBuilder;
 import gov.hhs.fha.nhinc.callback.opensaml.SAMLAssertionBuilderException;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.properties.PropertyAccessException;
 import gov.hhs.fha.nhinc.properties.PropertyAccessor;
 import gov.hhs.fha.nhinc.saml.extraction.SamlTokenCreator;
 import java.io.IOException;
@@ -44,6 +45,7 @@ import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.PhaseInterceptorChain;
 import org.apache.wss4j.common.crypto.Crypto;
 import org.apache.wss4j.common.crypto.CryptoFactory;
+import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.common.saml.SAMLCallback;
 import org.apache.wss4j.common.saml.bean.Version;
 import org.apache.wss4j.policy.SPConstants;
@@ -109,11 +111,9 @@ public class CXFSAMLCallbackHandler implements CallbackHandler {
                     final CallbackProperties properties = new CallbackMapProperties(addMessageProperties(
                         creator.createRequestContext(custAssertion, getResource(message), null), message));
                     oSAMLCallback.setAssertionElement(builder.build(properties));
-                } catch (SAMLAssertionBuilderException ex) {
-                    LOG.error("Failed to create saml: {}", ex.getLocalizedMessage(), ex);
-                    throw new IOException(ex.getMessage());
-                } catch (final Exception e) {
+                } catch (WSSecurityException | PropertyAccessException e) {
                     LOG.error("Failed to create saml: {}", e.getLocalizedMessage(), e);
+                    throw new SAMLAssertionBuilderException(e.getMessage(), e);
                 }
             }
         }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandler.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandler.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -79,6 +79,7 @@ public class CXFSAMLCallbackHandler implements CallbackHandler {
     @Override
     public void handle(final Callback[] callbacks) throws IOException, UnsupportedCallbackException {
         LOG.trace("CXFSAMLCallbackHandler.handle begin");
+
         for (final Callback callback : callbacks) {
             if (callback instanceof SAMLCallback) {
 
@@ -108,16 +109,18 @@ public class CXFSAMLCallbackHandler implements CallbackHandler {
                     final CallbackProperties properties = new CallbackMapProperties(addMessageProperties(
                         creator.createRequestContext(custAssertion, getResource(message), null), message));
                     oSAMLCallback.setAssertionElement(builder.build(properties));
-
                 } catch (SAMLAssertionBuilderException ex) {
                     LOG.error("Failed to create saml: {}", ex.getLocalizedMessage(), ex);
-                    throw new IOException(ex);
+                    throw new IOException(ex.getMessage());
                 } catch (final Exception e) {
                     LOG.error("Failed to create saml: {}", e.getLocalizedMessage(), e);
                 }
             }
         }
+
         LOG.trace("CXFSAMLCallbackHandler.handle end");
+
+        // throw new IllegalStateException("HCID is missing for assertion");
     }
 
     /**

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackMapProperties.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackMapProperties.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -44,7 +44,7 @@ import org.joda.time.format.ISODateTimeFormat;
  */
 public class CallbackMapProperties implements CallbackProperties {
 
-    private final Map<Object, Object> map = new HashMap<>();
+    private final Map<String, Object> map = new HashMap<>();
     private static final DateTimeFormatter XML_DATE_TIME_FORMAT = ISODateTimeFormat.dateTimeParser();
 
     /**
@@ -52,7 +52,7 @@ public class CallbackMapProperties implements CallbackProperties {
      *
      * @param properties
      */
-    public CallbackMapProperties(Map<?, Object> properties) {
+    public CallbackMapProperties(Map<String, Object> properties) {
         map.putAll(properties);
     }
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
@@ -582,8 +582,8 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
         final String userDisplay = properties.getUserDisplay();
 
         if (Arrays.asList(userCode, userSystem, userSystemName, userDisplay).contains(null)) {
-            LOG.error("No information provided to fill in user role attribute..");
-            throw new SAMLAssertionBuilderException("No information provided to fill in user role attribute.");
+            LOG.error("No information provided to fill in subject role attribute..");
+            throw new SAMLAssertionBuilderException("No information provided to fill in subject role attribute.");
         }
 
         final List<AttributeStatement> statements = new ArrayList<>();

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
@@ -39,7 +39,6 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
@@ -690,18 +689,13 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
     protected List<AttributeStatement> createHomeCommunityIdAttributeStatements(final CallbackProperties properties)
         throws SAMLAssertionBuilderException {
 
-        List<AttributeStatement> statements = Collections.emptyList();
-
         final String communityId = properties.getHomeCommunity();
-        if (StringUtils.isNotBlank(communityId)) {
-            statements = componentBuilder
-                .createHomeCommunitAttributeStatement(appendPrefixHomeCommunityID(communityId));
-        } else {
+        if (StringUtils.isBlank(communityId)) {
             LOG.error("No Home Community ID Attribute statement provided.");
             throw new SAMLAssertionBuilderException("No Home Community ID Attribute statement provided.");
         }
 
-        return statements;
+        return componentBuilder.createHomeCommunitAttributeStatement(appendPrefixHomeCommunityID(communityId));
 
     }
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -43,6 +43,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
+import javax.naming.InvalidNameException;
 import javax.naming.Name;
 import javax.naming.ldap.LdapName;
 import org.apache.commons.collections.CollectionUtils;
@@ -75,6 +76,13 @@ import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
 
 /**
+ * This class builds the SAML2 Assertion for Outbound requests from the given CONNECT AssertionType. All Inbound
+ * requests go through this assertion builder to in order to generate the appropriate SAML for Outbound requests via
+ * CXFSAMLCallbackHandler::handle(Callback[] callbacks).
+ *
+ * For more information regarding the SAML 2 Spec for use with CONNECT, please see section 3.2
+ * https://sequoiaproject.org/wp-content/uploads/2014/11/nhin-authorization-framework-production-specification-v3.0.pdf
+ *
  * @author bhumphrey
  *
  */
@@ -82,15 +90,18 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
 
     private static final Logger LOG = LoggerFactory.getLogger(HOKSAMLAssertionBuilder.class);
     private final CertificateManager certificateManager;
+    private final OpenSAML2ComponentBuilder componentBuilder;
     private static final String PROPERTY_FILE_NAME = "assertioninfo";
     private static final String PROPERTY_SAML_ISSUER_NAME = "SamlIssuerName";
 
     public HOKSAMLAssertionBuilder() {
         certificateManager = CertificateManagerImpl.getInstance();
+        componentBuilder = OpenSAML2ComponentBuilder.getInstance();
     }
 
     HOKSAMLAssertionBuilder(final CertificateManager certificateManager) {
         this.certificateManager = certificateManager;
+        componentBuilder = OpenSAML2ComponentBuilder.getInstance();
     }
 
     /**
@@ -102,13 +113,13 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
      */
     @Override
     public Element build(final CallbackProperties properties) throws SAMLAssertionBuilderException {
-        LOG.debug("SamlCallbackHandler.createHOKSAMLAssertion20()");
+        LOG.debug("SamlCallbackHandler.build() -- Start");
         Element signedAssertion = null;
         try {
             final X509Certificate certificate = certificateManager.getDefaultCertificate();
             final PublicKey publicKey = certificateManager.getDefaultPublicKey();
             final PrivateKey privateKey = certificateManager.getDefaultPrivateKey();
-            Assertion assertion = OpenSAML2ComponentBuilder.getInstance().createAssertion();
+            Assertion assertion = componentBuilder.createAssertion();
 
             // create the assertion id
             // Per GATEWAY-847 the id attribute should not be allowed to start
@@ -118,33 +129,22 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
             final String aID = createAssertionId();
             LOG.debug("Assertion ID: {}", aID);
 
-            // set assertion Id
             assertion.setID(aID);
 
-            // issue instant set to now.
             final DateTime issueInstant = new DateTime();
             assertion.setIssueInstant(issueInstant);
-
-            // set issuer
             assertion.setIssuer(createIssuer(properties, certificate));
-
-            // set subject
             assertion.setSubject(createSubject(properties, certificate, publicKey));
-
-            // add conditions statement
             assertion.setConditions(createConditions(properties));
-
-            // add attribute statements
             assertion.getStatements().addAll(
                 createAttributeStatements(properties, createEvidenceSubject(properties, certificate, publicKey)));
 
-            // sign the message
             signedAssertion = sign(assertion, certificate, privateKey, publicKey);
         } catch (final SAMLComponentBuilderException | CertificateManagerException ex) {
             LOG.error("Unable to create HOK Assertion: {}", ex.getLocalizedMessage());
             throw new SAMLAssertionBuilderException(ex.getLocalizedMessage(), ex);
         }
-        LOG.debug("SamlCallbackHandler.createHOKSAMLAssertion20() -- End");
+        LOG.debug("SamlCallbackHandler.build() -- End");
         return signedAssertion;
     }
 
@@ -154,7 +154,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
      * @param certificate
      * @param publicKey
      * @return
-     * @throws Exception
+     * @throws SAMLAssertionBuilderException
      */
     protected Element sign(final Assertion assertion, final X509Certificate certificate, final PrivateKey privateKey,
         final PublicKey publicKey) throws SAMLAssertionBuilderException {
@@ -210,24 +210,23 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
      * @param PSApk
      * @param certificate
      * @return
-     * @throws Exception
+     * @throws SAMLComponentBuilderException
      */
     protected Subject createSubject(final CallbackProperties properties, final X509Certificate certificate,
         final PublicKey publicKey) throws SAMLComponentBuilderException {
         String x509Name = properties.getUsername();
-        OpenSAML2ComponentBuilder openSamlBuilder = OpenSAML2ComponentBuilder.getInstance();
         if ((NullChecker.isNullish(x509Name) || !checkDistinguishedName(x509Name)) && null != certificate
             && null != certificate.getSubjectDN()) {
             x509Name = certificate.getSubjectDN().getName();
         }
-        Subject subject = openSamlBuilder.createSubject(x509Name, publicKey);
+        Subject subject = componentBuilder.createSubject(x509Name, publicKey);
         // Add additional subject confirmation if exist
         List<SAMLSubjectConfirmation> subjectConfirmations = properties.getSubjectConfirmations();
         if (CollectionUtils.isNotEmpty(subjectConfirmations)) {
             for (SAMLSubjectConfirmation confirmation : subjectConfirmations) {
-                SubjectConfirmation subjectConfirmation = openSamlBuilder.createSubjectConfirmation(confirmation);
+                SubjectConfirmation subjectConfirmation = componentBuilder.createSubjectConfirmation(confirmation);
                 if (subjectConfirmation != null) {
-                    subject.getSubjectConfirmations().add(openSamlBuilder.createSubjectConfirmation(confirmation));
+                    subject.getSubjectConfirmations().add(subjectConfirmation);
                 }
             }
         }
@@ -246,7 +245,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
         Name name = null;
         try {
             name = new LdapName(userName);
-        } catch (final Exception e) {
+        } catch (InvalidNameException e) {
             LOG.error("Invalid distinguished name {}", userName);
         }
         return name != null;
@@ -268,10 +267,10 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
         } else {
             x509Name = evidenceSubject;
         }
-        return OpenSAML2ComponentBuilder.getInstance().createSubject(x509Name, publicKey);
+        return componentBuilder.createSubject(x509Name, publicKey);
     }
 
-    protected Conditions createConditions(final CallbackProperties properties) throws SAMLAssertionBuilderException {
+    protected Conditions createConditions(final CallbackProperties properties) {
         DateTime issueInstant = new DateTime();
         DateTime beginValidTime = properties.getSamlConditionsNotBefore();
         DateTime endValidTime = properties.getSamlConditionsNotAfter();
@@ -284,24 +283,29 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
                 endValidTime = setEndValidTime(endValidTime, issueInstant);
             }
 
-            return OpenSAML2ComponentBuilder.getInstance().createConditions(beginValidTime, endValidTime);
+            return componentBuilder.createConditions(beginValidTime, endValidTime);
         }
         return null;
     }
 
-    @SuppressWarnings("unchecked")
     public List<Statement> createAttributeStatements(final CallbackProperties properties, final Subject subject)
         throws SAMLAssertionBuilderException {
         final List<Statement> statements = new ArrayList<>();
 
+        // TODO: Not a *single* one of these methods ever returns a list with more than one element.
+        // so in that case we can drop the whole "List" thing going on and just add individual elements.
         statements.addAll(createAuthenicationStatements(properties));
-        statements.addAll(createUserNameAttributeStatements(properties));
+
+        // The following 6 statements are required for NHIN Spec
+        statements.addAll(createSubjectIdAttributeStatement(properties));
         statements.addAll(createOrganizationAttributeStatements(properties));
-        statements.addAll(createOrganizationIdAttributeStatements(properties));
-        statements.addAll(createHomeCommunityIdAttributeStatements(properties));
-        statements.addAll(createPatientIdAttributeStatements(properties));
-        statements.addAll(createUserRoleStatements(properties));
+        statements.addAll(createSubjectRoleStatement(properties));
         statements.addAll(createPurposeOfUseStatements(properties));
+        statements.addAll(createHomeCommunityIdAttributeStatements(properties));
+        statements.addAll(createOrganizationIdAttributeStatements(properties));
+
+        // These are optional and may be omitted in the NHIN Spec
+        statements.addAll(createResourceIdAttributeStatements(properties));
         statements.addAll(createNPIAttributeStatements(properties));
         statements.addAll(createAcpAttributeStatements(properties));
         if (isAcpOrIacpExists(properties)) {
@@ -312,18 +316,14 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
     }
 
     protected Collection<AttributeStatement> createOrganizationIdAttributeStatements(
-        final CallbackProperties properties) {
-        LOG.debug("SamlCallbackHandler.createOrganizationIdAttributeStatements() -- Begin");
-        List<AttributeStatement> statements = Collections.emptyList();
-
-        // Set the Organization ID Attribute
-        final String organizationId = properties.getUserOrganizationId();
-        if (organizationId != null) {
-            statements = OpenSAML2ComponentBuilder.getInstance().createOrganizationIdAttributeStatement(organizationId);
-        } else {
-            LOG.debug("Home Community ID is missing");
+        final CallbackProperties properties) throws SAMLAssertionBuilderException {
+        String organizationId = properties.getUserOrganizationId();
+        if (organizationId == null) {
+            LOG.error("No Organization ID Attribute statement provided.");
+            throw new SAMLAssertionBuilderException("No Organization ID Attribute statement provided.");
         }
-        return statements;
+
+        return componentBuilder.createOrganizationIdAttributeStatement(organizationId);
     }
 
     public List<AuthnStatement> createAuthenicationStatements(final CallbackProperties properties)
@@ -357,7 +357,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
             final String inetAddr = properties.getSubjectLocality();
             final String dnsName = properties.getSubjectDNS();
 
-            final AuthnStatement authnStatement = OpenSAML2ComponentBuilder.getInstance()
+            final AuthnStatement authnStatement = componentBuilder
                 .createAuthenticationStatements(cntxCls, sessionIndex, authInstant, inetAddr, dnsName);
 
             authnStatements.add(authnStatement);
@@ -367,6 +367,8 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
     }
 
     /**
+     * Creates the optional Autorization Decision Statement for the SAML 2 Assertion
+     *
      * @param properties
      * @param subject
      * @return
@@ -379,12 +381,11 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
         final Boolean hasAuthzStmt = properties.getAuthorizationStatementExists();
         // The authorization Decision Statement is optional
         if (hasAuthzStmt) {
-            // Create resource for Authentication Decision Statement
+            // Get resource for Authentication Decision Statement
             final String resource = properties.getAuthorizationResource();
-
             final Evidence evidence = createEvidence(properties, subject);
 
-            authDecisionStatements.add(OpenSAML2ComponentBuilder.getInstance().createAuthzDecisionStatement(resource,
+            authDecisionStatements.add(componentBuilder.createAuthzDecisionStatement(resource,
                 AUTHZ_DECISION_PERMIT, AUTHZ_DECISION_ACTION_EXECUTE, evidence));
         }
 
@@ -422,10 +423,8 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
      * @param statements
      * @param subject
      * @return
-     * @throws SAMLAssertionBuilderException
      */
-    public Evidence buildEvidence(CallbackProperties properties, List<AttributeStatement> statements, Subject subject)
-        throws SAMLAssertionBuilderException {
+    public Evidence buildEvidence(CallbackProperties properties, List<AttributeStatement> statements, Subject subject) {
 
         DateTime issueInstant = properties.getEvidenceInstant();
         String format = properties.getEvidenceIssuerFormat();
@@ -436,10 +435,8 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
         final List<Assertion> evidenceAssertions = new ArrayList<>();
         if (evAssertionID == null) {
             evAssertionID = createAssertionId();
-        } else {
-            if (!evAssertionID.startsWith("_")) {
-                evAssertionID = ID_PREFIX.concat(evAssertionID);
-            }
+        } else if (!evAssertionID.startsWith("_")) {
+            evAssertionID = ID_PREFIX.concat(evAssertionID);
         }
 
         if (issueInstant == null) {
@@ -450,10 +447,8 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
             format = X509_NAME_ID;
         }
 
-        final Issuer evIssuerId = OpenSAML2ComponentBuilder.getInstance().createIssuer(format,
-            properties.getEvidenceIssuer());
-
-        final Assertion evidenceAssertion = OpenSAML2ComponentBuilder.getInstance().createAssertion(evAssertionID);
+        final Issuer evIssuerId = componentBuilder.createIssuer(format, properties.getEvidenceIssuer());
+        final Assertion evidenceAssertion = componentBuilder.createAssertion(evAssertionID);
 
         evidenceAssertion.getAttributeStatements().addAll(statements);
 
@@ -470,7 +465,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
                 endValidTime = setEndValidTime(endValidTime, issueInstant);
             }
 
-            final Conditions conditions = OpenSAML2ComponentBuilder.getInstance().createConditions(beginValidTime,
+            final Conditions conditions = componentBuilder.createConditions(beginValidTime,
                 endValidTime);
             evidenceAssertion.setConditions(conditions);
         }
@@ -480,7 +475,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
 
         evidenceAssertions.add(evidenceAssertion);
 
-        final Evidence evidence = OpenSAML2ComponentBuilder.getInstance().createEvidence(evidenceAssertions);
+        final Evidence evidence = componentBuilder.createEvidence(evidenceAssertions);
 
         LOG.debug("SamlCallbackHandler.createEvidence() -- End");
         return evidence;
@@ -502,10 +497,8 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
         }
         // If provided time is after the given issue instant,
         // modify it to include the issue instant
-        if (beginValidTime.isAfter(issueInstant)) {
-            if (issueInstant.isAfter(now)) {
-                beginValidTime = now;
-            }
+        if (beginValidTime.isAfter(issueInstant) && issueInstant.isAfter(now)) {
+            beginValidTime = now;
         } else {
             beginValidTime = issueInstant;
         }
@@ -552,14 +545,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
         final List evidenceInstanceAccessConsentValues = checkHcidPrefixInList(
             properties.getEvidenceInstantAccessConsent());
 
-        return createEvidenceStatements(accessConstentValues, evidenceInstanceAccessConsentValues);
-    }
-
-    public List<AttributeStatement> createEvidenceStatements(final List accessConstentValues,
-        final List evidenceInstanceAccessConsentValues) {
-        List<AttributeStatement> statements;
-
-        statements = OpenSAML2ComponentBuilder.getInstance().createEvidenceStatements(accessConstentValues,
+        List<AttributeStatement> statements = componentBuilder.createEvidenceStatements(accessConstentValues,
             evidenceInstanceAccessConsentValues, NHIN_NS);
 
         LOG.debug("SamlCallbackHandler.createEvidenceStatements() -- End");
@@ -567,61 +553,59 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
     }
 
     /**
-     * Creates the Attribute statements for UserName.
+     * Creates the Attribute statements for Subject ID.
      *
      * @throws SAMLAssertionBuilderException
      *
      */
-    protected List<AttributeStatement> createUserNameAttributeStatements(final CallbackProperties properties)
+    public List<AttributeStatement> createSubjectIdAttributeStatement(final CallbackProperties properties)
         throws SAMLAssertionBuilderException {
+
+        final String nameConstruct = properties.getUserFullName();
+
+        if (StringUtils.isEmpty(nameConstruct)) {
+            LOG.error("No information provided to fill in Subject ID attribute..");
+            throw new SAMLAssertionBuilderException("No information provided to fill in Subject ID attribute.");
+        }
 
         final List<AttributeStatement> statements = new ArrayList<>();
         final List<Attribute> attributes = new ArrayList<>();
 
-        // Set the User Name Attribute
-        final List<String> userNameValues = new ArrayList<>();
-        final String nameConstruct = properties.getUserFullName();
+        LOG.debug("UserName: {}", nameConstruct);
+        attributes.add(
+            componentBuilder.createAttribute(null, SamlConstants.USERNAME_ATTR, null, Arrays.asList(nameConstruct)));
 
-        if (StringUtils.isNotEmpty(nameConstruct)) {
-            LOG.debug("UserName: {}", nameConstruct);
-
-            userNameValues.add(nameConstruct);
-
-            attributes.add(OpenSAML2ComponentBuilder.getInstance().createAttribute(null, SamlConstants.USERNAME_ATTR,
-                null, userNameValues));
-        } else {
-            LOG.error("No information provided to fill in user name attribute..");
-            throw new SAMLAssertionBuilderException("No information provided to fill in user name attribute.");
-        }
-        if (!attributes.isEmpty()) {
-            statements.addAll(OpenSAML2ComponentBuilder.getInstance().createAttributeStatement(attributes));
-        }
+        statements.addAll(componentBuilder.createAttributeStatement(attributes));
 
         return statements;
     }
 
     /**
-     * Creates the Attribute statements UserRole
+     * Creates the Attribute statements for Subject Role
      *
-     * @param factory The factory object used to assist in the construction of
-     * the SAML Assertion token
+     * @param factory The factory object used to assist in the construction of the SAML Assertion token
      * @return The listing of all Attribute statements
+     * @throws SAMLAssertionBuilderException
      */
-    protected List<AttributeStatement> createUserRoleStatements(final CallbackProperties properties) {
-        final List<AttributeStatement> statements = new ArrayList<>();
-        final List<Attribute> attributes = new ArrayList<>();
+    protected List<AttributeStatement> createSubjectRoleStatement(final CallbackProperties properties)
+        throws SAMLAssertionBuilderException {
 
-        // Set the User Role Attribute
         final String userCode = properties.getUserCode();
         final String userSystem = properties.getUserSystem();
         final String userSystemName = properties.getUserSystemName();
         final String userDisplay = properties.getUserDisplay();
 
-        attributes.add(OpenSAML2ComponentBuilder.getInstance().createUserRoleAttribute(userCode, userSystem,
-            userSystemName, userDisplay));
+        if (Arrays.asList(userCode, userSystem, userSystemName, userDisplay).contains(null)) {
+            LOG.error("No information provided to fill in user role attribute..");
+            throw new SAMLAssertionBuilderException("No information provided to fill in user role attribute.");
+        }
+
+        final List<AttributeStatement> statements = new ArrayList<>();
+        final List<Attribute> attributes = new ArrayList<>();
+        attributes.add(componentBuilder.createUserRoleAttribute(userCode, userSystem, userSystemName, userDisplay));
 
         if (!attributes.isEmpty()) {
-            statements.addAll(OpenSAML2ComponentBuilder.getInstance().createAttributeStatement(attributes));
+            statements.addAll(componentBuilder.createAttributeStatement(attributes));
         }
 
         return statements;
@@ -634,8 +618,10 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
      * @param factory The factory object used to assist in the construction of
      * the SAML Assertion token
      * @return The listing of all Attribute statements
+     * @throws SAMLAssertionBuilderException
      */
-    protected List<AttributeStatement> createPurposeOfUseStatements(final CallbackProperties properties) {
+    protected List<AttributeStatement> createPurposeOfUseStatements(final CallbackProperties properties)
+        throws SAMLAssertionBuilderException {
         List<AttributeStatement> statements;
 
         final String purposeCode = properties.getPurposeCode();
@@ -643,6 +629,10 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
         final String purposeSystemName = properties.getPurposeSystemName();
         final String purposeDisplay = properties.getPurposeDisplay();
 
+        if (Arrays.asList(purposeCode, purposeSystem, purposeSystemName, purposeDisplay).contains(null)) {
+            LOG.error("No information provided to fill in Purpose For Use attribute..");
+            throw new SAMLAssertionBuilderException("No information provided to fill in Purpose For Use attribute.");
+        }
         /*
          * Gateway-347 - Support for both values will remain until NHIN Specs updated Determine whether to use
          * PurposeOfUse or PuposeForUse
@@ -651,10 +641,10 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
         // purposeofuse or purposeforuse.
         final PurposeOfForDecider pd = new PurposeOfForDecider();
         if (pd.isPurposeFor(properties)) {
-            statements = OpenSAML2ComponentBuilder.getInstance().createPurposeForUseAttributeStatements(purposeCode,
+            statements = componentBuilder.createPurposeForUseAttributeStatements(purposeCode,
                 purposeSystem, purposeSystemName, purposeDisplay);
         } else {
-            statements = OpenSAML2ComponentBuilder.getInstance().createPurposeOfUseAttributeStatements(purposeCode,
+            statements = componentBuilder.createPurposeOfUseAttributeStatements(purposeCode,
                 purposeSystem, purposeSystemName, purposeDisplay);
         }
 
@@ -662,55 +652,53 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
     }
 
     /**
-     * Creates the Attribute statements for UserName, UserOrganization,
-     * UserRole, and PurposeOfUse
+     * Creates the Attribute statements for UserOrganization
      *
-     * @param factory The factory object used to assist in the construction of
-     * the SAML Assertion token
+     * @param factory The factory object used to assist in the construction of the SAML Assertion token
      * @return The listing of all Attribute statements
+     * @throws SAMLAssertionBuilderException
      */
-    protected List<AttributeStatement> createOrganizationAttributeStatements(final CallbackProperties properties) {
+    protected List<AttributeStatement> createOrganizationAttributeStatements(final CallbackProperties properties)
+        throws SAMLAssertionBuilderException {
 
-        LOG.debug("SamlCallbackHandler.addAssertStatements() -- Begin");
         final List<AttributeStatement> statements = new ArrayList<>();
         final List<Attribute> attributes = new ArrayList<>();
 
-        // Set the User Organization ID Attribute
         final String organizationId = properties.getUserOrganization();
         if (organizationId != null) {
-            attributes.add(OpenSAML2ComponentBuilder.getInstance().createAttribute(null, SamlConstants.USER_ORG_ATTR,
+            attributes.add(componentBuilder.createAttribute(null, SamlConstants.USER_ORG_ATTR,
                 null, Arrays.asList(organizationId)));
+            if (!attributes.isEmpty()) {
+                statements.addAll(componentBuilder.createAttributeStatement(attributes));
+            }
+        } else {
+            LOG.error("No Organization Attribute statement provided.");
+            throw new SAMLAssertionBuilderException("No Organization Attribute statement provided.");
         }
 
-        if (!attributes.isEmpty()) {
-            statements.addAll(OpenSAML2ComponentBuilder.getInstance().createAttributeStatement(attributes));
-        }
-
-        LOG.debug("SamlCallbackHandler.addAssertStatements() -- End");
         return statements;
 
     }
 
     /**
-     * Creates the Attribute statements for UserName, UserOrganization,
-     * UserRole, and PurposeOfUse
+     * Creates the Attribute statements for Home Community ID
      *
-     * @param factory The factory object used to assist in the construction of
-     * the SAML Assertion token
+     * @param factory The factory object used to assist in the construction of the SAML Assertion token
      * @return The listing of all Attribute statements
+     * @throws SAMLAssertionBuilderException
      */
-    protected List<AttributeStatement> createHomeCommunityIdAttributeStatements(final CallbackProperties properties) {
+    protected List<AttributeStatement> createHomeCommunityIdAttributeStatements(final CallbackProperties properties)
+        throws SAMLAssertionBuilderException {
 
-        LOG.debug("SamlCallbackHandler.addAssertStatements() -- Begin");
         List<AttributeStatement> statements = Collections.emptyList();
 
-        // Set the Home Community ID Attribute
         final String communityId = properties.getHomeCommunity();
         if (StringUtils.isNotBlank(communityId)) {
-            statements = OpenSAML2ComponentBuilder.getInstance()
+            statements = componentBuilder
                 .createHomeCommunitAttributeStatement(appendPrefixHomeCommunityID(communityId));
         } else {
-            LOG.warn("Home Community ID is missing");
+            LOG.error("No Home Community ID Attribute statement provided.");
+            throw new SAMLAssertionBuilderException("No Home Community ID Attribute statement provided.");
         }
 
         return statements;
@@ -718,37 +706,27 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
     }
 
     /**
-     * Creates the Attribute statements for UserName, UserOrganization,
-     * UserRole, and PurposeOfUse
+     * Creates the Attribute statements for Resource ID
      *
-     * @param factory The factory object used to assist in the construction of
-     * the SAML Assertion token
+     * @param factory The factory object used to assist in the construction of the SAML Assertion token
      * @return The listing of all Attribute statements
      */
-    protected List<AttributeStatement> createPatientIdAttributeStatements(final CallbackProperties properties) {
-
+    protected List<AttributeStatement> createResourceIdAttributeStatements(final CallbackProperties properties) {
         final List<AttributeStatement> statements = new ArrayList<>();
-        Attribute attribute;
-
-        // Set the Patient ID Attribute
         final String patientId = properties.getPatientID();
         if (patientId != null) {
-            attribute = OpenSAML2ComponentBuilder.getInstance().createPatientIDAttribute(patientId);
-
-            statements
-            .addAll(OpenSAML2ComponentBuilder.getInstance().createAttributeStatement(Arrays.asList(attribute)));
+            Attribute attribute = componentBuilder.createPatientIDAttribute(patientId);
+            statements.addAll(componentBuilder.createAttributeStatement(Arrays.asList(attribute)));
         } else {
-            LOG.warn("patient id is missing");
+            LOG.warn("Resource Id is missing");
         }
         return statements;
-
     }
 
     /**
-     * Creates the Attribute statements for NPI
+     * Creates the Optional Attribute statements for NPI
      *
-     * @param factory The factory object used to assist in the construction of
-     * the SAML Assertion token
+     * @param factory The factory object used to assist in the construction of the SAML Assertion token
      * @return The listing of all Attribute statements
      */
     protected List<AttributeStatement> createNPIAttributeStatements(final CallbackProperties properties) {
@@ -756,13 +734,10 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
         final List<AttributeStatement> statements = new ArrayList<>();
         Attribute attribute;
 
-        // Set the NPI Attribute
         final String npi = properties.getNPI();
         if (npi != null) {
-            attribute = OpenSAML2ComponentBuilder.getInstance().createNPIAttribute(npi);
-
-            statements
-            .addAll(OpenSAML2ComponentBuilder.getInstance().createAttributeStatement(Arrays.asList(attribute)));
+            attribute = componentBuilder.createNPIAttribute(npi);
+            statements.addAll(componentBuilder.createAttributeStatement(Arrays.asList(attribute)));
         } else {
             LOG.warn("npi is missing");
         }
@@ -778,20 +753,20 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
         final String acp = properties.getAcpAttribute();
         final String iacp = properties.getIacpAttribute();
         if (StringUtils.isNotEmpty(acp)) {
-            acpAttribute = OpenSAML2ComponentBuilder.getInstance()
+            acpAttribute = componentBuilder
                 .createAttribute(SamlConstants.ATTRIBUTE_FRIENDLY_NAME_XUA_ACP, SamlConstants.ATTRIBUTE_NAME_XUA_ACP,
                     SamlConstants.URI_NAME_FORMAT);
-            acpAttribute.getAttributeValues().add(OpenSAML2ComponentBuilder.getInstance().createUriAttributeValue(acp));
+            acpAttribute.getAttributeValues().add(componentBuilder.createUriAttributeValue(acp));
             statements
-            .addAll(OpenSAML2ComponentBuilder.getInstance().createAttributeStatement(Arrays.asList(acpAttribute)));
+            .addAll(componentBuilder.createAttributeStatement(Arrays.asList(acpAttribute)));
         }
         if(StringUtils.isNotEmpty(iacp)) {
-            iacpAttribute = OpenSAML2ComponentBuilder.getInstance()
+            iacpAttribute = componentBuilder
                 .createAttribute(SamlConstants.ATTRIBUTE_FRIENDLY_NAME_XUA_IACP, SamlConstants.ATTRIBUTE_NAME_XUA_IACP,
                     SamlConstants.URI_NAME_FORMAT);
-            iacpAttribute.getAttributeValues().add(OpenSAML2ComponentBuilder.getInstance().createUriAttributeValue(iacp));
+            iacpAttribute.getAttributeValues().add(componentBuilder.createUriAttributeValue(iacp));
             statements
-            .addAll(OpenSAML2ComponentBuilder.getInstance().createAttributeStatement(Arrays.asList(iacpAttribute)));
+            .addAll(componentBuilder.createAttributeStatement(Arrays.asList(iacpAttribute)));
         }
         return statements;
     }
@@ -803,13 +778,12 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
     protected boolean isConditionsDefaultValueEnabled() {
         // if not provided or invalid return true else false
         try {
-            final Boolean conditionsDefaultValueEnabled = PropertyAccessor.getInstance().getPropertyBoolean(
+            return PropertyAccessor.getInstance().getPropertyBoolean(
                 NhincConstants.GATEWAY_PROPERTY_FILE, NhincConstants.ENABLE_CONDITIONS_DEFAULT_VALUE);
-            return !conditionsDefaultValueEnabled.equals(Boolean.FALSE);
         } catch (final PropertyAccessException pae) {
             LOG.error("Property not found exception: {}", pae.getLocalizedMessage(), pae);
         }
-        return Boolean.TRUE;
+        return true;
     }
 
     public static String appendPrefixHomeCommunityID(final String homeCommunityId) {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
@@ -111,7 +111,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
      * @throws Exception
      */
     @Override
-    public Element build(final CallbackProperties properties) throws SAMLAssertionBuilderException {
+    public Element build(final CallbackProperties properties) {
         LOG.debug("SamlCallbackHandler.build() -- Start");
         Element signedAssertion = null;
         try {
@@ -153,10 +153,9 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
      * @param certificate
      * @param publicKey
      * @return
-     * @throws SAMLAssertionBuilderException
      */
     protected Element sign(final Assertion assertion, final X509Certificate certificate, final PrivateKey privateKey,
-        final PublicKey publicKey) throws SAMLAssertionBuilderException {
+        final PublicKey publicKey) {
         Element assertionElement = null;
         try {
             final Signature signature = OpenSAML2ComponentBuilder.getInstance().createSignature(certificate, privateKey,
@@ -209,7 +208,6 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
      * @param PSApk
      * @param certificate
      * @return
-     * @throws SAMLComponentBuilderException
      */
     protected Subject createSubject(final CallbackProperties properties, final X509Certificate certificate,
         final PublicKey publicKey) throws SAMLComponentBuilderException {
@@ -287,8 +285,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
         return null;
     }
 
-    public List<Statement> createAttributeStatements(final CallbackProperties properties, final Subject subject)
-        throws SAMLAssertionBuilderException {
+    public List<Statement> createAttributeStatements(final CallbackProperties properties, final Subject subject) {
         final List<Statement> statements = new ArrayList<>();
 
         // TODO: Not a *single* one of these methods ever returns a list with more than one element.
@@ -315,7 +312,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
     }
 
     protected Collection<AttributeStatement> createOrganizationIdAttributeStatements(
-        final CallbackProperties properties) throws SAMLAssertionBuilderException {
+        final CallbackProperties properties) {
         String organizationId = properties.getUserOrganizationId();
         if (organizationId == null) {
             LOG.error("No Organization ID Attribute statement provided.");
@@ -325,8 +322,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
         return componentBuilder.createOrganizationIdAttributeStatement(organizationId);
     }
 
-    public List<AuthnStatement> createAuthenicationStatements(final CallbackProperties properties)
-        throws SAMLAssertionBuilderException {
+    public List<AuthnStatement> createAuthenicationStatements(final CallbackProperties properties) {
 
         final List<AuthnStatement> authnStatements = new ArrayList<>();
         if (properties.getAuthenticationStatementExists()) {
@@ -371,10 +367,9 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
      * @param properties
      * @param subject
      * @return
-     * @throws SAMLAssertionBuilderException
      */
     public List<AuthzDecisionStatement> createAuthorizationDecisionStatements(final CallbackProperties properties,
-        final Subject subject) throws SAMLAssertionBuilderException {
+        final Subject subject) {
         final List<AuthzDecisionStatement> authDecisionStatements = new ArrayList<>();
 
         final Boolean hasAuthzStmt = properties.getAuthorizationStatementExists();
@@ -402,10 +397,8 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
      * @param issueInstant The calendar representing the time of Assertion
      * issuance
      * @return The Evidence element
-     * @throws SAMLAssertionBuilderException
      */
-    public Evidence createEvidence(final CallbackProperties properties, final Subject subject)
-        throws SAMLAssertionBuilderException {
+    public Evidence createEvidence(final CallbackProperties properties, final Subject subject) {
         LOG.debug("SamlCallbackHandler.createEvidence() -- Begin");
         final List<AttributeStatement> statements = createEvidenceStatements(properties);
         return buildEvidence(properties, statements, subject);
@@ -553,12 +546,8 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
 
     /**
      * Creates the Attribute statements for Subject ID.
-     *
-     * @throws SAMLAssertionBuilderException
-     *
      */
-    public List<AttributeStatement> createSubjectIdAttributeStatement(final CallbackProperties properties)
-        throws SAMLAssertionBuilderException {
+    public List<AttributeStatement> createSubjectIdAttributeStatement(final CallbackProperties properties) {
 
         final String nameConstruct = properties.getUserFullName();
 
@@ -584,10 +573,8 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
      *
      * @param factory The factory object used to assist in the construction of the SAML Assertion token
      * @return The listing of all Attribute statements
-     * @throws SAMLAssertionBuilderException
      */
-    protected List<AttributeStatement> createSubjectRoleStatement(final CallbackProperties properties)
-        throws SAMLAssertionBuilderException {
+    protected List<AttributeStatement> createSubjectRoleStatement(final CallbackProperties properties) {
 
         final String userCode = properties.getUserCode();
         final String userSystem = properties.getUserSystem();
@@ -617,10 +604,8 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
      * @param factory The factory object used to assist in the construction of
      * the SAML Assertion token
      * @return The listing of all Attribute statements
-     * @throws SAMLAssertionBuilderException
      */
-    protected List<AttributeStatement> createPurposeOfUseStatements(final CallbackProperties properties)
-        throws SAMLAssertionBuilderException {
+    protected List<AttributeStatement> createPurposeOfUseStatements(final CallbackProperties properties) {
         List<AttributeStatement> statements;
 
         final String purposeCode = properties.getPurposeCode();
@@ -655,10 +640,8 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
      *
      * @param factory The factory object used to assist in the construction of the SAML Assertion token
      * @return The listing of all Attribute statements
-     * @throws SAMLAssertionBuilderException
      */
-    protected List<AttributeStatement> createOrganizationAttributeStatements(final CallbackProperties properties)
-        throws SAMLAssertionBuilderException {
+    protected List<AttributeStatement> createOrganizationAttributeStatements(final CallbackProperties properties) {
 
         final List<AttributeStatement> statements = new ArrayList<>();
         final List<Attribute> attributes = new ArrayList<>();
@@ -684,10 +667,8 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
      *
      * @param factory The factory object used to assist in the construction of the SAML Assertion token
      * @return The listing of all Attribute statements
-     * @throws SAMLAssertionBuilderException
      */
-    protected List<AttributeStatement> createHomeCommunityIdAttributeStatements(final CallbackProperties properties)
-        throws SAMLAssertionBuilderException {
+    protected List<AttributeStatement> createHomeCommunityIdAttributeStatements(final CallbackProperties properties) {
 
         final String communityId = properties.getHomeCommunity();
         if (StringUtils.isBlank(communityId)) {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
@@ -601,7 +601,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
 
         final List<AttributeStatement> statements = new ArrayList<>();
         final List<Attribute> attributes = new ArrayList<>();
-        attributes.add(componentBuilder.createUserRoleAttribute(userCode, userSystem, userSystemName, userDisplay));
+        attributes.add(componentBuilder.createSubjectRoleAttribute(userCode, userSystem, userSystemName, userDisplay));
 
         if (!attributes.isEmpty()) {
             statements.addAll(componentBuilder.createAttributeStatement(attributes));
@@ -709,7 +709,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
         final List<AttributeStatement> statements = new ArrayList<>();
         final String patientId = properties.getPatientID();
         if (patientId != null) {
-            Attribute attribute = componentBuilder.createPatientIDAttribute(patientId);
+            Attribute attribute = componentBuilder.createResourceIDAttribute(patientId);
             statements.addAll(componentBuilder.createAttributeStatement(Arrays.asList(attribute)));
         } else {
             LOG.warn("Resource Id is missing");

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
@@ -288,8 +288,8 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
     public List<Statement> createAttributeStatements(final CallbackProperties properties, final Subject subject) {
         final List<Statement> statements = new ArrayList<>();
 
-        // TODO: Not a *single* one of these methods ever returns a list with more than one element.
-        // so in that case we can drop the whole "List" thing going on and just add individual elements.
+        // Not a *single* one of these methods ever returns a list with more than one element.
+        // so in that case we can eventually drop the whole "List" thing going on and just add individual elements.
         statements.addAll(createAuthenicationStatements(properties));
 
         // The following 6 statements are required for NHIN Spec

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -92,42 +92,18 @@ import org.slf4j.LoggerFactory;
  */
 public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
 
-    /**
-     * The Constant attributeStatementBuilder.
-     */
+
     private final SAMLObjectBuilder<AttributeStatement> attributeStatementBuilder;
 
-    /**
-     * The Constant X509_NAME_ID.
-     */
     private static final String X509_NAME_ID = "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName";
 
-    /**
-     * The Constant NAME_FORMAT_STRING.
-     */
     private static final String NAME_FORMAT_STRING = "urn:oasis:names:tc:SAML:2.0:attrname-format:uri";
 
-    /**
-     * The evidence builder.
-     */
     private final SAMLObjectBuilder<Evidence> evidenceBuilder;
 
-    /**
-     * The xsAnyBuilder.
-     */
     private final XSAnyBuilder xsAnyBuilder;
 
-    /**
-     * The instance.
-     */
     private static OpenSAML2ComponentBuilder openSamlInstance;
-
-    /**
-     * The subject locality builder.
-     */
-    /**
-     * The builder factory.
-     */
 
     private static final Logger LOG = LoggerFactory.getLogger(OpenSAML2ComponentBuilder.class);
 
@@ -221,7 +197,6 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
      * @param value the value
      * @return the name id
      */
-    @SuppressWarnings("unchecked")
     public NameID createNameID(final String qualifier, final String format, final String value) {
         final NameIDBean nameIDBean = new NameIDBean();
         nameIDBean.setNameQualifier(qualifier);
@@ -276,7 +251,7 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
             final SubjectConfirmation subjectConfirmation = createHoKConfirmation(subjectConfirmationData);
             subject.getSubjectConfirmations().add(subjectConfirmation);
         } catch (SecurityException | WSSecurityException e) {
-            LOG.error("Unable to create Saml2Subject ", e.getLocalizedMessage());
+            LOG.error("Unable to create Saml2Subject: {}", e.getLocalizedMessage());
             throw new SAMLComponentBuilderException(e.getLocalizedMessage(), e);
         }
         return subject;
@@ -411,7 +386,7 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
      * @param nameFormat the name format
      * @return the attribute
      */
-    Attribute createAttribute(final String friendlyName, final String name, final String nameFormat) {
+    public Attribute createAttribute(final String friendlyName, final String name, final String nameFormat) {
         return SAML2ComponentBuilder.createAttribute(friendlyName, name,
             StringUtils.defaultIfBlank(nameFormat, NAME_FORMAT_STRING));
     }
@@ -425,7 +400,7 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
      * @param values the values
      * @return the attribute
      */
-    Attribute createAttribute(final String friendlyName, final String name, final String nameFormat,
+    public Attribute createAttribute(final String friendlyName, final String name, final String nameFormat,
         final List<?> values) {
         return SAML2ComponentBuilder.createAttribute(friendlyName, name, nameFormat, (List<Object>) values);
     }
@@ -439,7 +414,7 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
      * @return the xS any
      */
 
-    XSAny createAny(final String namespace, final String name, final String prefix) {
+    private XSAny createAny(final String namespace, final String name, final String prefix) {
         return xsAnyBuilder.buildObject(namespace, name, prefix);
 
     }
@@ -453,7 +428,7 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
      * @param attributes the attributes
      * @return the xS any
      */
-    XSAny createAny(final String namespace, final String name, final String prefix,
+    private XSAny createAny(final String namespace, final String name, final String prefix,
         final Map<QName, String> attributes) {
         final XSAny any = createAny(namespace, name, prefix);
         for (final Entry<QName, String> keyValue : attributes.entrySet()) {
@@ -472,7 +447,7 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
      * @param attributes the attributes
      * @return the xS any
      */
-    XSAny createAttributeValue(final String namespace, final String name, final String prefix,
+    private XSAny createAttributeValue(final String namespace, final String name, final String prefix,
         final Map<QName, String> attributes) {
         final XSAny attribute = createAny(namespace, name, prefix, attributes);
         return createAttributeValue(Arrays.asList(attribute));
@@ -485,7 +460,7 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
      * @return the xS any
      */
 
-    XSAny createAttributeValue(final List<XSAny> values) {
+    private XSAny createAttributeValue(final List<XSAny> values) {
         final XSAny attributeValue = xsAnyBuilder.buildObject(AttributeValue.DEFAULT_ELEMENT_NAME);
         attributeValue.getUnknownXMLObjects().addAll(values);
         return attributeValue;
@@ -563,11 +538,8 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
     public Attribute createUserRoleAttribute(final String userCode, final String userSystem,
         final String userSystemName, final String userDisplay) {
         final Object attributeValue = createHL7Attribute("Role", userCode, userSystem, userSystemName, userDisplay);
-        if (OpenSAML2ComponentBuilder.getInstance() != null) {
-            return OpenSAML2ComponentBuilder.getInstance().createAttribute(null, SamlConstants.USER_ROLE_ATTR, null,
-                Arrays.asList(attributeValue));
-        }
-        return null;
+        return createAttribute(null, SamlConstants.USER_ROLE_ATTR, null, Arrays.asList(attributeValue));
+
     }
 
     /**
@@ -610,11 +582,11 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
 
     }
 
-    QName createHl7QName(final String name, final boolean hasPrefix) {
+    private QName createHl7QName(final String name, final boolean hasPrefix) {
         return hasPrefix ? new QName(SamlConstants.HL7_NAMESPACE_URI, name, SamlConstants.HL7_PREFIX) : new QName(name);
     }
 
-    boolean getHl7PrefixProperty() {
+    private boolean getHl7PrefixProperty() {
         try {
             return PropertyAccessor.getInstance().getPropertyBoolean(NhincConstants.GATEWAY_PROPERTY_FILE,
                 NhincConstants.HL7_PREFIX_FOR_ATTR_PROPERTY);
@@ -661,22 +633,14 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
      */
     public List<AttributeStatement> createHomeCommunitAttributeStatement(final String communityId) {
         final List<AttributeStatement> statements = new ArrayList<>();
-        final Attribute attribute = createHomeCommunityAttribute(communityId);
+        final Attribute attribute = createAttribute(null, SamlConstants.HOME_COM_ID_ATTR, null,
+            Arrays.asList(communityId));
 
-        statements.addAll(OpenSAML2ComponentBuilder.getInstance().createAttributeStatement(Arrays.asList(attribute)));
+        statements.addAll(createAttributeStatement(Arrays.asList(attribute)));
 
         return statements;
     }
 
-    /**
-     * Creates the home community attribute.
-     *
-     * @param communityId the community id
-     * @return the attribute
-     */
-    Attribute createHomeCommunityAttribute(final String communityId) {
-        return createAttribute(null, SamlConstants.HOME_COM_ID_ATTR, null, Arrays.asList(communityId));
-    }
 
     /**
      * Creates the signature.
@@ -758,8 +722,7 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
         final String purposeSystemName, final String purposeDisplay) {
         final Object attributeValue = createHL7Attribute("PurposeOfUse", purposeCode, purposeSystem, purposeSystemName,
             purposeDisplay);
-        return OpenSAML2ComponentBuilder.getInstance().createAttribute(null, SamlConstants.PURPOSE_ROLE_ATTR, null,
-            Arrays.asList(attributeValue));
+        return createAttribute(null, SamlConstants.PURPOSE_ROLE_ATTR, null, Arrays.asList(attributeValue));
     }
 
     /**
@@ -771,16 +734,13 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
      * @param purposeDisplay the purpose display
      * @return the attribute
      */
-    Attribute createPurposeForUseAttribute(final String purposeCode, final String purposeSystem,
+    public Attribute createPurposeForUseAttribute(final String purposeCode, final String purposeSystem,
         final String purposeSystemName, final String purposeDisplay) {
 
         final Object attributeValue = createHL7Attribute("PurposeForUse", purposeCode, purposeSystem, purposeSystemName,
             purposeDisplay);
-        if (OpenSAML2ComponentBuilder.getInstance() != null) {
-            return OpenSAML2ComponentBuilder.getInstance().createAttribute(null, SamlConstants.PURPOSE_ROLE_ATTR, null,
-                Arrays.asList(attributeValue));
-        }
-        return null;
+        return createAttribute(null, SamlConstants.PURPOSE_ROLE_ATTR, null, Arrays.asList(attributeValue));
+
     }
 
     /**
@@ -793,7 +753,7 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
         final List<AttributeStatement> statements = new ArrayList<>();
         final Attribute attribute = createAttribute(null, SamlConstants.USER_ORG_ID_ATTR, null,
             Arrays.asList(organizationId));
-        statements.addAll(OpenSAML2ComponentBuilder.getInstance().createAttributeStatement(Arrays.asList(attribute)));
+        statements.addAll(createAttributeStatement(Arrays.asList(attribute)));
         return statements;
     }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
@@ -582,11 +582,11 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
 
     }
 
-    private QName createHl7QName(final String name, final boolean hasPrefix) {
+    private static QName createHl7QName(final String name, final boolean hasPrefix) {
         return hasPrefix ? new QName(SamlConstants.HL7_NAMESPACE_URI, name, SamlConstants.HL7_PREFIX) : new QName(name);
     }
 
-    private boolean getHl7PrefixProperty() {
+    private static boolean getHl7PrefixProperty() {
         try {
             return PropertyAccessor.getInstance().getPropertyBoolean(NhincConstants.GATEWAY_PROPERTY_FILE,
                 NhincConstants.HL7_PREFIX_FOR_ATTR_PROPERTY);

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
@@ -535,7 +535,7 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
      * @param userDisplay the user display
      * @return the attribute
      */
-    public Attribute createUserRoleAttribute(final String userCode, final String userSystem,
+    public Attribute createSubjectRoleAttribute(final String userCode, final String userSystem,
         final String userSystemName, final String userDisplay) {
         final Object attributeValue = createHL7Attribute("Role", userCode, userSystem, userSystemName, userDisplay);
         return createAttribute(null, SamlConstants.USER_ROLE_ATTR, null, Arrays.asList(attributeValue));
@@ -602,7 +602,7 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
      * @param patientId the patient id
      * @return the attribute
      */
-    public Attribute createPatientIDAttribute(final String patientId) {
+    public Attribute createResourceIDAttribute(final String patientId) {
         return createAttribute(null, SamlConstants.PATIENT_ID_ATTR, null, Collections.singletonList(patientId));
     }
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
@@ -652,7 +652,7 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
      * @throws SAMLComponentBuilderException the exception
      */
     public Signature createSignature(final X509Certificate certificate, final PrivateKey privateKey,
-        final PublicKey publicKey) throws SAMLAssertionBuilderException {
+        final PublicKey publicKey) {
         final BasicX509Credential credential = new BasicX509Credential(certificate, privateKey);
         credential.setEntityCertificate(certificate);
         credential.setPrivateKey(privateKey);

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/SAMLAssertionBuilderException.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/SAMLAssertionBuilderException.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -30,7 +30,9 @@ package gov.hhs.fha.nhinc.callback.opensaml;
  * @author mikhelamdex
  *
  */
-public class SAMLAssertionBuilderException extends Exception {
+public class SAMLAssertionBuilderException extends RuntimeException {
+
+    private static final long serialVersionUID = -4219112462888454641L;
 
     public SAMLAssertionBuilderException(String message) {
         super(message);

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/PDPurposeOfForDeciderDefaultConfigTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/PDPurposeOfForDeciderDefaultConfigTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilderTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilderTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -32,49 +32,30 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import gov.hhs.fha.nhinc.callback.SamlConstants;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants.GATEWAY_API_LEVEL;
 import gov.hhs.fha.nhinc.properties.PropertyAccessException;
 import gov.hhs.fha.nhinc.properties.PropertyAccessor;
-import gov.hhs.fha.nhinc.properties.PropertyFileDAO;
-import java.io.File;
-import java.io.IOException;
-import java.math.BigInteger;
-import java.security.InvalidKeyException;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.Principal;
 import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.security.SignatureException;
-import java.security.cert.CertificateEncodingException;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateExpiredException;
-import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPublicKey;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import javax.activation.DataHandler;
 import org.apache.commons.collections.CollectionUtils;
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.integration.junit4.JUnit4Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.opensaml.core.xml.schema.XSAny;
@@ -90,7 +71,10 @@ import org.opensaml.saml.saml2.core.Evidence;
 import org.opensaml.saml.saml2.core.Issuer;
 import org.opensaml.saml.saml2.core.Subject;
 import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.ls.DOMImplementationLS;
+import org.w3c.dom.ls.LSSerializer;
 
 /**
  * @author bhumphrey
@@ -101,36 +85,8 @@ public class HOKSAMLAssertionBuilderTest {
     private static RSAPublicKey publicKey;
     private static PrivateKey privateKey;
 
-    private static final String PROPERTY_FILE_NAME = "mock";
-    private static final String PROPERTY_NAME = "propertyName";
-    private static final String PROPERTY_VALUE_STRING = "CN=SAML User,OU=SU,O=SAML User,L=New York,ST=NY,C=US";
-
-    protected Mockery context = new JUnit4Mockery() {
-        {
-            setImposteriser(ClassImposteriser.INSTANCE);
-        }
-    };
-    final PropertyFileDAO mockFileDAO = context.mock(PropertyFileDAO.class);
-
     @Before
-    public void setMockFileDAOExpectations() throws PropertyAccessException {
-        context.checking(new Expectations() {
-            {
-                allowing(mockFileDAO).containsPropFile(with(any(String.class)));
-                will(returnValue(true));
-
-                allowing(mockFileDAO).getProperty(with(any(String.class)), with(any(String.class)));
-                will(returnValue(PROPERTY_VALUE_STRING));
-
-                allowing(mockFileDAO).loadPropertyFile(with(any(File.class)), with(any(String.class)));
-
-                allowing(mockFileDAO).printToLog(with(any(String.class)));
-            }
-        });
-    }
-
-    @BeforeClass
-    static public void setUp() throws NoSuchAlgorithmException {
+    public void setMockFileDAOExpectations() throws NoSuchAlgorithmException {
 
         KeyPairGenerator keyGen;
         keyGen = KeyPairGenerator.getInstance("RSA");
@@ -140,246 +96,144 @@ public class HOKSAMLAssertionBuilderTest {
 
     }
 
-    /**
-     *
-     * @throws Exception
-     */
+    private static CertificateManager setupCertManager() throws CertificateManagerException {
+        CertificateManager certManager = mock(CertificateManager.class);
+        X509Certificate cert = mock(X509Certificate.class);
+
+        when(certManager.getDefaultPublicKey()).thenReturn(publicKey);
+        when(certManager.getDefaultPrivateKey()).thenReturn(privateKey);
+        when(certManager.getDefaultCertificate()).thenReturn(cert);
+        when(certManager.deleteCertificate(Mockito.isA(String.class))).thenReturn(false);
+        when(certManager.updateCertificate(Mockito.isA(String.class), Mockito.isA(String.class),
+            Mockito.isA(String.class), Mockito.isA(String.class), Mockito.isA(String.class),
+            Mockito.isA(KeyStore.class))).thenReturn(false);
+
+        when(cert.hasUnsupportedCriticalExtension()).thenReturn(false);
+        when(cert.getNonCriticalExtensionOIDs()).thenReturn(Collections.EMPTY_SET);
+        when(cert.getCriticalExtensionOIDs()).thenReturn(Collections.EMPTY_SET);
+        when(cert.getPublicKey()).thenReturn(publicKey);
+        return certManager;
+    }
+
     @Test
-    public void testBuild() throws Exception {
-        final SAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder(new CertificateManager() {
-            @Override
-            public RSAPublicKey getDefaultPublicKey() {
-                return publicKey;
-            }
-
-            @Override
-            public PrivateKey getDefaultPrivateKey() throws CertificateManagerException {
-                return privateKey;
-            }
-
-            @Override
-            public KeyStore getKeyStore() {
-                return null;
-            }
-
-            @Override
-            public KeyStore getTrustStore() {
-                return null;
-            }
-
-            @Override
-            public X509Certificate getDefaultCertificate() throws CertificateManagerException {
-                return new X509Certificate() {
-                    @Override
-                    public boolean hasUnsupportedCriticalExtension() {
-                        return false;
-                    }
-
-                    @Override
-                    public Set<String> getNonCriticalExtensionOIDs() {
-                        return Collections.EMPTY_SET;
-                    }
-
-                    @Override
-                    public byte[] getExtensionValue(final String oid) {
-                        return new byte[1];
-                    }
-
-                    @Override
-                    public Set<String> getCriticalExtensionOIDs() {
-                        return Collections.EMPTY_SET;
-                    }
-
-                    @Override
-                    public void verify(final PublicKey key, final String sigProvider) throws CertificateException,
-                    NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException, SignatureException {
-
-                    }
-
-                    @Override
-                    public void verify(final PublicKey key) throws CertificateException, NoSuchAlgorithmException,
-                    InvalidKeyException, NoSuchProviderException, SignatureException {
-                    }
-
-                    @Override
-                    public String toString() {
-                        return null;
-                    }
-
-                    @Override
-                    public PublicKey getPublicKey() {
-                        return publicKey;
-                    }
-
-                    @Override
-                    public byte[] getEncoded() throws CertificateEncodingException {
-                        return new byte[1];
-                    }
-
-                    @Override
-                    public int getVersion() {
-                        return 0;
-                    }
-
-                    @Override
-                    public byte[] getTBSCertificate() throws CertificateEncodingException {
-                        return new byte[1];
-                    }
-
-                    @Override
-                    public boolean[] getSubjectUniqueID() {
-                        return new boolean[1];
-                    }
-
-                    @Override
-                    public Principal getSubjectDN() {
-                        return null;
-                    }
-
-                    @Override
-                    public byte[] getSignature() {
-                        return new byte[1];
-                    }
-
-                    @Override
-                    public byte[] getSigAlgParams() {
-                        return new byte[1];
-                    }
-
-                    @Override
-                    public String getSigAlgOID() {
-                        return null;
-                    }
-
-                    @Override
-                    public String getSigAlgName() {
-                        return null;
-                    }
-
-                    @Override
-                    public BigInteger getSerialNumber() {
-                        return null;
-                    }
-
-                    @Override
-                    public Date getNotBefore() {
-                        return null;
-                    }
-
-                    @Override
-                    public Date getNotAfter() {
-                        return null;
-                    }
-
-                    @Override
-                    public boolean[] getKeyUsage() {
-                        return new boolean[1];
-                    }
-
-                    @Override
-                    public boolean[] getIssuerUniqueID() {
-                        return new boolean[1];
-                    }
-
-                    @Override
-                    public Principal getIssuerDN() {
-                        return null;
-                    }
-
-                    @Override
-                    public int getBasicConstraints() {
-                        return 0;
-                    }
-
-                    @Override
-                    public void checkValidity(final Date date)
-                        throws CertificateExpiredException, CertificateNotYetValidException {
-                    }
-
-                    @Override
-                    public void checkValidity() throws CertificateExpiredException, CertificateNotYetValidException {
-                    }
-                };
-
-            }
-
-            @Override
-            public KeyStore refreshKeyStore() {
-                return null;
-            }
-
-            @Override
-            public String getKeyStoreLocation() {
-                return null;
-            }
-
-            @Override
-            public String getTrustStoreLocation() {
-                return null;
-            }
-
-            @Override
-            public KeyStore refreshTrustStore() {
-                return null;
-            }
-
-            @Override
-            public HashMap<String, String> getTrustStoreSystemProperties() {
-                return null;
-            }
-            
-            @Override
-            public void refreshServices() {
-                //do nothing
-            }
-
-            @Override
-            public void importCertificate(String alias, DataHandler data, boolean refreshCache) throws CertificateManagerException {
-                //do nothing
-            }
-
-            @Override
-            public HashMap<String, String> getKeyStoreSystemProperties() {
-                return null;
-            }
-
-            @Override
-            public X509Certificate getCertificateFromByteCode(DataHandler data) throws CertificateManagerException {
-                return null;
-            }
-
-            @Override
-            public DataHandler transformToHandler(byte[] encoded) {
-                return null;
-            }
-
-            @Override
-            public byte[] transformToByteCode(DataHandler handler) throws IOException {
-                return null;
-            }
-
-            @Override
-            public boolean deleteCertificate(String alias) throws CertificateManagerException {
-                return false;
-            }
-
-            @Override
-            public boolean updateCertificate(String oldAlias, String newAlias, String storeType,
-                String storeLoc, String passkey, KeyStore storeCert)
-                    throws CertificateManagerException {
-                return false;
-            }
-        });
-        final Element assertion = builder.build(getProperties());
+    public void testBuild() throws SAMLAssertionBuilderException, CertificateManagerException {
+        SAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder(setupCertManager());
+        final Element assertion = builder.build(makeCallbackProperties(null));
         assertNotNull(assertion);
     }
 
-    @Test(expected = SAMLAssertionBuilderException.class)
-    public void testCreateAuthenticationStatement() throws SAMLAssertionBuilderException {
+    @Test
+    public void testBuild_NoSubjectID() throws CertificateManagerException {
+        HOKSAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder(setupCertManager());
+
+        HashMap<String, Object> properties = getDefaultProperties();
+        properties.put(SamlConstants.USER_FIRST_PROP, null);
+        properties.put(SamlConstants.USER_MIDDLE_PROP, null);
+        properties.put(SamlConstants.USER_LAST_PROP, null);
+
+        try {
+            builder.build(makeCallbackProperties(properties));
+            fail("Builder does not fail when there is a missing user name / subject ID");
+        } catch (SAMLAssertionBuilderException e) {
+            assertEquals("No information provided to fill in Subject ID attribute.", e.getMessage());
+        }
+
+    }
+
+    @Test
+    public void testBuild_NoSubjectOrg() throws CertificateManagerException {
+
+        SAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder(setupCertManager());
+
+        HashMap<String, Object> properties = getDefaultProperties();
+        properties.put(SamlConstants.USER_ORG_PROP, null);
+
+        try {
+            builder.build(makeCallbackProperties(properties));
+            fail("Builder does not fail when there is a missing subject organization");
+        } catch (SAMLAssertionBuilderException e) {
+            assertEquals("No Organization Attribute statement provided.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testBuild_NoSubjectRole() throws CertificateManagerException {
+        SAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder(setupCertManager());
+
+        HashMap<String, Object> properties = getDefaultProperties();
+        properties.put(SamlConstants.USER_CODE_PROP, null);
+        properties.put(SamlConstants.USER_SYST_PROP, null);
+        properties.put(SamlConstants.USER_SYST_NAME_PROP, null);
+        properties.put(SamlConstants.USER_DISPLAY_PROP, null);
+
+        try {
+            builder.build(makeCallbackProperties(properties));
+            fail("Builder does not fail when there is a missing subject role");
+        } catch (SAMLAssertionBuilderException e) {
+            assertEquals("No information provided to fill in user role attribute.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testBuild_NoPurposeOfUse() throws CertificateManagerException {
+        SAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder(setupCertManager());
+
+        HashMap<String, Object> properties = getDefaultProperties();
+        properties.put(SamlConstants.PURPOSE_CODE_PROP, null);
+        properties.put(SamlConstants.PURPOSE_SYST_PROP, null);
+        properties.put(SamlConstants.PURPOSE_SYST_NAME_PROP, null);
+        properties.put(SamlConstants.PURPOSE_DISPLAY_PROP, null);
+
+        try {
+            builder.build(makeCallbackProperties(properties));
+            fail("Builder does not fail when there is a missing purpose of use");
+        } catch (SAMLAssertionBuilderException e) {
+            assertEquals("No information provided to fill in Purpose For Use attribute.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testBuild_NoHCID() throws CertificateManagerException {
+        SAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder(setupCertManager());
+
+        HashMap<String, Object> properties = getDefaultProperties();
+        properties.put(SamlConstants.HOME_COM_PROP, null);
+
+        try {
+            builder.build(makeCallbackProperties(properties));
+            fail("Builder does not fail when there is a missing HCID");
+        } catch (SAMLAssertionBuilderException e) {
+            assertEquals("No Home Community ID Attribute statement provided.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testBuild_NoOrgID() throws CertificateManagerException {
+        SAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder(setupCertManager());
+
+        HashMap<String, Object> properties = getDefaultProperties();
+        properties.put(SamlConstants.USER_ORG_ID_PROP, null);
+
+        try {
+            builder.build(makeCallbackProperties(properties));
+            fail("Builder does not fail when there is a missing organization ID");
+        } catch (SAMLAssertionBuilderException e) {
+            assertEquals("No Organization ID Attribute statement provided.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCreateAuthenticationStatement_NullProperty() {
         final CallbackProperties callbackProps = mock(CallbackProperties.class);
         final HOKSAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder();
         when(callbackProps.getAuthenticationStatementExists()).thenReturn(true);
-        final List<AuthnStatement> authnStatement = builder.createAuthenicationStatements(callbackProps);
+        try {
+            builder.createAuthenicationStatements(callbackProps);
+            fail();
+        } catch (SAMLAssertionBuilderException e) {
+            assertEquals("Assertion Authentication Statement <AuthnContext> element is null or not valid format.",
+                e.getMessage());
+        }
     }
 
     @Test
@@ -397,43 +251,20 @@ public class HOKSAMLAssertionBuilderTest {
         assertFalse(authnStatement.isEmpty());
     }
 
-    @Test(expected = SAMLAssertionBuilderException.class)
-    public void testCreateAuthenticationStatementWithDateNull() throws SAMLAssertionBuilderException {
+    @Test
+    public void testCreateAuthenticationStatementWithDateNull() {
         final CallbackProperties callbackProps = mock(CallbackProperties.class);
         final HOKSAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder();
 
         when(callbackProps.getAuthenticationContextClass()).thenReturn("urn:oasis:names:tc:SAML:2.0:ac:classes:X509");
         when(callbackProps.getAuthenticationStatementExists()).thenReturn(true);
 
-        final List<AuthnStatement> authnStatement = builder.createAuthenicationStatements(callbackProps);
-        assertNotNull(authnStatement);
-
-        assertFalse(authnStatement.isEmpty());
-    }
-
-    @Test(expected = SAMLAssertionBuilderException.class)
-    public void testCreateAuthenticationStatementWithNonDate() throws SAMLAssertionBuilderException {
-        final CallbackProperties callbackProps = mock(CallbackProperties.class);
-        final HOKSAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder();
-
-        when(callbackProps.getAuthenticationContextClass()).thenReturn("urn:oasis:names:tc:SAML:2.0:ac:classes:X509");
-        when(callbackProps.getAuthenticationStatementExists()).thenReturn(true);
-
-        final List<AuthnStatement> authnStatement = builder.createAuthenicationStatements(callbackProps);
-        assertNotNull(authnStatement);
-
-        assertFalse(authnStatement.isEmpty());
-    }
-
-    @Test(expected = SAMLAssertionBuilderException.class)
-    public void testCreateAtributeStatementUserName() throws SAMLAssertionBuilderException {
-        final CallbackProperties callbackProps = mock(CallbackProperties.class);
-        final HOKSAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder();
-        final Subject subject = mock(Subject.class);
-        final AttributeStatement e = mock(AttributeStatement.class);
-        final List<AttributeStatement> statements = builder.createUserNameAttributeStatements(callbackProps);
-        when(callbackProps.getUserFullName()).thenReturn(null);
-
+        try {
+            builder.createAuthenicationStatements(callbackProps);
+            fail("Auth statement did not throw when date provided is not provided");
+        } catch (SAMLAssertionBuilderException e) {
+            assertEquals("Assertion Authentication Statement <AuthnInstant> element is null.", e.getMessage());
+        }
     }
 
     @Test
@@ -449,7 +280,7 @@ public class HOKSAMLAssertionBuilderTest {
         List<AttributeStatement> aStatement = builder.createAcpAttributeStatements(callbackProps);
 
         assertNotNull(aStatement);
-        assertEquals(aStatement.size(), 2);
+        assertEquals(2, aStatement.size());
 
         boolean containsAcps = true;
         for(int i=0; i<2; i++) {
@@ -463,8 +294,7 @@ public class HOKSAMLAssertionBuilderTest {
     }
 
     @Test
-    public void testSamlConditionsNotBeforeAndNotAfterPresent()
-        throws PropertyAccessException, SAMLAssertionBuilderException {
+    public void testSamlConditionsNotBeforeAndNotAfterPresent() {
         final CallbackProperties callbackProps = mock(CallbackProperties.class);
         final HOKSAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder() {
             @Override
@@ -484,7 +314,7 @@ public class HOKSAMLAssertionBuilderTest {
     }
 
     @Test
-    public void testSamlConditionsNotBeforeIsNull() throws PropertyAccessException, SAMLAssertionBuilderException {
+    public void testSamlConditionsNotBeforeIsNull() {
         final CallbackProperties callbackProps = mock(CallbackProperties.class);
         final HOKSAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder() {
             @Override
@@ -503,14 +333,9 @@ public class HOKSAMLAssertionBuilderTest {
     }
 
     @Test
-    public void testSamlConditionsNotAfterIsNull() throws PropertyAccessException, SAMLAssertionBuilderException {
+    public void testSamlConditionsNotAfterIsNull() {
         final CallbackProperties callbackProps = mock(CallbackProperties.class);
-        final HOKSAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder() {
-            @Override
-            protected boolean isConditionsDefaultValueEnabled() {
-                return false;
-            }
-        };
+        final HOKSAMLAssertionBuilder builder = getNonDefaultConditionBuilder();
         final DateTime conditionNotBefore = new DateTime();
 
         when(callbackProps.getSamlConditionsNotBefore()).thenReturn(conditionNotBefore);
@@ -521,15 +346,9 @@ public class HOKSAMLAssertionBuilderTest {
     }
 
     @Test
-    public void testSamlConditionsPropertyOffBeginInvalid()
-        throws PropertyAccessException, SAMLAssertionBuilderException {
+    public void testSamlConditionsPropertyOffBeginInvalid() {
         final CallbackProperties callbackProps = mock(CallbackProperties.class);
-        final HOKSAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder() {
-            @Override
-            protected boolean isConditionsDefaultValueEnabled() {
-                return false;
-            }
-        };
+        final HOKSAMLAssertionBuilder builder = getNonDefaultConditionBuilder();
         final DateTime now = new DateTime();
         final DateTime conditionNotBefore = now.plusYears(2);
         final DateTime conditionNotAfter = now.plusYears(3);
@@ -544,15 +363,9 @@ public class HOKSAMLAssertionBuilderTest {
     }
 
     @Test
-    public void testSamlConditionsPropertyOffAfterInvalid()
-        throws PropertyAccessException, SAMLAssertionBuilderException {
+    public void testSamlConditionsPropertyOffAfterInvalid() {
         final CallbackProperties callbackProps = mock(CallbackProperties.class);
-        final HOKSAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder() {
-            @Override
-            protected boolean isConditionsDefaultValueEnabled() {
-                return false;
-            }
-        };
+        final HOKSAMLAssertionBuilder builder = getNonDefaultConditionBuilder();
         final DateTime now = new DateTime();
         final DateTime conditionNotBefore = now.minusYears(3);
         final DateTime conditionNotAfter = now.minusYears(2);
@@ -567,15 +380,9 @@ public class HOKSAMLAssertionBuilderTest {
     }
 
     @Test
-    public void testSamlConditionsPropertyOnInvalidBefore()
-        throws PropertyAccessException, SAMLAssertionBuilderException {
+    public void testSamlConditionsPropertyOnInvalidBefore() {
         final CallbackProperties callbackProps = mock(CallbackProperties.class);
-        final HOKSAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder() {
-            @Override
-            protected boolean isConditionsDefaultValueEnabled() {
-                return true;
-            }
-        };
+        final HOKSAMLAssertionBuilder builder = getDefaultConditionBuilder();
         final DateTime now = new DateTime();
         final DateTime conditionNotBefore = now.plusYears(2);
         final DateTime conditionNotAfter = now.plusYears(3);
@@ -589,15 +396,9 @@ public class HOKSAMLAssertionBuilderTest {
     }
 
     @Test
-    public void testSamlConditionsPropertyOnInvalidAfter()
-        throws PropertyAccessException, SAMLAssertionBuilderException {
+    public void testSamlConditionsPropertyOnInvalidAfter() {
         final CallbackProperties callbackProps = mock(CallbackProperties.class);
-        final HOKSAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder() {
-            @Override
-            protected boolean isConditionsDefaultValueEnabled() {
-                return true;
-            }
-        };
+        final HOKSAMLAssertionBuilder builder = getDefaultConditionBuilder();
         final DateTime now = new DateTime();
         final DateTime conditionNotBefore = now.minusYears(3);
         final DateTime conditionNotAfter = now.minusYears(2);
@@ -611,8 +412,8 @@ public class HOKSAMLAssertionBuilderTest {
     }
 
     @Test
-    public void testBuildEvidence() throws SAMLAssertionBuilderException {
-        Map<Object, Object> propertiesMap = new HashMap<Object, Object>();
+    public void testBuildEvidence() {
+        Map<String, Object> propertiesMap = new HashMap<String, Object>();
         propertiesMap.put(SamlConstants.EVIDENCE_ID_PROP, "_45678fdgrt543sweqt");
         CallbackProperties properties = new CallbackMapProperties(propertiesMap);
         final HOKSAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder();
@@ -625,8 +426,7 @@ public class HOKSAMLAssertionBuilderTest {
     }
 
     @Test
-    public void testCreateAuthenticationDecisionStatements()
-        throws PropertyAccessException, SAMLAssertionBuilderException {
+    public void testCreateAuthenticationDecisionStatements() throws SAMLAssertionBuilderException {
         final CallbackProperties callbackProps = mock(CallbackProperties.class);
         final Subject subject = mock(Subject.class);
         final DateTime beforeCreation = new DateTime();
@@ -643,15 +443,15 @@ public class HOKSAMLAssertionBuilderTest {
         when(callbackProps.getEvidenceAccessConstent()).thenReturn(evidenceAccessConstent);
         when(callbackProps.getEvidenceInstantAccessConsent()).thenReturn(evidenceInstantAccessConsent);
 
-        final List<AuthzDecisionStatement> statementList = getHOKSAMLAssertionBuilder()
+        final List<AuthzDecisionStatement> statementList = getNonDefaultConditionBuilder()
             .createAuthorizationDecisionStatements(callbackProps, subject);
 
         assertFalse(statementList.isEmpty());
         final AuthzDecisionStatement statement = statementList.get(0);
-        assertEquals(statement.getDecision(), DecisionTypeEnumeration.PERMIT);
+        assertEquals(DecisionTypeEnumeration.PERMIT, statement.getDecision());
 
         final Action action = statement.getActions().get(0);
-        assertEquals(action.getAction(), SAMLAssertionBuilder.AUTHZ_DECISION_ACTION_EXECUTE);
+        assertEquals(SAMLAssertionBuilder.AUTHZ_DECISION_ACTION_EXECUTE, action.getAction());
 
         final Evidence evidence = statement.getEvidence();
         final Assertion assertion = evidence.getAssertions().get(0);
@@ -661,7 +461,7 @@ public class HOKSAMLAssertionBuilderTest {
             || beforeCreation.isEqual(assertion.getIssueInstant()));
 
         final Issuer issuer = assertion.getIssuer();
-        assertEquals(issuer.getFormat(), SAMLAssertionBuilder.X509_NAME_ID);
+        assertEquals(SAMLAssertionBuilder.X509_NAME_ID, issuer.getFormat());
 
         final Conditions conditions = assertion.getConditions();
 
@@ -669,12 +469,12 @@ public class HOKSAMLAssertionBuilderTest {
         assertEquals(conditions.getNotOnOrAfter(), conditionNotAfter.withZone(DateTimeZone.UTC));
 
         final List<AttributeStatement> attributeStatement = assertion.getAttributeStatements();
-        assertEquals(attributeStatement.get(0).getAttributes().size(), 2);
+        assertEquals(2, attributeStatement.get(0).getAttributes().size());
 
         final Attribute firstAttribute = attributeStatement.get(0).getAttributes().get(0);
         final Attribute secondAttribute = attributeStatement.get(0).getAttributes().get(1);
-        assertEquals(firstAttribute.getName(), "AccessConsentPolicy");
-        assertEquals(secondAttribute.getName(), "InstanceAccessConsentPolicy");
+        assertEquals("AccessConsentPolicy", firstAttribute.getName());
+        assertEquals("InstanceAccessConsentPolicy", secondAttribute.getName());
     }
 
     @Test
@@ -692,7 +492,7 @@ public class HOKSAMLAssertionBuilderTest {
         when(callbackProps.getEvidenceConditionNotBefore()).thenReturn(conditionNotBefore);
         when(callbackProps.getEvidenceConditionNotAfter()).thenReturn(conditionNotAfter);
 
-        final List<AuthzDecisionStatement> statementList = getHOKSAMLAssertionBuilder()
+        final List<AuthzDecisionStatement> statementList = getNonDefaultConditionBuilder()
             .createAuthorizationDecisionStatements(callbackProps, subject);
 
         assertFalse(statementList.isEmpty());
@@ -719,7 +519,7 @@ public class HOKSAMLAssertionBuilderTest {
         when(callbackProps.getAuthorizationStatementExists()).thenReturn(true);
         when(callbackProps.getEvidenceConditionNotAfter()).thenReturn(conditionNotAfter);
         when(callbackProps.getEvidenceConditionNotBefore()).thenReturn(null);
-        final List<AuthzDecisionStatement> statementList = getHOKSAMLAssertionBuilder()
+        final List<AuthzDecisionStatement> statementList = getNonDefaultConditionBuilder()
             .createAuthorizationDecisionStatements(callbackProps, subject);
 
         assertFalse(statementList.isEmpty());
@@ -745,7 +545,7 @@ public class HOKSAMLAssertionBuilderTest {
         when(callbackProps.getEvidenceConditionNotBefore()).thenReturn(conditionNotBefore);
         when(callbackProps.getEvidenceConditionNotAfter()).thenReturn(null);
 
-        final List<AuthzDecisionStatement> statementList = getHOKSAMLAssertionBuilder()
+        final List<AuthzDecisionStatement> statementList = getNonDefaultConditionBuilder()
             .createAuthorizationDecisionStatements(callbackProps, subject);
 
         assertFalse(statementList.isEmpty());
@@ -758,7 +558,9 @@ public class HOKSAMLAssertionBuilderTest {
         assertNull(conditions);
     }
 
-    HOKSAMLAssertionBuilder getHOKSAMLAssertionBuilder() {
+    // Since this project is heavily focused on statics/singletons, and not using Spring's wiring, we have to override
+    // the method. Alternatively, we could use PowerMock with Mockito to mock the static calls, but that's overkill.
+    private static HOKSAMLAssertionBuilder getNonDefaultConditionBuilder() {
         // return isConditionsDefaultValueEnabled flag to false
         return new HOKSAMLAssertionBuilder() {
             @Override
@@ -767,234 +569,80 @@ public class HOKSAMLAssertionBuilderTest {
             }
         };
     }
-
-    CallbackProperties getProperties() {
-        return new CallbackProperties() {
+    private static HOKSAMLAssertionBuilder getDefaultConditionBuilder() {
+        // return isConditionsDefaultValueEnabled flag to true
+        return new HOKSAMLAssertionBuilder() {
             @Override
-            public String getUsername() {
-                return "userName";
-            }
-
-            @Override
-            public String getUserSystemName() {
-                return "sytemName";
-            }
-
-            @Override
-            public String getUserSystem() {
-                return "userSystem";
-            }
-
-            @Override
-            public String getUserOrganization() {
-                return "uerOrg";
-            }
-
-            @Override
-            public String getUserFullName() {
-                return "Full Name";
-            }
-
-            @Override
-            public String getUserDisplay() {
-                return "display";
-            }
-
-            @Override
-            public String getUserCode() {
-                return "userCode";
-            }
-
-            @Override
-            public String getSubjectLocality() {
-                return "subject";
-            }
-
-            @Override
-            public String getSubjectDNS() {
-                return "dns";
-            }
-
-            @Override
-            public String getPurposeSystemName() {
-                return "systemname";
-            }
-
-            @Override
-            public String getPurposeSystem() {
-                return "purpose";
-            }
-
-            @Override
-            public String getPurposeDisplay() {
-                return "disply";
-            }
-
-            @Override
-            public String getPurposeCode() {
-                return "code";
-            }
-
-            @Override
-            public String getPatientID() {
-                return "pid";
-            }
-
-            @Override
-            public String getIssuer() {
-                return "CN=SAML User,OU=connect,O=FHA,L=Melbourne,ST=FL,C=US";
-            }
-
-            @Override
-            public String getHomeCommunity() {
-                return "hci";
-            }
-
-            @Override
-            public DateTime getSamlConditionsNotBefore() {
-                return new DateTime();
-            }
-
-            @Override
-            public DateTime getSamlConditionsNotAfter() {
-                return new DateTime();
-            }
-
-            @Override
-            public String getEvidenceIssuerFormat() {
-                return "format";
-            }
-
-            @Override
-            public String getEvidenceIssuer() {
-                return "issuer";
-            }
-
-            @Override
-            public String getEvidenceSubject() {
-                return "evidenceSubject";
-            }
-
-            @Override
-            public DateTime getEvidenceInstant() {
-                return new DateTime();
-            }
-
-            @Override
-            public List getEvidenceInstantAccessConsent() {
-                return Collections.EMPTY_LIST;
-            }
-
-            @Override
-            public String getEvidenceID() {
-                return "evidence id";
-            }
-
-            @Override
-            public DateTime getEvidenceConditionNotBefore() {
-                return new DateTime();
-            }
-
-            @Override
-            public DateTime getEvidenceConditionNotAfter() {
-                return new DateTime();
-            }
-
-            @Override
-            public List getEvidenceAccessConstent() {
-                return Collections.EMPTY_LIST;
-            }
-
-            @Override
-            public String getAuthorizationResource() {
-                return "resource";
-            }
-
-            @Override
-            public Boolean getAuthorizationStatementExists() {
-                return false;
-            }
-
-            @Override
-            public Boolean getAuthenticationStatementExists() {
-                return false;
-            }
-
-            @Override
-            public String getAuthenticationSessionIndex() {
-                return "1";
-            }
-
-            @Override
-            public DateTime getAuthenticationInstant() {
-                return new DateTime();
-            }
-
-            @Override
-            public String getAuthorizationDecision() {
-                return null;
-            }
-
-            @Override
-            public String getAuthenticationContextClass() {
-                return "cntx";
-            }
-
-            @Override
-            public String getAssertionIssuerFormat() {
-                return "format";
-            }
-
-            @Override
-            public String getTargetHomeCommunityId() {
-                return "targetHomeCommunityId";
-            }
-
-            @Override
-            public String getServiceName() {
-                return "serviceName";
-            }
-
-            @Override
-            public String getAction() {
-                return "action";
-            }
-
-            @Override
-            public GATEWAY_API_LEVEL getTargetApiLevel() {
-                return GATEWAY_API_LEVEL.LEVEL_g1;
-            }
-
-            @Override
-            public String getNPI() {
-                return "npi";
-            }
-
-            @Override
-            public String getUserOrganizationId() {
-                return "orgId";
-            }
-
-            @Override
-            public List<SAMLSubjectConfirmation> getSubjectConfirmations() {
-                return null;
-            }
-
-            @Override
-            public String getAcpAttribute() {
-                return "urn:oid:1.2.3.4";
-            }
-
-            @Override
-            public String getIacpAttribute() {
-                return "urn:oid:1.2.3.4.5";
+            protected boolean isConditionsDefaultValueEnabled() {
+                return true;
             }
         };
     }
 
+    private static HashMap<String, Object> getDefaultProperties() {
+
+        DateTime date = new DateTime();
+
+        HashMap<String, Object> values = new HashMap<String, Object>();
+        values.put(SamlConstants.USER_NAME_PROP, "userName");
+        values.put(SamlConstants.USER_SYST_NAME_PROP, "sytemName");
+        values.put(SamlConstants.USER_SYST_PROP, "userSystem");
+        values.put(SamlConstants.USER_ORG_PROP, "userOrg");
+        values.put(SamlConstants.USER_ORG_ID_PROP, "userOrgId");
+        values.put(SamlConstants.USER_FIRST_PROP, "First");
+        values.put(SamlConstants.USER_MIDDLE_PROP, "Mid");
+        values.put(SamlConstants.USER_LAST_PROP, "Last");
+        values.put(SamlConstants.USER_DISPLAY_PROP, "display");
+        values.put(SamlConstants.USER_CODE_PROP, "userCode");
+        values.put(SamlConstants.SUBJECT_LOCALITY_ADDR_PROP, "locality");
+        values.put(SamlConstants.SUBJECT_LOCALITY_DNS_PROP, "dns");
+        values.put(SamlConstants.PURPOSE_SYST_NAME_PROP, "purposeSystemName");
+        values.put(SamlConstants.PURPOSE_SYST_PROP, "purposeSystem");
+        values.put(SamlConstants.PURPOSE_DISPLAY_PROP, "purposeDisplay");
+        values.put(SamlConstants.PURPOSE_CODE_PROP, "purposecode");
+        values.put(SamlConstants.PATIENT_ID_PROP, "patientId");
+        values.put(SamlConstants.ASSERTION_ISSUER_PROP, "CN=SAML User,OU=connect,O=FHA,L=Melbourne,ST=FL,C=US");
+        values.put(SamlConstants.HOME_COM_PROP, "hcid");
+        values.put(SamlConstants.SAMLCONDITIONS_NOT_BEFORE_PROP, date);
+        values.put(SamlConstants.SAMLCONDITIONS_NOT_AFTER_PROP, date);
+        values.put(SamlConstants.EVIDENCE_ISSUER_FORMAT_PROP, "format");
+        values.put(SamlConstants.EVIDENCE_ISSUER_PROP, "issuer");
+        values.put(SamlConstants.EVIDENCE_SUBJECT_PROP, "evidenceSubject");
+        values.put(SamlConstants.EVIDENCE_INSTANT_PROP, date);
+        values.put(SamlConstants.EVIDENCE_INST_ACCESS_CONSENT_PROP, Collections.EMPTY_LIST);
+        values.put(SamlConstants.EVIDENCE_ID_PROP, "evidence id");
+        values.put(SamlConstants.EVIDENCE_CONDITION_NOT_BEFORE_PROP, date);
+        values.put(SamlConstants.EVIDENCE_CONDITION_NOT_AFTER_PROP, date);
+        values.put(SamlConstants.EVIDENCE_ACCESS_CONSENT_PROP, Collections.EMPTY_LIST);
+        values.put(SamlConstants.RESOURCE_PROP, "resource");
+        values.put(SamlConstants.AUTHZ_STATEMENT_EXISTS_PROP, false);
+        values.put(SamlConstants.AUTHN_STATEMENT_EXISTS_PROP, false);
+        values.put(SamlConstants.AUTHN_SESSION_INDEX_PROP, "1");
+        values.put(SamlConstants.AUTHN_INSTANT_PROP, date);
+        values.put(SamlConstants.AUTHN_CONTEXT_CLASS_PROP, "contextClass");
+        values.put(SamlConstants.ASSERTION_ISSUER_FORMAT_PROP, "issueFormat");
+        values.put(NhincConstants.WS_SOAP_TARGET_HOME_COMMUNITY_ID, "targetHCID");
+        values.put(NhincConstants.SERVICE_NAME, "serviceName");
+        values.put(SamlConstants.ACTION_PROP, "action");
+        values.put(NhincConstants.TARGET_API_LEVEL, GATEWAY_API_LEVEL.LEVEL_g1);
+        values.put(SamlConstants.ATTRIBUTE_NAME_NPI, "npi");
+        values.put(SamlConstants.ACP_ATTRIBUTE_PROP, "urn:oid:1.2.3.4");
+        values.put(SamlConstants.IACP_ATTRIBUTE_PROP, "urn:oid:1.2.3.4.5");
+
+        return values;
+    }
+
+    private CallbackProperties makeCallbackProperties(HashMap<String, Object> overwriteValues) {
+        HashMap<String, Object> values = overwriteValues;
+        if (values == null) {
+            values = getDefaultProperties();
+        }
+
+        return new CallbackMapProperties(values);
+    }
+
     @Test
-    public void testCreateAuthenticationDecisionStatementsWithoutACPorIACP()
-        throws PropertyAccessException, SAMLAssertionBuilderException {
+    public void testCreateAuthenticationDecisionStatementsWithoutACPorIACP() throws SAMLAssertionBuilderException {
         final CallbackProperties callbackProps = mock(CallbackProperties.class);
         final Subject subject = mock(Subject.class);
         final DateTime beforeCreation = new DateTime();
@@ -1005,15 +653,15 @@ public class HOKSAMLAssertionBuilderTest {
         when(callbackProps.getEvidenceConditionNotAfter()).thenReturn(conditionNotAfter);
         when(callbackProps.getAuthorizationStatementExists()).thenReturn(true);
 
-        final List<AuthzDecisionStatement> statementList = getHOKSAMLAssertionBuilder()
+        final List<AuthzDecisionStatement> statementList = getNonDefaultConditionBuilder()
             .createAuthorizationDecisionStatements(callbackProps, subject);
 
         assertFalse(statementList.isEmpty());
         final AuthzDecisionStatement statement = statementList.get(0);
-        assertEquals(statement.getDecision(), DecisionTypeEnumeration.PERMIT);
+        assertEquals(DecisionTypeEnumeration.PERMIT, statement.getDecision());
 
         final Action action = statement.getActions().get(0);
-        assertEquals(action.getAction(), SAMLAssertionBuilder.AUTHZ_DECISION_ACTION_EXECUTE);
+        assertEquals(SAMLAssertionBuilder.AUTHZ_DECISION_ACTION_EXECUTE, action.getAction());
 
         final Evidence evidence = statement.getEvidence();
         final Assertion assertion = evidence.getAssertions().get(0);
@@ -1023,7 +671,7 @@ public class HOKSAMLAssertionBuilderTest {
             || beforeCreation.isEqual(assertion.getIssueInstant()));
 
         final Issuer issuer = assertion.getIssuer();
-        assertEquals(issuer.getFormat(), SAMLAssertionBuilder.X509_NAME_ID);
+        assertEquals(SAMLAssertionBuilder.X509_NAME_ID, issuer.getFormat());
 
         final Conditions conditions = assertion.getConditions();
         assertEquals(conditions.getNotBefore(), conditionNotBefore.withZone(DateTimeZone.UTC));
@@ -1056,36 +704,20 @@ public class HOKSAMLAssertionBuilderTest {
         assertTrue(subjectConfirmations.size() == 3);
     }
 
-    @Test
-    public void testIssuerName() throws PropertyAccessException {
-        final CallbackProperties callbackProps = mock(CallbackProperties.class);
-        String sIssuer = callbackProps.getIssuer();
-
-        PropertyAccessor propAccessor = createPropertyAccessor();
-        sIssuer = propAccessor.getProperty(PROPERTY_FILE_NAME, PROPERTY_NAME);
-
-        assertEquals(PROPERTY_VALUE_STRING, sIssuer);
-
-    }
-
-    private PropertyAccessor createPropertyAccessor() {
-        PropertyAccessor propAccessor = new PropertyAccessor() {
-            @Override
-            protected PropertyFileDAO createPropertyFileDAO() {
-                return mockFileDAO;
-            }
-
-        };
-        propAccessor.setPropertyFile(PROPERTY_FILE_NAME);
-
-        return propAccessor;
-    }
-
-    private SAMLSubjectConfirmation createSubjectConfirmationBean(String method) {
+    private static SAMLSubjectConfirmation createSubjectConfirmationBean(String method) {
         SAMLSubjectConfirmation subjectConfirmationBean = new SAMLSubjectConfirmation();
         subjectConfirmationBean.setAddress("localhost");
         subjectConfirmationBean.setMethod(method);
         return subjectConfirmationBean;
+    }
+
+    // Small helper method to view the XML when testing in debug.
+    public String getRawXML(Element element) {
+        Document document = element.getOwnerDocument();
+        DOMImplementationLS domImplLS = (DOMImplementationLS) document.getImplementation();
+        LSSerializer serializer = domImplLS.createLSSerializer();
+        String str = serializer.writeToString(element);
+        return str;
     }
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilderTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilderTest.java
@@ -170,7 +170,7 @@ public class HOKSAMLAssertionBuilderTest {
             builder.build(makeCallbackProperties(properties));
             fail("Builder does not fail when there is a missing subject role");
         } catch (SAMLAssertionBuilderException e) {
-            assertEquals("No information provided to fill in user role attribute.", e.getMessage());
+            assertEquals("No information provided to fill in subject role attribute.", e.getMessage());
         }
     }
 

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilderTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilderTest.java
@@ -229,7 +229,7 @@ public class HOKSAMLAssertionBuilderTest {
         when(callbackProps.getAuthenticationStatementExists()).thenReturn(true);
         try {
             builder.createAuthenicationStatements(callbackProps);
-            fail();
+            fail("Builder does not fail when there is missing authentication");
         } catch (SAMLAssertionBuilderException e) {
             assertEquals("Assertion Authentication Statement <AuthnContext> element is null or not valid format.",
                 e.getMessage());

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilderTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilderTest.java
@@ -103,7 +103,7 @@ public class OpenSAML2ComponentBuilderTest {
         final String userDisplay = "Public Health";
         final String type = "hl7:CE";
 
-        final Attribute attribute = OpenSAML2ComponentBuilder.getInstance().createUserRoleAttribute(userCode, userSystem,
+        final Attribute attribute = OpenSAML2ComponentBuilder.getInstance().createSubjectRoleAttribute(userCode, userSystem,
                 userSystemName, userDisplay);
         final List<XMLObject> attributeValue = attribute.getAttributeValues();
         for (final XMLObject value : attributeValue) {


### PR DESCRIPTION
Adding required attributes to be checked during CXF callback. Will now throw a 
SAMLAssertionBuilderException if any of the required fields are null or blank.

Refactored quite a bit of the Unit Test to avoid creating its own classes for the sake of the test. We have Mockito, and a setter to set the CallbackProperties. There is absolutely no need to override the classes methods.

Removed a number of useless/incorrect comments in the code that were not needed.