### PR TITLE
Conn 2250 - InitServlet refactor to use Spring Beans instead

### DIFF
--- a/Product/Production/Common/CONNECTCommonWeb/src/main/java/gov/hhs/fha/nhinc/configuration/InitServlet.java
+++ b/Product/Production/Common/CONNECTCommonWeb/src/main/java/gov/hhs/fha/nhinc/configuration/InitServlet.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -29,38 +29,38 @@ package gov.hhs.fha.nhinc.configuration;
 import gov.hhs.fha.nhinc.configuration.jmx.Configuration;
 import gov.hhs.fha.nhinc.gateway.AbstractJMXEnabledServlet;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
-import javax.servlet.ServletContext;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import org.springframework.stereotype.Component;
 
 /**
  * The Class InitServlet.
  *
  * @author msw
  */
+@Component
 public class InitServlet extends AbstractJMXEnabledServlet {
 
-    /** The Constant serialVersionUID. */
-    private static final long serialVersionUID = 7738036165392946446L;
-
-    /** The Constant MBEAN_NAME. */
-    private static final String MBEAN_NAME = NhincConstants.JMX_CONFIGURATION_BEAN_NAME;
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.gateway.AbstractJMXEnabledServlet#getMBeanName()
-     */
     @Override
-    public String getMBeanName() {
-        return MBEAN_NAME;
+    @PostConstruct
+    public void init() {
+        super.init();
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.gateway.AbstractJMXEnabledServlet#getMBeanInstance(javax.servlet.ServletContext)
-     */
     @Override
-    public Object getMBeanInstance(ServletContext sc) {
+    @PreDestroy
+    public void destroy() {
+        super.destroy();
+    }
+
+    @Override
+    public String getMBeanName() {
+        return NhincConstants.JMX_CONFIGURATION_BEAN_NAME;
+    }
+
+
+    @Override
+    public Object getMBeanInstance() {
         return new Configuration();
     }
 }

--- a/Product/Production/Common/CONNECTCommonWeb/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Common/CONNECTCommonWeb/src/main/webapp/WEB-INF/web.xml
@@ -6,12 +6,6 @@
     version="2.5">
 
     <servlet>
-        <servlet-name>InitServlet</servlet-name>
-        <servlet-class>gov.hhs.fha.nhinc.configuration.InitServlet</servlet-class>
-        <load-on-startup>1</load-on-startup>
-    </servlet>
-
-    <servlet>
         <servlet-name>cxf</servlet-name>
         <servlet-class>org.apache.cxf.transport.servlet.CXFServlet</servlet-class>
         <load-on-startup>1</load-on-startup>

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/configuration/jmx/AbstractPassthruRegistryEnabledServlet.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/configuration/jmx/AbstractPassthruRegistryEnabledServlet.java
@@ -77,7 +77,7 @@ public abstract class AbstractPassthruRegistryEnabledServlet extends HttpServlet
         PassthruMXBeanRegistry registry = PassthruMXBeanRegistry.getInstance();
         for (WebServicesMXBean bean : beans) {
             LOG.info("Removing MX Bean for service {} due to InitServlet shutdown", bean.getServiceName().name());
-            registry.unregisteredBean(bean);
+            registry.unregisterBean(bean);
         }
 
         super.destroy();

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/configuration/jmx/AbstractWebServicesMXBean.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/configuration/jmx/AbstractWebServicesMXBean.java
@@ -27,7 +27,6 @@
 package gov.hhs.fha.nhinc.configuration.jmx;
 
 import org.apache.commons.lang.StringUtils;
-import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
@@ -174,7 +173,7 @@ public abstract class AbstractWebServicesMXBean implements ApplicationContextAwa
 
 
     @Override
-    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    public void setApplicationContext(ApplicationContext applicationContext) {
         context = applicationContext;
     }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/configuration/jmx/AbstractWebServicesMXBean.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/configuration/jmx/AbstractWebServicesMXBean.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,10 +26,10 @@
  */
 package gov.hhs.fha.nhinc.configuration.jmx;
 
-import javax.servlet.ServletContext;
 import org.apache.commons.lang.StringUtils;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.context.support.WebApplicationContextUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 
 /**
  * The Class AbstractWebServicesMXBean. This abstract class provides some common methods for retrieving beans and
@@ -37,19 +37,9 @@ import org.springframework.web.context.support.WebApplicationContextUtils;
  *
  * @author msw
  */
-public abstract class AbstractWebServicesMXBean implements WebServicesMXBean {
+public abstract class AbstractWebServicesMXBean implements ApplicationContextAware, WebServicesMXBean {
 
-    /** The ServletContext. */
-    private ServletContext sc;
-
-    /**
-     * Instantiates a new abstract web services mx bean.
-     *
-     * @param sc the ServletContext
-     */
-    public AbstractWebServicesMXBean(ServletContext sc) {
-        this.sc = sc;
-    }
+    protected ApplicationContext context;
 
     /**
      * Gets the Nhin interface bean name.
@@ -110,9 +100,7 @@ public abstract class AbstractWebServicesMXBean implements WebServicesMXBean {
      * @return the t
      */
     protected <T> T retrieveBean(final Class<T> beanType, String beanName) {
-        WebApplicationContext webApplicationContext = WebApplicationContextUtils.getRequiredWebApplicationContext(sc);
-
-        return beanType.cast(webApplicationContext.getBean(beanName));
+        return beanType.cast(context.getBean(beanName));
     }
 
     /**
@@ -184,4 +172,9 @@ public abstract class AbstractWebServicesMXBean implements WebServicesMXBean {
         return matches;
     }
 
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        context = applicationContext;
+    }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/configuration/jmx/PassthruMXBeanRegistry.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/configuration/jmx/PassthruMXBeanRegistry.java
@@ -72,8 +72,8 @@ public class PassthruMXBeanRegistry {
         registeredBeans.add(bean);
     }
 
-    public void unregisteredBean(WebServicesMXBean bean) {
-        registeredBeans.remove(bean);
+    public boolean unregisterBean(WebServicesMXBean bean) {
+        return registeredBeans.remove(bean);
     }
 
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/gateway/executorservice/ExecutorServiceHelper.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/gateway/executorservice/ExecutorServiceHelper.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -54,15 +54,15 @@ public class ExecutorServiceHelper {
     private static final Logger LOG = LoggerFactory.getLogger(ExecutorServiceHelper.class);
 
     // default pool size is 100
-    private static int concurrentPoolSize;
+    private int concurrentPoolSize;
     // default large job pool size is 200
-    private static int largejobPoolSize;
+    private int largejobPoolSize;
     // default large job size percent is 75%
-    private static double largejobSizePercent;
+    private double largejobSizePercent;
 
     // timeoutValues no longer used (timeouts set in WebServiceProxyHelper)
     // timeoutValues Map contains web service client timeouts
-    private static Map timeoutValues = new HashMap();
+    private Map timeoutValues = new HashMap();
 
     // private constructor to ensure singleton
     private ExecutorServiceHelper() {
@@ -111,19 +111,19 @@ public class ExecutorServiceHelper {
         return SingletonHolder.INSTANCE;
     }
 
-    public static int getExecutorPoolSize() {
+    public int getExecutorPoolSize() {
         return concurrentPoolSize;
     }
 
-    public static int getLargeJobExecutorPoolSize() {
+    public int getLargeJobExecutorPoolSize() {
         return largejobPoolSize;
     }
 
-    public static double getLargeJobPercentage() {
+    public double getLargeJobPercentage() {
         return largejobSizePercent;
     }
 
-    public static Map getTimeoutValues() {
+    public Map getTimeoutValues() {
         return timeoutValues;
     }
 
@@ -134,7 +134,7 @@ public class ExecutorServiceHelper {
      * @param targetListCount is the fan-out count for the task
      * @return boolean true if task should be run using large job executor service
      */
-    public static boolean checkExecutorTaskIsLarge(int targetListCount) {
+    public boolean checkExecutorTaskIsLarge(int targetListCount) {
         boolean bigJob = false;
         Double maxSize = new Double(largejobSizePercent * concurrentPoolSize);
         if (targetListCount >= maxSize.intValue()) {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/registrar/AbstractMXBeanRegistrar.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/registrar/AbstractMXBeanRegistrar.java
@@ -1,0 +1,53 @@
+/**
+ *
+ */
+package gov.hhs.fha.nhinc.registrar;
+
+import gov.hhs.fha.nhinc.configuration.jmx.PassthruMXBeanRegistry;
+import gov.hhs.fha.nhinc.configuration.jmx.WebServicesMXBean;
+import java.util.HashSet;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractMXBeanRegistrar {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractMXBeanRegistrar.class);
+
+    protected  Set<WebServicesMXBean> beans = new HashSet<WebServicesMXBean>();
+
+    /**
+     * This method should be annotated with @PostConstruct in the concrete class as annotations are not inherited
+     *
+     * This method will register the beans from the PassthruBeanMXRegistry
+     */
+    public void init() {
+        LOG.info("Constuction of {} service beans has begun...", this.getClass());
+        beans = getWebServiceMXBean();
+        for(WebServicesMXBean bean : beans) {
+            LOG.info("Registering {} from {}", bean.getClass().getName(), Thread.currentThread().getStackTrace()[0].getClassName());
+            PassthruMXBeanRegistry.getInstance().registerWebServiceMXBean(bean);
+        }
+
+    }
+
+    /**
+     * This method should be annotated with @PreDestroy in the concrete class as annotations are not inherited
+     *
+     * This method will unregister the beans from the PassthruBeanMXRegistry
+     */
+    public void destroy() {
+        LOG.info("Destruction of {} has begun...", this.getClass());
+        for(WebServicesMXBean bean : beans) {
+            if (PassthruMXBeanRegistry.getInstance().unregisterBean(bean)) {
+                LOG.info("Unregistering {} from destruction of {} bean", bean.getClass().getName(), Thread.currentThread().getStackTrace()[0].getClassName());
+            } else {
+                LOG.error("Could not remove MX Bean {}! Was it not registered in the creation of {}?", bean.getClass().getName(), Thread.currentThread().getStackTrace()[0].getClassName() );
+            }
+
+        }
+
+    }
+
+    public abstract Set<WebServicesMXBean> getWebServiceMXBean();
+}

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/registrar/AbstractMXBeanRegistrar.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/registrar/AbstractMXBeanRegistrar.java
@@ -1,5 +1,28 @@
-/**
+/*
+ * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
  *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package gov.hhs.fha.nhinc.registrar;
 

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/gateway/executorservice/ExecutorServiceHelperTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/gateway/executorservice/ExecutorServiceHelperTest.java
@@ -59,7 +59,6 @@ public class ExecutorServiceHelperTest {
      */
     @Test
     public void testGetInstance() {
-        System.out.println("getInstance");
         ExecutorServiceHelper result = ExecutorServiceHelper.getInstance();
         assertNotNull(result);
     }
@@ -69,7 +68,6 @@ public class ExecutorServiceHelperTest {
      */
     @Test
     public void testGetExecutorPoolSize() {
-        System.out.println("getExecutorPoolSize");
         // default Pool Size
         int expResult = 100;
         int result = instance.getExecutorPoolSize();
@@ -81,7 +79,6 @@ public class ExecutorServiceHelperTest {
      */
     @Test
     public void testGetLargeJobExecutorPoolSize() {
-        System.out.println("getLargeJobExecutorPoolSize");
         // default value
         int expResult = 200;
         int result = instance.getLargeJobExecutorPoolSize();
@@ -93,7 +90,6 @@ public class ExecutorServiceHelperTest {
      */
     @Test
     public void testGetLargeJobPercentage() {
-        System.out.println("getLargeJobPercentage");
         double expResult = .75;
         double result = instance.getLargeJobPercentage();
         assertEquals(expResult, result, 0.0);
@@ -104,7 +100,6 @@ public class ExecutorServiceHelperTest {
      */
     @Test
     public void testGetTimeoutValues() {
-        System.out.println("getTimeoutValues");
         // set the default values
         Map expResult = new HashMap();
         Map result = instance.getTimeoutValues();
@@ -116,7 +111,6 @@ public class ExecutorServiceHelperTest {
      */
     @Test
     public void testCheckExecutorTaskIsLarge() {
-        System.out.println("checkExecutorTaskIsLarge");
         int targetListCount = 100;
         boolean expResult = true;
         boolean result = instance.checkExecutorTaskIsLarge(targetListCount);
@@ -132,7 +126,6 @@ public class ExecutorServiceHelperTest {
      */
     @Test
     public void testOutputCompleteException() {
-        System.out.println("outputCompleteException");
         Exception ex = new Exception("Test Error", new Throwable("Detailed Error Message"));
         ExecutorServiceHelper.outputCompleteException(ex);
     }

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/gateway/executorservice/ExecutorServiceHelperTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/gateway/executorservice/ExecutorServiceHelperTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -34,12 +34,16 @@ import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.Before;
 import org.junit.Test;
 
 public class ExecutorServiceHelperTest {
 
-    public ExecutorServiceHelperTest() {
-        ExecutorServiceHelper.getInstance();
+    private ExecutorServiceHelper instance;
+
+    @Before
+    public void setup() {
+        instance = ExecutorServiceHelper.getInstance();
     }
 
     @Test
@@ -68,7 +72,7 @@ public class ExecutorServiceHelperTest {
         System.out.println("getExecutorPoolSize");
         // default Pool Size
         int expResult = 100;
-        int result = ExecutorServiceHelper.getExecutorPoolSize();
+        int result = instance.getExecutorPoolSize();
         assertEquals(expResult, result);
     }
 
@@ -80,7 +84,7 @@ public class ExecutorServiceHelperTest {
         System.out.println("getLargeJobExecutorPoolSize");
         // default value
         int expResult = 200;
-        int result = ExecutorServiceHelper.getLargeJobExecutorPoolSize();
+        int result = instance.getLargeJobExecutorPoolSize();
         assertEquals(expResult, result);
     }
 
@@ -91,7 +95,7 @@ public class ExecutorServiceHelperTest {
     public void testGetLargeJobPercentage() {
         System.out.println("getLargeJobPercentage");
         double expResult = .75;
-        double result = ExecutorServiceHelper.getLargeJobPercentage();
+        double result = instance.getLargeJobPercentage();
         assertEquals(expResult, result, 0.0);
     }
 
@@ -103,7 +107,7 @@ public class ExecutorServiceHelperTest {
         System.out.println("getTimeoutValues");
         // set the default values
         Map expResult = new HashMap();
-        Map result = ExecutorServiceHelper.getTimeoutValues();
+        Map result = instance.getTimeoutValues();
         assertEquals(expResult, result);
     }
 
@@ -115,11 +119,11 @@ public class ExecutorServiceHelperTest {
         System.out.println("checkExecutorTaskIsLarge");
         int targetListCount = 100;
         boolean expResult = true;
-        boolean result = ExecutorServiceHelper.checkExecutorTaskIsLarge(targetListCount);
+        boolean result = instance.checkExecutorTaskIsLarge(targetListCount);
         assertEquals(expResult, result);
         targetListCount = 60;
         expResult = false;
-        result = ExecutorServiceHelper.checkExecutorTaskIsLarge(targetListCount);
+        result = instance.checkExecutorTaskIsLarge(targetListCount);
         assertEquals(expResult, result);
     }
 

--- a/Product/Production/Gateway/AdminDistribution_10/src/main/java/gov/hhs/fha/nhinc/admindistribution/configuration/jmx/AdminDistribution10WebServices.java
+++ b/Product/Production/Gateway/AdminDistribution_10/src/main/java/gov/hhs/fha/nhinc/admindistribution/configuration/jmx/AdminDistribution10WebServices.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -31,7 +31,6 @@ import gov.hhs.fha.nhinc.admindistribution._10.nhin.NhinAdministrativeDistributi
 import gov.hhs.fha.nhinc.admindistribution.inbound.InboundAdminDistribution;
 import gov.hhs.fha.nhinc.admindistribution.outbound.OutboundAdminDistribution;
 import gov.hhs.fha.nhinc.configuration.IConfiguration.serviceEnum;
-import javax.servlet.ServletContext;
 
 /**
  * The Class AdminDistribution10WebServices.
@@ -51,15 +50,6 @@ public class AdminDistribution10WebServices extends AbstractAdminDistributionWeb
 
     private final serviceEnum serviceName = serviceEnum.AdminDistribution;
 
-    /**
-     * Instantiates a new admin distribution10 web services.
-     *
-     * @param sc the sc
-     */
-    public AdminDistribution10WebServices(ServletContext sc) {
-        super(sc);
-    }
-
     /*
      * (non-Javadoc)
      *
@@ -78,7 +68,7 @@ public class AdminDistribution10WebServices extends AbstractAdminDistributionWeb
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.configuration.jmx.AbstractWebServicesMXBean#getNhinBeanName()
      */
     @Override
@@ -88,7 +78,7 @@ public class AdminDistribution10WebServices extends AbstractAdminDistributionWeb
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.configuration.jmx.AbstractWebServicesMXBean#getEntityUnsecuredBeanName()
      */
     @Override
@@ -98,7 +88,7 @@ public class AdminDistribution10WebServices extends AbstractAdminDistributionWeb
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.configuration.jmx.AbstractWebServicesMXBean#getEntitySecuredBeanName()
      */
     @Override

--- a/Product/Production/Gateway/AdminDistribution_10/src/main/java/gov/hhs/fha/nhinc/admindistribution/gateway/InitServlet.java
+++ b/Product/Production/Gateway/AdminDistribution_10/src/main/java/gov/hhs/fha/nhinc/admindistribution/gateway/InitServlet.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -27,11 +27,13 @@
 package gov.hhs.fha.nhinc.admindistribution.gateway;
 
 import gov.hhs.fha.nhinc.admindistribution.configuration.jmx.AdminDistribution10WebServices;
-import gov.hhs.fha.nhinc.configuration.jmx.AbstractPassthruRegistryEnabledServlet;
 import gov.hhs.fha.nhinc.configuration.jmx.WebServicesMXBean;
+import gov.hhs.fha.nhinc.registrar.AbstractMXBeanRegistrar;
 import java.util.Collections;
 import java.util.Set;
-import javax.servlet.ServletContext;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import org.springframework.stereotype.Component;
 
 /**
  * The Class InitServlet.
@@ -39,21 +41,24 @@ import javax.servlet.ServletContext;
  * @author msw
  *
  */
-public class InitServlet extends AbstractPassthruRegistryEnabledServlet {
+@Component
+public class InitServlet  extends AbstractMXBeanRegistrar {
 
-    /** The Constant serialVersionUID. */
-    private static final long serialVersionUID = -331241203887741599L;
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * gov.hhs.fha.nhinc.configuration.jmx.AbstractPassthruRegistryEnabledServlet#getWebServiceMXBean(javax.servlet.
-     * ServletContext)
-     */
     @Override
-    public Set<WebServicesMXBean> getWebServiceMXBean(ServletContext sc) {
-        WebServicesMXBean bean = new AdminDistribution10WebServices(sc);
+    @PostConstruct
+    public void init() {
+        super.init();
+    }
+
+    @Override
+    @PreDestroy
+    public void destroy() {
+        super.destroy();
+    }
+
+    @Override
+    public Set<WebServicesMXBean> getWebServiceMXBean() {
+        WebServicesMXBean bean = new AdminDistribution10WebServices();
         return Collections.singleton(bean);
     }
 }

--- a/Product/Production/Gateway/AdminDistribution_10/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/AdminDistribution_10/src/main/webapp/WEB-INF/web.xml
@@ -10,12 +10,14 @@
         <servlet-class>org.apache.cxf.transport.servlet.CXFServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
     </servlet>
-
+<!-- 
     <servlet>
         <servlet-name>PassthruMXBean</servlet-name>
         <servlet-class>gov.hhs.fha.nhinc.admindistribution.gateway.InitServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
     </servlet>
+ -->
+
 
     <context-param>
         <param-name>contextConfigLocation</param-name>

--- a/Product/Production/Gateway/AdminDistribution_10/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/AdminDistribution_10/src/main/webapp/WEB-INF/web.xml
@@ -10,14 +10,6 @@
         <servlet-class>org.apache.cxf.transport.servlet.CXFServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
     </servlet>
-<!-- 
-    <servlet>
-        <servlet-name>PassthruMXBean</servlet-name>
-        <servlet-class>gov.hhs.fha.nhinc.admindistribution.gateway.InitServlet</servlet-class>
-        <load-on-startup>1</load-on-startup>
-    </servlet>
- -->
-
 
     <context-param>
         <param-name>contextConfigLocation</param-name>

--- a/Product/Production/Gateway/AdminDistribution_20/src/main/java/gov/hhs/fha/nhinc/admindistribution/configuration/jmx/AdminDistribution20WebServices.java
+++ b/Product/Production/Gateway/AdminDistribution_20/src/main/java/gov/hhs/fha/nhinc/admindistribution/configuration/jmx/AdminDistribution20WebServices.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -32,7 +32,6 @@ import gov.hhs.fha.nhinc.admindistribution._20.nhin.NhinAdministrativeDistributi
 import gov.hhs.fha.nhinc.admindistribution.inbound.InboundAdminDistribution;
 import gov.hhs.fha.nhinc.admindistribution.outbound.OutboundAdminDistribution;
 import gov.hhs.fha.nhinc.configuration.IConfiguration.serviceEnum;
-import javax.servlet.ServletContext;
 
 /**
  * The Class AdminDistribution20WebServices.
@@ -52,18 +51,9 @@ public class AdminDistribution20WebServices extends AbstractAdminDistributionWeb
 
     private final serviceEnum serviceName = serviceEnum.AdminDistribution;
 
-    /**
-     * Instantiates a new admin distribution20 web services.
-     *
-     * @param sc the sc
-     */
-    public AdminDistribution20WebServices(ServletContext sc) {
-        super(sc);
-    }
-
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.configuration.jmx.WebServicesMXBean#isInboundPassthru()
      */
     @Override
@@ -80,7 +70,7 @@ public class AdminDistribution20WebServices extends AbstractAdminDistributionWeb
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.configuration.jmx.WebServicesMXBean#isOutboundPassthru()
      */
     @Override
@@ -97,7 +87,7 @@ public class AdminDistribution20WebServices extends AbstractAdminDistributionWeb
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.configuration.jmx.AbstractWebServicesMXBean#getNhinBeanName()
      */
     @Override
@@ -107,7 +97,7 @@ public class AdminDistribution20WebServices extends AbstractAdminDistributionWeb
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.configuration.jmx.AbstractWebServicesMXBean#getEntityUnsecuredBeanName()
      */
     @Override
@@ -117,7 +107,7 @@ public class AdminDistribution20WebServices extends AbstractAdminDistributionWeb
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.configuration.jmx.AbstractWebServicesMXBean#getEntitySecuredBeanName()
      */
     @Override
@@ -127,7 +117,7 @@ public class AdminDistribution20WebServices extends AbstractAdminDistributionWeb
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.configuration.jmx.AbstractWebServicesMXBean#configureInboundImpl(java.lang.String)
      */
     @Override
@@ -143,7 +133,7 @@ public class AdminDistribution20WebServices extends AbstractAdminDistributionWeb
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.configuration.jmx.AbstractWebServicesMXBean#configureOutboundImpl(java.lang.String)
      */
     @Override
@@ -173,7 +163,7 @@ public class AdminDistribution20WebServices extends AbstractAdminDistributionWeb
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.configuration.jmx.AbstractWebServicesMXBean#configureOutboundImpl(java.lang.String)
      */
     @Override
@@ -198,7 +188,7 @@ public class AdminDistribution20WebServices extends AbstractAdminDistributionWeb
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.configuration.jmx.WebServicesMXBean#isOutboundStandard()
      */
     @Override
@@ -215,7 +205,7 @@ public class AdminDistribution20WebServices extends AbstractAdminDistributionWeb
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see gov.hhs.fha.nhinc.configuration.jmx.WebServicesMXBean#isInboundStandard()
      */
     @Override

--- a/Product/Production/Gateway/AdminDistribution_20/src/main/java/gov/hhs/fha/nhinc/admindistribution/gateway/InitServlet.java
+++ b/Product/Production/Gateway/AdminDistribution_20/src/main/java/gov/hhs/fha/nhinc/admindistribution/gateway/InitServlet.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -27,11 +27,13 @@
 package gov.hhs.fha.nhinc.admindistribution.gateway;
 
 import gov.hhs.fha.nhinc.admindistribution.configuration.jmx.AdminDistribution20WebServices;
-import gov.hhs.fha.nhinc.configuration.jmx.AbstractPassthruRegistryEnabledServlet;
 import gov.hhs.fha.nhinc.configuration.jmx.WebServicesMXBean;
+import gov.hhs.fha.nhinc.registrar.AbstractMXBeanRegistrar;
 import java.util.Collections;
 import java.util.Set;
-import javax.servlet.ServletContext;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import org.springframework.stereotype.Component;
 
 /**
  * The Class InitServlet.
@@ -39,23 +41,25 @@ import javax.servlet.ServletContext;
  * @author msw
  *
  */
-public class InitServlet extends AbstractPassthruRegistryEnabledServlet {
+@Component
+public class InitServlet extends AbstractMXBeanRegistrar {
 
-    /**
-     * The Constant serialVersionUID.
-     */
-    private static final long serialVersionUID = -331241203887741599L;
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * gov.hhs.fha.nhinc.configuration.jmx.AbstractPassthruRegistryEnabledServlet#getWebServiceMXBean(javax.servlet.
-     * ServletContext)
-     */
     @Override
-    public Set<WebServicesMXBean> getWebServiceMXBean(ServletContext sc) {
-        WebServicesMXBean bean = new AdminDistribution20WebServices(sc);
+    @PostConstruct
+    public void init() {
+        super.init();
+    }
+
+    @Override
+    @PreDestroy
+    public void destroy() {
+        super.destroy();
+    }
+
+    @Override
+    public Set<WebServicesMXBean> getWebServiceMXBean() {
+        WebServicesMXBean bean = new AdminDistribution20WebServices();
         return Collections.singleton(bean);
     }
+
 }

--- a/Product/Production/Gateway/AdminDistribution_20/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/AdminDistribution_20/src/main/webapp/WEB-INF/web.xml
@@ -11,11 +11,15 @@
         <load-on-startup>1</load-on-startup>
     </servlet>
 
+<!--    
     <servlet>
         <servlet-name>PassthruMXBean</servlet-name>
         <servlet-class>gov.hhs.fha.nhinc.admindistribution.gateway.InitServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
     </servlet>
+     
+ -->
+
 
     <context-param>
         <param-name>contextConfigLocation</param-name>

--- a/Product/Production/Gateway/AdminDistribution_20/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/AdminDistribution_20/src/main/webapp/WEB-INF/web.xml
@@ -11,16 +11,6 @@
         <load-on-startup>1</load-on-startup>
     </servlet>
 
-<!--    
-    <servlet>
-        <servlet-name>PassthruMXBean</servlet-name>
-        <servlet-class>gov.hhs.fha.nhinc.admindistribution.gateway.InitServlet</servlet-class>
-        <load-on-startup>1</load-on-startup>
-    </servlet>
-     
- -->
-
-
     <context-param>
         <param-name>contextConfigLocation</param-name>
         <param-value>

--- a/Product/Production/Gateway/CONNECTGatewayWeb/src/main/java/gov/hhs/fha/nhinc/gateway/servlet/InitServlet.java
+++ b/Product/Production/Gateway/CONNECTGatewayWeb/src/main/java/gov/hhs/fha/nhinc/gateway/servlet/InitServlet.java
@@ -30,24 +30,29 @@ import gov.hhs.fha.nhinc.configuration.jmx.Configuration;
 import gov.hhs.fha.nhinc.event.EventLoggerFactory;
 import gov.hhs.fha.nhinc.gateway.AbstractJMXEnabledServlet;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import org.springframework.stereotype.Component;
 
 /**
  * @author paul.eftis
  */
+@Component
 public class InitServlet extends AbstractJMXEnabledServlet {
 
-    private static final long serialVersionUID = -8830568626032954198L;
+    @Override
+    @PostConstruct
+    public void init() {
+        EventLoggerFactory.getInstance().registerLoggers();
+        super.init();
+    }
 
     @Override
-    public void init(ServletConfig config) throws ServletException {
-        super.init(config);
-
-        // register event loggers as observers...
-        EventLoggerFactory.getInstance().registerLoggers();
+    @PreDestroy
+    public void destroy() {
+        super.destroy();
     }
+
 
     @Override
     public String getMBeanName() {
@@ -55,7 +60,7 @@ public class InitServlet extends AbstractJMXEnabledServlet {
     }
 
     @Override
-    public Object getMBeanInstance(ServletContext sc) {
+    public Object getMBeanInstance() {
         return new Configuration();
     }
 

--- a/Product/Production/Gateway/CONNECTGatewayWeb/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/CONNECTGatewayWeb/src/main/webapp/WEB-INF/web.xml
@@ -11,11 +11,14 @@
         <load-on-startup>1</load-on-startup>
     </servlet>
 
+<!-- 
     <servlet>
         <servlet-name>init</servlet-name>
         <servlet-class>gov.hhs.fha.nhinc.gateway.servlet.InitServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
     </servlet>
+ -->
+
 
     <context-param>
         <param-name>contextConfigLocation</param-name>

--- a/Product/Production/Gateway/CONNECTGatewayWeb/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/CONNECTGatewayWeb/src/main/webapp/WEB-INF/web.xml
@@ -11,15 +11,6 @@
         <load-on-startup>1</load-on-startup>
     </servlet>
 
-<!-- 
-    <servlet>
-        <servlet-name>init</servlet-name>
-        <servlet-class>gov.hhs.fha.nhinc.gateway.servlet.InitServlet</servlet-class>
-        <load-on-startup>1</load-on-startup>
-    </servlet>
- -->
-
-
     <context-param>
         <param-name>contextConfigLocation</param-name>
         <param-value>

--- a/Product/Production/Gateway/Direct/src/main/java/gov/hhs/fha/nhinc/direct/servlet/InitServlet.java
+++ b/Product/Production/Gateway/Direct/src/main/java/gov/hhs/fha/nhinc/direct/servlet/InitServlet.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -27,36 +27,27 @@
 package gov.hhs.fha.nhinc.direct.servlet;
 
 import gov.hhs.fha.nhinc.direct.DirectAdapterFactory;
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
-/**
- * Web Application initialization for Direct.
- */
-public class InitServlet extends HttpServlet {
+@Component
+public class InitServlet {
 
-    private static final long serialVersionUID = -2548417535183464693L;
     private static final Logger LOG = LoggerFactory.getLogger(InitServlet.class);
 
-    /**
-     * {@inheritDoc}
-     * @param config
-     * @throws javax.servlet.ServletException
-     */
-    @Override
-    public void init(ServletConfig config) throws ServletException {
-        super.init(config);
-        LOG.debug("Direct InitServlet start...");
+    @PostConstruct
+    public void init() {
+        LOG.info("InitServlet starting...");
         new DirectAdapterFactory().registerHandlers();
     }
 
-    @Override
+    @PreDestroy
     public void destroy() {
-        super.destroy();
-        //destroy all the resources opened explicitly
+        LOG.info("InitServlet stopping...");
         new DirectAdapterFactory().stopAll();
     }
+
 }

--- a/Product/Production/Gateway/Direct/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/Direct/src/main/webapp/WEB-INF/web.xml
@@ -35,15 +35,6 @@
         <param-value>514</param-value>
     </context-param-->
 
-<!-- 
-    <servlet>
-        <servlet-name>init</servlet-name>
-        <servlet-class>gov.hhs.fha.nhinc.direct.servlet.InitServlet</servlet-class>
-        <load-on-startup>1</load-on-startup>
-    </servlet>
- -->
-
-
     <servlet>
         <servlet-name>WebServicePort</servlet-name>
         <!-- For Metro, use this servlet-class instead:

--- a/Product/Production/Gateway/Direct/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/Direct/src/main/webapp/WEB-INF/web.xml
@@ -35,11 +35,14 @@
         <param-value>514</param-value>
     </context-param-->
 
+<!-- 
     <servlet>
         <servlet-name>init</servlet-name>
         <servlet-class>gov.hhs.fha.nhinc.direct.servlet.InitServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
     </servlet>
+ -->
+
 
     <servlet>
         <servlet-name>WebServicePort</servlet-name>

--- a/Product/Production/Gateway/DocumentQuery_20/src/main/java/gov/hhs/fha/nhinc/docquery/_20/servlet/InitServlet.java
+++ b/Product/Production/Gateway/DocumentQuery_20/src/main/java/gov/hhs/fha/nhinc/docquery/_20/servlet/InitServlet.java
@@ -26,25 +26,36 @@
  */
 package gov.hhs.fha.nhinc.docquery._20.servlet;
 
-import gov.hhs.fha.nhinc.configuration.jmx.AbstractPassthruRegistryEnabledServlet;
 import gov.hhs.fha.nhinc.configuration.jmx.WebServicesMXBean;
 import gov.hhs.fha.nhinc.docquery.configuration.jmx.DocumentQuery20WebServices;
+import gov.hhs.fha.nhinc.registrar.AbstractMXBeanRegistrar;
 import java.util.Collections;
 import java.util.Set;
-import javax.servlet.ServletContext;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import org.springframework.stereotype.Component;
 
 /**
  * @author paul.eftis, msw
  */
-public class InitServlet extends AbstractPassthruRegistryEnabledServlet {
-
-    /** The Constant serialVersionUID. */
-    private static final long serialVersionUID = -4229185731377926278L;
+@Component
+public class InitServlet  extends AbstractMXBeanRegistrar {
 
     @Override
-    public Set<WebServicesMXBean> getWebServiceMXBean(ServletContext sc) {
-        WebServicesMXBean bean = new DocumentQuery20WebServices(sc);
-        return Collections.singleton(bean);
+    @PostConstruct
+    public void init() {
+        super.init();
     }
 
+    @Override
+    @PreDestroy
+    public void destroy() {
+        super.destroy();
+    }
+
+    @Override
+    public Set<WebServicesMXBean> getWebServiceMXBean() {
+        WebServicesMXBean bean = new DocumentQuery20WebServices();
+        return Collections.singleton(bean);
+    }
 }

--- a/Product/Production/Gateway/DocumentQuery_20/src/main/java/gov/hhs/fha/nhinc/docquery/configuration/jmx/DocumentQuery20WebServices.java
+++ b/Product/Production/Gateway/DocumentQuery_20/src/main/java/gov/hhs/fha/nhinc/docquery/configuration/jmx/DocumentQuery20WebServices.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -32,7 +32,6 @@ import gov.hhs.fha.nhinc.docquery._20.entity.EntityDocQueryUnsecured;
 import gov.hhs.fha.nhinc.docquery._20.nhin.DocQuery;
 import gov.hhs.fha.nhinc.docquery.inbound.InboundDocQuery;
 import gov.hhs.fha.nhinc.docquery.outbound.OutboundDocQuery;
-import javax.servlet.ServletContext;
 
 /**
  * The Class DocumentQuery30WebServices.
@@ -43,15 +42,6 @@ public class DocumentQuery20WebServices extends AbstractDQWebServicesMXBean {
 
 	private final serviceEnum serviceName = serviceEnum.QueryForDocuments;
 
-	/**
-	 * Instantiates a new document query30 web services.
-	 *
-	 * @param sc
-	 *            the sc
-	 */
-	public DocumentQuery20WebServices(ServletContext sc) {
-		super(sc);
-	}
 
 	/**
 	 * Configure Standard inbound implementation. The inbound orchestration
@@ -226,7 +216,7 @@ public class DocumentQuery20WebServices extends AbstractDQWebServicesMXBean {
 
 	@Override
 	public serviceEnum getServiceName() {
-		return this.serviceName;
+		return serviceName;
 	}
 
 	/*

--- a/Product/Production/Gateway/DocumentQuery_20/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/DocumentQuery_20/src/main/webapp/WEB-INF/web.xml
@@ -5,11 +5,14 @@
     xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
     version="2.5">
 
+<!--
     <servlet>
         <servlet-name>InitServlet</servlet-name>
         <servlet-class>gov.hhs.fha.nhinc.docquery._20.servlet.InitServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
-    </servlet>
+    </servlet> 
+ -->
+
 
     <servlet>
         <servlet-name>cxf</servlet-name>

--- a/Product/Production/Gateway/DocumentQuery_20/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/DocumentQuery_20/src/main/webapp/WEB-INF/web.xml
@@ -5,15 +5,6 @@
     xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
     version="2.5">
 
-<!--
-    <servlet>
-        <servlet-name>InitServlet</servlet-name>
-        <servlet-class>gov.hhs.fha.nhinc.docquery._20.servlet.InitServlet</servlet-class>
-        <load-on-startup>1</load-on-startup>
-    </servlet> 
- -->
-
-
     <servlet>
         <servlet-name>cxf</servlet-name>
         <servlet-class>org.apache.cxf.transport.servlet.CXFServlet</servlet-class>

--- a/Product/Production/Gateway/DocumentQuery_30/src/main/java/gov/hhs/fha/nhinc/docquery/_30/servlet/InitServlet.java
+++ b/Product/Production/Gateway/DocumentQuery_30/src/main/java/gov/hhs/fha/nhinc/docquery/_30/servlet/InitServlet.java
@@ -26,25 +26,36 @@
  */
 package gov.hhs.fha.nhinc.docquery._30.servlet;
 
-import gov.hhs.fha.nhinc.configuration.jmx.AbstractPassthruRegistryEnabledServlet;
 import gov.hhs.fha.nhinc.configuration.jmx.WebServicesMXBean;
 import gov.hhs.fha.nhinc.docquery.configuration.jmx.DocumentQuery30WebServices;
+import gov.hhs.fha.nhinc.registrar.AbstractMXBeanRegistrar;
 import java.util.Collections;
 import java.util.Set;
-import javax.servlet.ServletContext;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import org.springframework.stereotype.Component;
 
 /**
  * @author paul.eftis, msw
  */
-public class InitServlet extends AbstractPassthruRegistryEnabledServlet {
-
-    /** The Constant serialVersionUID. */
-    private static final long serialVersionUID = -4229185731377926278L;
+@Component
+public class InitServlet  extends AbstractMXBeanRegistrar {
 
     @Override
-    public Set<WebServicesMXBean> getWebServiceMXBean(ServletContext sc) {
-        WebServicesMXBean bean = new DocumentQuery30WebServices(sc);
-        return Collections.singleton(bean);
+    @PostConstruct
+    public void init() {
+        super.init();
     }
 
+    @Override
+    @PreDestroy
+    public void destroy() {
+        super.destroy();
+    }
+
+    @Override
+    public Set<WebServicesMXBean> getWebServiceMXBean() {
+        WebServicesMXBean bean = new DocumentQuery30WebServices();
+        return Collections.singleton(bean);
+    }
 }

--- a/Product/Production/Gateway/DocumentQuery_30/src/main/java/gov/hhs/fha/nhinc/docquery/configuration/jmx/DocumentQuery30WebServices.java
+++ b/Product/Production/Gateway/DocumentQuery_30/src/main/java/gov/hhs/fha/nhinc/docquery/configuration/jmx/DocumentQuery30WebServices.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -32,7 +32,6 @@ import gov.hhs.fha.nhinc.docquery._30.entity.EntityDocQueryUnsecured;
 import gov.hhs.fha.nhinc.docquery._30.nhin.DocQuery;
 import gov.hhs.fha.nhinc.docquery.inbound.InboundDocQuery;
 import gov.hhs.fha.nhinc.docquery.outbound.OutboundDocQuery;
-import javax.servlet.ServletContext;
 
 /**
  * The Class DocumentQuery30WebServices.
@@ -42,14 +41,6 @@ import javax.servlet.ServletContext;
 public class DocumentQuery30WebServices extends AbstractDQWebServicesMXBean {
 
     private final serviceEnum serviceName = serviceEnum.QueryForDocuments;
-    /**
-     * Instantiates a new document query30 web services.
-     *
-     * @param sc the sc
-     */
-    public DocumentQuery30WebServices(ServletContext sc) {
-        super(sc);
-    }
 
     /**
      * Configure Standard inbound implementation. The inbound orchestration implementation provided via the className param is
@@ -188,7 +179,7 @@ public class DocumentQuery30WebServices extends AbstractDQWebServicesMXBean {
 
     @Override
     public serviceEnum getServiceName() {
-        return this.serviceName;
+        return serviceName;
     }
 
     /*

--- a/Product/Production/Gateway/DocumentQuery_30/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/DocumentQuery_30/src/main/webapp/WEB-INF/web.xml
@@ -5,11 +5,14 @@
     xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
     version="2.5">
 
+<!-- 
     <servlet>
         <servlet-name>InitServlet</servlet-name>
         <servlet-class>gov.hhs.fha.nhinc.docquery._30.servlet.InitServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
     </servlet>
+ -->
+
 
     <servlet>
         <servlet-name>cxf</servlet-name>

--- a/Product/Production/Gateway/DocumentQuery_30/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/DocumentQuery_30/src/main/webapp/WEB-INF/web.xml
@@ -5,15 +5,6 @@
     xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
     version="2.5">
 
-<!-- 
-    <servlet>
-        <servlet-name>InitServlet</servlet-name>
-        <servlet-class>gov.hhs.fha.nhinc.docquery._30.servlet.InitServlet</servlet-class>
-        <load-on-startup>1</load-on-startup>
-    </servlet>
- -->
-
-
     <servlet>
         <servlet-name>cxf</servlet-name>
         <servlet-class>org.apache.cxf.transport.servlet.CXFServlet</servlet-class>

--- a/Product/Production/Gateway/DocumentRetrieve_20/src/main/java/gov/hhs/fha/nhinc/docretrieve/_20/gateway/InitServlet.java
+++ b/Product/Production/Gateway/DocumentRetrieve_20/src/main/java/gov/hhs/fha/nhinc/docretrieve/_20/gateway/InitServlet.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,12 +26,14 @@
  */
 package gov.hhs.fha.nhinc.docretrieve._20.gateway;
 
-import gov.hhs.fha.nhinc.configuration.jmx.AbstractPassthruRegistryEnabledServlet;
 import gov.hhs.fha.nhinc.configuration.jmx.WebServicesMXBean;
 import gov.hhs.fha.nhinc.docretrieve.configuration.jmx.DocumentRetrieve20WebServices;
+import gov.hhs.fha.nhinc.registrar.AbstractMXBeanRegistrar;
 import java.util.Collections;
 import java.util.Set;
-import javax.servlet.ServletContext;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import org.springframework.stereotype.Component;
 
 /**
  * The Class InitServlet.
@@ -39,17 +41,24 @@ import javax.servlet.ServletContext;
  * @author msw
  *
  */
-public class InitServlet extends AbstractPassthruRegistryEnabledServlet {
+@Component
+public class InitServlet  extends AbstractMXBeanRegistrar {
 
-    /** The Constant serialVersionUID. */
-    private static final long serialVersionUID = -331241203887741599L;
-
-    /* (non-Javadoc)
-     * @see gov.hhs.fha.nhinc.configuration.jmx.AbstractPassthruRegistryEnabledServlet#getWebServiceMXBean(javax.servlet.ServletContext)
-     */
     @Override
-    public Set<WebServicesMXBean> getWebServiceMXBean(ServletContext sc) {
-        WebServicesMXBean bean = new DocumentRetrieve20WebServices(sc);
+    @PostConstruct
+    public void init() {
+        super.init();
+    }
+
+    @Override
+    @PreDestroy
+    public void destroy() {
+        super.destroy();
+    }
+
+    @Override
+    public Set<WebServicesMXBean> getWebServiceMXBean() {
+        WebServicesMXBean bean = new DocumentRetrieve20WebServices();
         return Collections.singleton(bean);
     }
 }

--- a/Product/Production/Gateway/DocumentRetrieve_20/src/main/java/gov/hhs/fha/nhinc/docretrieve/configuration/jmx/DocumentRetrieve20WebServices.java
+++ b/Product/Production/Gateway/DocumentRetrieve_20/src/main/java/gov/hhs/fha/nhinc/docretrieve/configuration/jmx/DocumentRetrieve20WebServices.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -31,7 +31,6 @@ import gov.hhs.fha.nhinc.docretrieve._20.entity.EntityDocRetrieve;
 import gov.hhs.fha.nhinc.docretrieve._20.inbound.DocRetrieve;
 import gov.hhs.fha.nhinc.docretrieve.inbound.InboundDocRetrieve;
 import gov.hhs.fha.nhinc.docretrieve.outbound.OutboundDocRetrieve;
-import javax.servlet.ServletContext;
 
 /**
  * The Class DocumentRetrieve30WebServices.
@@ -40,19 +39,10 @@ import javax.servlet.ServletContext;
  */
 public class DocumentRetrieve20WebServices extends AbstractDRWebServicesMXBean {
 
-    /** The Constant DEFAULT_OUTBOUND_STANDARD_IMPL_CLASS_NAME. */
-    public static final String DEFAULT_OUTBOUND_PASSTHRU_IMPL_CLASS_NAME = "gov.hhs.fha.nhinc.docretrieve._20.outbound.PassthroughOutboundDocRetrieve";
+    public static final String DEFAULT_OUTBOUND_20_PASSTHRU_IMPL_CLASS_NAME = "gov.hhs.fha.nhinc.docretrieve._20.outbound.PassthroughOutboundDocRetrieve";
 
     private final serviceEnum serviceName = serviceEnum.RetrieveDocuments;
 
-    /**
-     * Instantiates a new document retrieve30 web services.
-     *
-     * @param sc the sc
-     */
-    public DocumentRetrieve20WebServices(ServletContext sc) {
-        super(sc);
-    }
 
 
     /*
@@ -75,7 +65,7 @@ public class DocumentRetrieve20WebServices extends AbstractDRWebServicesMXBean {
         boolean isPassthru = false;
         EntityDocRetrieve docRetrieve = retrieveBean(EntityDocRetrieve.class, getEntityUnsecuredBeanName());
         OutboundDocRetrieve outboundDocRetrieve = docRetrieve.getOutboundDocRetrieve();
-        if (compareClassName(outboundDocRetrieve, DEFAULT_OUTBOUND_PASSTHRU_IMPL_CLASS_NAME)) {
+        if (compareClassName(outboundDocRetrieve, DEFAULT_OUTBOUND_20_PASSTHRU_IMPL_CLASS_NAME)) {
             isPassthru = true;
         }
         return isPassthru;
@@ -162,7 +152,7 @@ public class DocumentRetrieve20WebServices extends AbstractDRWebServicesMXBean {
 
     @Override
     public serviceEnum getServiceName() {
-        return this.serviceName;
+        return serviceName;
     }
 
     /*
@@ -191,7 +181,7 @@ public class DocumentRetrieve20WebServices extends AbstractDRWebServicesMXBean {
         boolean isStandard = false;
         EntityDocRetrieve entityDocRetrieve = retrieveBean(EntityDocRetrieve.class, getEntityUnsecuredBeanName());
         OutboundDocRetrieve outboundDocRetrieve = entityDocRetrieve.getOutboundDocRetrieve();
-        if (compareClassName(outboundDocRetrieve, DEFAULT_OUTBOUND_STANDARD_IMPL_CLASS_NAME)) {
+        if (compareClassName(outboundDocRetrieve, DEFAULT_OUTBOUND_20_PASSTHRU_IMPL_CLASS_NAME)) {
             isStandard = true;
         }
         return isStandard;

--- a/Product/Production/Gateway/DocumentRetrieve_20/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/DocumentRetrieve_20/src/main/webapp/WEB-INF/web.xml
@@ -26,16 +26,6 @@
         <load-on-startup>1</load-on-startup>
     </servlet>
 
-<!-- 
-    <servlet>
-        <servlet-name>PassthruMXBean</servlet-name>
-        <servlet-class>gov.hhs.fha.nhinc.docretrieve._20.gateway.InitServlet</servlet-class>
-        <load-on-startup>1</load-on-startup>
-    </servlet>
- -->
-
-
-
     <servlet-mapping>
         <servlet-name>cxf</servlet-name>
         <url-pattern>/*</url-pattern>

--- a/Product/Production/Gateway/DocumentRetrieve_20/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/DocumentRetrieve_20/src/main/webapp/WEB-INF/web.xml
@@ -26,11 +26,14 @@
         <load-on-startup>1</load-on-startup>
     </servlet>
 
+<!-- 
     <servlet>
         <servlet-name>PassthruMXBean</servlet-name>
         <servlet-class>gov.hhs.fha.nhinc.docretrieve._20.gateway.InitServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
     </servlet>
+ -->
+
 
 
     <servlet-mapping>

--- a/Product/Production/Gateway/DocumentRetrieve_30/src/main/java/gov/hhs/fha/nhinc/docretrieve/_30/gateway/InitServlet.java
+++ b/Product/Production/Gateway/DocumentRetrieve_30/src/main/java/gov/hhs/fha/nhinc/docretrieve/_30/gateway/InitServlet.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,12 +26,14 @@
  */
 package gov.hhs.fha.nhinc.docretrieve._30.gateway;
 
-import gov.hhs.fha.nhinc.configuration.jmx.AbstractPassthruRegistryEnabledServlet;
 import gov.hhs.fha.nhinc.configuration.jmx.WebServicesMXBean;
 import gov.hhs.fha.nhinc.docretrieve.configuration.jmx.DocumentRetrieve30WebServices;
+import gov.hhs.fha.nhinc.registrar.AbstractMXBeanRegistrar;
 import java.util.Collections;
 import java.util.Set;
-import javax.servlet.ServletContext;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import org.springframework.stereotype.Component;
 
 /**
  * The Class InitServlet.
@@ -39,17 +41,25 @@ import javax.servlet.ServletContext;
  * @author msw
  *
  */
-public class InitServlet extends AbstractPassthruRegistryEnabledServlet {
+@Component
+public class InitServlet extends AbstractMXBeanRegistrar {
 
-    /** The Constant serialVersionUID. */
-    private static final long serialVersionUID = -331241203887741599L;
-
-    /* (non-Javadoc)
-     * @see gov.hhs.fha.nhinc.configuration.jmx.AbstractPassthruRegistryEnabledServlet#getWebServiceMXBean(javax.servlet.ServletContext)
-     */
     @Override
-    public Set<WebServicesMXBean> getWebServiceMXBean(ServletContext sc) {
-        WebServicesMXBean bean = new DocumentRetrieve30WebServices(sc);
+    @PostConstruct
+    public void init() {
+        super.init();
+    }
+
+    @Override
+    @PreDestroy
+    public void destroy() {
+        super.destroy();
+    }
+
+    @Override
+    public Set<WebServicesMXBean> getWebServiceMXBean() {
+        WebServicesMXBean bean = new DocumentRetrieve30WebServices();
         return Collections.singleton(bean);
     }
+
 }

--- a/Product/Production/Gateway/DocumentRetrieve_30/src/main/java/gov/hhs/fha/nhinc/docretrieve/configuration/jmx/DocumentRetrieve30WebServices.java
+++ b/Product/Production/Gateway/DocumentRetrieve_30/src/main/java/gov/hhs/fha/nhinc/docretrieve/configuration/jmx/DocumentRetrieve30WebServices.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -31,7 +31,6 @@ import gov.hhs.fha.nhinc.docretrieve._30.entity.EntityDocRetrieve;
 import gov.hhs.fha.nhinc.docretrieve.inbound.DocRetrieve;
 import gov.hhs.fha.nhinc.docretrieve.inbound.InboundDocRetrieve;
 import gov.hhs.fha.nhinc.docretrieve.outbound.OutboundDocRetrieve;
-import javax.servlet.ServletContext;
 
 /**
  * The Class DocumentRetrieve30WebServices.
@@ -44,14 +43,6 @@ public class DocumentRetrieve30WebServices extends AbstractDRWebServicesMXBean {
     public static final String DEFAULT_OUTBOUND_PASSTHRU_IMPL_CLASS_NAME = "gov.hhs.fha.nhinc.docretrieve.outbound.PassthroughOutboundDocRetrieve";
 
     private serviceEnum serviceName = serviceEnum.RetrieveDocuments;
-    /**
-     * Instantiates a new document retrieve30 web services.
-     *
-     * @param sc the sc
-     */
-    public DocumentRetrieve30WebServices(ServletContext sc) {
-        super(sc);
-    }
 
     /* (non-Javadoc)
      * @see gov.hhs.fha.nhinc.configuration.jmx.WebServicesMXBean#isInboundPassthru()

--- a/Product/Production/Gateway/DocumentRetrieve_30/src/main/java/gov/hhs/fha/nhinc/docretrieve/inbound/DocRetrieve.java
+++ b/Product/Production/Gateway/DocumentRetrieve_30/src/main/java/gov/hhs/fha/nhinc/docretrieve/inbound/DocRetrieve.java
@@ -39,7 +39,6 @@ import javax.annotation.Resource;
 import javax.xml.ws.BindingType;
 import javax.xml.ws.WebServiceContext;
 import javax.xml.ws.soap.Addressing;
-import org.springframework.stereotype.Service;
 
 /**
  *
@@ -47,7 +46,6 @@ import org.springframework.stereotype.Service;
  */
 @BindingType(value = "http://www.w3.org/2003/05/soap/bindings/HTTP/")
 @Addressing(enabled = true)
-@Service
 public class DocRetrieve extends BaseService implements RespondingGatewayRetrievePortType {
 
     private WebServiceContext context;

--- a/Product/Production/Gateway/DocumentRetrieve_30/src/main/java/gov/hhs/fha/nhinc/docretrieve/inbound/DocRetrieve.java
+++ b/Product/Production/Gateway/DocumentRetrieve_30/src/main/java/gov/hhs/fha/nhinc/docretrieve/inbound/DocRetrieve.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -39,6 +39,7 @@ import javax.annotation.Resource;
 import javax.xml.ws.BindingType;
 import javax.xml.ws.WebServiceContext;
 import javax.xml.ws.soap.Addressing;
+import org.springframework.stereotype.Service;
 
 /**
  *
@@ -46,6 +47,7 @@ import javax.xml.ws.soap.Addressing;
  */
 @BindingType(value = "http://www.w3.org/2003/05/soap/bindings/HTTP/")
 @Addressing(enabled = true)
+@Service
 public class DocRetrieve extends BaseService implements RespondingGatewayRetrievePortType {
 
     private WebServiceContext context;
@@ -90,6 +92,6 @@ public class DocRetrieve extends BaseService implements RespondingGatewayRetriev
      * @return the inbound doc retrieve
      */
     public InboundDocRetrieve getInboundDocRetrieve() {
-        return this.service;
+        return service;
     }
 }

--- a/Product/Production/Gateway/DocumentRetrieve_30/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/DocumentRetrieve_30/src/main/webapp/WEB-INF/web.xml
@@ -10,14 +10,6 @@
         <servlet-class>org.apache.cxf.transport.servlet.CXFServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
     </servlet>
-<!-- 
-    <servlet>
-        <servlet-name>PassthruMXBean</servlet-name>
-        <servlet-class>gov.hhs.fha.nhinc.docretrieve._30.gateway.InitServlet</servlet-class>
-        <load-on-startup>1</load-on-startup>
-    </servlet>
- -->
-
 
     <servlet-mapping>
         <servlet-name>cxf</servlet-name>

--- a/Product/Production/Gateway/DocumentRetrieve_30/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/DocumentRetrieve_30/src/main/webapp/WEB-INF/web.xml
@@ -10,12 +10,14 @@
         <servlet-class>org.apache.cxf.transport.servlet.CXFServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
     </servlet>
-
+<!-- 
     <servlet>
         <servlet-name>PassthruMXBean</servlet-name>
         <servlet-class>gov.hhs.fha.nhinc.docretrieve._30.gateway.InitServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
     </servlet>
+ -->
+
 
     <servlet-mapping>
         <servlet-name>cxf</servlet-name>

--- a/Product/Production/Gateway/DocumentSubmission_11/src/main/java/gov/hhs/fha/nhinc/docsubmission/_11/gateway/InitServlet.java
+++ b/Product/Production/Gateway/DocumentSubmission_11/src/main/java/gov/hhs/fha/nhinc/docsubmission/_11/gateway/InitServlet.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,16 @@
  */
 package gov.hhs.fha.nhinc.docsubmission._11.gateway;
 
-import gov.hhs.fha.nhinc.configuration.jmx.AbstractPassthruRegistryEnabledServlet;
 import gov.hhs.fha.nhinc.configuration.jmx.WebServicesMXBean;
 import gov.hhs.fha.nhinc.docsubmission.configuration.jmx.DocumentSubmission11WebServices;
 import gov.hhs.fha.nhinc.docsubmission.configuration.jmx.DocumentSubmissionDefRequest11WebServices;
 import gov.hhs.fha.nhinc.docsubmission.configuration.jmx.DocumentSubmissionDefResponse11WebServices;
+import gov.hhs.fha.nhinc.registrar.AbstractMXBeanRegistrar;
 import java.util.HashSet;
 import java.util.Set;
-import javax.servlet.ServletContext;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import org.springframework.stereotype.Component;
 
 /**
  * The Class InitServlet.
@@ -41,24 +43,28 @@ import javax.servlet.ServletContext;
  * @author msw
  *
  */
-public class InitServlet extends AbstractPassthruRegistryEnabledServlet {
+@Component
+public class InitServlet  extends AbstractMXBeanRegistrar {
 
-    /** The Constant serialVersionUID. */
-    private static final long serialVersionUID = -331241203887741599L;
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * gov.hhs.fha.nhinc.configuration.jmx.AbstractPassthruRegistryEnabledServlet#getWebServiceMXBean(javax.servlet.
-     * ServletContext)
-     */
     @Override
-    public Set<WebServicesMXBean> getWebServiceMXBean(ServletContext sc) {
-        Set<WebServicesMXBean> beans = new HashSet<>();
-        beans.add(new DocumentSubmission11WebServices(sc));
-        beans.add(new DocumentSubmissionDefRequest11WebServices(sc));
-        beans.add(new DocumentSubmissionDefResponse11WebServices(sc));
-        return beans;
+    @PostConstruct
+    public void init() {
+        super.init();
     }
+
+    @Override
+    @PreDestroy
+    public void destroy() {
+        super.destroy();
+    }
+
+    @Override
+    public Set<WebServicesMXBean> getWebServiceMXBean() {
+        Set<WebServicesMXBean> nbeans = new HashSet<>();
+        nbeans.add(new DocumentSubmission11WebServices());
+        nbeans.add(new DocumentSubmissionDefRequest11WebServices());
+        nbeans.add(new DocumentSubmissionDefResponse11WebServices());
+        return nbeans;
+    }
+
 }

--- a/Product/Production/Gateway/DocumentSubmission_11/src/main/java/gov/hhs/fha/nhinc/docsubmission/configuration/jmx/DocumentSubmission11WebServices.java
+++ b/Product/Production/Gateway/DocumentSubmission_11/src/main/java/gov/hhs/fha/nhinc/docsubmission/configuration/jmx/DocumentSubmission11WebServices.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -32,7 +32,6 @@ import gov.hhs.fha.nhinc.docsubmission._11.entity.EntityDocSubmissionUnsecured;
 import gov.hhs.fha.nhinc.docsubmission._11.nhin.NhinXDR;
 import gov.hhs.fha.nhinc.docsubmission.inbound.InboundDocSubmission;
 import gov.hhs.fha.nhinc.docsubmission.outbound.OutboundDocSubmission;
-import javax.servlet.ServletContext;
 
 /**
  * The Class DocumentSubmission20WebServices.
@@ -51,14 +50,6 @@ public class DocumentSubmission11WebServices extends AbstractDSWebServicesMXBean
     private static final String ENTITY_SECURED_DS_BEAN_NAME = "entityXDRSecured";
 
     private final serviceEnum serviceName = serviceEnum.DocumentSubmission;
-    /**
-     * Instantiates a new document submission20 web services.
-     *
-     * @param sc the sc
-     */
-    public DocumentSubmission11WebServices(ServletContext sc) {
-        super(sc);
-    }
 
     /*
      * (non-Javadoc)
@@ -188,7 +179,7 @@ public class DocumentSubmission11WebServices extends AbstractDSWebServicesMXBean
 
     @Override
     public serviceEnum getServiceName() {
-        return this.serviceName;
+        return serviceName;
     }
 
     /*

--- a/Product/Production/Gateway/DocumentSubmission_11/src/main/java/gov/hhs/fha/nhinc/docsubmission/configuration/jmx/DocumentSubmissionDefRequest11WebServices.java
+++ b/Product/Production/Gateway/DocumentSubmission_11/src/main/java/gov/hhs/fha/nhinc/docsubmission/configuration/jmx/DocumentSubmissionDefRequest11WebServices.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -32,7 +32,6 @@ import gov.hhs.fha.nhinc.docsubmission._11.entity.deferred.request.EntityDocSubm
 import gov.hhs.fha.nhinc.docsubmission._11.nhin.deferred.request.NhinXDRRequest;
 import gov.hhs.fha.nhinc.docsubmission.inbound.deferred.request.InboundDocSubmissionDeferredRequest;
 import gov.hhs.fha.nhinc.docsubmission.outbound.deferred.request.OutboundDocSubmissionDeferredRequest;
-import javax.servlet.ServletContext;
 
 /**
  * The Class DocumentSubmissionDefRequest11WebServices.
@@ -51,15 +50,6 @@ public class DocumentSubmissionDefRequest11WebServices extends AbstractDSDeferre
     private static final String ENTITY_SECURED_DS_BEAN_NAME = "entityXDRDeferredRequestSecured";
 
     private final serviceEnum serviceName = serviceEnum.DocumentSubmissionDeferredRequest;
-
-    /**
-     * Instantiates a new document submission def request11 web services.
-     *
-     * @param sc the sc
-     */
-    public DocumentSubmissionDefRequest11WebServices(ServletContext sc) {
-        super(sc);
-    }
 
     /*
      * (non-Javadoc)
@@ -194,7 +184,7 @@ public class DocumentSubmissionDefRequest11WebServices extends AbstractDSDeferre
 
     @Override
     public serviceEnum getServiceName() {
-        return this.serviceName;
+        return serviceName;
     }
 
     /*

--- a/Product/Production/Gateway/DocumentSubmission_11/src/main/java/gov/hhs/fha/nhinc/docsubmission/configuration/jmx/DocumentSubmissionDefResponse11WebServices.java
+++ b/Product/Production/Gateway/DocumentSubmission_11/src/main/java/gov/hhs/fha/nhinc/docsubmission/configuration/jmx/DocumentSubmissionDefResponse11WebServices.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -32,7 +32,6 @@ import gov.hhs.fha.nhinc.docsubmission._11.entity.deferred.response.EntityDocSub
 import gov.hhs.fha.nhinc.docsubmission._11.nhin.deferred.response.NhinXDRResponse;
 import gov.hhs.fha.nhinc.docsubmission.inbound.deferred.response.InboundDocSubmissionDeferredResponse;
 import gov.hhs.fha.nhinc.docsubmission.outbound.deferred.response.OutboundDocSubmissionDeferredResponse;
-import javax.servlet.ServletContext;
 
 /**
  * The Class DocumentSubmissionDefRequest20WebServices.
@@ -51,15 +50,6 @@ public class DocumentSubmissionDefResponse11WebServices extends AbstractDSDeferr
     private static final String ENTITY_SECURED_DS_BEAN_NAME = "entityXDRDeferredResponseSecured";
 
     private final serviceEnum serviceName = serviceEnum.DocumentSubmissionDeferredResponse;
-
-    /**
-     * Instantiates a new document submission def request20 web services.
-     *
-     * @param sc the sc
-     */
-    public DocumentSubmissionDefResponse11WebServices(ServletContext sc) {
-        super(sc);
-    }
 
     /*
      * (non-Javadoc)
@@ -228,6 +218,6 @@ public class DocumentSubmissionDefResponse11WebServices extends AbstractDSDeferr
 
     @Override
     public serviceEnum getServiceName() {
-        return this.serviceName;
+        return serviceName;
     }
 }

--- a/Product/Production/Gateway/DocumentSubmission_11/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/DocumentSubmission_11/src/main/webapp/WEB-INF/web.xml
@@ -11,11 +11,14 @@
         <load-on-startup>1</load-on-startup>
     </servlet>
 
+<!-- 
     <servlet>
         <servlet-name>PassthruMXBean</servlet-name>
         <servlet-class>gov.hhs.fha.nhinc.docsubmission._11.gateway.InitServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
     </servlet>
+ -->
+
 
     <context-param>
         <param-name>contextConfigLocation</param-name>

--- a/Product/Production/Gateway/DocumentSubmission_11/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/DocumentSubmission_11/src/main/webapp/WEB-INF/web.xml
@@ -11,15 +11,6 @@
         <load-on-startup>1</load-on-startup>
     </servlet>
 
-<!-- 
-    <servlet>
-        <servlet-name>PassthruMXBean</servlet-name>
-        <servlet-class>gov.hhs.fha.nhinc.docsubmission._11.gateway.InitServlet</servlet-class>
-        <load-on-startup>1</load-on-startup>
-    </servlet>
- -->
-
-
     <context-param>
         <param-name>contextConfigLocation</param-name>
         <param-value>

--- a/Product/Production/Gateway/DocumentSubmission_20/src/main/java/gov/hhs/fha/nhinc/docsubmission/_20/gateway/InitServlet.java
+++ b/Product/Production/Gateway/DocumentSubmission_20/src/main/java/gov/hhs/fha/nhinc/docsubmission/_20/gateway/InitServlet.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,16 @@
  */
 package gov.hhs.fha.nhinc.docsubmission._20.gateway;
 
-import gov.hhs.fha.nhinc.configuration.jmx.AbstractPassthruRegistryEnabledServlet;
 import gov.hhs.fha.nhinc.configuration.jmx.WebServicesMXBean;
 import gov.hhs.fha.nhinc.docsubmission.configuration.jmx.DocumentSubmission20WebServices;
 import gov.hhs.fha.nhinc.docsubmission.configuration.jmx.DocumentSubmissionDefRequest20WebServices;
 import gov.hhs.fha.nhinc.docsubmission.configuration.jmx.DocumentSubmissionDefResponse20WebServices;
+import gov.hhs.fha.nhinc.registrar.AbstractMXBeanRegistrar;
 import java.util.HashSet;
 import java.util.Set;
-import javax.servlet.ServletContext;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import org.springframework.stereotype.Component;
 
 /**
  * The Class InitServlet.
@@ -41,24 +43,27 @@ import javax.servlet.ServletContext;
  * @author msw
  *
  */
-public class InitServlet extends AbstractPassthruRegistryEnabledServlet {
+@Component
+public class InitServlet  extends AbstractMXBeanRegistrar {
 
-    /** The Constant serialVersionUID. */
-    private static final long serialVersionUID = -331241203887741599L;
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * gov.hhs.fha.nhinc.configuration.jmx.AbstractPassthruRegistryEnabledServlet#getWebServiceMXBean(javax.servlet.
-     * ServletContext)
-     */
     @Override
-    public Set<WebServicesMXBean> getWebServiceMXBean(ServletContext sc) {
-        Set<WebServicesMXBean> beans = new HashSet<>();
-        beans.add(new DocumentSubmission20WebServices(sc));
-        beans.add(new DocumentSubmissionDefRequest20WebServices(sc));
-        beans.add(new DocumentSubmissionDefResponse20WebServices(sc));
-        return beans;
+    @PostConstruct
+    public void init() {
+        super.init();
+    }
+
+    @Override
+    @PreDestroy
+    public void destroy() {
+        super.destroy();
+    }
+
+    @Override
+    public Set<WebServicesMXBean> getWebServiceMXBean() {
+        Set<WebServicesMXBean> newBeans = new HashSet<>();
+        newBeans.add(new DocumentSubmission20WebServices());
+        newBeans.add(new DocumentSubmissionDefRequest20WebServices());
+        newBeans.add(new DocumentSubmissionDefResponse20WebServices());
+        return newBeans;
     }
 }

--- a/Product/Production/Gateway/DocumentSubmission_20/src/main/java/gov/hhs/fha/nhinc/docsubmission/configuration/jmx/DocumentSubmission20WebServices.java
+++ b/Product/Production/Gateway/DocumentSubmission_20/src/main/java/gov/hhs/fha/nhinc/docsubmission/configuration/jmx/DocumentSubmission20WebServices.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -32,7 +32,6 @@ import gov.hhs.fha.nhinc.docsubmission._20.entity.EntityDocSubmissionUnsecured_g
 import gov.hhs.fha.nhinc.docsubmission._20.nhin.NhinXDR_g1;
 import gov.hhs.fha.nhinc.docsubmission.inbound.InboundDocSubmission;
 import gov.hhs.fha.nhinc.docsubmission.outbound.OutboundDocSubmission;
-import javax.servlet.ServletContext;
 
 /**
  * The Class DocumentSubmission20WebServices.
@@ -51,14 +50,6 @@ public class DocumentSubmission20WebServices extends AbstractDSWebServicesMXBean
     private static final String ENTITY_SECURED_DS_BEAN_NAME = "entityXDRSecured_g1";
 
     private final serviceEnum serviceName = serviceEnum.DocumentSubmission;
-    /**
-     * Instantiates a new document submission20 web services.
-     *
-     * @param sc the sc
-     */
-    public DocumentSubmission20WebServices(ServletContext sc) {
-        super(sc);
-    }
 
     /*
      * (non-Javadoc)
@@ -188,7 +179,7 @@ public class DocumentSubmission20WebServices extends AbstractDSWebServicesMXBean
 
     @Override
     public serviceEnum getServiceName() {
-        return this.serviceName;
+        return serviceName;
     }
 
     /*

--- a/Product/Production/Gateway/DocumentSubmission_20/src/main/java/gov/hhs/fha/nhinc/docsubmission/configuration/jmx/DocumentSubmissionDefRequest20WebServices.java
+++ b/Product/Production/Gateway/DocumentSubmission_20/src/main/java/gov/hhs/fha/nhinc/docsubmission/configuration/jmx/DocumentSubmissionDefRequest20WebServices.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -32,7 +32,6 @@ import gov.hhs.fha.nhinc.docsubmission._20.entity.deferred.request.EntityDocSubm
 import gov.hhs.fha.nhinc.docsubmission._20.nhin.deferred.request.NhinXDRRequest20;
 import gov.hhs.fha.nhinc.docsubmission.inbound.deferred.request.InboundDocSubmissionDeferredRequest;
 import gov.hhs.fha.nhinc.docsubmission.outbound.deferred.request.OutboundDocSubmissionDeferredRequest;
-import javax.servlet.ServletContext;
 
 /**
  * The Class DocumentSubmissionDefRequest20WebServices.
@@ -51,15 +50,6 @@ public class DocumentSubmissionDefRequest20WebServices extends AbstractDSDeferre
     private static final String ENTITY_SECURED_DS_BEAN_NAME = "entityXDRDeferredRequestSecured_g1";
 
     private final serviceEnum serviceName = serviceEnum.DocumentSubmissionDeferredRequest;
-
-    /**
-     * Instantiates a new document submission def request20 web services.
-     *
-     * @param sc the sc
-     */
-    public DocumentSubmissionDefRequest20WebServices(ServletContext sc) {
-        super(sc);
-    }
 
     /*
      * (non-Javadoc)
@@ -194,7 +184,7 @@ public class DocumentSubmissionDefRequest20WebServices extends AbstractDSDeferre
 
     @Override
     public serviceEnum getServiceName() {
-        return this.serviceName;
+        return serviceName;
     }
 
     /*

--- a/Product/Production/Gateway/DocumentSubmission_20/src/main/java/gov/hhs/fha/nhinc/docsubmission/configuration/jmx/DocumentSubmissionDefResponse20WebServices.java
+++ b/Product/Production/Gateway/DocumentSubmission_20/src/main/java/gov/hhs/fha/nhinc/docsubmission/configuration/jmx/DocumentSubmissionDefResponse20WebServices.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -32,7 +32,6 @@ import gov.hhs.fha.nhinc.docsubmission._20.entity.deferred.response.EntityDocSub
 import gov.hhs.fha.nhinc.docsubmission._20.nhin.deferred.response.NhinXDRResponse20;
 import gov.hhs.fha.nhinc.docsubmission.inbound.deferred.response.InboundDocSubmissionDeferredResponse;
 import gov.hhs.fha.nhinc.docsubmission.outbound.deferred.response.OutboundDocSubmissionDeferredResponse;
-import javax.servlet.ServletContext;
 
 /**
  * The Class DocumentSubmissionDefRequest20WebServices.
@@ -51,15 +50,6 @@ public class DocumentSubmissionDefResponse20WebServices extends AbstractDSDeferr
     private static final String ENTITY_SECURED_DS_BEAN_NAME = "entityXDRDeferredResponseSecured_g1";
 
     private final serviceEnum serviceName = serviceEnum.DocumentSubmissionDeferredResponse;
-
-    /**
-     * Instantiates a new document submission def request20 web services.
-     *
-     * @param sc the sc
-     */
-    public DocumentSubmissionDefResponse20WebServices(ServletContext sc) {
-        super(sc);
-    }
 
     /*
      * (non-Javadoc)
@@ -195,7 +185,7 @@ public class DocumentSubmissionDefResponse20WebServices extends AbstractDSDeferr
 
     @Override
     public serviceEnum getServiceName() {
-        return this.serviceName;
+        return serviceName;
     }
 
     /*

--- a/Product/Production/Gateway/DocumentSubmission_20/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/DocumentSubmission_20/src/main/webapp/WEB-INF/web.xml
@@ -10,14 +10,6 @@
         <servlet-class>org.apache.cxf.transport.servlet.CXFServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
     </servlet>
-<!-- 
-    <servlet>
-        <servlet-name>PassthruMXBean</servlet-name>
-        <servlet-class>gov.hhs.fha.nhinc.docsubmission._20.gateway.InitServlet</servlet-class>
-        <load-on-startup>1</load-on-startup>
-    </servlet>
- -->
-
 
     <context-param>
         <param-name>contextConfigLocation</param-name>

--- a/Product/Production/Gateway/DocumentSubmission_20/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/DocumentSubmission_20/src/main/webapp/WEB-INF/web.xml
@@ -10,12 +10,14 @@
         <servlet-class>org.apache.cxf.transport.servlet.CXFServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
     </servlet>
-
+<!-- 
     <servlet>
         <servlet-name>PassthruMXBean</servlet-name>
         <servlet-class>gov.hhs.fha.nhinc.docsubmission._20.gateway.InitServlet</servlet-class>
         <load-on-startup>1</load-on-startup>
     </servlet>
+ -->
+
 
     <context-param>
         <param-name>contextConfigLocation</param-name>

--- a/Product/Production/Gateway/PatientDiscovery_10/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/_10/servlet/InitServlet.java
+++ b/Product/Production/Gateway/PatientDiscovery_10/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/_10/servlet/InitServlet.java
@@ -26,19 +26,18 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery._10.servlet;
 
-import gov.hhs.fha.nhinc.configuration.jmx.AbstractPassthruRegistryEnabledServlet;
 import gov.hhs.fha.nhinc.configuration.jmx.WebServicesMXBean;
 import gov.hhs.fha.nhinc.gateway.executorservice.ExecutorServiceHelper;
 import gov.hhs.fha.nhinc.patientdiscovery.configuration.jmx.PatientDiscovery10WebServices;
 import gov.hhs.fha.nhinc.patientdiscovery.configuration.jmx.PatientDiscoveryDeferredReq10WebServices;
 import gov.hhs.fha.nhinc.patientdiscovery.configuration.jmx.PatientDiscoveryDeferredResp10WebServices;
+import gov.hhs.fha.nhinc.registrar.AbstractMXBeanRegistrar;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,44 +54,26 @@ import org.slf4j.LoggerFactory;
  *
  * @author paul.eftis, msw
  */
-public class InitServlet extends AbstractPassthruRegistryEnabledServlet {
 
-    /** The Constant serialVersionUID. */
-    private static final long serialVersionUID = -4229185731377926278L;
+//@Component
+public class InitServlet  extends AbstractMXBeanRegistrar {
 
-    /** The Constant LOG. */
     private static final Logger LOG = LoggerFactory.getLogger(InitServlet.class);
-
-    /** The executor. */
     private static ExecutorService executor = null;
-
-    /** The large job executor. */
     private static ExecutorService largeJobExecutor = null;
 
-    /**
-     * Initializes the servlet with parallel fanout executors as well as calling super.init().
-     *
-     * @param config the config
-     * @throws ServletException the servlet exception
-     * @see gov.fha.hhs.nhinc.gateway.AbstractJMXEnabledServlet#init(javax.servlet.ServletConfig)
-     */
+    @PostConstruct
     @Override
-    @SuppressWarnings("static-access")
-    public void init(ServletConfig config) throws ServletException {
-        LOG.debug("InitServlet start...");
-        ExecutorService newExecutor = Executors.newFixedThreadPool(ExecutorServiceHelper.getInstance().getExecutorPoolSize());
+    public void init() {
+        LOG.info("PatientDiscovery InitServlet starting...");
+        ExecutorService newExecutor = Executors.newFixedThreadPool(ExecutorServiceHelper.getExecutorPoolSize());
         setExecutorService(newExecutor);
-        ExecutorService newLargeJobExecutor = Executors.newFixedThreadPool(ExecutorServiceHelper.getInstance()
-                .getLargeJobExecutorPoolSize());
+        ExecutorService newLargeJobExecutor = Executors.newFixedThreadPool(ExecutorServiceHelper.getLargeJobExecutorPoolSize());
         setLargeJobExecutorService(newLargeJobExecutor);
-        super.init(config);
+        super.init();
+
     }
 
-    /**
-     * Gets the executor service.
-     *
-     * @return the executor service
-     */
     public static ExecutorService getExecutorService() {
         return executor;
     }
@@ -101,11 +82,6 @@ public class InitServlet extends AbstractPassthruRegistryEnabledServlet {
         executor = newExecutor;
     }
 
-    /**
-     * Gets the large job executor service.
-     *
-     * @return the large job executor service
-     */
     public static ExecutorService getLargeJobExecutorService() {
         return largeJobExecutor;
     }
@@ -113,15 +89,11 @@ public class InitServlet extends AbstractPassthruRegistryEnabledServlet {
     public static void setLargeJobExecutorService(ExecutorService newLargeJobExecutor) {
         largeJobExecutor = newLargeJobExecutor;
     }
-    /**
-     * Destroys the servlet. Since we don't want to halt the servlet destroy process, we don't propagate any exceptions
-     * through this method.
-     *
-     * @see gov.hhs.fha.nhinc.gateway.AbstractJMXEnabledServlet#destroy()
-     */
+
     @Override
+    @PreDestroy
     public void destroy() {
-        LOG.debug("InitServlet shutdown stopping executor(s)....");
+        LOG.info("Shutting down executors...");
         if (executor != null) {
             try {
                 executor.shutdown();
@@ -137,19 +109,17 @@ public class InitServlet extends AbstractPassthruRegistryEnabledServlet {
             }
         }
 
-        super.destroy();
+       super.destroy();
+
     }
 
-    /* (non-Javadoc)
-     * @see gov.hhs.fha.nhinc.configuration.jmx.AbstractPassthruRegistryEnabledServlet#getWebServiceMXBean(javax.servlet.ServletContext)
-     */
     @Override
-    public Set<WebServicesMXBean> getWebServiceMXBean(ServletContext sc) {
-        Set<WebServicesMXBean> beans = new HashSet<>();
-        beans.add(new PatientDiscovery10WebServices(sc));
-        beans.add(new PatientDiscoveryDeferredReq10WebServices(sc));
-        beans.add(new PatientDiscoveryDeferredResp10WebServices(sc));
-        return beans;
+    public Set<WebServicesMXBean> getWebServiceMXBean() {
+        Set<WebServicesMXBean> newBeans = new HashSet<>();
+        newBeans.add(new PatientDiscovery10WebServices());
+        newBeans.add(new PatientDiscoveryDeferredReq10WebServices());
+        newBeans.add(new PatientDiscoveryDeferredResp10WebServices());
+        return newBeans;
     }
 
 }

--- a/Product/Production/Gateway/PatientDiscovery_10/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/_10/servlet/InitServlet.java
+++ b/Product/Production/Gateway/PatientDiscovery_10/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/_10/servlet/InitServlet.java
@@ -40,9 +40,10 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
 /**
- * Started on webapplication init, creates the main ExecutorService and CamelContext instances Note the following: 1.
+ * Started on spring init, creates the main ExecutorService and CamelContext instances Note the following: 1.
  * Main ExecutorService creates a new thread pool of size specified on construction, independent/in addition to
  * glassfish thread pool(s) set in domain.xml. 2. ExecutorService automatically handles any thread death condition and
  * creates a new thread in this case
@@ -55,8 +56,8 @@ import org.slf4j.LoggerFactory;
  * @author paul.eftis, msw
  */
 
-//@Component
-public class InitServlet  extends AbstractMXBeanRegistrar {
+@Component
+public class InitServlet extends AbstractMXBeanRegistrar {
 
     private static final Logger LOG = LoggerFactory.getLogger(InitServlet.class);
     private static ExecutorService executor = null;
@@ -66,9 +67,9 @@ public class InitServlet  extends AbstractMXBeanRegistrar {
     @Override
     public void init() {
         LOG.info("PatientDiscovery InitServlet starting...");
-        ExecutorService newExecutor = Executors.newFixedThreadPool(ExecutorServiceHelper.getExecutorPoolSize());
+        ExecutorService newExecutor = Executors.newFixedThreadPool(ExecutorServiceHelper.getInstance().getExecutorPoolSize());
         setExecutorService(newExecutor);
-        ExecutorService newLargeJobExecutor = Executors.newFixedThreadPool(ExecutorServiceHelper.getLargeJobExecutorPoolSize());
+        ExecutorService newLargeJobExecutor = Executors.newFixedThreadPool(ExecutorServiceHelper.getInstance().getLargeJobExecutorPoolSize());
         setLargeJobExecutorService(newLargeJobExecutor);
         super.init();
 

--- a/Product/Production/Gateway/PatientDiscovery_10/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/configuration/jmx/PatientDiscovery10WebServices.java
+++ b/Product/Production/Gateway/PatientDiscovery_10/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/configuration/jmx/PatientDiscovery10WebServices.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -31,7 +31,6 @@ import gov.hhs.fha.nhinc.patientdiscovery._10.gateway.ws.EntityPatientDiscoveryU
 import gov.hhs.fha.nhinc.patientdiscovery._10.gateway.ws.NhinPatientDiscovery;
 import gov.hhs.fha.nhinc.patientdiscovery.inbound.InboundPatientDiscovery;
 import gov.hhs.fha.nhinc.patientdiscovery.outbound.OutboundPatientDiscovery;
-import javax.servlet.ServletContext;
 
 /**
  * The Class PatientDiscovery10WebServices.
@@ -41,14 +40,6 @@ import javax.servlet.ServletContext;
 public class PatientDiscovery10WebServices extends AbstractPDWebServicesMXBean {
 
     private final serviceEnum serviceName = serviceEnum.PatientDiscovery;
-    /**
-     * Instantiates a new patient discovery10 web services.
-     *
-     * @param sc the sc
-     */
-    public PatientDiscovery10WebServices(ServletContext sc) {
-        super(sc);
-    }
 
     /*
      * (non-Javadoc)
@@ -158,7 +149,7 @@ public class PatientDiscovery10WebServices extends AbstractPDWebServicesMXBean {
 
     @Override
     public serviceEnum getServiceName() {
-        return this.serviceName;
+        return serviceName;
     }
 
     @Override

--- a/Product/Production/Gateway/PatientDiscovery_10/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/configuration/jmx/PatientDiscoveryDeferredReq10WebServices.java
+++ b/Product/Production/Gateway/PatientDiscovery_10/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/configuration/jmx/PatientDiscoveryDeferredReq10WebServices.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -32,7 +32,6 @@ import gov.hhs.fha.nhinc.patientdiscovery._10.gateway.ws.EntityPatientDiscoveryD
 import gov.hhs.fha.nhinc.patientdiscovery._10.gateway.ws.NhinPatientDiscoveryDeferredRequest;
 import gov.hhs.fha.nhinc.patientdiscovery.inbound.deferred.request.InboundPatientDiscoveryDeferredRequest;
 import gov.hhs.fha.nhinc.patientdiscovery.outbound.deferred.request.OutboundPatientDiscoveryDeferredRequest;
-import javax.servlet.ServletContext;
 
 /**
  * @author msw
@@ -41,12 +40,6 @@ import javax.servlet.ServletContext;
 public class PatientDiscoveryDeferredReq10WebServices extends AbstractPDDeferredRequestWebServicesMXBean {
 
     private final serviceEnum serviceName = serviceEnum.PatientDiscoveryDeferredRequest;
-    /**
-     * @param sc
-     */
-    public PatientDiscoveryDeferredReq10WebServices(ServletContext sc) {
-        super(sc);
-    }
 
     /*
      * (non-Javadoc)

--- a/Product/Production/Gateway/PatientDiscovery_10/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/configuration/jmx/PatientDiscoveryDeferredResp10WebServices.java
+++ b/Product/Production/Gateway/PatientDiscovery_10/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/configuration/jmx/PatientDiscoveryDeferredResp10WebServices.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -32,7 +32,6 @@ import gov.hhs.fha.nhinc.patientdiscovery._10.gateway.ws.EntityPatientDiscoveryD
 import gov.hhs.fha.nhinc.patientdiscovery._10.gateway.ws.NhinPatientDiscoveryDeferredResponse;
 import gov.hhs.fha.nhinc.patientdiscovery.inbound.deferred.response.InboundPatientDiscoveryDeferredResponse;
 import gov.hhs.fha.nhinc.patientdiscovery.outbound.deferred.response.OutboundPatientDiscoveryDeferredResponse;
-import javax.servlet.ServletContext;
 
 /**
  * @author msw
@@ -41,13 +40,6 @@ import javax.servlet.ServletContext;
 public class PatientDiscoveryDeferredResp10WebServices extends AbstractPDDeferredResponseWebServicesMXBean {
 
     private final serviceEnum serviceName = serviceEnum.PatientDiscoveryDeferredResponse;
-
-    /**
-     * @param sc
-     */
-    public PatientDiscoveryDeferredResp10WebServices(ServletContext sc) {
-        super(sc);
-    }
 
     /*
      * (non-Javadoc)

--- a/Product/Production/Gateway/PatientDiscovery_10/src/main/webapp/WEB-INF/web.xml
+++ b/Product/Production/Gateway/PatientDiscovery_10/src/main/webapp/WEB-INF/web.xml
@@ -6,12 +6,6 @@
     version="2.5">
 
     <servlet>
-        <servlet-name>InitServlet</servlet-name>
-        <servlet-class>gov.hhs.fha.nhinc.patientdiscovery._10.servlet.InitServlet</servlet-class>
-        <load-on-startup>1</load-on-startup>
-    </servlet>
-
-    <servlet>
         <servlet-name>cxf</servlet-name>
         <servlet-class>org.apache.cxf.transport.servlet.CXFServlet</servlet-class>
         <load-on-startup>1</load-on-startup>

--- a/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/configuration/jmx/AbstractAdminDistributionWebServicesMXBean.java
+++ b/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/configuration/jmx/AbstractAdminDistributionWebServicesMXBean.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -27,7 +27,6 @@
 package gov.hhs.fha.nhinc.admindistribution.configuration.jmx;
 
 import gov.hhs.fha.nhinc.configuration.jmx.AbstractWebServicesMXBean;
-import javax.servlet.ServletContext;
 
 /**
  * The Class AbstractAdminDistributionWebServicesMXBean.
@@ -151,14 +150,5 @@ public abstract class AbstractAdminDistributionWebServicesMXBean extends Abstrac
     @Override
     public abstract void configureInboundPtImpl()
         throws InstantiationException, IllegalAccessException, ClassNotFoundException;
-
-    /**
-     * Instantiates a new abstract admin distribution web services mx bean.
-     *
-     * @param sc the sc
-     */
-    public AbstractAdminDistributionWebServicesMXBean(ServletContext sc) {
-        super(sc);
-    }
 
 }

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/configuration/jmx/AbstractDQWebServicesMXBean.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/configuration/jmx/AbstractDQWebServicesMXBean.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -27,7 +27,6 @@
 package gov.hhs.fha.nhinc.docquery.configuration.jmx;
 
 import gov.hhs.fha.nhinc.configuration.jmx.AbstractWebServicesMXBean;
-import javax.servlet.ServletContext;
 
 /**
  * The Class AbstractDQWebServicesMXBean.
@@ -69,14 +68,6 @@ public abstract class AbstractDQWebServicesMXBean extends AbstractWebServicesMXB
     /** The Constant DEFAULT_OUTBOUND_PASSTHRU_IMPL_CLASS_NAME. */
     public static final String DEFAULT_OUTBOUND_PASSTHRU_IMPL_CLASS_NAME = "gov.hhs.fha.nhinc.docquery.outbound.PassthroughOutboundDocQuery";
 
-    /**
-     * Constructor for AbstractDQWebServicesMXBean.
-     *
-     * @param sc the sc
-     */
-    public AbstractDQWebServicesMXBean(ServletContext sc) {
-        super(sc);
-    }
 
     /*
      * (non-Javadoc)

--- a/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/configuration/jmx/AbstractDRWebServicesMXBean.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/configuration/jmx/AbstractDRWebServicesMXBean.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -27,7 +27,6 @@
 package gov.hhs.fha.nhinc.docretrieve.configuration.jmx;
 
 import gov.hhs.fha.nhinc.configuration.jmx.AbstractWebServicesMXBean;
-import javax.servlet.ServletContext;
 
 /**
  * The Class AbstractDRWebServicesMXBean. This class does not implement
@@ -67,20 +66,8 @@ public abstract class AbstractDRWebServicesMXBean extends AbstractWebServicesMXB
     /** The Constant DEFAULT_INBOUND_PASSTHRU_IMPL_CLASS_NAME. */
     public static final String DEFAULT_INBOUND_PASSTHRU_IMPL_CLASS_NAME = "gov.hhs.fha.nhinc.docretrieve.inbound.PassthroughInboundDocRetrieve";
 
-    /** The Constant DEFAULT_OUTBOUND_PASSTHRU_IMPL_CLASS_NAME. */
-    public static final String DEFAULT_OUTBOUND_PASSTHRU_IMPL_CLASS_NAME = "gov.hhs.fha.nhinc.docretrieve.inbound.PassthroughOutboundDocRetrieve";
-
     /** The Constant DEFAULT_OUTBOUND_STANDARD_IMPL_CLASS_NAME. */
     public static final String DEFAULT_OUTBOUND_STANDARD_IMPL_CLASS_NAME = "gov.hhs.fha.nhinc.docretrieve.outbound.StandardOutboundDocRetrieve";
-
-    /**
-     * Instantiates a new abstract dr web services mx bean.
-     *
-     * @param sc the sc
-     */
-    public AbstractDRWebServicesMXBean(ServletContext sc) {
-        super(sc);
-    }
 
     /*
      * (non-Javadoc)

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/configuration/jmx/AbstractDSDeferredReqWebServicesMXBean.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/configuration/jmx/AbstractDSDeferredReqWebServicesMXBean.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -27,7 +27,6 @@
 package gov.hhs.fha.nhinc.docsubmission.configuration.jmx;
 
 import gov.hhs.fha.nhinc.configuration.jmx.AbstractWebServicesMXBean;
-import javax.servlet.ServletContext;
 
 /**
  * The Class AbstractDSDeferredReqWebServicesMXBean.
@@ -59,15 +58,6 @@ public abstract class AbstractDSDeferredReqWebServicesMXBean extends AbstractWeb
 
     /** The Constant Passthrough_InboundOrch_DS_BEAN_NAME. */
     private static final String PtInbound_DS_Bean_Name = "ptDSReqInbound";
-
-    /**
-     * Instantiates a new abstract ds deferred req web services mx bean.
-     *
-     * @param sc the sc
-     */
-    public AbstractDSDeferredReqWebServicesMXBean(ServletContext sc) {
-        super(sc);
-    }
 
     /*
      * (non-Javadoc)

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/configuration/jmx/AbstractDSDeferredRespWebServicesMXBean.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/configuration/jmx/AbstractDSDeferredRespWebServicesMXBean.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -27,7 +27,6 @@
 package gov.hhs.fha.nhinc.docsubmission.configuration.jmx;
 
 import gov.hhs.fha.nhinc.configuration.jmx.AbstractWebServicesMXBean;
-import javax.servlet.ServletContext;
 
 /**
  * The Class AbstractDSDeferredReqWebServicesMXBean.
@@ -59,15 +58,6 @@ public abstract class AbstractDSDeferredRespWebServicesMXBean extends AbstractWe
 
     /** The Constant Passthrough_InboundOrch_DS_BEAN_NAME. */
     private static final String PtInbound_DS_Bean_Name = "ptDSRespInbound";
-
-    /**
-     * Instantiates a new abstract ds deferred req web services mx bean.
-     *
-     * @param sc the sc
-     */
-    public AbstractDSDeferredRespWebServicesMXBean(ServletContext sc) {
-        super(sc);
-    }
 
     /*
      * (non-Javadoc)

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/configuration/jmx/AbstractDSWebServicesMXBean.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/configuration/jmx/AbstractDSWebServicesMXBean.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -27,7 +27,6 @@
 package gov.hhs.fha.nhinc.docsubmission.configuration.jmx;
 
 import gov.hhs.fha.nhinc.configuration.jmx.AbstractWebServicesMXBean;
-import javax.servlet.ServletContext;
 
 /**
  * @author msw
@@ -58,13 +57,6 @@ public abstract class AbstractDSWebServicesMXBean extends AbstractWebServicesMXB
 
     /** The Constant Passthrough_InboundOrch_DS_BEAN_NAME. */
     private static final String PtInbound_DS_Bean_Name = "ptDSInbound";
-
-    /**
-     * @param sc
-     */
-    public AbstractDSWebServicesMXBean(ServletContext sc) {
-        super(sc);
-    }
 
     /*
      * (non-Javadoc)

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/configuration/jmx/AbstractPDDeferredRequestWebServicesMXBean.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/configuration/jmx/AbstractPDDeferredRequestWebServicesMXBean.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -27,7 +27,6 @@
 package gov.hhs.fha.nhinc.patientdiscovery.configuration.jmx;
 
 import gov.hhs.fha.nhinc.configuration.jmx.AbstractWebServicesMXBean;
-import javax.servlet.ServletContext;
 
 /**
  * @author achidambaram
@@ -89,15 +88,6 @@ public abstract class AbstractPDDeferredRequestWebServicesMXBean extends Abstrac
      * The Constant Passthrough_InboundOrch_PDDeferredRequest_BEAN_NAME.
      */
     private static final String PTINBOUND_PD_BEAN_NAME_REQ = "ptPDReqInbound";
-
-    /**
-     * Constructor for AbstractPDWebServicesMXBean.
-     *
-     * @param sc the sc
-     */
-    public AbstractPDDeferredRequestWebServicesMXBean(ServletContext sc) {
-        super(sc);
-    }
 
     /*
      * (non-Javadoc)

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/configuration/jmx/AbstractPDDeferredResponseWebServicesMXBean.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/configuration/jmx/AbstractPDDeferredResponseWebServicesMXBean.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -27,7 +27,6 @@
 package gov.hhs.fha.nhinc.patientdiscovery.configuration.jmx;
 
 import gov.hhs.fha.nhinc.configuration.jmx.AbstractWebServicesMXBean;
-import javax.servlet.ServletContext;
 
 /**
  * @author achidambaram
@@ -89,15 +88,6 @@ public abstract class AbstractPDDeferredResponseWebServicesMXBean extends Abstra
      * The Constant Passthrough_InboundOrch_PDDeferredResponse_BEAN_NAME.
      */
     private static final String PTINBOUND_PD_BEAN_NAME_RESP = "ptPDRespInbound";
-
-    /**
-     * Constructor for AbstractPDWebServicesMXBean.
-     *
-     * @param sc the sc
-     */
-    public AbstractPDDeferredResponseWebServicesMXBean(ServletContext sc) {
-        super(sc);
-    }
 
     /*
      * (non-Javadoc)

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/configuration/jmx/AbstractPDWebServicesMXBean.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/configuration/jmx/AbstractPDWebServicesMXBean.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -27,7 +27,6 @@
 package gov.hhs.fha.nhinc.patientdiscovery.configuration.jmx;
 
 import gov.hhs.fha.nhinc.configuration.jmx.AbstractWebServicesMXBean;
-import javax.servlet.ServletContext;
 
 /**
  * The Class AbstractPDWebServicesMXBean.
@@ -68,15 +67,6 @@ public abstract class AbstractPDWebServicesMXBean extends AbstractWebServicesMXB
 
     /** The Constant DEFAULT_OUTBOUND_PASSTHRU_IMPL_CLASS_NAME. */
     public static final String DEFAULT_OUTBOUND_PASSTHRU_IMPL_CLASS_NAME = "gov.hhs.fha.nhinc.patientdiscovery.outbound.PassthroughOutboundPatientDiscovery";
-
-    /**
-     * Constructor for AbstractPDWebServicesMXBean.
-     *
-     * @param sc the sc
-     */
-    public AbstractPDWebServicesMXBean(ServletContext sc) {
-        super(sc);
-    }
 
     /*
      * (non-Javadoc)


### PR DESCRIPTION
The InitServlets were not shutting down correctly and holding open resources and classes on the classloaders, preventing them from being GC'd. Converted them from an HttpServlet to a simple spring component which will create the service POJOs for the MX Beans.