### PR TITLE
Use default refresh interval if empty

### DIFF
--- a/Product/Production/Services/ConnectionManagerCore/src/main/java/gov/hhs/fha/nhinc/exchangemgr/ExchangeSchedulerConfig.java
+++ b/Product/Production/Services/ConnectionManagerCore/src/main/java/gov/hhs/fha/nhinc/exchangemgr/ExchangeSchedulerConfig.java
@@ -39,8 +39,8 @@ public class ExchangeSchedulerConfig {
         long intervalMinutes = DEFAULT_EXCHANGE_REFRESH_INTERVAL;
         try {
             ExchangeInfoType exInfo = ExchangeInfoDAOFileImpl.getInstance().loadExchangeInfo();
-            long interval = exInfo.getRefreshInterval();
-            if (interval <= 0) {
+            Long interval = exInfo.getRefreshInterval();
+            if (interval == null || interval <= 0) {
                 intervalMinutes = DEFAULT_EXCHANGE_REFRESH_INTERVAL;
             } else {
                 intervalMinutes = interval;


### PR DESCRIPTION
Some of regression tests doesn't have refresh interval.  Fix exchangeManager to use default if omit. 