### PR TITLE
CONN_2192b: JSON Exception Message fix

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/ErrorLogBean.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/ErrorLogBean.java
@@ -151,10 +151,7 @@ public class ErrorLogBean {
     }
 
     private Object getJsonProperty(String key) {
-        if (null == selectedEventJson) {
-            return null;
-        }
-        return selectedEventJson.get(key);
+        return null != selectedEventJson && selectedEventJson.has(key) ? selectedEventJson.get(key) : "Not Provided";
     }
 
     public JSONArray getJsonStackTrace() {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/ErrorEventBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/ErrorEventBuilder.java
@@ -61,7 +61,8 @@ public class ErrorEventBuilder implements EventBuilder {
 
             try {
                 if (throwable != null) {
-                    jsonObject.put("exceptionMessage", throwable.getMessage());
+                    String message = StringUtils.isBlank(throwable.getMessage()) ? "N/A" : throwable.getMessage();
+                    jsonObject.put("exceptionMessage", message);
                     jsonObject.put("exceptionClass", throwable.getClass().getName());
                     jsonObject.put("stackTrace", throwable.getStackTrace());
                 }

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/aspect/ErrorEventBuilderTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/aspect/ErrorEventBuilderTest.java
@@ -128,6 +128,6 @@ public class ErrorEventBuilderTest {
         Event event = builder.getEvent();
         assertNotNull(event.getDescription());
         assertEquals(MessageProcessingFailedEvent.EVENT_NAME, event.getEventName());
-        JSONAssert.assertEquals("{\"exceptionClass\": \"" + t.getClass().getName() + "\", \"stackTrace\":[]}", event.getDescription(), true);
+        JSONAssert.assertEquals("{\"exceptionMessage\":\"N/A\",\"exceptionClass\": \"" + t.getClass().getName() + "\", \"stackTrace\":[]}", event.getDescription(), true);
     }
 }


### PR DESCRIPTION
removing assumption that exception message will always be provided via the throwable