### PR TITLE
SonarQube fixes

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/impl/InternalExchangeManagerServiceImpl.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/impl/InternalExchangeManagerServiceImpl.java
@@ -26,12 +26,8 @@
  */
 package gov.hhs.fha.nhinc.admingui.services.impl;
 
-import static gov.hhs.fha.nhinc.admingui.util.HelperUtil.buildConfigAssertion;
-import static gov.hhs.fha.nhinc.nhinclib.NhincConstants.ADMIN_INTERNAL_EXCHANGE_LIST_ENDPOINTS;
-import static gov.hhs.fha.nhinc.nhinclib.NhincConstants.ADMIN_INTERNAL_EXCHANGE_UPDATE_ENDPOINT;
-import static gov.hhs.fha.nhinc.nhinclib.NhincConstants.ENTITY_INTERNAL_EXCHANGE_MANAGEMENT_SERVICE_NAME;
-
 import gov.hhs.fha.nhinc.admingui.services.InternalExchangeManagerService;
+import static gov.hhs.fha.nhinc.admingui.util.HelperUtil.buildConfigAssertion;
 import gov.hhs.fha.nhinc.common.internalexchangemanagement.EndpointPropertyType;
 import gov.hhs.fha.nhinc.common.internalexchangemanagement.ListEndpointsRequestMessageType;
 import gov.hhs.fha.nhinc.common.internalexchangemanagement.SimpleInternalExchangeManagementResponseMessageType;
@@ -43,6 +39,9 @@ import gov.hhs.fha.nhinc.internalexchangemanagement.EntityInternalExchangeManage
 import gov.hhs.fha.nhinc.messaging.client.CONNECTClient;
 import gov.hhs.fha.nhinc.messaging.client.CONNECTClientFactory;
 import gov.hhs.fha.nhinc.messaging.service.port.ServicePortDescriptor;
+import static gov.hhs.fha.nhinc.nhinclib.NhincConstants.ADMIN_EXCHANGE_LIST_ENDPOINTS;
+import static gov.hhs.fha.nhinc.nhinclib.NhincConstants.ADMIN_EXCHANGE_UPDATE_ENDPOINT;
+import static gov.hhs.fha.nhinc.nhinclib.NhincConstants.ENTITY_INTERNAL_EXCHANGE_MANAGEMENT_SERVICE_NAME;
 import gov.hhs.fha.nhinc.webserviceproxy.WebServiceProxyHelper;
 import java.util.ArrayList;
 import java.util.List;
