### PR TITLE
AdminGUI fixes for CONN-2280

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/CertficateBean.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/CertficateBean.java
@@ -26,13 +26,12 @@
  */
 package gov.hhs.fha.nhinc.admingui.managed;
 
-import static gov.hhs.fha.nhinc.admingui.util.HelperUtil.execPFHideDialog;
-import static gov.hhs.fha.nhinc.admingui.util.HelperUtil.execPFShowDialog;
-
 import gov.hhs.fha.nhinc.admingui.services.CertificateManagerService;
 import gov.hhs.fha.nhinc.admingui.services.impl.CertificateManagerServiceImpl;
 import gov.hhs.fha.nhinc.admingui.util.GUIConstants.COLOR_CODING_CSS;
 import gov.hhs.fha.nhinc.admingui.util.HelperUtil;
+import static gov.hhs.fha.nhinc.admingui.util.HelperUtil.execPFHideDialog;
+import static gov.hhs.fha.nhinc.admingui.util.HelperUtil.execPFShowDialog;
 import gov.hhs.fha.nhinc.callback.opensaml.CertificateDTO;
 import gov.hhs.fha.nhinc.callback.opensaml.CertificateManagerException;
 import java.security.cert.CertificateExpiredException;
@@ -71,7 +70,7 @@ public class CertficateBean {
     private static final String IMPORT_PASS_ERR_MSG_ID = "importPassKeyErrorMsg";
     private static final String DELETE_PASS_ERR_MSG_ID = "deletePassKeyErrorMsg";
     private static final String EDIT_PASS_ERROR_MSG = "editPassKeyErrorMsg";
-    private static final String ALIAS_PLACEHOLDER = "<Enter Alias>";
+    private static final String ALIAS_PLACEHOLDER = "Enter Alias";
     private static final String BAD_MISMATCH_TOKEN = "Bad token or Mismatch token";
     private UploadedFile importCertFile;
     private CertificateDTO selectedCertificate;
@@ -480,6 +479,7 @@ public class CertficateBean {
     public void viewChainOfTrust() {
         chainOfTrust = new HashMap<>();
         selectedCertsChain = new ArrayList<>();
+        selectedCertsChain.add(selectedTSCertificate);
         isChainCompleted = false;
 
         if (null == selectedTSCertificate) {
@@ -489,6 +489,9 @@ public class CertficateBean {
 
         try {
             chainOfTrust = buildChainOfTrustMap(service.listChainOfTrust(selectedTSCertificate.getAlias()));
+            // Below line overrides the user selected certificate in chainOfTrust map.
+            // This is done in order to highlight the alias on View Chain Of Trust when the page first loads.
+            chainOfTrust.put(selectedTSCertificate.getAlias(), selectedTSCertificate);
             isChainCompleted = checkCompletedChain(chainOfTrust);
         } catch (CertificateManagerException ex) {
             LOG.error("Error while calling server to get certificate chain: {}", ex.getMessage(), ex);
@@ -499,17 +502,17 @@ public class CertficateBean {
     private static Map<String, CertificateDTO> buildChainOfTrustMap(List<CertificateDTO> list) {
         Map<String, CertificateDTO> retVal = new HashMap<>();
 
-        for(CertificateDTO item: list){
+        for (CertificateDTO item : list) {
             retVal.put(item.getAlias(), item);
         }
 
         return retVal;
     }
 
-    private static boolean checkCompletedChain(Map<String, CertificateDTO> chain){
+    private static boolean checkCompletedChain(Map<String, CertificateDTO> chain) {
         List<String> certAKIDs = new ArrayList<>();
 
-        for(CertificateDTO item: chain.values()){
+        for (CertificateDTO item : chain.values()) {
             certAKIDs.add(item.getAuthorityKeyID());
         }
 
@@ -521,6 +524,5 @@ public class CertficateBean {
         }
         return true;
     }
-
 
 }

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/dlgCertMgrChain.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/dlgCertMgrChain.xhtml
@@ -16,8 +16,8 @@
                         <p:selectManyMenu id="chainOfTrustSelection" converter="certificateDTOConverter"
                             value="#{certificateBean.selectedCertsChain}" var="rec" filter="true"
                             filterMatchMode="contains" showCheckbox="true" styleClass="list-group" style="width: 100%;">
-                            <f:selectItems value="#{certificateBean.chainOfTrust}" var="rec2" itemValue="#{rec2}"
-                                itemLabel="#{rec2.alias}" />
+                            <f:selectItems value="#{certificateBean.chainOfTrust.entrySet()}" var="entry" itemValue="#{entry.value}"
+                                           itemLabel="#{entry.key}"  />
                             <p:ajax event="change" update=":datagridChain" />
                             <p:column style="padding-left: 5px;">
                                 <h:outputText value="#{rec.alias}" />

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/importCertDialog.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/importCertDialog.xhtml
@@ -16,13 +16,13 @@
                             </div>
                         </div>
                         <div class="table-responsive table-props">
-                            <p:dataTable id="importCertTable" value="#{certificateBean.importCertificate}" resizableColumns="false" scrollable="true" scrollHeight="300" var="importSelCert" selection="#{certificateBean.selectedCertificate}" rowKey="#{importSelCert.serialNumber}" widgetVar="cellProps" sortMode="Single" styleClass="table table-striped table-domains" editable="true" editMode="cell">
+                            <p:dataTable id="importCertTable" value="#{certificateBean.importCertificate}" resizableColumns="false" scrollable="true" scrollHeight="220" var="importSelCert" selection="#{certificateBean.selectedCertificate}" rowKey="#{importSelCert.serialNumber}" widgetVar="cellProps" sortMode="Single" styleClass="table table-striped table-domains" editable="true" editMode="cell">
                                 <p:ajax event="cellEdit" listener="#{certificateBean.onAliasValueEdit}" update=":importCertDlgForm:importCertTable" />
                                 <p:column selectionMode="single" />
                                 <p:column>
                                     <f:facet name="header">Alias</f:facet>
                                     <p:cellEditor >
-                                        <f:facet name="output"><h:outputText value="#{importSelCert.alias}"/></f:facet>
+                                        <f:facet name="output"><h:outputText value="#{importSelCert.alias}" style="font-weight: bold"/></f:facet>
                                         <f:facet name="input"><p:inputText id="aliasInput" value="#{importSelCert.alias}" style="width:100%" required="true"/></f:facet>
                                     </p:cellEditor>
                                 </p:column>
@@ -56,14 +56,14 @@
                                 </p:column>
                             </p:dataTable>
                         </div>
-                        
+
                         <div class="form-group">
                             <h:outputLabel for="checkbox-refreshCache" class="col-sm-3 control-label" id="check-refreshCacheLabel" value="Refresh Services Cache (recommended when replacing previous cert): " />
                             <div class="col-sm-9">
                                 <p:selectBooleanCheckbox id="checkbox-refreshCache" value="#{certificateBean.refreshCache}" />
                             </div>
-                        </div> 
-                        
+                        </div>
+
                         <div class="form-group">
                             <div class="col-sm-12">
                                 <div class="form-button-row">

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/HeaderForBaseTemplate.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/resources/Templates/HeaderForBaseTemplate.xhtml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  /* 
+  /*
    * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
-   * All rights reserved. 
+   * All rights reserved.
    *
-   * Redistribution and use in source and binary forms, with or without  
-   * modification, are permitted provided that the following conditions are met:  
-   *     * Redistributions of source code must retain the above  
-   *       copyright notice, this list of conditions and the following disclaimer. 
-   *     * Redistributions in binary form must reproduce the above copyright  
-   *       notice, this list of conditions and the following disclaimer in the documentation  
-   *       and/or other materials provided with the distribution.  
-   *     * Neither the name of the United States Government nor the  
-   *       names of its contributors may be used to endorse or promote products  
-   *       derived from this software without specific prior written permission.  
-   * 
-   * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  
-   * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED  
-   * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE  
-   * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY  
-   * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES  
-   * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;  
-   * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND  
-   * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT  
-   * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS  
+   * Redistribution and use in source and binary forms, with or without
+   * modification, are permitted provided that the following conditions are met:
+   *     * Redistributions of source code must retain the above
+   *       copyright notice, this list of conditions and the following disclaimer.
+   *     * Redistributions in binary form must reproduce the above copyright
+   *       notice, this list of conditions and the following disclaimer in the documentation
+   *       and/or other materials provided with the distribution.
+   *     * Neither the name of the United States Government nor the
+   *       names of its contributors may be used to endorse or promote products
+   *       derived from this software without specific prior written permission.
+   *
+   * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+   * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+   * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
    * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-   */ 
+   */
 -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
@@ -37,12 +37,12 @@
         <ui:composition>
             <header id="header">
                 <div class="">
-                   
+
                     <ul class="nav navbar-nav">
                         <li>
                             <h:form>
                                 <p:menubar>
-                                    <p:menuitem>
+                                    <p:menuitem style="padding:0px">
                                         <p:graphicImage value="resources/images/logo-connect-108x40.png"/>
                                     </p:menuitem>
                                     <p:submenu label="Logged in as #{manageUserBean.currentUser}">

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/status.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/status.xhtml
@@ -51,8 +51,8 @@
                             widgetVar="alertsPanel" style="width: 100%; margin: 0 auto;">
                             <h2 class="subsection-header">System Alerts and Notifications</h2>
                             <div class="table-responsive table-orgs">
-                                <p:dataTable id="certificateTable" rows="5" widgetVar="certificateTable" var="cert"
-                                    value="#{statusBean.certificateList}" scrollable="TRUE" scrollHeight="200"
+                                <p:dataTable id="certificateTable" rows="3" widgetVar="certificateTable" var="cert"
+                                    value="#{statusBean.certificateList}" scrollable="TRUE" scrollHeight="100"
                                     styleClass="table table-striped table-status" lazy="true">
                                     <p:column>
                                         <h:outputText rendered="#{cert.expiryColorCoding eq 'RED' and cert.expiresInDays le 0 }"

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
@@ -154,13 +154,58 @@ public class NhincConstants {
         }
     }
 
+    public enum EVENT_LOGGING_SERVICE_NAME {
+
+        PATIENT_DISCOVERY("Patient Discovery"), PATIENT_DISCOVERY_DEFERRED_REQUEST("Patient Discovery Deferred Request"),
+        PATIENT_DISCOVERY_DEFERRED_RESPONSE("Patient Discovery Deferred Response"), DOCUMENT_QUERY("Document Query"),
+        DOCUMENT_RETRIEVE("Retrieve Document"), DOCUMENT_SUBMISSION("Document Submission"),
+        DOCUMENT_SUBMISSION_DEFERRED_REQUEST("Document Submission Deferred Request"),
+        DOCUMENT_SUBMISSION_DEFERRED_RESPONSE("Document Submission Deferred Response"),
+        ADMINISTRATIVE_DISTRIBUTION("Admin Distribution"), DOCUMENT_DATA_SUBMISSION("Document Data Submission"),
+        PATIENT_LOCATION_QUERY("Patient Location Query");
+
+        String abbServiceName = null;
+
+        EVENT_LOGGING_SERVICE_NAME(String value) {
+            abbServiceName = value;
+        }
+
+        public String getAbbServiceName() {
+            return abbServiceName;
+        }
+
+        public static EVENT_LOGGING_SERVICE_NAME fromValueString(String valueString) {
+            if (valueString != null) {
+                for (EVENT_LOGGING_SERVICE_NAME enumValue : EVENT_LOGGING_SERVICE_NAME.values()) {
+                    if (valueString.equals(enumValue.abbServiceName)) {
+                        return enumValue;
+                    }
+                }
+            }
+            throw new IllegalArgumentException("Event Logging not implemented for " + valueString);
+        }
+
+        public static List<String> getEventLoggingServiceForDisplay() {
+            final List<String> enumServiceNames = new ArrayList<>();
+            for (final EVENT_LOGGING_SERVICE_NAME m : values()) {
+                if (!m.equals(EVENT_LOGGING_SERVICE_NAME.DOCUMENT_SUBMISSION_DEFERRED_REQUEST) && !m.equals(
+                    EVENT_LOGGING_SERVICE_NAME.DOCUMENT_SUBMISSION_DEFERRED_RESPONSE) && !m.equals(
+                        EVENT_LOGGING_SERVICE_NAME.PATIENT_DISCOVERY_DEFERRED_REQUEST)
+                    && !m.equals(EVENT_LOGGING_SERVICE_NAME.PATIENT_DISCOVERY_DEFERRED_RESPONSE)) {
+                    enumServiceNames.add(m.toString());
+                }
+            }
+            return enumServiceNames;
+        }
+    }
+
     // Authorization Framework
     public static final String AUTH_FRWK_NAME_ID_FORMAT_EMAIL_ADDRESS
-    = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
+        = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
     public static final String AUTH_FRWK_NAME_ID_FORMAT_X509
-    = "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName";
+        = "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName";
     public static final String AUTH_FRWK_NAME_ID_FORMAT_WINDOWS_NAME
-    = "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName";
+        = "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName";
     // SAML constants
     public static final String SAML_DEFAULT_ISSUER_NAME = "CN=SAML User,OU=SU,O=SAML User,L=Los Angeles,ST=CA,C=US";
     public static final String ACTION_NAMESPACE_STRING = "urn:oasis:names:tc:SAML:1.0:action:rwedc";
@@ -326,7 +371,7 @@ public class NhincConstants {
     public static final String WS_SOAP_HEADER_ACTION = "Action";
     public static final String WS_RETRIEVE_DOCUMENT_ACTION = "urn:ihe:iti:2007:RetrieveDocumentSet";
     public static final String WS_PROVIDE_AND_REGISTER_DOCUMENT_ACTION
-    = "urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b";
+        = "urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b";
     public static final String WS_SOAP_ATTR_MUSTUNDERSTAND = "mustUnderstand";
     public static final String WS_SOAP_HEADER_TO = "To";
     public static final String WS_SOAP_HEADER_REPLYTO = "ReplyTo";
@@ -343,7 +388,7 @@ public class NhincConstants {
     public static final String ENTITY_DOC_QUERY_PROXY_SERVICE_NAME = "entitydocqueryproxy";
     public static final String ENTITY_DOC_QUERY_SECURED_SERVICE_NAME = "entitydocquerysecured";
     public static final String NHINC_ADHOC_QUERY_SUCCESS_RESPONSE
-    = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success";
+        = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success";
     public static final BigInteger NHINC_ADHOC_QUERY_NO_RESULT_COUNT = BigInteger.valueOf(0L);
     // Document Retrieve Constants
     public static final String ADAPTER_DOC_RETRIEVE_SERVICE_NAME = "adapterdocretrieve";
@@ -367,28 +412,28 @@ public class NhincConstants {
     public static final String ADAPTER_PATIENT_DISCOVERY_SECURED_SERVICE_NAME = "adapterpatientdiscoverysecured";
     public static final String PATIENT_DISCOVERY_ADAPTER_ASYNC_REQ_SERVICE_NAME = "adapterpatientdiscoveryasyncreq";
     public static final String PATIENT_DISCOVERY_ADAPTER_SECURED_ASYNC_REQ_SERVICE_NAME
-    = "adapterpatientdiscoverysecuredasyncreq";
+        = "adapterpatientdiscoverysecuredasyncreq";
     public static final String PATIENT_DISCOVERY_ADAPTER_ASYNC_REQ_ERROR_SERVICE_NAME
-    = "adapterpatientdiscoveryasyncreqerror";
+        = "adapterpatientdiscoveryasyncreqerror";
     public static final String PATIENT_DISCOVERY_ADAPTER_SECURED_ASYNC_REQ_ERROR_SERVICE_NAME
-    = "adapterpatientdiscoverysecuredasyncreqerror";
+        = "adapterpatientdiscoverysecuredasyncreqerror";
     public static final String PATIENT_DISCOVERY_ADAPTER_ASYNC_RESP_SERVICE_NAME = "adapterpatientdiscoveryasyncresp";
     public static final String PATIENT_DISCOVERY_ADAPTER_SECURED_ASYNC_RESP_SERVICE_NAME
-    = "adapterpatientdiscoverysecuredasyncresp";
+        = "adapterpatientdiscoverysecuredasyncresp";
     public static final String ENTITY_PATIENT_DISCOVERY_SECURED_SERVICE_NAME = "entitypatientdiscoverysecured";
     public static final String ENTITY_PATIENT_DISCOVERY_SERVICE_NAME = "entitypatientdiscovery";
     public static final String PATIENT_DISCOVERY_ENTITY_ASYNC_REQ_SERVICE_NAME = "entitypatientdiscoveryasyncreq";
     public static final String PATIENT_DISCOVERY_ENTITY_SECURED_ASYNC_REQ_SERVICE_NAME
-    = "entitypatientdiscoverysecuredasyncreq";
+        = "entitypatientdiscoverysecuredasyncreq";
     public static final String PATIENT_DISCOVERY_ENTITY_ASYNC_RESP_SERVICE_NAME = "entitypatientdiscoveryasyncresp";
     public static final String PATIENT_DISCOVERY_ENTITY_SECURED_ASYNC_RESP_SERVICE_NAME
-    = "entitypatientdiscoverysecuredasyncresp";
+        = "entitypatientdiscoverysecuredasyncresp";
     public static final String PATIENT_DISCOVERY_ADAPTER_ASYNC_REQ_QUEUE_SERVICE_NAME
-    = "adapterpatientdiscoveryasyncreqqueue";
+        = "adapterpatientdiscoveryasyncreqqueue";
     public static final String PATIENT_DISCOVERY_ADAPTER_SECURED_ASYNC_REQ_QUEUE_SERVICE_NAME
-    = "adapterpatientdiscoverysecuredasyncreqqueue";
+        = "adapterpatientdiscoverysecuredasyncreqqueue";
     public static final String PATIENT_DISCOVERY_ADAPTER_ASYNC_REQ_QUEUE_PROCESS_SERVICE_NAME
-    = "adapterpatientdiscoverydeferredreqqueueprocess";
+        = "adapterpatientdiscoverydeferredreqqueueprocess";
 
     // Patient Discovery Error Constants
     public static final String PATIENT_DISCOVERY_ANSWER_NOT_AVAIL_ERR_CODE = "AnswerNotAvailable";
@@ -398,7 +443,7 @@ public class NhincConstants {
     public static final String PATIENT_DISCOVERY_TELCOM_MORE_CODE = "PatientTelecomRequested";
     public static final String PATIENT_DISCOVERY_BIRTH_PLACE_NAME_MORE_CODE = "LivingSubjectBirthPlaceNameRequested";
     public static final String PATIENT_DISCOVERY_BIRTH_PLACE_ADDRESS_MORE_CODE
-    = "LivingSubjectBirthPlaceAddressRequested";
+        = "LivingSubjectBirthPlaceAddressRequested";
     public static final String PATIENT_DISCOVERY_MOTHERS_MAIDEN_NAME_MORE_CODE = "MothersMaidenNameRequested";
     public static final String PATIENT_DISCOVERY_SSN_MORE_CODE = "SSNRequested";
     // XDR Constants
@@ -429,7 +474,7 @@ public class NhincConstants {
     public static final String ADAPTER_COMPONENT_XDR_RESPONSE_SERVICE_NAME = "adaptercomponentxdrresponse";
     public static final String XDR_ACK_STATUS_MSG = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:RequestAccepted";
     public static final String XDR_RESP_ACK_STATUS_MSG
-    = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:ResponseAccepted";
+        = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:ResponseAccepted";
     public static final String XDR_ACK_FAILURE_STATUS_MSG = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Failure";
 
     // Administrative Distribution Constants
@@ -458,39 +503,39 @@ public class NhincConstants {
 
     public static final String NHIN_CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME = "nhincore_x12dsgenericbatchrequest";
     public static final String NHIN_CORE_X12DS_GENERICBATCH_REQUEST_SECURED_SERVICE_NAME
-    = "nhincore_x12dsgenericbatchrequestwssecured";
+        = "nhincore_x12dsgenericbatchrequestwssecured";
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME
-    = "entitycore_x12dsgenericbatchrequest";
+        = "entitycore_x12dsgenericbatchrequest";
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_REQUEST_SECURED_SERVICE_NAME
-    = "entitycore_x12dsgenericbatchrequestsecured";
+        = "entitycore_x12dsgenericbatchrequestsecured";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME
-    = "adaptercore_x12dsgenericbatchrequest";
+        = "adaptercore_x12dsgenericbatchrequest";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_SECURED_SERVICE_NAME
-    = "adaptercore_x12dsgenericbatchrequestsecured";
+        = "adaptercore_x12dsgenericbatchrequestsecured";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_NOOP_SERVICE_NAME
-    = "adaptercore_x12dsgenericbatchrequestnoop";
+        = "adaptercore_x12dsgenericbatchrequestnoop";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_JAVA_SERVICE_NAME
-    = "adaptercore_x12dsgenericbatchrequestjava";
+        = "adaptercore_x12dsgenericbatchrequestjava";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_PROXY_SERVICE_NAME
-    = "adaptercore_x12dsgenericbatchrequestproxybean";
+        = "adaptercore_x12dsgenericbatchrequestproxybean";
 
     public static final String NHIN_CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME = "nhincore_x12dsgenericbatchresponse";
     public static final String NHIN_CORE_X12DS_GENERICBATCH_RESPONSE_SECURED_SERVICE_NAME
-    = "nhincore_x12dsgenericbatchresponsewssecured";
+        = "nhincore_x12dsgenericbatchresponsewssecured";
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME
-    = "entitycore_x12dsgenericbatchresponse";
+        = "entitycore_x12dsgenericbatchresponse";
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_RESPONSE_SECURED_SERVICE_NAME
-    = "entitycore_x12dsgenericbatchresponsesecured";
+        = "entitycore_x12dsgenericbatchresponsesecured";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME
-    = "adaptercore_x12dsgenericbatchresponse";
+        = "adaptercore_x12dsgenericbatchresponse";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_SECURED_SERVICE_NAME
-    = "adaptercore_x12dsgenericbatchresponsesecured";
+        = "adaptercore_x12dsgenericbatchresponsesecured";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_NOOP_SERVICE_NAME
-    = "adaptercore_x12dsgenericbatchresponsenoop";
+        = "adaptercore_x12dsgenericbatchresponsenoop";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_JAVA_SERVICE_NAME
-    = "adaptercore_x12dsgenericbatchresponsejava";
+        = "adaptercore_x12dsgenericbatchresponsejava";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_PROXY_SERVICE_NAME
-    = "adaptercore_x12dsgenericbatchresponseproxybean";
+        = "adaptercore_x12dsgenericbatchresponseproxybean";
     public static final String CORE_X12DS_GENERICBATCH_PROXY_CONFIG_FILE_NAME = "CORE_X12DSGenericBatchProxyConfig.xml";
     public static final String CORE_X12DS_ACK_ERROR_MSG = null;
     public static final String CORE_X12DS_ACK_ERROR_CODE = null;
@@ -517,20 +562,20 @@ public class NhincConstants {
     public static final String HIBERNATE_ADMINGUI_REPOSITORY = "admingui.hibernate.cfg.xml";
 
     public static final String XDS_REGISTRY_ERROR_SEVERITY_WARNING
-    = "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Warning";
+        = "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Warning";
     public static final String XDS_REGISTRY_ERROR_SEVERITY_ERROR
-    = "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error";
+        = "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error";
     public static final String DIRECT_SOAP_EDGE_SERVICE_NAME = "directsoapedge";
     // JMX configurations
     public static final String JMX_ENABLED_SYSTEM_PROPERTY = "org.connectopensource.enablejmx";
     public static final String JMX_CONFIGURATION_BEAN_NAME = "org.connectopensource.mbeans:type=Configuration";
 
     public static final String JMX_DOCUMENT_QUERY_30_BEAN_NAME
-    = "org.connectopensource.mbeans:type=DocumentQuery30WebServices";
+        = "org.connectopensource.mbeans:type=DocumentQuery30WebServices";
     public static final String JMX_DOCUMENT_QUERY_20_BEAN_NAME
-    = "org.connectopensource.mbeans:type=DocumentQuery20WebServices";
+        = "org.connectopensource.mbeans:type=DocumentQuery20WebServices";
     public static final String JMX_PATIENT_DISCOVERY_10_BEAN_NAME
-    = "org.connectopensource.mbeans:type=PatientDiscovery10WebServices";
+        = "org.connectopensource.mbeans:type=PatientDiscovery10WebServices";
     // Standard Format for parsing String into Date
     public static final String DATE_PARSE_FORMAT = "yyyyMMddHHmmss";
     // Document Type property for UClient


### PR DESCRIPTION
- Fixed CONNECT logo  placement.
- Bar Chart and Pie Chart were not getting displayed  at all as there was no data in the database. Fixed it and now it will display an empty bar chart and legends for  pie chart.
- At-most 3 Alerts are displayed on Dashboard page. User can click on View All Alerts to see all the alerts.
- Removed string *&lts;Enter Alias &gt;* on  Import certificate datatable. User will now see a bold Enter Alias string. 
- Selected Certificate will now appear selected and displayed in the Viewing pane when View Chain Of trust is loaded. 
-Added an Event_Logging_Servcie_name enum to NhincConstants to help display empty bar and pie charts. In future, EventLogging annotations can use this enum to record service name in database. 