### PR TITLE
Event chart fixes

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/StatusBean.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/StatusBean.java
@@ -45,7 +45,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
@@ -54,7 +53,6 @@ import org.primefaces.model.chart.HorizontalBarChartModel;
 import org.primefaces.model.chart.PieChartModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.util.CollectionUtils;
 
 /**
  *
@@ -168,16 +166,16 @@ public class StatusBean {
 
     private void refreshPieChart() {
         if (snapshot.getEvents().isEmpty()) {
-            List<String> serviceNames = NhincConstants.EVENT_LOGGING_SERVICE_NAME.getEventLoggingServiceForDisplay();
-            for (String serviceName : serviceNames) {
-                eventPieChart.getData().put(serviceName, 0);
-            }
             eventPieChart.setTitle(NO_DATA_FOUND);
-        } else {
-            for (EventCount event : snapshot.getEvents().values()) {
-                eventPieChart.getData().put(event.getEvent(), event.getTotal());
-            }
         }
+        List<String> serviceNames = NhincConstants.EVENT_LOGGING_SERVICE_NAME.getEventLoggingServiceForDisplay();
+        int count;
+        for (String serviceName : serviceNames) {
+            count = (snapshot.getEvents().get(serviceName) == null || snapshot.getEvents().get(serviceName).getTotal()
+                == null) ? 0 : snapshot.getEvents().get(serviceName).getTotal().intValue();
+            eventPieChart.getData().put(serviceName, count);
+        }
+
         eventPieChart.setFill(false);
         eventPieChart.setSeriesColors("10253F, CC0000, 33D6FF, FFCC00, 98FB98, FFA500, 00CCFF");
         eventPieChart.setShowDataLabels(true);
@@ -198,6 +196,7 @@ public class StatusBean {
         eventBarChart.setSeriesColors("10253F, CC0000");
         eventBarChart.setStacked(true);
         eventBarChart.setLegendPosition("se");
+        eventBarChart.setBarWidth(30);
         if (inboundEventCounts.isEmpty() && outboundEventCounts.isEmpty()) {
             eventBarChart.setTitle(NO_DATA_FOUND);
         }
@@ -206,15 +205,12 @@ public class StatusBean {
     private static ChartSeries createChart(String label, Map<String, Long> eventCounts) {
         ChartSeries series = new ChartSeries();
         series.setLabel(label);
-        if (CollectionUtils.isEmpty(eventCounts)) {
-            List<String> serviceNames = NhincConstants.EVENT_LOGGING_SERVICE_NAME.getEventLoggingServiceForDisplay();
-            for (String serviceName : serviceNames) {
-                series.set(serviceName, 0);
-            }
-        } else {
-            for (Entry<String, Long> serviceEntry : eventCounts.entrySet()) {
-                series.set(serviceEntry.getKey(), serviceEntry.getValue());
-            }
+
+        List<String> serviceNames = NhincConstants.EVENT_LOGGING_SERVICE_NAME.getEventLoggingServiceForDisplay();
+        int count = 0;
+        for (String serviceName : serviceNames) {
+            count = eventCounts.get(serviceName) == null ? 0 : eventCounts.get(serviceName).intValue();
+            series.set(serviceName, count);
         }
         return series;
     }

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/status.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/status.xhtml
@@ -136,8 +136,8 @@
 
 
                                     <h2 class="subsection-header">SERVICES</h2>
-                                    <h:panelGrid columns="2" styleClass="gridStatus" style="width: 1040px;">
-                                        <p:panel style="width: 500px; padding: 10px;">
+                                    <p:panelGrid columns="2" styleClass="gridStatus" layout="grid">
+                                        <p:panel style="padding: 10px;">
                                             <p>Green Available / Red Unavailable</p>
                                             <div class="table-responsive table-orgs">
                                                 <p:dataTable id="servicesTable" widgetVar="servicesTable" var="service"
@@ -153,11 +153,11 @@
                                                 </p:dataTable>
                                             </div>
                                         </p:panel>
-                                        <p:panel style="width: 800px; padding: 10px;">
+                                        <p:panel style="padding: 10px;">
                                             <p:chart type="bar" id="eventBarChart" model="#{statusBean.eventBarChart}" />
                                             <p:chart type="pie" id="eventPieChart" model="#{statusBean.eventPieChart}" />
                                         </p:panel>
-                                    </h:panelGrid>
+                                    </p:panelGrid>
                                     <p:poll interval="5" update="statusGrid eventPieChart eventBarChart" />
                                 </h:form>
                             </div>

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
@@ -192,7 +192,7 @@ public class NhincConstants {
                     EVENT_LOGGING_SERVICE_NAME.DOCUMENT_SUBMISSION_DEFERRED_RESPONSE) && !m.equals(
                         EVENT_LOGGING_SERVICE_NAME.PATIENT_DISCOVERY_DEFERRED_REQUEST)
                     && !m.equals(EVENT_LOGGING_SERVICE_NAME.PATIENT_DISCOVERY_DEFERRED_RESPONSE)) {
-                    enumServiceNames.add(m.toString());
+                    enumServiceNames.add(m.getAbbServiceName());
                 }
             }
             return enumServiceNames;
@@ -201,11 +201,11 @@ public class NhincConstants {
 
     // Authorization Framework
     public static final String AUTH_FRWK_NAME_ID_FORMAT_EMAIL_ADDRESS
-    = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
+        = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
     public static final String AUTH_FRWK_NAME_ID_FORMAT_X509
-    = "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName";
+        = "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName";
     public static final String AUTH_FRWK_NAME_ID_FORMAT_WINDOWS_NAME
-    = "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName";
+        = "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName";
     // SAML constants
     public static final String SAML_DEFAULT_ISSUER_NAME = "CN=SAML User,OU=SU,O=SAML User,L=Los Angeles,ST=CA,C=US";
     public static final String ACTION_NAMESPACE_STRING = "urn:oasis:names:tc:SAML:1.0:action:rwedc";
@@ -372,7 +372,7 @@ public class NhincConstants {
     public static final String WS_SOAP_HEADER_ACTION = "Action";
     public static final String WS_RETRIEVE_DOCUMENT_ACTION = "urn:ihe:iti:2007:RetrieveDocumentSet";
     public static final String WS_PROVIDE_AND_REGISTER_DOCUMENT_ACTION
-    = "urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b";
+        = "urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b";
     public static final String WS_SOAP_ATTR_MUSTUNDERSTAND = "mustUnderstand";
     public static final String WS_SOAP_HEADER_TO = "To";
     public static final String WS_SOAP_HEADER_REPLYTO = "ReplyTo";
@@ -389,7 +389,7 @@ public class NhincConstants {
     public static final String ENTITY_DOC_QUERY_PROXY_SERVICE_NAME = "entitydocqueryproxy";
     public static final String ENTITY_DOC_QUERY_SECURED_SERVICE_NAME = "entitydocquerysecured";
     public static final String NHINC_ADHOC_QUERY_SUCCESS_RESPONSE
-    = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success";
+        = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success";
     public static final BigInteger NHINC_ADHOC_QUERY_NO_RESULT_COUNT = BigInteger.valueOf(0L);
     // Document Retrieve Constants
     public static final String ADAPTER_DOC_RETRIEVE_SERVICE_NAME = "adapterdocretrieve";
@@ -413,28 +413,28 @@ public class NhincConstants {
     public static final String ADAPTER_PATIENT_DISCOVERY_SECURED_SERVICE_NAME = "adapterpatientdiscoverysecured";
     public static final String PATIENT_DISCOVERY_ADAPTER_ASYNC_REQ_SERVICE_NAME = "adapterpatientdiscoveryasyncreq";
     public static final String PATIENT_DISCOVERY_ADAPTER_SECURED_ASYNC_REQ_SERVICE_NAME
-    = "adapterpatientdiscoverysecuredasyncreq";
+        = "adapterpatientdiscoverysecuredasyncreq";
     public static final String PATIENT_DISCOVERY_ADAPTER_ASYNC_REQ_ERROR_SERVICE_NAME
-    = "adapterpatientdiscoveryasyncreqerror";
+        = "adapterpatientdiscoveryasyncreqerror";
     public static final String PATIENT_DISCOVERY_ADAPTER_SECURED_ASYNC_REQ_ERROR_SERVICE_NAME
-    = "adapterpatientdiscoverysecuredasyncreqerror";
+        = "adapterpatientdiscoverysecuredasyncreqerror";
     public static final String PATIENT_DISCOVERY_ADAPTER_ASYNC_RESP_SERVICE_NAME = "adapterpatientdiscoveryasyncresp";
     public static final String PATIENT_DISCOVERY_ADAPTER_SECURED_ASYNC_RESP_SERVICE_NAME
-    = "adapterpatientdiscoverysecuredasyncresp";
+        = "adapterpatientdiscoverysecuredasyncresp";
     public static final String ENTITY_PATIENT_DISCOVERY_SECURED_SERVICE_NAME = "entitypatientdiscoverysecured";
     public static final String ENTITY_PATIENT_DISCOVERY_SERVICE_NAME = "entitypatientdiscovery";
     public static final String PATIENT_DISCOVERY_ENTITY_ASYNC_REQ_SERVICE_NAME = "entitypatientdiscoveryasyncreq";
     public static final String PATIENT_DISCOVERY_ENTITY_SECURED_ASYNC_REQ_SERVICE_NAME
-    = "entitypatientdiscoverysecuredasyncreq";
+        = "entitypatientdiscoverysecuredasyncreq";
     public static final String PATIENT_DISCOVERY_ENTITY_ASYNC_RESP_SERVICE_NAME = "entitypatientdiscoveryasyncresp";
     public static final String PATIENT_DISCOVERY_ENTITY_SECURED_ASYNC_RESP_SERVICE_NAME
-    = "entitypatientdiscoverysecuredasyncresp";
+        = "entitypatientdiscoverysecuredasyncresp";
     public static final String PATIENT_DISCOVERY_ADAPTER_ASYNC_REQ_QUEUE_SERVICE_NAME
-    = "adapterpatientdiscoveryasyncreqqueue";
+        = "adapterpatientdiscoveryasyncreqqueue";
     public static final String PATIENT_DISCOVERY_ADAPTER_SECURED_ASYNC_REQ_QUEUE_SERVICE_NAME
-    = "adapterpatientdiscoverysecuredasyncreqqueue";
+        = "adapterpatientdiscoverysecuredasyncreqqueue";
     public static final String PATIENT_DISCOVERY_ADAPTER_ASYNC_REQ_QUEUE_PROCESS_SERVICE_NAME
-    = "adapterpatientdiscoverydeferredreqqueueprocess";
+        = "adapterpatientdiscoverydeferredreqqueueprocess";
 
     // Patient Discovery Error Constants
     public static final String PATIENT_DISCOVERY_ANSWER_NOT_AVAIL_ERR_CODE = "AnswerNotAvailable";
@@ -444,7 +444,7 @@ public class NhincConstants {
     public static final String PATIENT_DISCOVERY_TELCOM_MORE_CODE = "PatientTelecomRequested";
     public static final String PATIENT_DISCOVERY_BIRTH_PLACE_NAME_MORE_CODE = "LivingSubjectBirthPlaceNameRequested";
     public static final String PATIENT_DISCOVERY_BIRTH_PLACE_ADDRESS_MORE_CODE
-    = "LivingSubjectBirthPlaceAddressRequested";
+        = "LivingSubjectBirthPlaceAddressRequested";
     public static final String PATIENT_DISCOVERY_MOTHERS_MAIDEN_NAME_MORE_CODE = "MothersMaidenNameRequested";
     public static final String PATIENT_DISCOVERY_SSN_MORE_CODE = "SSNRequested";
     // XDR Constants
@@ -475,7 +475,7 @@ public class NhincConstants {
     public static final String ADAPTER_COMPONENT_XDR_RESPONSE_SERVICE_NAME = "adaptercomponentxdrresponse";
     public static final String XDR_ACK_STATUS_MSG = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:RequestAccepted";
     public static final String XDR_RESP_ACK_STATUS_MSG
-    = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:ResponseAccepted";
+        = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:ResponseAccepted";
     public static final String XDR_ACK_FAILURE_STATUS_MSG = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Failure";
 
     // Administrative Distribution Constants
@@ -505,39 +505,39 @@ public class NhincConstants {
 
     public static final String NHIN_CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME = "nhincore_x12dsgenericbatchrequest";
     public static final String NHIN_CORE_X12DS_GENERICBATCH_REQUEST_SECURED_SERVICE_NAME
-    = "nhincore_x12dsgenericbatchrequestwssecured";
+        = "nhincore_x12dsgenericbatchrequestwssecured";
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME
-    = "entitycore_x12dsgenericbatchrequest";
+        = "entitycore_x12dsgenericbatchrequest";
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_REQUEST_SECURED_SERVICE_NAME
-    = "entitycore_x12dsgenericbatchrequestsecured";
+        = "entitycore_x12dsgenericbatchrequestsecured";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME
-    = "adaptercore_x12dsgenericbatchrequest";
+        = "adaptercore_x12dsgenericbatchrequest";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_SECURED_SERVICE_NAME
-    = "adaptercore_x12dsgenericbatchrequestsecured";
+        = "adaptercore_x12dsgenericbatchrequestsecured";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_NOOP_SERVICE_NAME
-    = "adaptercore_x12dsgenericbatchrequestnoop";
+        = "adaptercore_x12dsgenericbatchrequestnoop";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_JAVA_SERVICE_NAME
-    = "adaptercore_x12dsgenericbatchrequestjava";
+        = "adaptercore_x12dsgenericbatchrequestjava";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_PROXY_SERVICE_NAME
-    = "adaptercore_x12dsgenericbatchrequestproxybean";
+        = "adaptercore_x12dsgenericbatchrequestproxybean";
 
     public static final String NHIN_CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME = "nhincore_x12dsgenericbatchresponse";
     public static final String NHIN_CORE_X12DS_GENERICBATCH_RESPONSE_SECURED_SERVICE_NAME
-    = "nhincore_x12dsgenericbatchresponsewssecured";
+        = "nhincore_x12dsgenericbatchresponsewssecured";
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME
-    = "entitycore_x12dsgenericbatchresponse";
+        = "entitycore_x12dsgenericbatchresponse";
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_RESPONSE_SECURED_SERVICE_NAME
-    = "entitycore_x12dsgenericbatchresponsesecured";
+        = "entitycore_x12dsgenericbatchresponsesecured";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME
-    = "adaptercore_x12dsgenericbatchresponse";
+        = "adaptercore_x12dsgenericbatchresponse";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_SECURED_SERVICE_NAME
-    = "adaptercore_x12dsgenericbatchresponsesecured";
+        = "adaptercore_x12dsgenericbatchresponsesecured";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_NOOP_SERVICE_NAME
-    = "adaptercore_x12dsgenericbatchresponsenoop";
+        = "adaptercore_x12dsgenericbatchresponsenoop";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_JAVA_SERVICE_NAME
-    = "adaptercore_x12dsgenericbatchresponsejava";
+        = "adaptercore_x12dsgenericbatchresponsejava";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_PROXY_SERVICE_NAME
-    = "adaptercore_x12dsgenericbatchresponseproxybean";
+        = "adaptercore_x12dsgenericbatchresponseproxybean";
     public static final String CORE_X12DS_GENERICBATCH_PROXY_CONFIG_FILE_NAME = "CORE_X12DSGenericBatchProxyConfig.xml";
     public static final String CORE_X12DS_ACK_ERROR_MSG = null;
     public static final String CORE_X12DS_ACK_ERROR_CODE = null;
@@ -564,20 +564,20 @@ public class NhincConstants {
     public static final String HIBERNATE_ADMINGUI_REPOSITORY = "admingui.hibernate.cfg.xml";
 
     public static final String XDS_REGISTRY_ERROR_SEVERITY_WARNING
-    = "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Warning";
+        = "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Warning";
     public static final String XDS_REGISTRY_ERROR_SEVERITY_ERROR
-    = "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error";
+        = "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error";
     public static final String DIRECT_SOAP_EDGE_SERVICE_NAME = "directsoapedge";
     // JMX configurations
     public static final String JMX_ENABLED_SYSTEM_PROPERTY = "org.connectopensource.enablejmx";
     public static final String JMX_CONFIGURATION_BEAN_NAME = "org.connectopensource.mbeans:type=Configuration";
 
     public static final String JMX_DOCUMENT_QUERY_30_BEAN_NAME
-    = "org.connectopensource.mbeans:type=DocumentQuery30WebServices";
+        = "org.connectopensource.mbeans:type=DocumentQuery30WebServices";
     public static final String JMX_DOCUMENT_QUERY_20_BEAN_NAME
-    = "org.connectopensource.mbeans:type=DocumentQuery20WebServices";
+        = "org.connectopensource.mbeans:type=DocumentQuery20WebServices";
     public static final String JMX_PATIENT_DISCOVERY_10_BEAN_NAME
-    = "org.connectopensource.mbeans:type=PatientDiscovery10WebServices";
+        = "org.connectopensource.mbeans:type=PatientDiscovery10WebServices";
     // Standard Format for parsing String into Date
     public static final String DATE_PARSE_FORMAT = "yyyyMMddHHmmss";
     // Document Type property for UClient


### PR DESCRIPTION
1. Service names are displayed instead of constant strings.
2. Service names are displayed on the bar chart even if there are no events for that service.