### PR TITLE
CONN-2289: Disable to delete its own public cert

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/CertificateManagerService.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/CertificateManagerService.java
@@ -26,6 +26,8 @@
  */
 package gov.hhs.fha.nhinc.admingui.services;
 
+import gov.hhs.fha.nhinc.common.configadmin.SimpleCertificateResponseMessageType;
+
 import gov.hhs.fha.nhinc.callback.opensaml.CertificateDTO;
 import gov.hhs.fha.nhinc.callback.opensaml.CertificateManagerException;
 import java.util.List;
@@ -56,7 +58,7 @@ public interface CertificateManagerService {
 
     public boolean importCertificate(CertificateDTO cert, boolean refresh, String hashToken) throws Exception;
 
-    public boolean deleteCertificateFromTrustStore(String alias, String hashToken)
+    public SimpleCertificateResponseMessageType deleteCertificateFromTrustStore(String alias, String hashToken)
         throws CertificateManagerException;
 
     public boolean updateCertificate(String oldAlias, CertificateDTO cert, String hashToken)

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/impl/CertificateManagerServiceImpl.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/impl/CertificateManagerServiceImpl.java
@@ -256,15 +256,14 @@ public class CertificateManagerServiceImpl implements CertificateManagerService 
     }
 
     @Override
-    public boolean deleteCertificateFromTrustStore(String alias, String hashToken) throws CertificateManagerException {
+    public SimpleCertificateResponseMessageType deleteCertificateFromTrustStore(String alias, String hashToken) throws CertificateManagerException {
         DeleteCertificateRequestMessageType request = new DeleteCertificateRequestMessageType();
         request.setConfigAssertion(buildConfigAssertion());
         request.setHashToken(hashToken);
         request.setAlias(alias);
         try {
-            SimpleCertificateResponseMessageType response = (SimpleCertificateResponseMessageType) getClient()
+            return (SimpleCertificateResponseMessageType) getClient()
                 .invokePort(EntityConfigAdminPortType.class, NhincConstants.ADMIN_CERT_DELETE, request);
-            return response.isStatus();
         } catch (Exception e) {
             throw new CertificateManagerException("Error deleting the selected certificate.", e);
         }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/CertificateManagerImpl.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/CertificateManagerImpl.java
@@ -160,6 +160,12 @@ public class CertificateManagerImpl implements CertificateManager {
                 is = new FileInputStream(storeLoc);
             }
             tstore.load(is, passkey.toCharArray());
+            // restrict deleting from its own public cert
+            X509Certificate publicCert = getDefaultCertificate();
+            String publicAlias = tstore.getCertificateAlias(publicCert);
+            if (StringUtils.equalsIgnoreCase(alias, publicAlias)) {
+                throw new CertificateManagerException("System cannot remove its own public cert");
+            }
             if (tstore.containsAlias(alias)) {
                 tstore.deleteEntry(alias);
                 os = new FileOutputStream(storeLoc);


### PR DESCRIPTION
Without its public cert, the CONNECT Gateway won't allow clients to communicate through https.  Therefore, we will restrict user to delete its public cert accidently. 