### PR TITLE
CONN_2339: Used Try with Resources on Http request

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/client/fhir/ConformanceClient.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/client/fhir/ConformanceClient.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -41,6 +41,7 @@ import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.hl7.fhir.instance.client.EFhirClientException;
 import org.hl7.fhir.instance.client.FeedFormat;
@@ -107,9 +108,9 @@ public class ConformanceClient {
     protected static HttpResponse sendRequest(HttpUriRequest request) {
         HttpResponse response;
         LOG.info("Conformance request method: {}", request.getURI().getQuery());
-        try {
+        try(CloseableHttpClient client = HttpClientBuilder.create().build()) {
 
-            response = HttpClientBuilder.create().build().execute(request);
+            response = client.execute(request);
         } catch (IOException ioe) {
             throw new EFhirClientException("Error sending Http Request", ioe);
         }


### PR DESCRIPTION
Adding Http call via try with resources to close out the request in order to resolve a fortify/sonar violation