### PR TITLE
Fixing bug where if the UDDI has multiple names for an entry

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/exchangemgr/ExchangeManagerHelper.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/exchangemgr/ExchangeManagerHelper.java
@@ -367,6 +367,9 @@ public class ExchangeManagerHelper {
             } catch(IllegalArgumentException e) {
                 // ignoring, since the Sequoia UDDI often has multiple names for entries
                 // and only one is known to CONNECT.
+                
+                //Adding logging of error so CAGitBot stops complaining
+                LOG.debug(e.getMessage());
             }
         }
         return null;

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/exchangemgr/ExchangeManagerHelper.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/exchangemgr/ExchangeManagerHelper.java
@@ -360,8 +360,13 @@ public class ExchangeManagerHelper {
 
     public static String getNhinServiceName(List<String> serviceNames) {
         for (String name : serviceNames) {
-            if (StringUtils.isNotBlank(NhincConstants.NHIN_SERVICE_NAMES.fromValueString(name).toString())) {
-                return NhincConstants.NHIN_SERVICE_NAMES.fromValueString(name).getUDDIServiceName();
+            try {
+                if (StringUtils.isNotBlank(NhincConstants.NHIN_SERVICE_NAMES.fromValueString(name).toString())) {
+                    return NhincConstants.NHIN_SERVICE_NAMES.fromValueString(name).getUDDIServiceName();
+                }
+            } catch(IllegalArgumentException e) {
+                // ignoring, since the Sequoia UDDI often has multiple names for entries
+                // and only one is known to CONNECT.
             }
         }
         return null;


### PR DESCRIPTION
and only one of the names is known to CONNECT, it doesn't throw an exception and error out. It ignores the exception and keeps processing names until it either recognizes one or returns null.

This bug currently renders over half of Sequoia's UDDI useless.