### PR TITLE
Added fix for multiple service names

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/PurposeOfForDecider.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/PurposeOfForDecider.java
@@ -62,7 +62,7 @@ public class PurposeOfForDecider {
 
         serviceName = NHIN_SERVICE_NAMES.fromValueString(action);
         if (null == serviceName) {
-            LOG.warn("Could not read purpose of / for action: service name is null");
+            LOG.warn("Could not read purpose of / for action: service name is null for action {}", action);
             return purposeFor;
         }
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/PurposeOfForDecider.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/PurposeOfForDecider.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -27,7 +27,6 @@
 package gov.hhs.fha.nhinc.callback;
 
 import gov.hhs.fha.nhinc.callback.opensaml.CallbackProperties;
-
 import gov.hhs.fha.nhinc.callback.purposeuse.PurposeUseProxy;
 import gov.hhs.fha.nhinc.callback.purposeuse.PurposeUseProxyObjectFactory;
 import gov.hhs.fha.nhinc.connectmgr.NhinEndpointManager;
@@ -60,11 +59,10 @@ public class PurposeOfForDecider {
         boolean purposeFor = false;
 
         String action = properties.getAction();
-        try {
-            serviceName = NHIN_SERVICE_NAMES.fromValueString(action);
-        } catch (IllegalArgumentException ex) {
-            LOG.warn("Could not read purpose of / for action: {}", ex.getLocalizedMessage());
-            LOG.trace("Could not read purpose of / for action: {}", ex.getLocalizedMessage(), ex);
+
+        serviceName = NHIN_SERVICE_NAMES.fromValueString(action);
+        if (null == serviceName) {
+            LOG.warn("Could not read purpose of / for action: service name is null");
             return purposeFor;
         }
 
@@ -76,7 +74,7 @@ public class PurposeOfForDecider {
             hcid = hcid.replace(NhincConstants.HCID_PREFIX, "");
         }
 
-        if (apiLevel == null && serviceName != null && hcid != null) {
+        if (apiLevel == null && hcid != null) {
             NhinEndpointManager nem = getNhinEndpointManager();
             apiLevel = nem.getApiVersion(hcid, serviceName);
         }
@@ -87,7 +85,7 @@ public class PurposeOfForDecider {
         }
 
         if (LOG.isDebugEnabled()) {
-            logPurposeDecision(purposeFor, hcid, serviceName != null ? serviceName.getUDDIServiceName() : null);
+            logPurposeDecision(purposeFor, hcid, serviceName.getUDDIServiceName());
         }
 
         return purposeFor;
@@ -102,6 +100,6 @@ public class PurposeOfForDecider {
         }
 
         LOG.debug("PurposeOfForDecider decision for HCID: " + hcid + " and Service Name: " + serviceName + " is = "
-                + purposeName + ".");
+            + purposeName + ".");
     }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/exchangemgr/ExchangeManagerHelper.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/exchangemgr/ExchangeManagerHelper.java
@@ -360,7 +360,7 @@ public class ExchangeManagerHelper {
 
     public static String getNhinServiceName(List<String> serviceNames) {
         for (String name : serviceNames) {
-            if (StringUtils.isNotBlank(NhincConstants.NHIN_SERVICE_NAMES.fromValueString(name).toString())) {
+            if (isServiceNameMatch(name)) {
                 return NhincConstants.NHIN_SERVICE_NAMES.fromValueString(name).getUDDIServiceName();
             }
         }
@@ -432,6 +432,9 @@ public class ExchangeManagerHelper {
             }
         }
         return exList;
+    }
 
+    private static boolean isServiceNameMatch(String name) {
+        return StringUtils.isNotBlank(name) && null != NhincConstants.NHIN_SERVICE_NAMES.fromValueString(name);
     }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
@@ -102,12 +102,12 @@ public class NhincConstants {
         public static NHIN_SERVICE_NAMES fromValueString(final String valueString) {
             if (valueString != null) {
                 for (final NHIN_SERVICE_NAMES enumValue : NHIN_SERVICE_NAMES.values()) {
-                    if (valueString.equals(enumValue.UDDIServiceName)) {
+                    if (enumValue.UDDIServiceName.equals(valueString)) {
                         return enumValue;
                     }
                 }
             }
-            throw new IllegalArgumentException("No enum constant " + valueString);
+            return null;
         }
 
         public static List<String> getEnumServiceNamesList() {

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/exchangemgr/ExchangeManagerHelperTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/exchangemgr/ExchangeManagerHelperTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.exchangemgr;
+
+import java.util.ArrayList;
+import java.util.List;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+/**
+ *
+ * @author tjafri
+ */
+public class ExchangeManagerHelperTest {
+
+    private static final String QUERY_FOR_DOCUMENT = "QueryForDocument";
+    private static final String QUERY_FOR_DOCUMENTS = "QueryForDocuments";
+
+    @Test
+    public void multipleEndpointNamesTest() {
+        List<String> epNames = new ArrayList<>();
+        epNames.add("null");
+        epNames.add(null);
+        epNames.add("   ");
+        epNames.add(QUERY_FOR_DOCUMENT);
+        epNames.add(QUERY_FOR_DOCUMENTS);
+        String serviceName = ExchangeManagerHelper.getNhinServiceName(epNames);
+        assertEquals("Service Name not found", QUERY_FOR_DOCUMENTS, serviceName);
+    }
+}


### PR DESCRIPTION
Fix:
ExchangeManagerHelper -- modified the if check in getNhinServiceName method
NhincConstant - removed the IllegalArgumentException
PurposeOfUse -- removed the try catch block for IllegalArgumentException and added  if service is null, log and return