@@ -57,6 +56,7 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class InternalExchangeManagerServiceImpl implements InternalExchangeManagerService {
+
     private static final Logger LOG = LoggerFactory.getLogger(InternalExchangeManagerServiceImpl.class);
     private static final WebServiceProxyHelper oProxyHelper = new WebServiceProxyHelper();
     private static CONNECTClient<EntityInternalExchangeManagementPortType> client = null;
@@ -67,9 +67,10 @@ public class InternalExchangeManagerServiceImpl implements InternalExchangeManag
         request.setConfigAssertion(buildConfigAssertion());
         request.setEndpoint(endpointProp);
         try {
-            SimpleInternalExchangeManagementResponseMessageType response = (SimpleInternalExchangeManagementResponseMessageType) invokeClientPort(
-                ADMIN_INTERNAL_EXCHANGE_UPDATE_ENDPOINT, request);
-            logDebug(ADMIN_INTERNAL_EXCHANGE_UPDATE_ENDPOINT, response.isStatus(), response.getMessage());
+            SimpleInternalExchangeManagementResponseMessageType response
+                = (SimpleInternalExchangeManagementResponseMessageType) invokeClientPort(
+                    ADMIN_EXCHANGE_UPDATE_ENDPOINT, request);
+            logDebug(ADMIN_EXCHANGE_UPDATE_ENDPOINT, response.isStatus(), response.getMessage());
             return response.isStatus();
         } catch (Exception e) {
             LOG.error("error during update-endpoint: {}", e.getLocalizedMessage(), e);
@@ -77,12 +78,12 @@ public class InternalExchangeManagerServiceImpl implements InternalExchangeManag
         return false;
     }
 
-
     private static CONNECTClient<EntityInternalExchangeManagementPortType> getClient() throws ExchangeManagerException {
         if (null == client) {
             String url = oProxyHelper
                 .getAdapterEndPointFromConnectionManager(ENTITY_INTERNAL_EXCHANGE_MANAGEMENT_SERVICE_NAME);
-            ServicePortDescriptor<EntityInternalExchangeManagementPortType> portDescriptor = new InternalExchangeManagementPortDescriptor();
+            ServicePortDescriptor<EntityInternalExchangeManagementPortType> portDescriptor
+                = new InternalExchangeManagementPortDescriptor();
             client = CONNECTClientFactory.getInstance().getCONNECTClientUnsecured(portDescriptor, url,
                 new AssertionType());
         }
@@ -105,9 +106,10 @@ public class InternalExchangeManagerServiceImpl implements InternalExchangeManag
         request.setConfigAssertion(buildConfigAssertion());
 
         try {
-            SimpleInternalExchangeManagementResponseMessageType response = (SimpleInternalExchangeManagementResponseMessageType) invokeClientPort(
-                ADMIN_INTERNAL_EXCHANGE_LIST_ENDPOINTS, request);
-            logDebug(ADMIN_INTERNAL_EXCHANGE_LIST_ENDPOINTS, response.getEndpointsList().size());
+            SimpleInternalExchangeManagementResponseMessageType response
+                = (SimpleInternalExchangeManagementResponseMessageType) invokeClientPort(
+                    ADMIN_EXCHANGE_LIST_ENDPOINTS, request);
+            logDebug(ADMIN_EXCHANGE_LIST_ENDPOINTS, response.getEndpointsList().size());
             return response.getEndpointsList();
         } catch (Exception e) {
             LOG.error("error during list-exchanges: {}", e.getLocalizedMessage(), e);

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
@@ -678,8 +678,7 @@ public class NhincConstants {
     public static final String ADMIN_EXCHANGE_SAVE_CONFIG = "saveExchangeConfig";
 
     // internal-exchange-management
-    public static final String ADMIN_INTERNAL_EXCHANGE_LIST_ENDPOINTS = "listEndpoints";
-    public static final String ADMIN_INTERNAL_EXCHANGE_UPDATE_ENDPOINT = "updateEndpoint";
+    public static final String ADMIN_EXCHANGE_UPDATE_ENDPOINT = "updateEndpoint";
     // Patient Location Query
     public static final String PLQ_NHIN_SERVICE_NAME = "PatientLocationQuery";
     public static final String PLQ_ENTITY_SERVICE_NAME = "patientlocationqueryservice";

--- a/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/ADMessageGeneratorUtils.java
+++ b/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/ADMessageGeneratorUtils.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -33,15 +33,17 @@ import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.common.nhinccommonentity.RespondingGatewaySendAlertMessageSecuredType;
 import gov.hhs.fha.nhinc.common.nhinccommonentity.RespondingGatewaySendAlertMessageType;
 import gov.hhs.fha.nhinc.connectmgr.UrlInfo;
+import gov.hhs.fha.nhinc.util.MessageGeneratorUtils;
 
 /**
  * @author akong
  *
  */
-public class MessageGeneratorUtils extends gov.hhs.fha.nhinc.util.MessageGeneratorUtils {
-    private static MessageGeneratorUtils INSTANCE = new MessageGeneratorUtils();
+public class ADMessageGeneratorUtils extends MessageGeneratorUtils {
 
-    MessageGeneratorUtils() {
+    private static final ADMessageGeneratorUtils INSTANCE = new ADMessageGeneratorUtils();
+
+    ADMessageGeneratorUtils() {
     }
 
     /**
@@ -49,7 +51,7 @@ public class MessageGeneratorUtils extends gov.hhs.fha.nhinc.util.MessageGenerat
      *
      * @return the singleton instance
      */
-    public static MessageGeneratorUtils getInstance() {
+    public static ADMessageGeneratorUtils getInstance() {
         return INSTANCE;
     }
 
@@ -62,8 +64,8 @@ public class MessageGeneratorUtils extends gov.hhs.fha.nhinc.util.MessageGenerat
      * @return the unsecured format of the message
      */
     public RespondingGatewaySendAlertMessageType convertToUnsecured(
-            RespondingGatewaySendAlertMessageSecuredType message, AssertionType assertion,
-            NhinTargetCommunitiesType target) {
+        RespondingGatewaySendAlertMessageSecuredType message, AssertionType assertion,
+        NhinTargetCommunitiesType target) {
         RespondingGatewaySendAlertMessageType request = new RespondingGatewaySendAlertMessageType();
 
         request.setAssertion(assertion);

--- a/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/outbound/PassthroughOutboundAdminDistribution.java
+++ b/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/outbound/PassthroughOutboundAdminDistribution.java
@@ -28,7 +28,7 @@ package gov.hhs.fha.nhinc.admindistribution.outbound;
 
 import static gov.hhs.fha.nhinc.util.CoreHelpUtils.logInfoServiceProcess;
 
-import gov.hhs.fha.nhinc.admindistribution.MessageGeneratorUtils;
+import gov.hhs.fha.nhinc.admindistribution.ADMessageGeneratorUtils;
 import gov.hhs.fha.nhinc.admindistribution.entity.OutboundAdminDistributionDelegate;
 import gov.hhs.fha.nhinc.admindistribution.entity.OutboundAdminDistributionOrchestratable;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
@@ -39,7 +39,7 @@ import gov.hhs.fha.nhinc.common.nhinccommonentity.RespondingGatewaySendAlertMess
 
 public class PassthroughOutboundAdminDistribution implements OutboundAdminDistribution {
 
-    private MessageGeneratorUtils msgUtils = MessageGeneratorUtils.getInstance();
+    private ADMessageGeneratorUtils msgUtils = ADMessageGeneratorUtils.getInstance();
     private OutboundAdminDistributionDelegate adDelegate = new OutboundAdminDistributionDelegate();
 
     /**
@@ -60,7 +60,7 @@ public class PassthroughOutboundAdminDistribution implements OutboundAdminDistri
     public void sendAlertMessage(RespondingGatewaySendAlertMessageSecuredType message, AssertionType assertion,
         NhinTargetCommunitiesType target) {
         RespondingGatewaySendAlertMessageType request = msgUtils.convertToUnsecured(message,
-            MessageGeneratorUtils.getInstance().generateMessageId(assertion), target);
+            ADMessageGeneratorUtils.getInstance().generateMessageId(assertion), target);
 
         sendAlertMessage(request, assertion, target);
     }
@@ -77,7 +77,7 @@ public class PassthroughOutboundAdminDistribution implements OutboundAdminDistri
         NhinTargetCommunitiesType targetCommunities) {
 
         NhinTargetSystemType target = msgUtils.convertFirstToNhinTargetSystemType(targetCommunities);
-        sendToNhin(request, MessageGeneratorUtils.getInstance().generateMessageId(assertion), target);
+        sendToNhin(request, ADMessageGeneratorUtils.getInstance().generateMessageId(assertion), target);
     }
 
     private void sendToNhin(RespondingGatewaySendAlertMessageType request, AssertionType assertion,

--- a/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/outbound/StandardOutboundAdminDistribution.java
+++ b/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/outbound/StandardOutboundAdminDistribution.java
@@ -30,7 +30,7 @@ import static gov.hhs.fha.nhinc.util.CoreHelpUtils.logInfoServiceProcess;
 
 import gov.hhs.fha.nhinc.admindistribution.AdminDistributionAuditLogger;
 import gov.hhs.fha.nhinc.admindistribution.AdminDistributionPolicyChecker;
-import gov.hhs.fha.nhinc.admindistribution.MessageGeneratorUtils;
+import gov.hhs.fha.nhinc.admindistribution.ADMessageGeneratorUtils;
 import gov.hhs.fha.nhinc.admindistribution.aspect.ADRequestTransformingBuilder;
 import gov.hhs.fha.nhinc.admindistribution.entity.OutboundAdminDistributionDelegate;
 import gov.hhs.fha.nhinc.admindistribution.entity.OutboundAdminDistributionOrchestratable;
@@ -58,7 +58,7 @@ public class StandardOutboundAdminDistribution implements OutboundAdminDistribut
 
     private static final Logger LOG = LoggerFactory.getLogger(StandardOutboundAdminDistribution.class);
     private AdminDistributionAuditLogger auditLogger = null;
-    private final MessageGeneratorUtils msgUtils = MessageGeneratorUtils.getInstance();
+    private final ADMessageGeneratorUtils msgUtils = ADMessageGeneratorUtils.getInstance();
 
     /**
      * This method sends AlertMessage to the target.
@@ -73,7 +73,7 @@ public class StandardOutboundAdminDistribution implements OutboundAdminDistribut
     public void sendAlertMessage(RespondingGatewaySendAlertMessageSecuredType message, AssertionType assertion,
         NhinTargetCommunitiesType target) {
         RespondingGatewaySendAlertMessageType unsecured = msgUtils.convertToUnsecured(message,
-            MessageGeneratorUtils.getInstance().generateMessageId(assertion), target);
+            ADMessageGeneratorUtils.getInstance().generateMessageId(assertion), target);
 
         this.sendAlertMessage(unsecured, assertion, target);
 
@@ -90,7 +90,7 @@ public class StandardOutboundAdminDistribution implements OutboundAdminDistribut
     public void sendAlertMessage(RespondingGatewaySendAlertMessageType message, AssertionType assertion,
         NhinTargetCommunitiesType target) {
         logInfoServiceProcess(this.getClass());
-        auditMessage(message, MessageGeneratorUtils.getInstance().generateMessageId(assertion),
+        auditMessage(message, ADMessageGeneratorUtils.getInstance().generateMessageId(assertion),
             NhincConstants.AUDIT_LOG_INBOUND_DIRECTION);
 
         List<UrlInfo> urlInfoList = getEndpoints(target);

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/retrieve/AuditRetrieveEventsUtil.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/audit/retrieve/AuditRetrieveEventsUtil.java
@@ -26,36 +26,21 @@
  */
 package gov.hhs.fha.nhinc.audit.retrieve;
 
-import static gov.hhs.fha.nhinc.util.CoreHelpUtils.getXMLGregorianCalendarFrom;
-
-import com.services.nhinc.schema.auditmessage.AuditMessageType;
 import gov.hhs.fha.nhinc.auditrepository.hibernate.AuditRepositoryRecord;
+import gov.hhs.fha.nhinc.auditrepository.util.AuditUtils;
 import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsBlobResponse;
 import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsResponseType;
 import gov.hhs.fha.nhinc.common.auditquerylog.QueryAuditEventsResults;
-import gov.hhs.fha.nhinc.transform.marshallers.JAXBContextHandler;
-import gov.hhs.fha.nhinc.util.JAXBUnmarshallingUtil;
-import gov.hhs.fha.nhinc.util.StreamUtils;
-import java.io.InputStream;
+import static gov.hhs.fha.nhinc.util.CoreHelpUtils.getXMLGregorianCalendarFrom;
 import java.sql.Blob;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
-import javax.xml.stream.XMLStreamException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  * @author tjafri
  */
 public class AuditRetrieveEventsUtil {
-
-    private static final Logger LOG = LoggerFactory.getLogger(AuditRetrieveEventsUtil.class);
 
     private AuditRetrieveEventsUtil() {
     }
@@ -86,31 +71,8 @@ public class AuditRetrieveEventsUtil {
     public static QueryAuditEventsBlobResponse getQueryAuditEventBlobResponse(Blob auditBlob) {
         QueryAuditEventsBlobResponse response = new QueryAuditEventsBlobResponse();
         if (auditBlob != null) {
-            response.setAuditMessage(unmarshallBlobToAuditMsg(auditBlob));
+            response.setAuditMessage(AuditUtils.unMarshallBlobToAuditMessage(auditBlob));
         }
         return response;
-    }
-
-    private static AuditMessageType unmarshallBlobToAuditMsg(Blob auditBlob) {
-
-        AuditMessageType auditMessageType = null;
-        InputStream in = null;
-        try {
-            if (auditBlob != null && (int) auditBlob.length() > 0) {
-                JAXBUnmarshallingUtil util = new JAXBUnmarshallingUtil();
-                in = auditBlob.getBinaryStream();
-                JAXBContextHandler oHandler = new JAXBContextHandler();
-                JAXBContext jc = oHandler.getJAXBContext("com.services.nhinc.schema.auditmessage");
-                Unmarshaller unmarshaller = jc.createUnmarshaller();
-                JAXBElement jaxEle = (JAXBElement) unmarshaller.unmarshal(util.getSafeStreamReaderFromInputStream(in));
-                auditMessageType = (AuditMessageType) jaxEle.getValue();
-            }
-        } catch (SQLException | JAXBException | XMLStreamException e) {
-            LOG.error("Blob to Audit Message Conversion Error : " + e.getLocalizedMessage(), e);
-        } finally {
-            StreamUtils.closeStreamSilently(in);
-        }
-
-        return auditMessageType;
     }
 }

--- a/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/util/AuditUtils.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/main/java/gov/hhs/fha/nhinc/auditrepository/util/AuditUtils.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.auditrepository.util;
+
+import com.services.nhinc.schema.auditmessage.AuditMessageType;
+import gov.hhs.fha.nhinc.transform.marshallers.JAXBContextHandler;
+import gov.hhs.fha.nhinc.util.JAXBUnmarshallingUtil;
+import gov.hhs.fha.nhinc.util.StreamUtils;
+import java.io.InputStream;
+import java.sql.Blob;
+import java.sql.SQLException;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.stream.XMLStreamException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author tjafri
+ */
+public class AuditUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AuditUtils.class);
+
+    private AuditUtils() {
+    }
+
+    /**
+     * This method un-marshall XML Blob to AuditMessage
+     *
+     * @param auditBlob
+     * @return AuditMessageType
+     */
+    public static AuditMessageType unMarshallBlobToAuditMessage(Blob auditBlob) {
+        LOG.info("Inside unMarshallBlobToAuditMessage");
+        AuditMessageType auditMessageType = null;
+        InputStream in = null;
+        try {
+            if (auditBlob != null && (int) auditBlob.length() > 0) {
+                JAXBUnmarshallingUtil util = new JAXBUnmarshallingUtil();
+                in = auditBlob.getBinaryStream();
+                JAXBContextHandler oHandler = new JAXBContextHandler();
+                JAXBContext jc = oHandler.getJAXBContext("com.services.nhinc.schema.auditmessage");
+                Unmarshaller unmarshaller = jc.createUnmarshaller();
+                JAXBElement jaxEle = (JAXBElement) unmarshaller.unmarshal(util.
+                    getSafeStreamReaderFromInputStream(in));
+                if (jaxEle.getValue() != null) {
+                    auditMessageType = (AuditMessageType) jaxEle.getValue();
+                }
+            }
+        } catch (SQLException | JAXBException | XMLStreamException e) {
+            LOG.error("Blob to Audit Message Conversion Error: {}", e.getLocalizedMessage(), e);
+        } finally {
+            StreamUtils.closeStreamSilently(in);
+        }
+
+        return auditMessageType;
+    }
+
+}

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/genericbatch/common/adapter/proxy/AdapterX12BatchProxyObjectFactory.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/genericbatch/common/adapter/proxy/AdapterX12BatchProxyObjectFactory.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -44,7 +44,7 @@ public abstract class AdapterX12BatchProxyObjectFactory extends ComponentProxyOb
      *
      * @return AdapterX12BatchProxy
      */
-    public final AdapterX12BatchProxy getAdapterCORE_X12DocSubmissionProxy() {
+    public final AdapterX12BatchProxy getAdapterCOREX12DocSubmissionProxy() {
         return getBean(getBeanName(), AdapterX12BatchProxy.class);
     }
 

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/genericbatch/common/entity/OutboundX12BatchStrategyImpl_g0.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/genericbatch/common/entity/OutboundX12BatchStrategyImpl_g0.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -51,7 +51,7 @@ public abstract class OutboundX12BatchStrategyImpl_g0 implements OrchestrationSt
     }
 
     private void process(OutboundX12BatchOrchestratable message) {
-        message.setResponse(getProxyObjectFactory().getNhinCORE_X12DSGenericBatchProxy()
+        message.setResponse(getProxyObjectFactory().getNhinCOREX12DSGenericBatchProxy()
             .batchSubmitTransaction(message.getRequest(), message.getAssertion(), message.getTarget(),
                 NhincConstants.GATEWAY_API_LEVEL.LEVEL_g0));
     }

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/genericbatch/common/nhin/proxy/NhinX12BatchProxyObjectFactory.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/genericbatch/common/nhin/proxy/NhinX12BatchProxyObjectFactory.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -39,7 +39,7 @@ public abstract class NhinX12BatchProxyObjectFactory extends ComponentProxyObjec
      *
      * @return NhinCORE_X12DSGenericBatchRequestProxy
      */
-    public NhinX12BatchProxy getNhinCORE_X12DSGenericBatchProxy() {
+    public NhinX12BatchProxy getNhinCOREX12DSGenericBatchProxy() {
         return getBean(getBeanName(), NhinX12BatchProxy.class);
     }
 

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/genericbatch/common/request/inbound/AbstractInboundX12Batch.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/genericbatch/common/request/inbound/AbstractInboundX12Batch.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -97,7 +97,7 @@ public abstract class AbstractInboundX12Batch implements InboundX12Batch {
         COREEnvelopeBatchSubmissionResponse response = null;
         try {
             X12LargePayloadUtils.convertDataToFileLocationIfEnabled(msg);
-            response = adapterFactory.getAdapterCORE_X12DocSubmissionProxy().batchSubmitTransaction(msg, assertion);
+            response = adapterFactory.getAdapterCOREX12DocSubmissionProxy().batchSubmitTransaction(msg, assertion);
             X12LargePayloadUtils.convertFileLocationToDataIfEnabled(response);
         } catch (LargePayloadException e) {
             LOG.error("Failed to retrieve data from the file uri in the payload: {}", e.getLocalizedMessage(), e);

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/realtime/adapter/proxy/AdapterX12RealTimeProxyObjectFactory.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/realtime/adapter/proxy/AdapterX12RealTimeProxyObjectFactory.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -40,7 +40,7 @@ public class AdapterX12RealTimeProxyObjectFactory extends ComponentProxyObjectFa
         return NhincConstants.CORE_X12DS_REALTIME_PROXY_CONFIG_FILE_NAME;
     }
 
-    public AdapterX12RealTimeProxy getAdapterCORE_X12DocSubmissionProxy() {
+    public AdapterX12RealTimeProxy getAdapterCOREX12DocSubmissionProxy() {
         return getBean(NhincConstants.ADAPTER_CORE_X12DS_REALTIME_SERVICE_NAME, AdapterX12RealTimeProxy.class);
     }
 }

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/realtime/entity/OutboundX12DSRealTimeStrategyImpl_g0.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/realtime/entity/OutboundX12DSRealTimeStrategyImpl_g0.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,13 +26,13 @@
  */
 package gov.hhs.fha.nhinc.corex12.ds.realtime.entity;
 
+import gov.hhs.fha.nhinc.corex12.ds.realtime.nhin.proxy.NhinX12RealTimeProxy;
 import gov.hhs.fha.nhinc.corex12.ds.realtime.nhin.proxy.NhinX12RealTimeProxyObjectFactory;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.orchestration.Orchestratable;
 import gov.hhs.fha.nhinc.orchestration.OrchestrationStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import gov.hhs.fha.nhinc.corex12.ds.realtime.nhin.proxy.NhinX12RealTimeProxy;
 
 /**
  *
@@ -42,8 +42,8 @@ class OutboundX12DSRealTimeStrategyImpl_g0 implements OrchestrationStrategy {
 
     private static final Logger LOG = LoggerFactory.getLogger(OutboundX12DSRealTimeStrategyImpl_g0.class);
 
-    protected NhinX12RealTimeProxy getNhinCORE_X12DSRealTimeProxy() {
-        return new NhinX12RealTimeProxyObjectFactory().getNhinCORE_X12DocSubmissionProxy();
+    protected NhinX12RealTimeProxy getNhinCOREX12DSRealTimeProxy() {
+        return new NhinX12RealTimeProxyObjectFactory().getNhinCOREX12DocSubmissionProxy();
     }
 
     @Override
@@ -58,7 +58,7 @@ class OutboundX12DSRealTimeStrategyImpl_g0 implements OrchestrationStrategy {
     public void execute(OutboundX12RealTimeOrchestratable message) {
         LOG.trace("Begin OutboundCORE_X12DSRealTimeOrchestratableImpl_g0.process");
 
-        message.setResponse(getNhinCORE_X12DSRealTimeProxy().realTimeTransaction(message.getRequest(),
+        message.setResponse(getNhinCOREX12DSRealTimeProxy().realTimeTransaction(message.getRequest(),
             message.getAssertion(), message.getTarget(), NhincConstants.GATEWAY_API_LEVEL.LEVEL_g0));
 
         LOG.trace("End OutboundCORE_X12DSRealTimeOrchestratableImpl_g0.process");

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/realtime/inbound/AbstractInboundX12RealTime.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/realtime/inbound/AbstractInboundX12RealTime.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -90,7 +90,7 @@ public abstract class AbstractInboundX12RealTime implements InboundX12RealTime {
     protected COREEnvelopeRealTimeResponse sendToAdapter(COREEnvelopeRealTimeRequest request,
         AssertionType assertion) {
 
-        AdapterX12RealTimeProxy proxy = adapterFactory.getAdapterCORE_X12DocSubmissionProxy();
+        AdapterX12RealTimeProxy proxy = adapterFactory.getAdapterCOREX12DocSubmissionProxy();
         return proxy.realTimeTransaction(request, assertion);
     }
 

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/realtime/nhin/proxy/NhinX12RealTimeProxyObjectFactory.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/corex12/ds/realtime/nhin/proxy/NhinX12RealTimeProxyObjectFactory.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -40,7 +40,7 @@ public class NhinX12RealTimeProxyObjectFactory extends ComponentProxyObjectFacto
         return NhincConstants.CORE_X12DS_REALTIME_PROXY_CONFIG_FILE_NAME;
     }
 
-    public NhinX12RealTimeProxy getNhinCORE_X12DocSubmissionProxy() {
+    public NhinX12RealTimeProxy getNhinCOREX12DocSubmissionProxy() {
         return getBean(getBeanName(), NhinX12RealTimeProxy.class);
     }
 

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/ds/genericbatch/request/inbound/PassthroughInboundX12BatchRequestTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/ds/genericbatch/request/inbound/PassthroughInboundX12BatchRequestTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -31,20 +31,20 @@ import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.corex12.ds.audit.X12BatchAuditLogger;
 import gov.hhs.fha.nhinc.corex12.ds.audit.transform.X12BatchAuditTransforms;
+import gov.hhs.fha.nhinc.corex12.ds.genericbatch.common.adapter.proxy.AdapterX12BatchProxy;
 import gov.hhs.fha.nhinc.corex12.ds.genericbatch.request.adapter.proxy.AdapterX12BatchRequestProxyObjectFactory;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import java.util.Properties;
 import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeBatchSubmission;
 import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeBatchSubmissionResponse;
 import org.junit.Test;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.when;
-import gov.hhs.fha.nhinc.corex12.ds.genericbatch.common.adapter.proxy.AdapterX12BatchProxy;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  *
@@ -65,7 +65,7 @@ public class PassthroughInboundX12BatchRequestTest {
 
     @Test
     public void auditLoggingOnForInboundX12BatchRequest() {
-        when(adpFactory.getAdapterCORE_X12DocSubmissionProxy()).thenReturn(reqProxy);
+        when(adpFactory.getAdapterCOREX12DocSubmissionProxy()).thenReturn(reqProxy);
         when(reqProxy.batchSubmitTransaction(request, assertion)).thenReturn(expectedResponse);
         batchReq = new PassthroughInboundX12BatchRequest(adpFactory, getAuditLogger(true));
         actualResposne = batchReq.batchSubmitTransaction(request, assertion, webContextProperties);
@@ -78,7 +78,7 @@ public class PassthroughInboundX12BatchRequestTest {
 
     @Test
     public void auditLoggingOffForInboundX12BatchRequest() {
-        when(adpFactory.getAdapterCORE_X12DocSubmissionProxy()).thenReturn(reqProxy);
+        when(adpFactory.getAdapterCOREX12DocSubmissionProxy()).thenReturn(reqProxy);
         when(reqProxy.batchSubmitTransaction(request, assertion)).thenReturn(expectedResponse);
         batchReq = new PassthroughInboundX12BatchRequest(adpFactory, getAuditLogger(false));
         actualResposne = batchReq.batchSubmitTransaction(request, assertion, webContextProperties);

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/ds/genericbatch/response/inbound/PassthroughInboundX12BatchResponseTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/ds/genericbatch/response/inbound/PassthroughInboundX12BatchResponseTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -31,21 +31,21 @@ import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.corex12.ds.audit.X12BatchAuditLogger;
 import gov.hhs.fha.nhinc.corex12.ds.audit.transform.X12BatchAuditTransforms;
+import gov.hhs.fha.nhinc.corex12.ds.genericbatch.common.adapter.proxy.AdapterX12BatchProxy;
 import gov.hhs.fha.nhinc.corex12.ds.genericbatch.response.adapter.proxy.AdapterX12BatchResponseProxyObjectFactory;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import java.util.Properties;
 import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeBatchSubmission;
 import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeBatchSubmissionResponse;
-import org.junit.Test;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.when;
-import gov.hhs.fha.nhinc.corex12.ds.genericbatch.common.adapter.proxy.AdapterX12BatchProxy;
 import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  *
@@ -66,7 +66,7 @@ public class PassthroughInboundX12BatchResponseTest {
         PassthroughInboundX12BatchResponse inboundResp
             = new PassthroughInboundX12BatchResponse(mockFactory, getAuditLogger(true));
         COREEnvelopeBatchSubmissionResponse expectedResponse = new COREEnvelopeBatchSubmissionResponse();
-        when(mockFactory.getAdapterCORE_X12DocSubmissionProxy()).thenReturn(mockResponseProxy);
+        when(mockFactory.getAdapterCOREX12DocSubmissionProxy()).thenReturn(mockResponseProxy);
         when(mockResponseProxy.batchSubmitTransaction(eq(request), eq(assertion))).thenReturn(expectedResponse);
 
         COREEnvelopeBatchSubmissionResponse actualResponse = inboundResp.batchSubmitTransaction(request, assertion,
@@ -85,7 +85,7 @@ public class PassthroughInboundX12BatchResponseTest {
         PassthroughInboundX12BatchResponse inboundResp
             = new PassthroughInboundX12BatchResponse(mockFactory, getAuditLogger(false));
         COREEnvelopeBatchSubmissionResponse expectedResponse = new COREEnvelopeBatchSubmissionResponse();
-        when(mockFactory.getAdapterCORE_X12DocSubmissionProxy()).thenReturn(mockResponseProxy);
+        when(mockFactory.getAdapterCOREX12DocSubmissionProxy()).thenReturn(mockResponseProxy);
         when(mockResponseProxy.batchSubmitTransaction(eq(request), eq(assertion))).thenReturn(expectedResponse);
 
         COREEnvelopeBatchSubmissionResponse actualResponse = inboundResp.batchSubmitTransaction(request, assertion,

--- a/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/ds/realtime/inbound/PassthroughInboundX12RealTimeTest.java
+++ b/Product/Production/Services/CORE_X12DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/corex12/ds/realtime/inbound/PassthroughInboundX12RealTimeTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -31,20 +31,20 @@ import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.corex12.ds.audit.X12RealTimeAuditLogger;
 import gov.hhs.fha.nhinc.corex12.ds.audit.transform.X12RealTimeAuditTransforms;
+import gov.hhs.fha.nhinc.corex12.ds.realtime.adapter.proxy.AdapterX12RealTimeProxy;
 import gov.hhs.fha.nhinc.corex12.ds.realtime.adapter.proxy.AdapterX12RealTimeProxyObjectFactory;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import java.util.Properties;
 import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeRealTimeRequest;
 import org.caqh.soap.wsdl.corerule2_2_0.COREEnvelopeRealTimeResponse;
 import org.junit.Test;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.when;
-import gov.hhs.fha.nhinc.corex12.ds.realtime.adapter.proxy.AdapterX12RealTimeProxy;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  *
@@ -64,7 +64,7 @@ public class PassthroughInboundX12RealTimeTest {
     public void auditLoggingOnForInboundRealTime() {
         PassthroughInboundX12RealTime realTimeX12
             = new PassthroughInboundX12RealTime(mockFactory, getAuditLogger(true));
-        when(mockFactory.getAdapterCORE_X12DocSubmissionProxy()).thenReturn(mockAdapterProxy);
+        when(mockFactory.getAdapterCOREX12DocSubmissionProxy()).thenReturn(mockAdapterProxy);
         COREEnvelopeRealTimeResponse expectedResponse = new COREEnvelopeRealTimeResponse();
         when(mockAdapterProxy.realTimeTransaction(request, assertion)).thenReturn(expectedResponse);
         COREEnvelopeRealTimeResponse actualResponse = realTimeX12.realTimeTransaction(request, assertion,
@@ -80,7 +80,7 @@ public class PassthroughInboundX12RealTimeTest {
         PassthroughInboundX12RealTime realTimeX12
             = new PassthroughInboundX12RealTime(mockFactory, getAuditLogger(false));
 
-        when(mockFactory.getAdapterCORE_X12DocSubmissionProxy()).thenReturn(mockAdapterProxy);
+        when(mockFactory.getAdapterCOREX12DocSubmissionProxy()).thenReturn(mockAdapterProxy);
         COREEnvelopeRealTimeResponse expectedResponse = new COREEnvelopeRealTimeResponse();
         when(mockAdapterProxy.realTimeTransaction(request, assertion)).thenReturn(expectedResponse);
         COREEnvelopeRealTimeResponse actualResponse = realTimeX12.realTimeTransaction(request, assertion,

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectAdapterUtils.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectAdapterUtils.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -51,8 +51,12 @@ public class DirectAdapterUtils {
     private static final Logger LOG = LoggerFactory.getLogger(DirectAdapterUtils.class);
     private static final String MDN_CONTENT_TYPE = "DISPOSITION-NOTIFICATION";
 
+    private DirectAdapterUtils() {
+    }
+
     /**
      * Extract the NHINDAddressCollection from the mime headers of the message.
+     *
      * @param message mime message
      * @return NHINDAddressCollection - collection of NHIND Addresses
      * @throws MessagingException if there was an exception
@@ -83,8 +87,9 @@ public class DirectAdapterUtils {
     }
 
     /**
-     * Extract the Address for the sender from the mime headers of the message. Ensures that one and only one Sender
-     * is extracted.
+     * Extract the Address for the sender from the mime headers of the message. Ensures that one and only one Sender is
+     * extracted.
+     *
      * @param message mime message
      * @return Address for the sender
      * @throws MessagingException if there was an error
@@ -98,9 +103,8 @@ public class DirectAdapterUtils {
         return fromAddresses[0];
     }
 
-
     private static void addRecipients(NHINDAddressCollection recipients, Message message, RecipientType type,
-            AddressSource source) throws MessagingException {
+        AddressSource source) throws MessagingException {
 
         Address[] addresses = message.getRecipients(type);
         if (addresses == null) {
@@ -114,6 +118,7 @@ public class DirectAdapterUtils {
 
     /**
      * Return MDN Notification Messages present in a DIRECT Process result, and perform logging.
+     *
      * @param result to pull notification messages from.
      * @return collection of Notification Messages.
      */

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectReceiverImpl.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectReceiverImpl.java
@@ -89,8 +89,10 @@ public class DirectReceiverImpl extends DirectAdapter implements DirectReceiver 
      */
     public static final String SUPPRESS_MDN_EDGE_NOTIFICATION = "org.connectopensource.suppressmdnedgenotification";
     //Default CONNECT failed notifcation header, error message, footer text.
-    private static final String HEADER = "We were permanently unable to deliver your message to the following recipients.  Please contact your system administrator with further questions.";
-    private static final String ERROR_MESSAGE = "The Direct address that you tried to reach is not responding. Try double-checking the recipient's address for typos or unnecessary spaces.";
+    private static final String HEADER
+        = "We were permanently unable to deliver your message to the following recipients.  Please contact your system administrator with further questions.";
+    private static final String ERROR_MESSAGE
+        = "The Direct address that you tried to reach is not responding. Try double-checking the recipient's address for typos or unnecessary spaces.";
     private static final String FOOTER = "";
     //specifies which Postmaster account to be user for DSN. Default value Sender's postmaster account.
     private static final boolean USE_SENDER_POSTMASTER_ACCOUNT = false;
@@ -260,14 +262,16 @@ public class DirectReceiverImpl extends DirectAdapter implements DirectReceiver 
     private void sendMdns(Collection<NotificationMessage> mdnMessages, boolean processed) {
         if (mdnMessages != null) {
             for (NotificationMessage mdnMessage : mdnMessages) {
-                getDirectEventLogger().log(processed ? DirectEventType.BEGIN_OUTBOUND_MDN_PROCESSED : DirectEventType.BEGIN_OUTBOUND_MDN_DISPATCHED, mdnMessage);
+                getDirectEventLogger().log(processed ? DirectEventType.BEGIN_OUTBOUND_MDN_PROCESSED
+                    : DirectEventType.BEGIN_OUTBOUND_MDN_DISPATCHED, mdnMessage);
                 try {
                     MimeMessage message = process(mdnMessage).getProcessedMessage().getMessage();
                     getExternalMailSender().send(mdnMessage.getAllRecipients(), message);
                 } catch (Exception e) {
                     throw new DirectException("Exception sending outbound direct mdn.", e, mdnMessage);
                 }
-                getDirectEventLogger().log(processed ? DirectEventType.END_OUTBOUND_MDN_PROCESSED : DirectEventType.END_OUTBOUND_MDN_DISPATCHED, mdnMessage);
+                getDirectEventLogger().log(processed ? DirectEventType.END_OUTBOUND_MDN_PROCESSED
+                    : DirectEventType.END_OUTBOUND_MDN_DISPATCHED, mdnMessage);
                 LOG.info("MDN notification sent.");
             }
         }
@@ -298,18 +302,21 @@ public class DirectReceiverImpl extends DirectAdapter implements DirectReceiver 
      * @return returns a collection of DSN messages using message information provided.
      * @throws javax.mail.MessagingException
      */
-    public Collection<MimeMessage> createFailedDeliveryDSNFailureMessage(MimeMessage message, Tx tx, String notificationFailureMessage) throws MessagingException {
+    public Collection<MimeMessage> createFailedDeliveryDSNFailureMessage(MimeMessage message, Tx tx,
+        String notificationFailureMessage) throws MessagingException {
         //Default properties can be set in a property file agentSettings.properties
         //always use null
         Mailet mailet = null;
         //use the default prefix
         DSNGenerator generator = new DSNGenerator(RejectedRecipientDSNCreatorOptions.DEFAULT_PREFIX);
         //use the default postmasterbox
-        String postmasterMailbox = GatewayConfiguration.getConfigurationParam(RejectedRecipientDSNCreatorOptions.DSN_POSTMASTER,
+        String postmasterMailbox = GatewayConfiguration.getConfigurationParam(
+            RejectedRecipientDSNCreatorOptions.DSN_POSTMASTER,
             mailet, RejectedRecipientDSNCreatorOptions.DEFAULT_POSTMASTER);
         //use the default reporting MTA
-        String reportingMta = GatewayConfiguration.getConfigurationParam(RejectedRecipientDSNCreatorOptions.DSN_MTA_NAME,
-            mailet, RejectedRecipientDSNCreatorOptions.DEFAULT_MTA_NAME);
+        String reportingMta = GatewayConfiguration.
+            getConfigurationParam(RejectedRecipientDSNCreatorOptions.DSN_MTA_NAME,
+                mailet, RejectedRecipientDSNCreatorOptions.DEFAULT_MTA_NAME);
         DSNFailureTextBodyPartGenerator textGenerator = new DefaultDSNFailureTextBodyPartGenerator(
             GatewayConfiguration.getConfigurationParam(RejectedRecipientDSNCreatorOptions.DSN_FAILED_HEADER,
                 mailet, HEADER),
@@ -322,7 +329,8 @@ public class DirectReceiverImpl extends DirectAdapter implements DirectReceiver 
                 mailet, ERROR_MESSAGE),
             HumanReadableTextAssemblerFactory.getInstance());
 
-        FailedDeliveryDSNCreator rejectedDNSCreator = new FailedDeliveryDSNCreator(generator, postmasterMailbox, reportingMta, textGenerator);
+        FailedDeliveryDSNCreator rejectedDNSCreator = new FailedDeliveryDSNCreator(generator, postmasterMailbox,
+            reportingMta, textGenerator);
         final NHINDAddressCollection xdRecipients = new NHINDAddressCollection();
         Address[] recipients = message.getAllRecipients();
         xdRecipients.add(new NHINDAddress((InternetAddress) recipients[0]));
@@ -354,7 +362,8 @@ public class DirectReceiverImpl extends DirectAdapter implements DirectReceiver 
      *
      */
     private void sendMdnFailed(MimeMessage message, String notificationFailureMessage) throws MessagingException {
-        Collection<MimeMessage> mimeMessage = createFailedDeliveryDSNFailureMessage(message, convertMessagetoTx(message), notificationFailureMessage);
+        Collection<MimeMessage> mimeMessage
+            = createFailedDeliveryDSNFailureMessage(message, convertMessagetoTx(message), notificationFailureMessage);
         sendDSN(mimeMessage);
     }
 

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/event/DirectEventLogger.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/event/DirectEventLogger.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -41,7 +41,11 @@ public class DirectEventLogger {
      * Singleton holder for {@link DirectEventLogger}.
      */
     private static class SingletonHolder {
+
         public static final DirectEventLogger INSTANCE = new DirectEventLogger();
+
+        private SingletonHolder() {
+        }
     }
 
     /**
@@ -60,6 +64,7 @@ public class DirectEventLogger {
 
     /**
      * Log a success direct event using event logger.
+     *
      * @param type direct event type.
      * @param message used to pull info from.
      */
@@ -69,6 +74,7 @@ public class DirectEventLogger {
 
     /**
      * Log a failed event due to exception.
+     *
      * @param type of event which failed.
      * @param message used to pull info from.
      * @param exception encountered triggering event.
@@ -83,6 +89,7 @@ public class DirectEventLogger {
 
     /**
      * Log a success or failed direct event using event logger.
+     *
      * @param type direct event type.
      * @param message used to pull info from.
      * @param errorMsg optional error message - if not null status = error.
@@ -93,6 +100,7 @@ public class DirectEventLogger {
 
     /**
      * Log a success or failed direct event using event logger.
+     *
      * @param type direct event type.
      * @param errorMsg optional error message - if not null status = error.
      */

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/messagemonitoring/dao/impl/MessageMonitoringDAOImpl.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/messagemonitoring/dao/impl/MessageMonitoringDAOImpl.java
@@ -26,15 +26,14 @@
  */
 package gov.hhs.fha.nhinc.direct.messagemonitoring.dao.impl;
 
-import static gov.hhs.fha.nhinc.util.GenericDBUtils.closeSession;
-import static gov.hhs.fha.nhinc.util.GenericDBUtils.rollbackTransaction;
-
 import gov.hhs.fha.nhinc.direct.messagemonitoring.dao.MessageMonitoringDAO;
 import gov.hhs.fha.nhinc.direct.messagemonitoring.dao.MessageMonitoringDAOException;
 import gov.hhs.fha.nhinc.direct.messagemonitoring.domain.MonitoredMessage;
 import gov.hhs.fha.nhinc.direct.messagemonitoring.domain.MonitoredMessageNotification;
 import gov.hhs.fha.nhinc.direct.messagemonitoring.persistence.HibernateUtil;
 import gov.hhs.fha.nhinc.persistence.HibernateUtilFactory;
+import static gov.hhs.fha.nhinc.util.GenericDBUtils.closeSession;
+import static gov.hhs.fha.nhinc.util.GenericDBUtils.rollbackTransaction;
 import java.util.ArrayList;
 import java.util.List;
 import org.hibernate.HibernateException;
@@ -52,8 +51,10 @@ import org.slf4j.LoggerFactory;
 public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
 
     private static final Logger LOG = LoggerFactory.getLogger(MessageMonitoringDAOImpl.class);
+    private static final String INSERTION_ERROR_LOG = "Exception during insertion caused by : {}";
 
     private static class SingletonHolder {
+
         public static final MessageMonitoringDAO INSTANCE = new MessageMonitoringDAOImpl();
 
         private SingletonHolder() {
@@ -97,7 +98,7 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
         } catch (final HibernateException e) {
             result = false;
             rollbackTransaction(tx);
-            LOG.error("Exception during insertion caused by : {}", e.getMessage(), e);
+            LOG.error(INSERTION_ERROR_LOG, e.getMessage(), e);
         } finally {
             closeSession(session);
         }
@@ -122,7 +123,7 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
         boolean result = true;
 
         try {
-            LOG.debug("Inside addOutgoingMessage()");
+            LOG.debug("Inside updateOutgoingMessage()");
             session = getSession();
             if (session != null) {
                 tx = session.beginTransaction();
@@ -132,7 +133,7 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
         } catch (final HibernateException e) {
             result = false;
             rollbackTransaction(tx);
-            LOG.error("Exception during insertion caused by : {}", e.getMessage(), e);
+            LOG.error(INSERTION_ERROR_LOG, e.getMessage(), e);
         } finally {
             closeSession(session);
         }
@@ -156,7 +157,7 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
         boolean result = true;
 
         try {
-            LOG.debug("Inside addOutgoingMessage()");
+            LOG.debug("Inside updateMessageNotification()");
             session = getSession();
             if (session != null) {
                 tx = session.beginTransaction();
@@ -166,7 +167,7 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
         } catch (final HibernateException e) {
             result = false;
             rollbackTransaction(tx);
-            LOG.error("Exception during insertion caused by : {}", e.getMessage(), e);
+            LOG.error(INSERTION_ERROR_LOG, e.getMessage(), e);
         } finally {
             closeSession(session);
         }
@@ -189,7 +190,7 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
         boolean result = true;
 
         try {
-            LOG.debug("Inside addOutgoingMessage()");
+            LOG.debug("Inside deleteCompletedMessages()");
             session = getSession();
             if (session != null) {
                 tx = session.beginTransaction();
@@ -199,7 +200,7 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
         } catch (final HibernateException e) {
             result = false;
             rollbackTransaction(tx);
-            LOG.error("Exception during insertion caused by : {}", e.getMessage(), e);
+            LOG.error(INSERTION_ERROR_LOG, e.getMessage(), e);
         } finally {
             closeSession(session);
         }
@@ -217,13 +218,13 @@ public class MessageMonitoringDAOImpl implements MessageMonitoringDAO {
         List<MonitoredMessage> pendingList = new ArrayList<>();
 
         try {
-            LOG.debug("Inside addOutgoingMessage()");
+            LOG.debug("Inside getAllPendingMessages()");
             session = getSession();
             if (session != null) {
                 pendingList = session.createCriteria(MonitoredMessage.class).list();
             }
         } catch (final HibernateException e) {
-            LOG.error("Exception during insertion caused by : {}", e.getMessage(), e);
+            LOG.error(INSERTION_ERROR_LOG, e.getMessage(), e);
         } finally {
             closeSession(session);
         }

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/messagemonitoring/impl/MessageMonitoringAPI.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/messagemonitoring/impl/MessageMonitoringAPI.java
@@ -73,6 +73,7 @@ public class MessageMonitoringAPI {
     private static final String STATUS_COMPLETED = "Completed";
     private static final String STATUS_PROCESSED = "Processed";
     private static final String STATUS_ARCHIVED = "Archived";
+    private static final String MSG_MONITORING_NOT_ENABLED = "Message Monitoring is not enabled.";
 
     public MessageMonitoringAPI() {
         // set the default value
@@ -84,6 +85,9 @@ public class MessageMonitoringAPI {
     private static class SingletonHolder {
 
         public static final MessageMonitoringAPI INSTANCE = new MessageMonitoringAPI();
+
+        private SingletonHolder() {
+        }
     }
 
     public static MessageMonitoringAPI getInstance() {
@@ -94,7 +98,7 @@ public class MessageMonitoringAPI {
         // Always
         // check if the message monitoring is enabled
         if (!MessageMonitoringUtil.isMessageMonitoringEnabled()) {
-            LOG.debug("Message Monitoring is not enabled.");
+            LOG.debug(MSG_MONITORING_NOT_ENABLED);
             return;
         }
         LOG.debug("Message Monitoring is enabled.");
@@ -165,7 +169,7 @@ public class MessageMonitoringAPI {
     public void addOutgoingMessage(final MimeMessage message, final boolean failed) {
         // Always check if message monitoring enabled
         if (!MessageMonitoringUtil.isMessageMonitoringEnabled()) {
-            LOG.debug("Message Monitoring is not enabled.");
+            LOG.debug(MSG_MONITORING_NOT_ENABLED);
             return;
         }
         try {
@@ -224,7 +228,7 @@ public class MessageMonitoringAPI {
         LOG.debug("Inside buildCache");
         // Always check if message monitoring enabled
         if (!MessageMonitoringUtil.isMessageMonitoringEnabled()) {
-            LOG.debug("Message Monitoring is not enabled.");
+            LOG.debug(MSG_MONITORING_NOT_ENABLED);
             return;
         }
         LOG.debug("Message Monitoring is enabled.");
@@ -237,7 +241,8 @@ public class MessageMonitoringAPI {
         for (final MonitoredMessage trackMessage : pendingMessages) {
             if (!trackMessage.getStatus().equals(STATUS_ARCHIVED)) {
                 messageMonitoringCache.put(trackMessage.getMessageid(), trackMessage);
-                LOG.debug("Total child rows for the messageId: {}", trackMessage.getMonitoredmessagenotifications().size());
+                LOG.debug("Total child rows for the messageId: {}", trackMessage.getMonitoredmessagenotifications().
+                    size());
             } else {
                 deleteElapsedArchivedMessage(trackMessage);
             }
@@ -426,7 +431,7 @@ public class MessageMonitoringAPI {
 
         // Always check if the message monitoring is enabled
         if (!MessageMonitoringUtil.isMessageMonitoringEnabled()) {
-            LOG.debug("Message Monitoring is not enabled.");
+            LOG.debug(MSG_MONITORING_NOT_ENABLED);
             return;
         }
         // check all the pending messages and update the status
@@ -447,7 +452,7 @@ public class MessageMonitoringAPI {
     }
 
     private void checkAndUpdateMessageStatus() {
-        LOG.debug("Exiting Message Monitoring API checkAndUpdateMessageStatus() method.");
+        LOG.debug("Entering Message Monitoring API checkAndUpdateMessageStatus() method.");
         // get the pending message list
         final List<MonitoredMessage> pendingMessages = getAllPendingMessages();
 
@@ -480,7 +485,7 @@ public class MessageMonitoringAPI {
      * MessageId in order to make event assertions for Automated testing
      */
     public void processAllMessages() throws MessageMonitoringDAOException {
-        LOG.debug("Inside Message Monitoring API checkAndUpdateMessageStatus() method.");
+        LOG.debug("Inside Message Monitoring API processAllMessages() method.");
         // ********FAILED MESSAGES***********
         // get all the failed messages
         final List<MonitoredMessage> failedMessages = getAllFailedMessages();
@@ -514,7 +519,7 @@ public class MessageMonitoringAPI {
             }
         }
 
-        LOG.debug("Exiting Message Monitoring API checkAndUpdateMessageStatus() method.");
+        LOG.debug("Exiting Message Monitoring API processAllMessages() method.");
     }
 
     /**
@@ -541,7 +546,7 @@ public class MessageMonitoringAPI {
             getDirectEventLogger().log(DirectEventType.DIRECT_EDGE_NOTIFICATION_SUCCESSFUL, message);
         } catch (final MessagingException ex) {
             errorMsg = ex.getLocalizedMessage();
-            LOG.error(errorMsg,ex);
+            LOG.error(errorMsg, ex);
         }
         LOG.debug("Exiting Message Monitoring API sendSuccessEdgeNotification() method.");
     }

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/messagemonitoring/util/MessageMonitoringUtil.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/messagemonitoring/util/MessageMonitoringUtil.java
@@ -100,6 +100,9 @@ public class MessageMonitoringUtil {
     public static final String AGENT_SETTINGS_CACHE_REFRESH_TIME = "AgentSettingsCacheRefreshTime";
     public static final String AGENT_SETTINGS_CACHE_REFRESH_ACTIVE = "AgentSettingsCacheRefreshActive";
 
+    private MessageMonitoringUtil() {
+    }
+
     /**
      * Returns Mail Recipients as a NHINDAddressCollection
      *

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/mail/MailUtils.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/mail/MailUtils.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -61,6 +61,9 @@ public class MailUtils {
      * boolean flag when we don't want to expunge the inbox.
      */
     public static final boolean FOLDER_EXPUNGE_INBOX_FALSE = false;
+
+    private MailUtils() {
+    }
 
     /**
      * Close the java mail store and folder, specifying whether deleted messages should be expunged. Log exceptions.

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/DQMessageGeneratorUtils.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/DQMessageGeneratorUtils.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -28,6 +28,7 @@ package gov.hhs.fha.nhinc.docquery;
 
 import gov.hhs.fha.nhinc.document.DocumentConstants;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.util.MessageGeneratorUtils;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryResponse;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryObjectListType;
 import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryError;
@@ -37,11 +38,11 @@ import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryErrorList;
  * @author akong
  *
  */
-public class MessageGeneratorUtils extends gov.hhs.fha.nhinc.util.MessageGeneratorUtils {
+public class DQMessageGeneratorUtils extends MessageGeneratorUtils {
 
-    private static MessageGeneratorUtils INSTANCE = new MessageGeneratorUtils();
+    private static final DQMessageGeneratorUtils INSTANCE = new DQMessageGeneratorUtils();
 
-    MessageGeneratorUtils() {
+    DQMessageGeneratorUtils() {
     }
 
     /**
@@ -49,7 +50,7 @@ public class MessageGeneratorUtils extends gov.hhs.fha.nhinc.util.MessageGenerat
      *
      * @return the singleton instance
      */
-    public static MessageGeneratorUtils getInstance() {
+    public static DQMessageGeneratorUtils getInstance() {
         return INSTANCE;
     }
 
@@ -97,7 +98,7 @@ public class MessageGeneratorUtils extends gov.hhs.fha.nhinc.util.MessageGenerat
      */
     public AdhocQueryResponse createPolicyErrorResponse() {
         return createAdhocQueryErrorResponse("Policy check failed.", DocumentConstants.XDS_ERRORCODE_REPOSITORY_ERROR,
-                DocumentConstants.XDS_QUERY_RESPONSE_STATUS_FAILURE);
+            DocumentConstants.XDS_QUERY_RESPONSE_STATUS_FAILURE);
     }
 
     /**
@@ -108,7 +109,7 @@ public class MessageGeneratorUtils extends gov.hhs.fha.nhinc.util.MessageGenerat
      */
     public AdhocQueryResponse createRepositoryErrorResponse(String codeContext) {
         return createAdhocQueryErrorResponse(codeContext, DocumentConstants.XDS_ERRORCODE_REPOSITORY_ERROR,
-                DocumentConstants.XDS_QUERY_RESPONSE_STATUS_FAILURE);
+            DocumentConstants.XDS_QUERY_RESPONSE_STATUS_FAILURE);
     }
 
 }

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/AggregationService.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/AggregationService.java
@@ -33,7 +33,7 @@ import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.common.nhinccommon.QualifiedSubjectIdentifierType;
 import gov.hhs.fha.nhinc.common.patientcorrelationfacade.RetrievePatientCorrelationsRequestType;
 import gov.hhs.fha.nhinc.connectmgr.UrlInfo;
-import gov.hhs.fha.nhinc.docquery.MessageGeneratorUtils;
+import gov.hhs.fha.nhinc.docquery.DQMessageGeneratorUtils;
 import gov.hhs.fha.nhinc.docquery.outbound.StandardOutboundDocQueryHelper;
 import gov.hhs.fha.nhinc.document.DocumentConstants;
 import gov.hhs.fha.nhinc.event.error.ErrorEventException;
@@ -161,7 +161,7 @@ public class AggregationService {
                 list.add(orchestratable);
             }
         } catch (Exception e) {
-            AdhocQueryResponse response = MessageGeneratorUtils.getInstance()
+            AdhocQueryResponse response = DQMessageGeneratorUtils.getInstance()
                 .createAdhocQueryErrorResponse("XDSRegistryError", "Unable to create fanout requests for query",
                 DocumentConstants.XDS_QUERY_RESPONSE_STATUS_FAILURE);
             throw new ErrorEventException(e, response,"Unable to create fanout requests for query");
@@ -241,7 +241,7 @@ public class AggregationService {
      * @return AdhocQUery Request.
      */
     protected AdhocQueryRequest cloneRequest(AdhocQueryRequest request) {
-        return MessageGeneratorUtils.getInstance().clone(request);
+        return DQMessageGeneratorUtils.getInstance().clone(request);
     }
 
     /**
@@ -255,10 +255,9 @@ public class AggregationService {
     private AssertionType createNewAssertion(AssertionType assertion, int numTargets) {
         AssertionType newAssertion;
         if (numTargets == 1) {
-            newAssertion = MessageGeneratorUtils.getInstance().clone(
-                MessageGeneratorUtils.getInstance().generateMessageId(assertion));
+            newAssertion = DQMessageGeneratorUtils.getInstance().clone(DQMessageGeneratorUtils.getInstance().generateMessageId(assertion));
         } else {
-            newAssertion = MessageGeneratorUtils.getInstance().cloneWithNewMsgId(assertion);
+            newAssertion = DQMessageGeneratorUtils.getInstance().cloneWithNewMsgId(assertion);
         }
 
         return newAssertion;

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/OutboundDocQueryAggregator.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/OutboundDocQueryAggregator.java
@@ -26,7 +26,7 @@
  */
 package gov.hhs.fha.nhinc.docquery.entity;
 
-import gov.hhs.fha.nhinc.docquery.MessageGeneratorUtils;
+import gov.hhs.fha.nhinc.docquery.DQMessageGeneratorUtils;
 import gov.hhs.fha.nhinc.document.DocumentConstants;
 import gov.hhs.fha.nhinc.orchestration.NhinAggregator;
 import gov.hhs.fha.nhinc.orchestration.OutboundOrchestratable;
@@ -170,7 +170,7 @@ public class OutboundDocQueryAggregator implements NhinAggregator {
         initializeResponse(to);
         AdhocQueryResponse singleResponse = from.getResponse();
         if (singleResponse == null) {
-            singleResponse = MessageGeneratorUtils.getInstance().createAdhocQueryErrorResponse("Null response.",
+            singleResponse = DQMessageGeneratorUtils.getInstance().createAdhocQueryErrorResponse("Null response.",
                 DocumentConstants.XDS_ERRORCODE_REPOSITORY_ERROR,
                 DocumentConstants.XDS_QUERY_RESPONSE_STATUS_FAILURE);
         }

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/OutboundDocQueryStrategy.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/entity/OutboundDocQueryStrategy.java
@@ -27,7 +27,7 @@
 package gov.hhs.fha.nhinc.docquery.entity;
 
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
-import gov.hhs.fha.nhinc.docquery.MessageGeneratorUtils;
+import gov.hhs.fha.nhinc.docquery.DQMessageGeneratorUtils;
 import gov.hhs.fha.nhinc.docquery.audit.DocQueryAuditLogger;
 import gov.hhs.fha.nhinc.docquery.nhin.proxy.NhinDocQueryProxyFactory;
 import gov.hhs.fha.nhinc.docquery.nhin.proxy.NhinDocQueryProxyObjectFactory;
@@ -49,7 +49,7 @@ public abstract class OutboundDocQueryStrategy implements OrchestrationStrategy 
     private static final Logger LOG = LoggerFactory.getLogger(OutboundDocQueryStrategy.class);
     private DocQueryAuditLogger auditLogger = null;
     private NhinDocQueryProxyFactory proxyFactory;
-    private MessageGeneratorUtils messageGeneratorUtils;
+    private DQMessageGeneratorUtils messageGeneratorUtils;
     WebServiceProxyHelper webServiceProxyHelper;
 
     /**
@@ -58,7 +58,7 @@ public abstract class OutboundDocQueryStrategy implements OrchestrationStrategy 
     OutboundDocQueryStrategy() {
         proxyFactory = new NhinDocQueryProxyObjectFactory();
         webServiceProxyHelper = new WebServiceProxyHelper();
-        messageGeneratorUtils = MessageGeneratorUtils.getInstance();
+        messageGeneratorUtils = DQMessageGeneratorUtils.getInstance();
     }
 
     /**
@@ -149,7 +149,7 @@ public abstract class OutboundDocQueryStrategy implements OrchestrationStrategy 
         return auditLogger;
     }
 
-    protected void setMessageGeneratorUtils(MessageGeneratorUtils messageGeneratorUtils) {
+    protected void setMessageGeneratorUtils(DQMessageGeneratorUtils messageGeneratorUtils) {
         this.messageGeneratorUtils = messageGeneratorUtils;
     }
 }

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/inbound/StandardInboundDocQuery.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/inbound/StandardInboundDocQuery.java
@@ -31,7 +31,7 @@ import static gov.hhs.fha.nhinc.util.CoreHelpUtils.logInfoServiceProcess;
 import gov.hhs.fha.nhinc.aspect.InboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docquery.DocQueryPolicyChecker;
-import gov.hhs.fha.nhinc.docquery.MessageGeneratorUtils;
+import gov.hhs.fha.nhinc.docquery.DQMessageGeneratorUtils;
 import gov.hhs.fha.nhinc.docquery.adapter.proxy.AdapterDocQueryProxyObjectFactory;
 import gov.hhs.fha.nhinc.docquery.aspect.AdhocQueryRequestDescriptionBuilder;
 import gov.hhs.fha.nhinc.docquery.aspect.AdhocQueryResponseDescriptionBuilder;
@@ -106,7 +106,7 @@ public class StandardInboundDocQuery extends AbstractInboundDocQuery {
         if (isPolicyValid(msg, assertion)) {
             resp = sendToAdapter(msg, assertion);
         } else {
-            resp = MessageGeneratorUtils.getInstance().createPolicyErrorResponse();
+            resp = DQMessageGeneratorUtils.getInstance().createPolicyErrorResponse();
         }
 
         return resp;

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/outbound/PassthroughOutboundDocQuery.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/outbound/PassthroughOutboundDocQuery.java
@@ -32,7 +32,7 @@ import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunityType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
-import gov.hhs.fha.nhinc.docquery.MessageGeneratorUtils;
+import gov.hhs.fha.nhinc.docquery.DQMessageGeneratorUtils;
 import gov.hhs.fha.nhinc.docquery.audit.DocQueryAuditLogger;
 import gov.hhs.fha.nhinc.docquery.entity.OutboundDocQueryDelegate;
 import gov.hhs.fha.nhinc.docquery.entity.OutboundDocQueryOrchestratable;
@@ -70,14 +70,14 @@ public class PassthroughOutboundDocQuery implements OutboundDocQuery {
         NhinTargetCommunitiesType targets) {
         logInfoServiceProcess(this.getClass());
 
-        NhinTargetSystemType target = MessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(targets);
+        NhinTargetSystemType target = DQMessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(targets);
         String targetHCID = getTargetHCID(target);
 
         if (targets.getNhinTargetCommunity().size() > 1) {
             warnTooManyTargets(targetHCID, targets);
         }
 
-        return sendRequestToNwhin(request, MessageGeneratorUtils.getInstance().generateMessageId(
+        return sendRequestToNwhin(request, DQMessageGeneratorUtils.getInstance().generateMessageId(
             assertion), target, targetHCID);
     }
 
@@ -103,7 +103,7 @@ public class PassthroughOutboundDocQuery implements OutboundDocQuery {
 
         } catch (Exception ex) {
             String errorMsg = "Error from target homeId = " + targetCommunityID + ". " + ex.getMessage();
-            throw new ErrorEventException(ex, MessageGeneratorUtils.getInstance().createRepositoryErrorResponse(errorMsg),
+            throw new ErrorEventException(ex, DQMessageGeneratorUtils.getInstance().createRepositoryErrorResponse(errorMsg),
                 "Unable to call Nhin Doc Query");
         }
 

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/outbound/StandardOutboundDocQuery.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/outbound/StandardOutboundDocQuery.java
@@ -26,14 +26,12 @@
  */
 package gov.hhs.fha.nhinc.docquery.outbound;
 
-import static gov.hhs.fha.nhinc.util.CoreHelpUtils.logInfoServiceProcess;
-
 import gov.hhs.fha.nhinc.aspect.OutboundProcessingEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
+import gov.hhs.fha.nhinc.docquery.DQMessageGeneratorUtils;
 import gov.hhs.fha.nhinc.docquery.DocQueryPolicyChecker;
-import gov.hhs.fha.nhinc.docquery.MessageGeneratorUtils;
 import gov.hhs.fha.nhinc.docquery.aspect.AdhocQueryRequestDescriptionBuilder;
 import gov.hhs.fha.nhinc.docquery.aspect.AdhocQueryResponseDescriptionBuilder;
 import gov.hhs.fha.nhinc.docquery.audit.DocQueryAuditLogger;
@@ -45,6 +43,7 @@ import gov.hhs.fha.nhinc.docquery.entity.OutboundDocQueryOrchestratable;
 import gov.hhs.fha.nhinc.document.DocumentConstants;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.orchestration.OutboundOrchestratable;
+import static gov.hhs.fha.nhinc.util.CoreHelpUtils.logInfoServiceProcess;
 import gov.hhs.fha.nhinc.util.HomeCommunityMap;
 import java.util.ArrayList;
 import java.util.List;
@@ -88,7 +87,8 @@ public class StandardOutboundDocQuery implements OutboundDocQuery {
      * @return AdhocQueryResponse from Entity Interface.
      */
     @Override
-    @OutboundProcessingEvent(beforeBuilder = AdhocQueryRequestDescriptionBuilder.class, afterReturningBuilder = AdhocQueryResponseDescriptionBuilder.class, serviceType = "Document Query", version = "")
+    @OutboundProcessingEvent(beforeBuilder = AdhocQueryRequestDescriptionBuilder.class, afterReturningBuilder
+        = AdhocQueryResponseDescriptionBuilder.class, serviceType = "Document Query", version = "")
     public AdhocQueryResponse respondingGatewayCrossGatewayQuery(AdhocQueryRequest adhocQueryRequest,
         AssertionType assertion, NhinTargetCommunitiesType targets) {
         logInfoServiceProcess(this.getClass());
@@ -99,7 +99,7 @@ public class StandardOutboundDocQuery implements OutboundDocQuery {
         OutboundDocQueryAggregate aggregate = new OutboundDocQueryAggregate();
 
         List<OutboundOrchestratable> aggregateRequests = fanoutService.createChildRequests(adhocQueryRequest,
-            MessageGeneratorUtils.getInstance().generateMessageId(assertion), targets);
+            DQMessageGeneratorUtils.getInstance().generateMessageId(assertion), targets);
 
         if (aggregateRequests.isEmpty()) {
             LOG.info("no patient correlation found.");
@@ -159,7 +159,7 @@ public class StandardOutboundDocQuery implements OutboundDocQuery {
      * @return AdhocQueryResponse.
      */
     private static AdhocQueryResponse createErrorResponse(String errorCode, String codeContext) {
-        return MessageGeneratorUtils.getInstance().createAdhocQueryErrorResponse(codeContext, errorCode,
+        return DQMessageGeneratorUtils.getInstance().createAdhocQueryErrorResponse(codeContext, errorCode,
             DocumentConstants.XDS_QUERY_RESPONSE_STATUS_FAILURE);
     }
 

--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/DQMessageGeneratorUtilsTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/DQMessageGeneratorUtilsTest.java
@@ -29,11 +29,11 @@ package gov.hhs.fha.nhinc.docquery;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryResponse;
 import org.junit.Test;
 
-public class MessageGeneratorUtilsTest {
+public class DQMessageGeneratorUtilsTest {
 
     @Test
     public void errorResponseHasRegistryObjectList() throws Exception {
-        AdhocQueryResponse response = MessageGeneratorUtils.getInstance().createAdhocQueryErrorResponse("msg", "code",
+        AdhocQueryResponse response = DQMessageGeneratorUtils.getInstance().createAdhocQueryErrorResponse("msg", "code",
                 "status");
         AdhocQueryResponseAsserter.assertSchemaCompliant(response);
     }

--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/entity/OutboundDocQueryStrategyTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/entity/OutboundDocQueryStrategyTest.java
@@ -27,7 +27,7 @@
 package gov.hhs.fha.nhinc.docquery.entity;
 
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
-import gov.hhs.fha.nhinc.docquery.MessageGeneratorUtils;
+import gov.hhs.fha.nhinc.docquery.DQMessageGeneratorUtils;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryResponse;
 import org.junit.Test;
@@ -51,7 +51,7 @@ public class OutboundDocQueryStrategyTest {
 
     @Test
     public void errorHandlingUsesMessageUtils() {
-        MessageGeneratorUtils mockUtils = mock(MessageGeneratorUtils.class);
+        DQMessageGeneratorUtils mockUtils = mock(DQMessageGeneratorUtils.class);
         when(mockUtils.createRepositoryErrorResponse(any(String.class))).thenReturn(mockResponse);
 
         OutboundDocQueryStrategy strategy = mock(OutboundDocQueryStrategy.class, Mockito.CALLS_REAL_METHODS);

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/PDMessageGeneratorUtils.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/PDMessageGeneratorUtils.java
@@ -32,6 +32,8 @@ import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunityType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
+import gov.hhs.fha.nhinc.util.MessageGeneratorUtils;
+import org.apache.commons.collections.CollectionUtils;
 import org.hl7.v3.CommunityPRPAIN201306UV02ResponseType;
 import org.hl7.v3.II;
 import org.hl7.v3.PRPAIN201305UV02;
@@ -44,11 +46,11 @@ import org.hl7.v3.RespondingGatewayPRPAIN201306UV02RequestType;
  *
  * @author JHOPPESC
  */
-public class MessageGeneratorUtils extends gov.hhs.fha.nhinc.util.MessageGeneratorUtils {
+public class PDMessageGeneratorUtils extends MessageGeneratorUtils {
 
-    private static MessageGeneratorUtils INSTANCE = new MessageGeneratorUtils();
+    private static final PDMessageGeneratorUtils INSTANCE = new PDMessageGeneratorUtils();
 
-    MessageGeneratorUtils() {
+    PDMessageGeneratorUtils() {
     }
 
     /**
@@ -56,35 +58,31 @@ public class MessageGeneratorUtils extends gov.hhs.fha.nhinc.util.MessageGenerat
      *
      * @return the singleton instance
      */
-    public static MessageGeneratorUtils getInstance() {
+    public static PDMessageGeneratorUtils getInstance() {
         return INSTANCE;
     }
 
     /**
      * Extracts the patient id from response message subject element
      *
-     * @param msg
+     * @param subject
      * @return <code>II</code> with extracted patient id
      */
     public II extractPatientIdFromSubject(PRPAIN201306UV02MFMIMT700711UV01Subject1 subject) {
-        II id = new II();
-
-        if (subject != null
-            && subject.getRegistrationEvent() != null
-            && subject.getRegistrationEvent().getSubject1() != null
-            && subject.getRegistrationEvent().getSubject1().getPatient() != null
-            && NullChecker.isNotNullish(subject.getRegistrationEvent().getSubject1().getPatient().getId())
-            && subject.getRegistrationEvent().getSubject1().getPatient().getId().get(0) != null
-            && NullChecker.isNotNullish(subject.getRegistrationEvent().getSubject1().getPatient().getId().get(0)
-                .getExtension())
+        II id = null;
+        boolean hasPatient = subject != null && subject.getRegistrationEvent() != null
+            && subject.getRegistrationEvent().getSubject1() != null && subject.getRegistrationEvent().getSubject1().
+            getPatient() != null;
+        boolean hasId = hasPatient && CollectionUtils.isNotEmpty(subject.getRegistrationEvent().getSubject1().
+            getPatient().getId()) && subject.getRegistrationEvent().getSubject1().getPatient().getId().get(0) != null;
+        if (hasId && NullChecker.isNotNullish(subject.getRegistrationEvent().getSubject1().getPatient().getId().get(0)
+            .getExtension())
             && NullChecker.isNotNullish(subject.getRegistrationEvent().getSubject1().getPatient().getId().get(0)
                 .getRoot())) {
+            id = new II();
             id.setExtension(subject.getRegistrationEvent().getSubject1().getPatient().getId().get(0).getExtension());
             id.setRoot(subject.getRegistrationEvent().getSubject1().getPatient().getId().get(0).getRoot());
-        } else {
-            id = null;
         }
-
         return id;
     }
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredResponseAuditTransforms.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/audit/transform/PatientDiscoveryDeferredResponseAuditTransforms.java
@@ -35,7 +35,7 @@ import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.common.nhinccommon.UserType;
 import gov.hhs.fha.nhinc.exchangemgr.ExchangeManagerException;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
-import gov.hhs.fha.nhinc.patientdiscovery.MessageGeneratorUtils;
+import gov.hhs.fha.nhinc.patientdiscovery.PDMessageGeneratorUtils;
 import gov.hhs.fha.nhinc.patientdiscovery.parser.PRPAIN201306UV02Parser;
 import gov.hhs.fha.nhinc.properties.PropertyAccessException;
 import gov.hhs.fha.nhinc.properties.PropertyAccessor;
@@ -168,7 +168,7 @@ public class PatientDiscoveryDeferredResponseAuditTransforms extends
     protected String getPDDeferredRequestInitiatorAddress() {
         try {
             String hcid = PRPAIN201306UV02Parser.getReceiverHCID(getRequest());
-            return new URL(getWebServiceUrlFromRemoteObject(MessageGeneratorUtils.getInstance().
+            return new URL(getWebServiceUrlFromRemoteObject(PDMessageGeneratorUtils.getInstance().
                 convertToNhinTargetSystemType(createNhinTargetCommunity(hcid)),
                 NhincConstants.PATIENT_DISCOVERY_DEFERRED_REQ_SERVICE_NAME)).getHost();
         } catch (MalformedURLException ex) {
@@ -211,7 +211,7 @@ public class PatientDiscoveryDeferredResponseAuditTransforms extends
     }
 
     private NhinTargetSystemType convertToNhinTarget(String hcid) {
-        return MessageGeneratorUtils.getInstance().convertToNhinTargetSystemType(createNhinTargetCommunity(hcid));
+        return PDMessageGeneratorUtils.getInstance().convertToNhinTargetSystemType(createNhinTargetCommunity(hcid));
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/entity/OutboundPatientDiscoveryProcessor.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/entity/OutboundPatientDiscoveryProcessor.java
@@ -34,7 +34,7 @@ import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.orchestration.OutboundOrchestratable;
 import gov.hhs.fha.nhinc.orchestration.OutboundOrchestratableMessage;
 import gov.hhs.fha.nhinc.orchestration.OutboundResponseProcessor;
-import gov.hhs.fha.nhinc.patientdiscovery.MessageGeneratorUtils;
+import gov.hhs.fha.nhinc.patientdiscovery.PDMessageGeneratorUtils;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscovery201306Processor;
 import gov.hhs.fha.nhinc.patientdiscovery.response.ResponseFactory;
 import gov.hhs.fha.nhinc.patientdiscovery.response.ResponseParams;
@@ -54,7 +54,7 @@ public class OutboundPatientDiscoveryProcessor implements OutboundResponseProces
 
     private static final Logger LOG = LoggerFactory.getLogger(OutboundPatientDiscoveryProcessor.class);
 
-    private MessageGeneratorUtils msgUtils = MessageGeneratorUtils.getInstance();
+    private PDMessageGeneratorUtils msgUtils = PDMessageGeneratorUtils.getInstance();
 
     private NhincConstants.GATEWAY_API_LEVEL cumulativeSpecLevel = null;
     private int count = 0;

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/PassthroughOutboundPatientDiscovery.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/PassthroughOutboundPatientDiscovery.java
@@ -34,7 +34,7 @@ import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.gateway.executorservice.ExecutorServiceHelper;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.orchestration.OutboundResponseProcessor;
-import gov.hhs.fha.nhinc.patientdiscovery.MessageGeneratorUtils;
+import gov.hhs.fha.nhinc.patientdiscovery.PDMessageGeneratorUtils;
 import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryAuditLogger;
 import gov.hhs.fha.nhinc.patientdiscovery.entity.OutboundPatientDiscoveryDelegate;
 import gov.hhs.fha.nhinc.patientdiscovery.entity.OutboundPatientDiscoveryOrchestratable;
@@ -48,7 +48,7 @@ import org.hl7.v3.RespondingGatewayPRPAIN201306UV02ResponseType;
 
 public class PassthroughOutboundPatientDiscovery implements OutboundPatientDiscovery {
 
-    private static final MessageGeneratorUtils msgUtils = MessageGeneratorUtils.getInstance();
+    private static final PDMessageGeneratorUtils msgUtils = PDMessageGeneratorUtils.getInstance();
     private final OutboundPatientDiscoveryDelegate delegate;
     private final PatientDiscoveryAuditLogger auditLogger;
 
@@ -80,7 +80,7 @@ public class PassthroughOutboundPatientDiscovery implements OutboundPatientDisco
         auditRequest(request, assertion,
             msgUtils.convertFirstToNhinTargetSystemType(request.getNhinTargetCommunities()));
         RespondingGatewayPRPAIN201306UV02ResponseType response = sendToNhin(request.getPRPAIN201305UV02(),
-            MessageGeneratorUtils.getInstance().generateMessageId(assertion),
+            PDMessageGeneratorUtils.getInstance().generateMessageId(assertion),
             msgUtils.convertFirstToNhinTargetSystemType(request.getNhinTargetCommunities()));
 
         return response;

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/request/PassthroughOutboundPatientDiscoveryDeferredRequest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/request/PassthroughOutboundPatientDiscoveryDeferredRequest.java
@@ -31,7 +31,7 @@ import static gov.hhs.fha.nhinc.util.CoreHelpUtils.logInfoServiceProcess;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
-import gov.hhs.fha.nhinc.patientdiscovery.MessageGeneratorUtils;
+import gov.hhs.fha.nhinc.patientdiscovery.PDMessageGeneratorUtils;
 import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryDeferredRequestAuditLogger;
 import gov.hhs.fha.nhinc.patientdiscovery.entity.deferred.request.OutboundPatientDiscoveryDeferredRequestDelegate;
 import gov.hhs.fha.nhinc.patientdiscovery.entity.deferred.request.OutboundPatientDiscoveryDeferredRequestOrchestratable;
@@ -40,7 +40,7 @@ import org.hl7.v3.PRPAIN201305UV02;
 
 public class PassthroughOutboundPatientDiscoveryDeferredRequest extends AbstractOutboundPatientDiscoveryDeferredRequest {
 
-    private static final MessageGeneratorUtils msgUtils = MessageGeneratorUtils.getInstance();
+    private static final PDMessageGeneratorUtils msgUtils = PDMessageGeneratorUtils.getInstance();
 
     private final OutboundPatientDiscoveryDeferredRequestDelegate delegate;
     private final PatientDiscoveryDeferredRequestAuditLogger auditLogger;
@@ -78,7 +78,7 @@ public class PassthroughOutboundPatientDiscoveryDeferredRequest extends Abstract
         NhinTargetCommunitiesType targets) {
         logInfoServiceProcess(this.getClass());
 
-        auditRequest(request, MessageGeneratorUtils.getInstance().generateMessageId(assertion),
+        auditRequest(request, PDMessageGeneratorUtils.getInstance().generateMessageId(assertion),
             msgUtils.convertFirstToNhinTargetSystemType(targets));
         return sendToNhin(request, assertion, targets);
     }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/request/StandardOutboundPatientDiscoveryDeferredRequest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/request/StandardOutboundPatientDiscoveryDeferredRequest.java
@@ -39,7 +39,7 @@ import gov.hhs.fha.nhinc.exchangemgr.ExchangeManagerException;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import gov.hhs.fha.nhinc.patientcorrelation.nhinc.dao.PDDeferredCorrelationDao;
-import gov.hhs.fha.nhinc.patientdiscovery.MessageGeneratorUtils;
+import gov.hhs.fha.nhinc.patientdiscovery.PDMessageGeneratorUtils;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscovery201305Processor;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryPolicyChecker;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.MCCIIN000002UV01EventDescriptionBuilder;
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
 
 public class StandardOutboundPatientDiscoveryDeferredRequest extends AbstractOutboundPatientDiscoveryDeferredRequest {
 
-    private static final MessageGeneratorUtils msgUtils = MessageGeneratorUtils.getInstance();
+    private static final PDMessageGeneratorUtils msgUtils = PDMessageGeneratorUtils.getInstance();
 
     private static final Logger LOG = LoggerFactory.getLogger(StandardOutboundPatientDiscoveryDeferredRequest.class);
     private final PatientDiscovery201305Processor pd201305Processor;

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/AbstractOutboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/AbstractOutboundPatientDiscoveryDeferredResponse.java
@@ -30,7 +30,7 @@ import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
-import gov.hhs.fha.nhinc.patientdiscovery.MessageGeneratorUtils;
+import gov.hhs.fha.nhinc.patientdiscovery.PDMessageGeneratorUtils;
 import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryDeferredResponseAuditLogger;
 import gov.hhs.fha.nhinc.patientdiscovery.entity.deferred.response.OutboundPatientDiscoveryDeferredResponseDelegate;
 import gov.hhs.fha.nhinc.patientdiscovery.entity.deferred.response.OutboundPatientDiscoveryDeferredResponseOrchestratable;
@@ -60,7 +60,7 @@ public abstract class AbstractOutboundPatientDiscoveryDeferredResponse implement
     public MCCIIN000002UV01 processPatientDiscoveryAsyncResp(PRPAIN201306UV02 request, AssertionType assertion,
         NhinTargetCommunitiesType target) {
 
-        return process(request, MessageGeneratorUtils.getInstance().generateMessageId(assertion),
+        return process(request, PDMessageGeneratorUtils.getInstance().generateMessageId(assertion),
             target);
     }
 
@@ -78,12 +78,12 @@ public abstract class AbstractOutboundPatientDiscoveryDeferredResponse implement
     public void auditRequest(PRPAIN201306UV02 message, AssertionType assertion,
         NhinTargetCommunitiesType targets) {
         getAuditLogger().auditRequestMessage(message, assertion,
-            MessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(targets),
+            PDMessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(targets),
             NhincConstants.AUDIT_LOG_OUTBOUND_DIRECTION, NhincConstants.AUDIT_LOG_NHIN_INTERFACE, Boolean.TRUE,
             null, NhincConstants.PATIENT_DISCOVERY_DEFERRED_RESP_SERVICE_NAME);
     }
 
     protected NhinTargetSystemType convertToNhinTargetSystemType(NhinTargetCommunitiesType targets) {
-        return MessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(targets);
+        return PDMessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(targets);
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/PassthroughOutboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/PassthroughOutboundPatientDiscoveryDeferredResponse.java
@@ -31,7 +31,7 @@ import static gov.hhs.fha.nhinc.util.CoreHelpUtils.logInfoServiceProcess;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
-import gov.hhs.fha.nhinc.patientdiscovery.MessageGeneratorUtils;
+import gov.hhs.fha.nhinc.patientdiscovery.PDMessageGeneratorUtils;
 import gov.hhs.fha.nhinc.patientdiscovery.audit.PatientDiscoveryDeferredResponseAuditLogger;
 import gov.hhs.fha.nhinc.patientdiscovery.entity.deferred.response.OutboundPatientDiscoveryDeferredResponseDelegate;
 import org.hl7.v3.MCCIIN000002UV01;
@@ -40,7 +40,7 @@ import org.hl7.v3.PRPAIN201306UV02;
 public class PassthroughOutboundPatientDiscoveryDeferredResponse extends
 AbstractOutboundPatientDiscoveryDeferredResponse {
 
-    private static final MessageGeneratorUtils msgUtils = MessageGeneratorUtils.getInstance();
+    private static final PDMessageGeneratorUtils msgUtils = PDMessageGeneratorUtils.getInstance();
 
     private final PatientDiscoveryDeferredResponseAuditLogger auditLogger;
     private final OutboundPatientDiscoveryDeferredResponseDelegate delegate;

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/StandardOutboundPatientDiscoveryDeferredResponse.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/deferred/response/StandardOutboundPatientDiscoveryDeferredResponse.java
@@ -36,7 +36,7 @@ import gov.hhs.fha.nhinc.connectmgr.UrlInfo;
 import gov.hhs.fha.nhinc.exchangemgr.ExchangeManager;
 import gov.hhs.fha.nhinc.exchangemgr.ExchangeManagerException;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
-import gov.hhs.fha.nhinc.patientdiscovery.MessageGeneratorUtils;
+import gov.hhs.fha.nhinc.patientdiscovery.PDMessageGeneratorUtils;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscovery201306PolicyChecker;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscovery201306Processor;
 import gov.hhs.fha.nhinc.patientdiscovery.PolicyChecker;
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
 
 public class StandardOutboundPatientDiscoveryDeferredResponse extends AbstractOutboundPatientDiscoveryDeferredResponse {
 
-    private final static MessageGeneratorUtils msgUtils = MessageGeneratorUtils.getInstance();
+    private final static PDMessageGeneratorUtils msgUtils = PDMessageGeneratorUtils.getInstance();
 
     private final PolicyChecker<RespondingGatewayPRPAIN201306UV02RequestType, PRPAIN201306UV02> policyChecker;
     private final PatientDiscovery201306Processor pd201306Processor;
@@ -101,7 +101,7 @@ public class StandardOutboundPatientDiscoveryDeferredResponse extends AbstractOu
     public MCCIIN000002UV01 processPatientDiscoveryAsyncResp(PRPAIN201306UV02 request, AssertionType assertion,
         NhinTargetCommunitiesType target) {
 
-        return process(request, MessageGeneratorUtils.getInstance().generateMessageId(assertion),
+        return process(request, PDMessageGeneratorUtils.getInstance().generateMessageId(assertion),
             target);
     }
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/PDMessageGeneratorUtilsTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/PDMessageGeneratorUtilsTest.java
@@ -37,9 +37,9 @@ import static org.junit.Assert.assertNull;
 import org.junit.Test;
 
 
-public class MessageGeneratorUtilsTest {
+public class PDMessageGeneratorUtilsTest {
 
-    private MessageGeneratorUtils msgUtils = MessageGeneratorUtils.getInstance();
+    private PDMessageGeneratorUtils msgUtils = PDMessageGeneratorUtils.getInstance();
 
     @Test
     public void extractPatientIdFromSubject() {

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscoveryTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/outbound/StandardOutboundPatientDiscoveryTest.java
@@ -47,7 +47,7 @@ import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.connectmgr.UrlInfo;
 import gov.hhs.fha.nhinc.event.error.ErrorEventException;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
-import gov.hhs.fha.nhinc.patientdiscovery.MessageGeneratorUtils;
+import gov.hhs.fha.nhinc.patientdiscovery.PDMessageGeneratorUtils;
 import gov.hhs.fha.nhinc.patientdiscovery.PatientDiscoveryPolicyChecker;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201305UV02ArgTransformer;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.RespondingGatewayPRPAIN201306UV02Builder;
@@ -99,7 +99,7 @@ public class StandardOutboundPatientDiscoveryTest {
         request.setPRPAIN201305UV02(new PRPAIN201305UV02());
         NhinTargetCommunitiesType targets = createNhinTargetCommunitiesType(TARGET_HCID);
         request.setNhinTargetCommunities(createNhinTargetCommunitiesType(TARGET_HCID));
-        NhinTargetSystemType target = MessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(targets);
+        NhinTargetSystemType target = PDMessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(targets);
         AssertionType assertion = createAssertion();
         request.setAssertion(assertion);
 
@@ -202,7 +202,7 @@ public class StandardOutboundPatientDiscoveryTest {
 
             @Override
             protected List<UrlInfo> getEndpoints(NhinTargetCommunitiesType targetCommunities) {
-                return getEndPoints(MessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(
+                return getEndPoints(PDMessageGeneratorUtils.getInstance().convertFirstToNhinTargetSystemType(
                     targetCommunities));
             }
 


### PR DESCRIPTION
Method names should comply with a naming convention
Utility classes should not have a public constructor
String literals should not be duplicated
Class names should not shadow interfaces