### PR TITLE
Fix fips mode

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/TLSClientParametersFactory.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/TLSClientParametersFactory.java
@@ -124,15 +124,13 @@ public class TLSClientParametersFactory {
         try {
             TrustManagerFactory trustFactory = getInstance().trustFactory;
             if (trustFactory != null) {
-                TrustManager trustManager[] = trustFactory.getTrustManagers();
+                TrustManager[] trustManager = trustFactory.getTrustManagers();
                 if (trustManager != null) {
-                    LOG.debug("Trust Manager is not empty {}", trustManager.length);
                     tlsClientParameters.setTrustManagers(trustManager);
                 }
             } else {
                 LOG.debug("Trust Factory is empty");
             }
-
         } catch (IllegalStateException e) {
             LOG.error(e.getLocalizedMessage(), e);
         }
@@ -145,9 +143,8 @@ public class TLSClientParametersFactory {
         try {
             KeyManagerFactory keyFactory = getInstance().keyFactory;
             if (keyFactory != null) {
-                KeyManager keyManager[] = keyFactory.getKeyManagers();
+                KeyManager[] keyManager = keyFactory.getKeyManagers();
                 if (keyManager != null) {
-                    LOG.debug("Key Manger is not empty {} ", keyManager.length);
                     tlsClientParameters.setKeyManagers(keyManager);
                 }
             } else {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/properties/IPropertyAcessor.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/properties/IPropertyAcessor.java
@@ -34,6 +34,8 @@ public interface IPropertyAcessor {
 
     public boolean getPropertyBoolean(String propertyFile, String propertyName) throws PropertyAccessException;
 
+    public boolean getPropertyBoolean(String propertyFile, String propertyName, boolean defaultValue);
+
     public void setProperty(String propertyFileName, String key, String value) throws PropertyAccessException;
 
     public String getPropertyComment(String propertyFileName, String key) throws PropertyAccessException;

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/properties/PropertyAccessor.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/properties/PropertyAccessor.java
@@ -148,6 +148,27 @@ public class PropertyAccessor implements IPropertyAcessor {
     }
 
     /**
+     * This will return true if the property value is: T, t, or any case combination of "TRUE" and it will return false
+     * for all other values. If entry is not found, it will return the default value
+     *
+     * @param propertyFile The name of the property file.
+     * @param propertyName The name of the property that contains a boolean value. This will return true if the value
+     *            is: T, t, or any case combination of "TRUE" and it will return false for all other values.
+     * @param defaultValue default value if entry doesn't exist in property file
+     */
+    @Override
+    public synchronized boolean getPropertyBoolean(String propertyFile, String propertyName, boolean defaultValue) {
+        try {
+            return getPropertyBoolean(propertyFile, propertyName);
+        } catch (PropertyAccessException e) {
+            LOG.error("Fail to retrieve {} from {}.property file. Default to {} ", propertyName, defaultValue,
+                propertyFile, e);
+            return defaultValue;
+        }
+
+    }
+
+    /**
      * This will return the long value conversion of the property. If the property value cannot be converted to a long,
      * an exception will be thrown.
      *


### PR DESCRIPTION
When fips mode is enabled, cxf client doesn't send its certificate during ssl handshake.  It appears CXF always load JVM default Key Manager which is different when it is in fips mode.  This fix will force CXF to load from our specified keymanager and trust manager into the client.  