### PR TITLE
CONN_1779: Fix event logging to record the correct Action into the description

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/BaseEventAdviceDelegate.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/BaseEventAdviceDelegate.java
@@ -32,6 +32,7 @@ import gov.hhs.fha.nhinc.event.DefaultEventDescriptionBuilder;
 import gov.hhs.fha.nhinc.event.Event;
 import gov.hhs.fha.nhinc.event.EventBuilder;
 import gov.hhs.fha.nhinc.event.EventContextAccessor;
+import gov.hhs.fha.nhinc.event.EventDescription;
 import gov.hhs.fha.nhinc.event.EventDescriptionBuilder;
 import gov.hhs.fha.nhinc.event.EventDescriptionDirector;
 import gov.hhs.fha.nhinc.event.EventDirector;
@@ -95,14 +96,16 @@ public abstract class BaseEventAdviceDelegate implements EventAdviceDelegate {
      * java.lang.String)
      */
     @Override
-    public void begin(Object[] args, String serviceType, String version,
+    public EventDescription begin(Object[] args, String serviceType, String version,
         Class<? extends EventDescriptionBuilder> eventDescriptionbuilderClass) {
+        EventDescription eventDescription = null;
         if (eventRecorder != null && eventRecorder.isRecordEventEnabled()) {
             EventDescriptionBuilder eventDescriptionBuilder = createAndInitializeEventDecriptionBuilder(args,
                 createEventContextAccessor(serviceType, version), eventDescriptionbuilderClass, null);
-
             createAndRecordEvent(getBeginEventBuilder(eventDescriptionBuilder, args));
+            eventDescription = eventDescriptionBuilder.getEventDescription();
         }
+        return eventDescription;
     }
 
     /**

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/BeginEventAdviceDelegate.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/aspect/BeginEventAdviceDelegate.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,6 +26,7 @@
  */
 package gov.hhs.fha.nhinc.aspect;
 
+import gov.hhs.fha.nhinc.event.EventDescription;
 import gov.hhs.fha.nhinc.event.EventDescriptionBuilder;
 
 /**
@@ -34,7 +35,7 @@ import gov.hhs.fha.nhinc.event.EventDescriptionBuilder;
  */
 public interface BeginEventAdviceDelegate {
 
-    void begin(Object[] args, String serviceType, String version,
+    EventDescription begin(Object[] args, String serviceType, String version,
             Class<? extends EventDescriptionBuilder> eventDescriptionbuilder);
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/event/BaseEventDescriptionBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/event/BaseEventDescriptionBuilder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -43,9 +43,9 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class BaseEventDescriptionBuilder implements EventDescriptionBuilder {
 
-    private BaseEventDescription description;
-    private MessageRoutingAccessor msgRouting;
-    private EventContextAccessor msgContext;
+    protected BaseEventDescription description;
+    protected MessageRoutingAccessor msgRouting;
+    protected EventContextAccessor msgContext;
 
     private static final Logger LOG = LoggerFactory.getLogger(BaseEventDescriptionBuilder.class);
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/event/TargetEventDescriptionBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/event/TargetEventDescriptionBuilder.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,18 +26,16 @@
  */
 package gov.hhs.fha.nhinc.event;
 
+import com.google.common.base.Optional;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetCommunitiesType;
 import gov.hhs.fha.nhinc.common.nhinccommon.NhinTargetSystemType;
 import gov.hhs.fha.nhinc.event.builder.TargetDescriptionExtractor;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Optional;
 
 /**
  *
@@ -104,8 +102,19 @@ public abstract class TargetEventDescriptionBuilder extends AssertionEventDescri
             && communities.getNhinTargetCommunity().get(0).getHomeCommunity() != null) {
             NhinTargetSystemType targetSystem = new NhinTargetSystemType();
             targetSystem.setHomeCommunity(communities.getNhinTargetCommunity().get(0).getHomeCommunity());
+            targetSystem.setUseSpecVersion(communities.getUseSpecVersion());
             return targetSystem;
         }
         return null;
+    }
+
+
+    @Override
+    public void buildAction() {
+        String action = msgContext.getAction();
+        if (StringUtils.isBlank(action) && target.isPresent()) {
+            action = target.get().getUseSpecVersion();
+        }
+        description.setAction(action);
     }
 }

--- a/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/adapter/proxy/AdapterAdminDistributionProxyJavaImpl.java
+++ b/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/adapter/proxy/AdapterAdminDistributionProxyJavaImpl.java
@@ -50,7 +50,7 @@ public class AdapterAdminDistributionProxyJavaImpl implements AdapterAdminDistri
      */
     @AdapterDelegationEvent(beforeBuilder = EDXLDistributionEventDescriptionBuilder.class,
         afterReturningBuilder = EDXLDistributionEventDescriptionBuilder.class, serviceType = "Admin Distribution",
-        version = "LEVEL_A0")
+        version = "LEVEL_a0")
     @Override
     public void sendAlertMessage(EDXLDistribution body, AssertionType assertion) {
         LOG.debug("Begin sendAlertMessage");

--- a/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/adapter/proxy/AdapterAdminDistributionProxyJavaImpl.java
+++ b/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/adapter/proxy/AdapterAdminDistributionProxyJavaImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -48,7 +48,9 @@ public class AdapterAdminDistributionProxyJavaImpl implements AdapterAdminDistri
      * @param body Emergency Message Distribution Element transaction message body received.
      * @param assertion Assertion received.
      */
-    @AdapterDelegationEvent(beforeBuilder = EDXLDistributionEventDescriptionBuilder.class, afterReturningBuilder = EDXLDistributionEventDescriptionBuilder.class, serviceType = "Admin Distribution", version = "")
+    @AdapterDelegationEvent(beforeBuilder = EDXLDistributionEventDescriptionBuilder.class,
+        afterReturningBuilder = EDXLDistributionEventDescriptionBuilder.class, serviceType = "Admin Distribution",
+        version = "LEVEL_A0")
     @Override
     public void sendAlertMessage(EDXLDistribution body, AssertionType assertion) {
         LOG.debug("Begin sendAlertMessage");

--- a/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/adapter/proxy/AdapterAdminDistributionProxyNoOpImpl.java
+++ b/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/adapter/proxy/AdapterAdminDistributionProxyNoOpImpl.java
@@ -49,7 +49,7 @@ public class AdapterAdminDistributionProxyNoOpImpl implements AdapterAdminDistri
      */
     @AdapterDelegationEvent(beforeBuilder = EDXLDistributionEventDescriptionBuilder.class,
         afterReturningBuilder = EDXLDistributionEventDescriptionBuilder.class, serviceType = "Admin Distribution",
-        version = "LEVEL_A0")
+        version = "LEVEL_a0")
     @Override
     public void sendAlertMessage(EDXLDistribution body, AssertionType assertion) {
         LOG.debug("Begin sendAlertMessage");

--- a/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/adapter/proxy/AdapterAdminDistributionProxyNoOpImpl.java
+++ b/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/adapter/proxy/AdapterAdminDistributionProxyNoOpImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -47,7 +47,9 @@ public class AdapterAdminDistributionProxyNoOpImpl implements AdapterAdminDistri
      * @param body Emergency Message Distribution Element transaction message body received.
      * @param assertion Assertion received.
      */
-    @AdapterDelegationEvent(beforeBuilder = EDXLDistributionEventDescriptionBuilder.class, afterReturningBuilder = EDXLDistributionEventDescriptionBuilder.class, serviceType = "Admin Distribution", version = "")
+    @AdapterDelegationEvent(beforeBuilder = EDXLDistributionEventDescriptionBuilder.class,
+        afterReturningBuilder = EDXLDistributionEventDescriptionBuilder.class, serviceType = "Admin Distribution",
+        version = "LEVEL_A0")
     @Override
     public void sendAlertMessage(EDXLDistribution body, AssertionType assertion) {
         LOG.debug("Begin sendAlertMessage");

--- a/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/adapter/proxy/AdapterAdminDistributionProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/adapter/proxy/AdapterAdminDistributionProxyWebServiceSecuredImpl.java
@@ -97,7 +97,7 @@ public class AdapterAdminDistributionProxyWebServiceSecuredImpl implements Adapt
      */
     @AdapterDelegationEvent(beforeBuilder = EDXLDistributionEventDescriptionBuilder.class,
         afterReturningBuilder = EDXLDistributionEventDescriptionBuilder.class, serviceType = "Admin Distribution",
-        version = "LEVEL_A0")
+        version = "LEVEL_a0")
     @Override
     public void sendAlertMessage(EDXLDistribution body, AssertionType assertion) {
         LOG.debug("Begin sendAlertMessage");

--- a/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/adapter/proxy/AdapterAdminDistributionProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/adapter/proxy/AdapterAdminDistributionProxyWebServiceSecuredImpl.java
@@ -95,7 +95,9 @@ public class AdapterAdminDistributionProxyWebServiceSecuredImpl implements Adapt
      * @param body Emergency Message Distribution Element transaction message body received.
      * @param assertion Assertion received.
      */
-    @AdapterDelegationEvent(beforeBuilder = EDXLDistributionEventDescriptionBuilder.class, afterReturningBuilder = EDXLDistributionEventDescriptionBuilder.class, serviceType = "Admin Distribution", version = "")
+    @AdapterDelegationEvent(beforeBuilder = EDXLDistributionEventDescriptionBuilder.class,
+        afterReturningBuilder = EDXLDistributionEventDescriptionBuilder.class, serviceType = "Admin Distribution",
+        version = "LEVEL_A0")
     @Override
     public void sendAlertMessage(EDXLDistribution body, AssertionType assertion) {
         LOG.debug("Begin sendAlertMessage");

--- a/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/adapter/proxy/AdapterAdminDistributionProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/adapter/proxy/AdapterAdminDistributionProxyWebServiceUnsecuredImpl.java
@@ -97,7 +97,7 @@ public class AdapterAdminDistributionProxyWebServiceUnsecuredImpl implements Ada
      */
     @AdapterDelegationEvent(beforeBuilder = EDXLDistributionEventDescriptionBuilder.class,
         afterReturningBuilder = EDXLDistributionEventDescriptionBuilder.class, serviceType = "Admin Distribution",
-        version = "LEVEL_A0")
+        version = "LEVEL_a0")
     @Override
     public void sendAlertMessage(EDXLDistribution body, AssertionType assertion) {
         LOG.debug("Begin sendAlertMessage");

--- a/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/adapter/proxy/AdapterAdminDistributionProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/AdminDistributionCore/src/main/java/gov/hhs/fha/nhinc/admindistribution/adapter/proxy/AdapterAdminDistributionProxyWebServiceUnsecuredImpl.java
@@ -95,7 +95,9 @@ public class AdapterAdminDistributionProxyWebServiceUnsecuredImpl implements Ada
      * @param body Emergency Message Distribution Element transaction message body received.
      * @param assertion Assertion received.
      */
-    @AdapterDelegationEvent(beforeBuilder = EDXLDistributionEventDescriptionBuilder.class, afterReturningBuilder = EDXLDistributionEventDescriptionBuilder.class, serviceType = "Admin Distribution", version = "")
+    @AdapterDelegationEvent(beforeBuilder = EDXLDistributionEventDescriptionBuilder.class,
+        afterReturningBuilder = EDXLDistributionEventDescriptionBuilder.class, serviceType = "Admin Distribution",
+        version = "LEVEL_A0")
     @Override
     public void sendAlertMessage(EDXLDistribution body, AssertionType assertion) {
         LOG.debug("Begin sendAlertMessage");

--- a/Product/Production/Services/AdminDistributionCore/src/test/java/gov/hhs/fha/nhinc/admindistribution/adapter/proxy/AdapterAdminDistributionProxyTest.java
+++ b/Product/Production/Services/AdminDistributionCore/src/test/java/gov/hhs/fha/nhinc/admindistribution/adapter/proxy/AdapterAdminDistributionProxyTest.java
@@ -78,7 +78,7 @@ public class AdapterAdminDistributionProxyTest {
             assertEquals(EDXLDistributionEventDescriptionBuilder.class, annotation.beforeBuilder());
             assertEquals(EDXLDistributionEventDescriptionBuilder.class, annotation.afterReturningBuilder());
             assertEquals("Admin Distribution", annotation.serviceType());
-            assertEquals("LEVEL_A0", annotation.version());
+            assertEquals("LEVEL_a0", annotation.version());
         }
     }
 

--- a/Product/Production/Services/AdminDistributionCore/src/test/java/gov/hhs/fha/nhinc/admindistribution/adapter/proxy/AdapterAdminDistributionProxyTest.java
+++ b/Product/Production/Services/AdminDistributionCore/src/test/java/gov/hhs/fha/nhinc/admindistribution/adapter/proxy/AdapterAdminDistributionProxyTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -78,7 +78,7 @@ public class AdapterAdminDistributionProxyTest {
             assertEquals(EDXLDistributionEventDescriptionBuilder.class, annotation.beforeBuilder());
             assertEquals(EDXLDistributionEventDescriptionBuilder.class, annotation.afterReturningBuilder());
             assertEquals("Admin Distribution", annotation.serviceType());
-            assertEquals("", annotation.version());
+            assertEquals("LEVEL_A0", annotation.version());
         }
     }
 

--- a/Product/Production/Services/DocumentDataSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docdatasubmission/adapter/proxy/AdapterDocDataSubmissionProxyJavaImpl.java
+++ b/Product/Production/Services/DocumentDataSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docdatasubmission/adapter/proxy/AdapterDocDataSubmissionProxyJavaImpl.java
@@ -39,7 +39,7 @@ public class AdapterDocDataSubmissionProxyJavaImpl implements AdapterDocDataSubm
 
     private static final Logger LOG = LoggerFactory.getLogger(AdapterDocDataSubmissionProxyJavaImpl.class);
 
-    @AdapterDelegationEvent(serviceType = "Document Data Submission", version = "",
+    @AdapterDelegationEvent(serviceType = "Document Data Submission", version = "LEVEL_A0",
         beforeBuilder = DocDataSubmissionBaseEventDescriptionBuilder.class,
         afterReturningBuilder = DocDataSubmissionBaseEventDescriptionBuilder.class)
     @Override

--- a/Product/Production/Services/DocumentDataSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docdatasubmission/adapter/proxy/AdapterDocDataSubmissionProxyJavaImpl.java
+++ b/Product/Production/Services/DocumentDataSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docdatasubmission/adapter/proxy/AdapterDocDataSubmissionProxyJavaImpl.java
@@ -39,7 +39,7 @@ public class AdapterDocDataSubmissionProxyJavaImpl implements AdapterDocDataSubm
 
     private static final Logger LOG = LoggerFactory.getLogger(AdapterDocDataSubmissionProxyJavaImpl.class);
 
-    @AdapterDelegationEvent(serviceType = "Document Data Submission", version = "LEVEL_A0",
+    @AdapterDelegationEvent(serviceType = "Document Data Submission", version = "LEVEL_a0",
         beforeBuilder = DocDataSubmissionBaseEventDescriptionBuilder.class,
         afterReturningBuilder = DocDataSubmissionBaseEventDescriptionBuilder.class)
     @Override

--- a/Product/Production/Services/DocumentDataSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docdatasubmission/adapter/proxy/AdapterDocDataSubmissionProxyNoOpImpl.java
+++ b/Product/Production/Services/DocumentDataSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docdatasubmission/adapter/proxy/AdapterDocDataSubmissionProxyNoOpImpl.java
@@ -39,7 +39,7 @@ public class AdapterDocDataSubmissionProxyNoOpImpl implements AdapterDocDataSubm
 
     private static final Logger LOG = LoggerFactory.getLogger(AdapterDocDataSubmissionProxyNoOpImpl.class);
 
-    @AdapterDelegationEvent(serviceType = "Document Data Submission", version = "",
+    @AdapterDelegationEvent(serviceType = "Document Data Submission", version = "LEVEL_A0",
         beforeBuilder = DocDataSubmissionBaseEventDescriptionBuilder.class,
         afterReturningBuilder = DocDataSubmissionBaseEventDescriptionBuilder.class)
     @Override

--- a/Product/Production/Services/DocumentDataSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docdatasubmission/adapter/proxy/AdapterDocDataSubmissionProxyNoOpImpl.java
+++ b/Product/Production/Services/DocumentDataSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docdatasubmission/adapter/proxy/AdapterDocDataSubmissionProxyNoOpImpl.java
@@ -39,7 +39,7 @@ public class AdapterDocDataSubmissionProxyNoOpImpl implements AdapterDocDataSubm
 
     private static final Logger LOG = LoggerFactory.getLogger(AdapterDocDataSubmissionProxyNoOpImpl.class);
 
-    @AdapterDelegationEvent(serviceType = "Document Data Submission", version = "LEVEL_A0",
+    @AdapterDelegationEvent(serviceType = "Document Data Submission", version = "LEVEL_a0",
         beforeBuilder = DocDataSubmissionBaseEventDescriptionBuilder.class,
         afterReturningBuilder = DocDataSubmissionBaseEventDescriptionBuilder.class)
     @Override

--- a/Product/Production/Services/DocumentDataSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docdatasubmission/adapter/proxy/AdapterDocDataSubmissionProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/DocumentDataSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docdatasubmission/adapter/proxy/AdapterDocDataSubmissionProxyWebServiceSecuredImpl.java
@@ -47,7 +47,7 @@ public class AdapterDocDataSubmissionProxyWebServiceSecuredImpl implements Adapt
 
     private WebServiceProxyHelper oProxyHelper = new WebServiceProxyHelper();
 
-    @AdapterDelegationEvent(serviceType = "Document Data Submission", version = "",
+    @AdapterDelegationEvent(serviceType = "Document Data Submission", version = "LEVEL_A0",
         beforeBuilder = DocDataSubmissionBaseEventDescriptionBuilder.class,
         afterReturningBuilder = DocDataSubmissionBaseEventDescriptionBuilder.class)
     @Override

--- a/Product/Production/Services/DocumentDataSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docdatasubmission/adapter/proxy/AdapterDocDataSubmissionProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/DocumentDataSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docdatasubmission/adapter/proxy/AdapterDocDataSubmissionProxyWebServiceSecuredImpl.java
@@ -47,7 +47,7 @@ public class AdapterDocDataSubmissionProxyWebServiceSecuredImpl implements Adapt
 
     private WebServiceProxyHelper oProxyHelper = new WebServiceProxyHelper();
 
-    @AdapterDelegationEvent(serviceType = "Document Data Submission", version = "LEVEL_A0",
+    @AdapterDelegationEvent(serviceType = "Document Data Submission", version = "LEVEL_a0",
         beforeBuilder = DocDataSubmissionBaseEventDescriptionBuilder.class,
         afterReturningBuilder = DocDataSubmissionBaseEventDescriptionBuilder.class)
     @Override

--- a/Product/Production/Services/DocumentDataSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docdatasubmission/adapter/proxy/AdapterDocDataSubmissionProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/DocumentDataSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docdatasubmission/adapter/proxy/AdapterDocDataSubmissionProxyWebServiceUnsecuredImpl.java
@@ -52,7 +52,7 @@ public class AdapterDocDataSubmissionProxyWebServiceUnsecuredImpl implements Ada
         .getLogger(AdapterDocDataSubmissionProxyWebServiceUnsecuredImpl.class);
     private WebServiceProxyHelper oProxyHelper = new WebServiceProxyHelper();
 
-    @AdapterDelegationEvent(serviceType = "Document Data Submission", version = "",
+    @AdapterDelegationEvent(serviceType = "Document Data Submission", version = "LEVEL_A0",
         beforeBuilder = DocDataSubmissionBaseEventDescriptionBuilder.class,
         afterReturningBuilder = DocDataSubmissionBaseEventDescriptionBuilder.class)
     @Override

--- a/Product/Production/Services/DocumentDataSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docdatasubmission/adapter/proxy/AdapterDocDataSubmissionProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/DocumentDataSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docdatasubmission/adapter/proxy/AdapterDocDataSubmissionProxyWebServiceUnsecuredImpl.java
@@ -52,7 +52,7 @@ public class AdapterDocDataSubmissionProxyWebServiceUnsecuredImpl implements Ada
         .getLogger(AdapterDocDataSubmissionProxyWebServiceUnsecuredImpl.class);
     private WebServiceProxyHelper oProxyHelper = new WebServiceProxyHelper();
 
-    @AdapterDelegationEvent(serviceType = "Document Data Submission", version = "LEVEL_A0",
+    @AdapterDelegationEvent(serviceType = "Document Data Submission", version = "LEVEL_a0",
         beforeBuilder = DocDataSubmissionBaseEventDescriptionBuilder.class,
         afterReturningBuilder = DocDataSubmissionBaseEventDescriptionBuilder.class)
     @Override

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyJavaImpl.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyJavaImpl.java
@@ -50,7 +50,7 @@ public class AdapterDocQueryProxyJavaImpl implements AdapterDocQueryProxy {
      */
     @AdapterDelegationEvent(beforeBuilder = AdhocQueryRequestDescriptionBuilder.class,
             afterReturningBuilder = AdhocQueryResponseDescriptionBuilder.class, serviceType = "Document Query",
-            version = "LEVEL_A0")
+            version = "LEVEL_a0")
     @Override
     public AdhocQueryResponse respondingGatewayCrossGatewayQuery(AdhocQueryRequest msg, AssertionType assertion) {
         LOG.debug("Using Java Implementation for Adapter Doc Query Service");

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyJavaImpl.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyJavaImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -50,7 +50,7 @@ public class AdapterDocQueryProxyJavaImpl implements AdapterDocQueryProxy {
      */
     @AdapterDelegationEvent(beforeBuilder = AdhocQueryRequestDescriptionBuilder.class,
             afterReturningBuilder = AdhocQueryResponseDescriptionBuilder.class, serviceType = "Document Query",
-            version = "")
+            version = "LEVEL_A0")
     @Override
     public AdhocQueryResponse respondingGatewayCrossGatewayQuery(AdhocQueryRequest msg, AssertionType assertion) {
         LOG.debug("Using Java Implementation for Adapter Doc Query Service");

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyNoOpImpl.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyNoOpImpl.java
@@ -56,7 +56,7 @@ public class AdapterDocQueryProxyNoOpImpl implements AdapterDocQueryProxy {
      */
     @AdapterDelegationEvent(beforeBuilder = AdhocQueryRequestDescriptionBuilder.class,
             afterReturningBuilder = AdhocQueryResponseDescriptionBuilder.class, serviceType = "Document Query",
-            version = "LEVEL_A0")
+            version = "LEVEL_a0")
     @Override
     public AdhocQueryResponse respondingGatewayCrossGatewayQuery(AdhocQueryRequest msg, AssertionType assertion) {
         LOG.debug("Using NoOp Implementation for Adapter Doc Query Service");

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyNoOpImpl.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyNoOpImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -56,7 +56,7 @@ public class AdapterDocQueryProxyNoOpImpl implements AdapterDocQueryProxy {
      */
     @AdapterDelegationEvent(beforeBuilder = AdhocQueryRequestDescriptionBuilder.class,
             afterReturningBuilder = AdhocQueryResponseDescriptionBuilder.class, serviceType = "Document Query",
-            version = "")
+            version = "LEVEL_A0")
     @Override
     public AdhocQueryResponse respondingGatewayCrossGatewayQuery(AdhocQueryRequest msg, AssertionType assertion) {
         LOG.debug("Using NoOp Implementation for Adapter Doc Query Service");

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyWebServiceSecuredImpl.java
@@ -67,7 +67,7 @@ public class AdapterDocQueryProxyWebServiceSecuredImpl extends BaseAdapterDocQue
      */
     @AdapterDelegationEvent(beforeBuilder = AdhocQueryRequestDescriptionBuilder.class,
         afterReturningBuilder = AdhocQueryResponseDescriptionBuilder.class, serviceType = "Document Query",
-        version = "LEVEL_A0")
+        version = "LEVEL_a0")
     @Override
     public AdhocQueryResponse respondingGatewayCrossGatewayQuery(final AdhocQueryRequest msg,
             final AssertionType assertion) {

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyWebServiceSecuredImpl.java
@@ -65,7 +65,9 @@ public class AdapterDocQueryProxyWebServiceSecuredImpl extends BaseAdapterDocQue
      * @param assertion Assertion received.
      * @return AdhocQuery Response from Adapter interface.
      */
-    @AdapterDelegationEvent(beforeBuilder = AdhocQueryRequestDescriptionBuilder.class, afterReturningBuilder = AdhocQueryResponseDescriptionBuilder.class, serviceType = "Document Query", version = "")
+    @AdapterDelegationEvent(beforeBuilder = AdhocQueryRequestDescriptionBuilder.class,
+        afterReturningBuilder = AdhocQueryResponseDescriptionBuilder.class, serviceType = "Document Query",
+        version = "LEVEL_A0")
     @Override
     public AdhocQueryResponse respondingGatewayCrossGatewayQuery(final AdhocQueryRequest msg,
             final AssertionType assertion) {

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyWebServiceUnsecuredImpl.java
@@ -71,7 +71,7 @@ public class AdapterDocQueryProxyWebServiceUnsecuredImpl extends BaseAdapterDocQ
      */
     @AdapterDelegationEvent(beforeBuilder = AdhocQueryRequestDescriptionBuilder.class,
     afterReturningBuilder = AdhocQueryResponseDescriptionBuilder.class, serviceType = "Document Query",
-    version = "LEVEL_A0")
+    version = "LEVEL_a0")
     @Override
     public AdhocQueryResponse respondingGatewayCrossGatewayQuery(AdhocQueryRequest msg, AssertionType assertion) {
         LOG.debug("Begin respondingGatewayCrossGatewayQuery");

--- a/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/DocumentQueryCore/src/main/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryProxyWebServiceUnsecuredImpl.java
@@ -71,7 +71,7 @@ public class AdapterDocQueryProxyWebServiceUnsecuredImpl extends BaseAdapterDocQ
      */
     @AdapterDelegationEvent(beforeBuilder = AdhocQueryRequestDescriptionBuilder.class,
     afterReturningBuilder = AdhocQueryResponseDescriptionBuilder.class, serviceType = "Document Query",
-    version = "")
+    version = "LEVEL_A0")
     @Override
     public AdhocQueryResponse respondingGatewayCrossGatewayQuery(AdhocQueryRequest msg, AssertionType assertion) {
         LOG.debug("Begin respondingGatewayCrossGatewayQuery");

--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryWebServiceProxyTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryWebServiceProxyTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,15 @@
  */
 package gov.hhs.fha.nhinc.docquery.adapter.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docquery.aspect.AdhocQueryRequestDescriptionBuilder;
 import gov.hhs.fha.nhinc.docquery.aspect.AdhocQueryResponseDescriptionBuilder;
 import java.lang.reflect.Method;
 import oasis.names.tc.ebxml_regrep.xsd.query._3.AdhocQueryRequest;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -58,6 +59,6 @@ public class AdapterDocQueryWebServiceProxyTest {
         assertEquals(AdhocQueryRequestDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(AdhocQueryResponseDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Query", annotation.serviceType());
-        assertEquals("", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryWebServiceProxyTest.java
+++ b/Product/Production/Services/DocumentQueryCore/src/test/java/gov/hhs/fha/nhinc/docquery/adapter/proxy/AdapterDocQueryWebServiceProxyTest.java
@@ -59,6 +59,6 @@ public class AdapterDocQueryWebServiceProxyTest {
         assertEquals(AdhocQueryRequestDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(AdhocQueryResponseDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Query", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyJavaImpl.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyJavaImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -54,7 +54,7 @@ public class AdapterDocRetrieveProxyJavaImpl implements AdapterDocRetrieveProxy 
      */
     @AdapterDelegationEvent(beforeBuilder = RetrieveDocumentSetRequestTypeDescriptionBuilder.class,
             afterReturningBuilder = RetrieveDocumentSetResponseTypeDescriptionBuilder.class,
-            serviceType = "Retrieve Document", version = "")
+            serviceType = "Retrieve Document", version = "LEVEL_A0")
     @Override
     public RetrieveDocumentSetResponseType retrieveDocumentSet(RetrieveDocumentSetRequestType request,
             AssertionType assertion) {

--- a/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyJavaImpl.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyJavaImpl.java
@@ -54,7 +54,7 @@ public class AdapterDocRetrieveProxyJavaImpl implements AdapterDocRetrieveProxy 
      */
     @AdapterDelegationEvent(beforeBuilder = RetrieveDocumentSetRequestTypeDescriptionBuilder.class,
             afterReturningBuilder = RetrieveDocumentSetResponseTypeDescriptionBuilder.class,
-            serviceType = "Retrieve Document", version = "LEVEL_A0")
+            serviceType = "Retrieve Document", version = "LEVEL_a0")
     @Override
     public RetrieveDocumentSetResponseType retrieveDocumentSet(RetrieveDocumentSetRequestType request,
             AssertionType assertion) {

--- a/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyNoOpImpl.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyNoOpImpl.java
@@ -49,7 +49,7 @@ public class AdapterDocRetrieveProxyNoOpImpl implements AdapterDocRetrieveProxy 
      */
     @AdapterDelegationEvent(beforeBuilder = RetrieveDocumentSetRequestTypeDescriptionBuilder.class,
             afterReturningBuilder = RetrieveDocumentSetResponseTypeDescriptionBuilder.class,
-            serviceType = "Retrieve Document", version = "LEVEL_A0")
+            serviceType = "Retrieve Document", version = "LEVEL_a0")
     @Override
     public RetrieveDocumentSetResponseType retrieveDocumentSet(RetrieveDocumentSetRequestType request,
             AssertionType assertion) {

--- a/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyNoOpImpl.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyNoOpImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -49,7 +49,7 @@ public class AdapterDocRetrieveProxyNoOpImpl implements AdapterDocRetrieveProxy 
      */
     @AdapterDelegationEvent(beforeBuilder = RetrieveDocumentSetRequestTypeDescriptionBuilder.class,
             afterReturningBuilder = RetrieveDocumentSetResponseTypeDescriptionBuilder.class,
-            serviceType = "Retrieve Document", version = "")
+            serviceType = "Retrieve Document", version = "LEVEL_A0")
     @Override
     public RetrieveDocumentSetResponseType retrieveDocumentSet(RetrieveDocumentSetRequestType request,
             AssertionType assertion) {

--- a/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyWebServiceSecuredImpl.java
@@ -63,7 +63,7 @@ public class AdapterDocRetrieveProxyWebServiceSecuredImpl extends BaseAdapterDoc
     @Override
     @AdapterDelegationEvent(beforeBuilder = RetrieveDocumentSetRequestTypeDescriptionBuilder.class,
     afterReturningBuilder = RetrieveDocumentSetResponseTypeDescriptionBuilder.class,
-    serviceType = "Retrieve Document", version = "LEVEL_A0")
+    serviceType = "Retrieve Document", version = "LEVEL_a0")
     public RetrieveDocumentSetResponseType retrieveDocumentSet(RetrieveDocumentSetRequestType request,
         AssertionType assertion) {
         String url;

--- a/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyWebServiceSecuredImpl.java
@@ -63,7 +63,7 @@ public class AdapterDocRetrieveProxyWebServiceSecuredImpl extends BaseAdapterDoc
     @Override
     @AdapterDelegationEvent(beforeBuilder = RetrieveDocumentSetRequestTypeDescriptionBuilder.class,
     afterReturningBuilder = RetrieveDocumentSetResponseTypeDescriptionBuilder.class,
-    serviceType = "Retrieve Document", version = "")
+    serviceType = "Retrieve Document", version = "LEVEL_A0")
     public RetrieveDocumentSetResponseType retrieveDocumentSet(RetrieveDocumentSetRequestType request,
         AssertionType assertion) {
         String url;

--- a/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyWebServiceUnsecuredImpl.java
@@ -63,7 +63,7 @@ public class AdapterDocRetrieveProxyWebServiceUnsecuredImpl extends BaseAdapterD
      */
     @AdapterDelegationEvent(beforeBuilder = RetrieveDocumentSetRequestTypeDescriptionBuilder.class,
     afterReturningBuilder = RetrieveDocumentSetResponseTypeDescriptionBuilder.class,
-    serviceType = "Retrieve Document", version = "")
+    serviceType = "Retrieve Document", version = "LEVEL_A0")
     @Override
     public RetrieveDocumentSetResponseType retrieveDocumentSet(RetrieveDocumentSetRequestType request,
         AssertionType assertion) {

--- a/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/main/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyWebServiceUnsecuredImpl.java
@@ -63,7 +63,7 @@ public class AdapterDocRetrieveProxyWebServiceUnsecuredImpl extends BaseAdapterD
      */
     @AdapterDelegationEvent(beforeBuilder = RetrieveDocumentSetRequestTypeDescriptionBuilder.class,
     afterReturningBuilder = RetrieveDocumentSetResponseTypeDescriptionBuilder.class,
-    serviceType = "Retrieve Document", version = "LEVEL_A0")
+    serviceType = "Retrieve Document", version = "LEVEL_a0")
     @Override
     public RetrieveDocumentSetResponseType retrieveDocumentSet(RetrieveDocumentSetRequestType request,
         AssertionType assertion) {

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyJavaImplTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyJavaImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,15 @@
  */
 package gov.hhs.fha.nhinc.docretrieve.adapter.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docretrieve.aspect.RetrieveDocumentSetRequestTypeDescriptionBuilder;
 import gov.hhs.fha.nhinc.docretrieve.aspect.RetrieveDocumentSetResponseTypeDescriptionBuilder;
 import ihe.iti.xds_b._2007.RetrieveDocumentSetRequestType;
 import java.lang.reflect.Method;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -51,7 +52,7 @@ public class AdapterDocRetrieveProxyJavaImplTest {
         assertEquals(RetrieveDocumentSetRequestTypeDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(RetrieveDocumentSetResponseTypeDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Retrieve Document", annotation.serviceType());
-        assertEquals("", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyJavaImplTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyJavaImplTest.java
@@ -52,7 +52,7 @@ public class AdapterDocRetrieveProxyJavaImplTest {
         assertEquals(RetrieveDocumentSetRequestTypeDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(RetrieveDocumentSetResponseTypeDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Retrieve Document", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyNoOpImplTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyNoOpImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,15 @@
  */
 package gov.hhs.fha.nhinc.docretrieve.adapter.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docretrieve.aspect.RetrieveDocumentSetRequestTypeDescriptionBuilder;
 import gov.hhs.fha.nhinc.docretrieve.aspect.RetrieveDocumentSetResponseTypeDescriptionBuilder;
 import ihe.iti.xds_b._2007.RetrieveDocumentSetRequestType;
 import java.lang.reflect.Method;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -51,6 +52,6 @@ public class AdapterDocRetrieveProxyNoOpImplTest {
         assertEquals(RetrieveDocumentSetRequestTypeDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(RetrieveDocumentSetResponseTypeDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Retrieve Document", annotation.serviceType());
-        assertEquals("", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyNoOpImplTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyNoOpImplTest.java
@@ -52,6 +52,6 @@ public class AdapterDocRetrieveProxyNoOpImplTest {
         assertEquals(RetrieveDocumentSetRequestTypeDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(RetrieveDocumentSetResponseTypeDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Retrieve Document", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyWebServiceSecuredImplTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyWebServiceSecuredImplTest.java
@@ -59,7 +59,7 @@ public class AdapterDocRetrieveProxyWebServiceSecuredImplTest {
         assertEquals(RetrieveDocumentSetRequestTypeDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(RetrieveDocumentSetResponseTypeDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Retrieve Document", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 
     @Test

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyWebServiceSecuredImplTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyWebServiceSecuredImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,6 +26,13 @@
  */
 package gov.hhs.fha.nhinc.docretrieve.adapter.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docretrieve.aspect.RetrieveDocumentSetRequestTypeDescriptionBuilder;
@@ -34,13 +41,7 @@ import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.webserviceproxy.WebServiceProxyHelper;
 import ihe.iti.xds_b._2007.RetrieveDocumentSetRequestType;
 import java.lang.reflect.Method;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author achidamb
@@ -58,7 +59,7 @@ public class AdapterDocRetrieveProxyWebServiceSecuredImplTest {
         assertEquals(RetrieveDocumentSetRequestTypeDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(RetrieveDocumentSetResponseTypeDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Retrieve Document", annotation.serviceType());
-        assertEquals("", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 
     @Test

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyWebServiceUnsecuredImplTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyWebServiceUnsecuredImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,6 +26,13 @@
  */
 package gov.hhs.fha.nhinc.docretrieve.adapter.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docretrieve.aspect.RetrieveDocumentSetRequestTypeDescriptionBuilder;
@@ -34,13 +41,7 @@ import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.webserviceproxy.WebServiceProxyHelper;
 import ihe.iti.xds_b._2007.RetrieveDocumentSetRequestType;
 import java.lang.reflect.Method;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author achidamb
@@ -59,7 +60,7 @@ public class AdapterDocRetrieveProxyWebServiceUnsecuredImplTest {
         assertEquals(RetrieveDocumentSetRequestTypeDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(RetrieveDocumentSetResponseTypeDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Retrieve Document", annotation.serviceType());
-        assertEquals("", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 
     @Test

--- a/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyWebServiceUnsecuredImplTest.java
+++ b/Product/Production/Services/DocumentRetrieveCore/src/test/java/gov/hhs/fha/nhinc/docretrieve/adapter/proxy/AdapterDocRetrieveProxyWebServiceUnsecuredImplTest.java
@@ -60,7 +60,7 @@ public class AdapterDocRetrieveProxyWebServiceUnsecuredImplTest {
         assertEquals(RetrieveDocumentSetRequestTypeDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(RetrieveDocumentSetResponseTypeDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Retrieve Document", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 
     @Test

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyJavaImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyJavaImpl.java
@@ -48,7 +48,7 @@ AdapterDocSubmissionDeferredRequestErrorProxy {
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
     afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
     serviceType = "Document Submission Deferred Request",
-    version = "LEVEL_A0")
+    version = "LEVEL_a0")
     public XDRAcknowledgementType provideAndRegisterDocumentSetBRequestError(
         ProvideAndRegisterDocumentSetRequestType request, String errorMessage, AssertionType assertion) {
         LOG.trace("Begin AdapterDocSubmissionDeferredRequestErrorProxyJavaImpl.provideAndRegisterDocumentSetBRequestError");

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyJavaImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyJavaImpl.java
@@ -48,7 +48,7 @@ AdapterDocSubmissionDeferredRequestErrorProxy {
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
     afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
     serviceType = "Document Submission Deferred Request",
-    version = "")
+    version = "LEVEL_A0")
     public XDRAcknowledgementType provideAndRegisterDocumentSetBRequestError(
         ProvideAndRegisterDocumentSetRequestType request, String errorMessage, AssertionType assertion) {
         LOG.trace("Begin AdapterDocSubmissionDeferredRequestErrorProxyJavaImpl.provideAndRegisterDocumentSetBRequestError");

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyNoOpImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyNoOpImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -48,7 +48,7 @@ public class AdapterDocSubmissionDeferredRequestErrorProxyNoOpImpl implements
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
             serviceType = "Document Submission Deferred Request",
-            version = "")
+            version = "LEVEL_A0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBRequestError(
             ProvideAndRegisterDocumentSetRequestType request, String errorMessage, AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyNoOpImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyNoOpImpl.java
@@ -48,7 +48,7 @@ public class AdapterDocSubmissionDeferredRequestErrorProxyNoOpImpl implements
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
             serviceType = "Document Submission Deferred Request",
-            version = "LEVEL_A0")
+            version = "LEVEL_a0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBRequestError(
             ProvideAndRegisterDocumentSetRequestType request, String errorMessage, AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyWebServiceSecureImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyWebServiceSecureImpl.java
@@ -74,7 +74,7 @@ public class AdapterDocSubmissionDeferredRequestErrorProxyWebServiceSecureImpl i
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
     afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
     serviceType = "Document Submission Deferred Request",
-    version = "")
+    version = "LEVEL_A0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBRequestError(
         ProvideAndRegisterDocumentSetRequestType request, String errorMessage, AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyWebServiceSecureImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyWebServiceSecureImpl.java
@@ -74,7 +74,7 @@ public class AdapterDocSubmissionDeferredRequestErrorProxyWebServiceSecureImpl i
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
     afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
     serviceType = "Document Submission Deferred Request",
-    version = "LEVEL_A0")
+    version = "LEVEL_a0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBRequestError(
         ProvideAndRegisterDocumentSetRequestType request, String errorMessage, AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyWebServiceUnsecureImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyWebServiceUnsecureImpl.java
@@ -73,7 +73,7 @@ public class AdapterDocSubmissionDeferredRequestErrorProxyWebServiceUnsecureImpl
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
     afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
     serviceType = "Document Submission Deferred Request",
-    version = "LEVEL_A0")
+    version = "LEVEL_a0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBRequestError(
         ProvideAndRegisterDocumentSetRequestType request, String errorMessage, AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyWebServiceUnsecureImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyWebServiceUnsecureImpl.java
@@ -73,7 +73,7 @@ public class AdapterDocSubmissionDeferredRequestErrorProxyWebServiceUnsecureImpl
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
     afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
     serviceType = "Document Submission Deferred Request",
-    version = "")
+    version = "LEVEL_A0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBRequestError(
         ProvideAndRegisterDocumentSetRequestType request, String errorMessage, AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyJavaImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyJavaImpl.java
@@ -46,7 +46,7 @@ public class AdapterDocSubmissionDeferredRequestProxyJavaImpl implements Adapter
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
             serviceType = "Document Submission Deferred Request",
-            version = "LEVEL_A0")
+            version = "LEVEL_a0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBRequest(
             ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyJavaImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyJavaImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -46,7 +46,7 @@ public class AdapterDocSubmissionDeferredRequestProxyJavaImpl implements Adapter
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
             serviceType = "Document Submission Deferred Request",
-            version = "")
+            version = "LEVEL_A0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBRequest(
             ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyNoOpImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyNoOpImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -48,7 +48,7 @@ public class AdapterDocSubmissionDeferredRequestProxyNoOpImpl implements Adapter
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
             serviceType = "Document Submission Deferred Request",
-            version = "")
+            version = "LEVEL_A0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBRequest(ProvideAndRegisterDocumentSetRequestType body,
             AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyNoOpImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyNoOpImpl.java
@@ -48,7 +48,7 @@ public class AdapterDocSubmissionDeferredRequestProxyNoOpImpl implements Adapter
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
             serviceType = "Document Submission Deferred Request",
-            version = "LEVEL_A0")
+            version = "LEVEL_a0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBRequest(ProvideAndRegisterDocumentSetRequestType body,
             AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyWebServiceSecuredImpl.java
@@ -80,7 +80,7 @@ public class AdapterDocSubmissionDeferredRequestProxyWebServiceSecuredImpl imple
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
     afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
     serviceType = "Document Submission Deferred Request",
-    version = "LEVEL_A0")
+    version = "LEVEL_a0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBRequest(
         ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyWebServiceSecuredImpl.java
@@ -80,7 +80,7 @@ public class AdapterDocSubmissionDeferredRequestProxyWebServiceSecuredImpl imple
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
     afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
     serviceType = "Document Submission Deferred Request",
-    version = "")
+    version = "LEVEL_A0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBRequest(
         ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyWebServiceUnsecuredImpl.java
@@ -78,7 +78,7 @@ public class AdapterDocSubmissionDeferredRequestProxyWebServiceUnsecuredImpl imp
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
             serviceType = "Document Submission Deferred Request",
-            version = "")
+            version = "LEVEL_A0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBRequest(
             ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyWebServiceUnsecuredImpl.java
@@ -78,7 +78,7 @@ public class AdapterDocSubmissionDeferredRequestProxyWebServiceUnsecuredImpl imp
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
             serviceType = "Document Submission Deferred Request",
-            version = "LEVEL_A0")
+            version = "LEVEL_a0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBRequest(
             ProvideAndRegisterDocumentSetRequestType request, AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyJavaImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyJavaImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -45,7 +45,7 @@ public class AdapterDocSubmissionDeferredResponseProxyJavaImpl implements Adapte
 
     @AdapterDelegationEvent(beforeBuilder = DeferredResponseDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
-            serviceType = "Document Submission Deferred Response", version = "")
+            serviceType = "Document Submission Deferred Response", version = "LEVEL_A0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBResponse(RegistryResponseType regResponse,
             AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyJavaImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyJavaImpl.java
@@ -45,7 +45,7 @@ public class AdapterDocSubmissionDeferredResponseProxyJavaImpl implements Adapte
 
     @AdapterDelegationEvent(beforeBuilder = DeferredResponseDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
-            serviceType = "Document Submission Deferred Response", version = "LEVEL_A0")
+            serviceType = "Document Submission Deferred Response", version = "LEVEL_a0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBResponse(RegistryResponseType regResponse,
             AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyNoOpImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyNoOpImpl.java
@@ -45,7 +45,7 @@ public class AdapterDocSubmissionDeferredResponseProxyNoOpImpl implements Adapte
 
     @AdapterDelegationEvent(beforeBuilder = DeferredResponseDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
-            serviceType = "Document Submission Deferred Response", version = "LEVEL_A0")
+            serviceType = "Document Submission Deferred Response", version = "LEVEL_a0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBResponse(RegistryResponseType regResponse,
             AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyNoOpImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyNoOpImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -45,7 +45,7 @@ public class AdapterDocSubmissionDeferredResponseProxyNoOpImpl implements Adapte
 
     @AdapterDelegationEvent(beforeBuilder = DeferredResponseDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
-            serviceType = "Document Submission Deferred Response", version = "")
+            serviceType = "Document Submission Deferred Response", version = "LEVEL_A0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBResponse(RegistryResponseType regResponse,
             AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyWebServiceSecuredImpl.java
@@ -71,7 +71,7 @@ public class AdapterDocSubmissionDeferredResponseProxyWebServiceSecuredImpl impl
 
     @AdapterDelegationEvent(beforeBuilder = DeferredResponseDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
-            serviceType = "Document Submission Deferred Response", version = "LEVEL_A0")
+            serviceType = "Document Submission Deferred Response", version = "LEVEL_a0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBResponse(RegistryResponseType regResponse,
             AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyWebServiceSecuredImpl.java
@@ -71,7 +71,7 @@ public class AdapterDocSubmissionDeferredResponseProxyWebServiceSecuredImpl impl
 
     @AdapterDelegationEvent(beforeBuilder = DeferredResponseDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
-            serviceType = "Document Submission Deferred Response", version = "")
+            serviceType = "Document Submission Deferred Response", version = "LEVEL_A0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBResponse(RegistryResponseType regResponse,
             AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyWebServiceUnsecuredImpl.java
@@ -71,7 +71,7 @@ public class AdapterDocSubmissionDeferredResponseProxyWebServiceUnsecuredImpl im
 
     @AdapterDelegationEvent(beforeBuilder = DeferredResponseDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
-            serviceType = "Document Submission Deferred Response", version = "")
+            serviceType = "Document Submission Deferred Response", version = "LEVEL_A0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBResponse(RegistryResponseType regResponse,
             AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyWebServiceUnsecuredImpl.java
@@ -71,7 +71,7 @@ public class AdapterDocSubmissionDeferredResponseProxyWebServiceUnsecuredImpl im
 
     @AdapterDelegationEvent(beforeBuilder = DeferredResponseDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionArgTransformerBuilder.class,
-            serviceType = "Document Submission Deferred Response", version = "LEVEL_A0")
+            serviceType = "Document Submission Deferred Response", version = "LEVEL_a0")
     @Override
     public XDRAcknowledgementType provideAndRegisterDocumentSetBResponse(RegistryResponseType regResponse,
             AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxy.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxy.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,17 +26,12 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.adapter.proxy;
 
-import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
-import gov.hhs.fha.nhinc.event.DefaultEventDescriptionBuilder;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
 
 public interface AdapterDocSubmissionProxy {
 
-    @AdapterDelegationEvent(serviceType = "Document Submission", version = "",
-            beforeBuilder = DefaultEventDescriptionBuilder.class,
-            afterReturningBuilder = DefaultEventDescriptionBuilder.class)
     public RegistryResponseType provideAndRegisterDocumentSetB(ProvideAndRegisterDocumentSetRequestType msg,
             AssertionType assertion);
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyJavaImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyJavaImpl.java
@@ -44,7 +44,7 @@ public class AdapterDocSubmissionProxyJavaImpl implements AdapterDocSubmissionPr
 
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
         afterReturningBuilder = DocSubmissionBaseEventDescriptionBuilder.class, serviceType = "Document Submission",
-        version = "LEVEL_A0")
+        version = "LEVEL_a0")
     @Override
     public RegistryResponseType provideAndRegisterDocumentSetB(ProvideAndRegisterDocumentSetRequestType msg,
         AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyJavaImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyJavaImpl.java
@@ -44,7 +44,7 @@ public class AdapterDocSubmissionProxyJavaImpl implements AdapterDocSubmissionPr
 
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
         afterReturningBuilder = DocSubmissionBaseEventDescriptionBuilder.class, serviceType = "Document Submission",
-        version = "")
+        version = "LEVEL_A0")
     @Override
     public RegistryResponseType provideAndRegisterDocumentSetB(ProvideAndRegisterDocumentSetRequestType msg,
         AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyNoOpImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyNoOpImpl.java
@@ -39,7 +39,7 @@ public class AdapterDocSubmissionProxyNoOpImpl implements AdapterDocSubmissionPr
 
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionBaseEventDescriptionBuilder.class, serviceType = "Document Submission",
-            version = "LEVEL_A0")
+            version = "LEVEL_a0")
     @Override
     public RegistryResponseType provideAndRegisterDocumentSetB(ProvideAndRegisterDocumentSetRequestType msg,
             AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyNoOpImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyNoOpImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -39,7 +39,7 @@ public class AdapterDocSubmissionProxyNoOpImpl implements AdapterDocSubmissionPr
 
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionBaseEventDescriptionBuilder.class, serviceType = "Document Submission",
-            version = "")
+            version = "LEVEL_A0")
     @Override
     public RegistryResponseType provideAndRegisterDocumentSetB(ProvideAndRegisterDocumentSetRequestType msg,
             AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyWebServiceSecuredImpl.java
@@ -67,7 +67,7 @@ public class AdapterDocSubmissionProxyWebServiceSecuredImpl implements AdapterDo
      */
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
     afterReturningBuilder = DocSubmissionBaseEventDescriptionBuilder.class, serviceType = "Document Submission",
-    version = "LEVEL_A0")
+    version = "LEVEL_a0")
     @Override
     public RegistryResponseType provideAndRegisterDocumentSetB(ProvideAndRegisterDocumentSetRequestType msg,
         AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyWebServiceSecuredImpl.java
@@ -67,7 +67,7 @@ public class AdapterDocSubmissionProxyWebServiceSecuredImpl implements AdapterDo
      */
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
     afterReturningBuilder = DocSubmissionBaseEventDescriptionBuilder.class, serviceType = "Document Submission",
-    version = "")
+    version = "LEVEL_A0")
     @Override
     public RegistryResponseType provideAndRegisterDocumentSetB(ProvideAndRegisterDocumentSetRequestType msg,
         AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyWebServiceUnsecuredImpl.java
@@ -69,7 +69,7 @@ public class AdapterDocSubmissionProxyWebServiceUnsecuredImpl implements Adapter
      */
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionBaseEventDescriptionBuilder.class, serviceType = "Document Submission",
-            version = "LEVEL_A0")
+            version = "LEVEL_a0")
     @Override
     public RegistryResponseType provideAndRegisterDocumentSetB(ProvideAndRegisterDocumentSetRequestType msg,
             AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/main/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyWebServiceUnsecuredImpl.java
@@ -69,7 +69,7 @@ public class AdapterDocSubmissionProxyWebServiceUnsecuredImpl implements Adapter
      */
     @AdapterDelegationEvent(beforeBuilder = DocSubmissionBaseEventDescriptionBuilder.class,
             afterReturningBuilder = DocSubmissionBaseEventDescriptionBuilder.class, serviceType = "Document Submission",
-            version = "")
+            version = "LEVEL_A0")
     @Override
     public RegistryResponseType provideAndRegisterDocumentSetB(ProvideAndRegisterDocumentSetRequestType msg,
             AssertionType assertion) {

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyJavaImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyJavaImplTest.java
@@ -53,7 +53,7 @@ public class AdapterDocSubmissionDeferredRequestErrorProxyJavaImplTest {
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Request", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyJavaImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyJavaImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,15 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.adapter.deferred.request.error.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionArgTransformerBuilder;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionBaseEventDescriptionBuilder;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 import java.lang.reflect.Method;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -52,7 +53,7 @@ public class AdapterDocSubmissionDeferredRequestErrorProxyJavaImplTest {
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Request", annotation.serviceType());
-        assertEquals("", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyNoOpImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyNoOpImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,15 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.adapter.deferred.request.error.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionArgTransformerBuilder;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionBaseEventDescriptionBuilder;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 import java.lang.reflect.Method;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -52,7 +53,7 @@ public class AdapterDocSubmissionDeferredRequestErrorProxyNoOpImplTest {
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Request", annotation.serviceType());
-        assertEquals("", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyNoOpImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyNoOpImplTest.java
@@ -53,7 +53,7 @@ public class AdapterDocSubmissionDeferredRequestErrorProxyNoOpImplTest {
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Request", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyWebServiceSecureImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyWebServiceSecureImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,15 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.adapter.deferred.request.error.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionArgTransformerBuilder;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionBaseEventDescriptionBuilder;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 import java.lang.reflect.Method;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -52,7 +53,7 @@ public class AdapterDocSubmissionDeferredRequestErrorProxyWebServiceSecureImplTe
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Request", annotation.serviceType());
-        assertEquals("", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyWebServiceSecureImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyWebServiceSecureImplTest.java
@@ -53,7 +53,7 @@ public class AdapterDocSubmissionDeferredRequestErrorProxyWebServiceSecureImplTe
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Request", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyWebServiceUnsecureImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyWebServiceUnsecureImplTest.java
@@ -53,7 +53,7 @@ public class AdapterDocSubmissionDeferredRequestErrorProxyWebServiceUnsecureImpl
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Request", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyWebServiceUnsecureImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/error/proxy/AdapterDocSubmissionDeferredRequestErrorProxyWebServiceUnsecureImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,15 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.adapter.deferred.request.error.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionArgTransformerBuilder;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionBaseEventDescriptionBuilder;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 import java.lang.reflect.Method;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -52,7 +53,7 @@ public class AdapterDocSubmissionDeferredRequestErrorProxyWebServiceUnsecureImpl
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Request", annotation.serviceType());
-        assertEquals("", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyJavaImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyJavaImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,15 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.adapter.deferred.request.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionArgTransformerBuilder;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionBaseEventDescriptionBuilder;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 import java.lang.reflect.Method;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -52,6 +53,6 @@ public class AdapterDocSubmissionDeferredRequestProxyJavaImplTest {
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Request", annotation.serviceType());
-        assertEquals("", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyJavaImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyJavaImplTest.java
@@ -53,6 +53,6 @@ public class AdapterDocSubmissionDeferredRequestProxyJavaImplTest {
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Request", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyNoOpImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyNoOpImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,15 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.adapter.deferred.request.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionArgTransformerBuilder;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionBaseEventDescriptionBuilder;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 import java.lang.reflect.Method;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -52,6 +53,6 @@ public class AdapterDocSubmissionDeferredRequestProxyNoOpImplTest {
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Request", annotation.serviceType());
-        assertEquals("", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyNoOpImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyNoOpImplTest.java
@@ -53,6 +53,6 @@ public class AdapterDocSubmissionDeferredRequestProxyNoOpImplTest {
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Request", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyWebServiceSecuredImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyWebServiceSecuredImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,6 +25,12 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package gov.hhs.fha.nhinc.docsubmission.adapter.deferred.request.proxy;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import gov.hhs.fha.nhinc.adapterxdrrequestsecured.AdapterXDRRequestSecuredPortType;
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
@@ -42,14 +48,9 @@ import java.lang.reflect.Method;
 import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
 import org.junit.After;
 import org.junit.AfterClass;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  *
@@ -189,6 +190,6 @@ public class AdapterDocSubmissionDeferredRequestProxyWebServiceSecuredImplTest {
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Request", annotation.serviceType());
-        assertEquals("", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyWebServiceSecuredImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyWebServiceSecuredImplTest.java
@@ -190,6 +190,6 @@ public class AdapterDocSubmissionDeferredRequestProxyWebServiceSecuredImplTest {
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Request", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyWebServiceUnsecuredImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyWebServiceUnsecuredImplTest.java
@@ -53,6 +53,6 @@ public class AdapterDocSubmissionDeferredRequestProxyWebServiceUnsecuredImplTest
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Request", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyWebServiceUnsecuredImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/request/proxy/AdapterDocSubmissionDeferredRequestProxyWebServiceUnsecuredImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,15 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.adapter.deferred.request.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionArgTransformerBuilder;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionBaseEventDescriptionBuilder;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 import java.lang.reflect.Method;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -52,6 +53,6 @@ public class AdapterDocSubmissionDeferredRequestProxyWebServiceUnsecuredImplTest
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Request", annotation.serviceType());
-        assertEquals("", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyJavaImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyJavaImplTest.java
@@ -52,6 +52,6 @@ public class AdapterDocSubmissionDeferredResponseProxyJavaImplTest {
         assertEquals(DeferredResponseDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Response", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyJavaImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyJavaImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,15 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.adapter.deferred.response.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DeferredResponseDescriptionBuilder;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionArgTransformerBuilder;
 import java.lang.reflect.Method;
 import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -51,6 +52,6 @@ public class AdapterDocSubmissionDeferredResponseProxyJavaImplTest {
         assertEquals(DeferredResponseDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Response", annotation.serviceType());
-        assertEquals("", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyNoOpImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyNoOpImplTest.java
@@ -52,6 +52,6 @@ public class AdapterDocSubmissionDeferredResponseProxyNoOpImplTest {
         assertEquals(DeferredResponseDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Response", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyNoOpImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyNoOpImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,15 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.adapter.deferred.response.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DeferredResponseDescriptionBuilder;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionArgTransformerBuilder;
 import java.lang.reflect.Method;
 import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -51,6 +52,6 @@ public class AdapterDocSubmissionDeferredResponseProxyNoOpImplTest {
         assertEquals(DeferredResponseDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Response", annotation.serviceType());
-        assertEquals("", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyWebServiceSecuredImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyWebServiceSecuredImplTest.java
@@ -194,6 +194,6 @@ public class AdapterDocSubmissionDeferredResponseProxyWebServiceSecuredImplTest 
         assertEquals(DeferredResponseDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Response", annotation.serviceType());
-        assertEquals("", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyWebServiceSecuredImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyWebServiceSecuredImplTest.java
@@ -194,6 +194,6 @@ public class AdapterDocSubmissionDeferredResponseProxyWebServiceSecuredImplTest 
         assertEquals(DeferredResponseDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Response", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyWebServiceUnsecuredImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyWebServiceUnsecuredImplTest.java
@@ -52,6 +52,6 @@ public class AdapterDocSubmissionDeferredResponseProxyWebServiceUnsecuredImplTes
         assertEquals(DeferredResponseDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Response", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyWebServiceUnsecuredImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/deferred/response/proxy/AdapterDocSubmissionDeferredResponseProxyWebServiceUnsecuredImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,15 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.adapter.deferred.response.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DeferredResponseDescriptionBuilder;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionArgTransformerBuilder;
 import java.lang.reflect.Method;
 import oasis.names.tc.ebxml_regrep.xsd.rs._3.RegistryResponseType;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -51,6 +52,6 @@ public class AdapterDocSubmissionDeferredResponseProxyWebServiceUnsecuredImplTes
         assertEquals(DeferredResponseDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionArgTransformerBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission Deferred Response", annotation.serviceType());
-        assertEquals("", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyJavaImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyJavaImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,13 +26,14 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.adapter.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionBaseEventDescriptionBuilder;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 import java.lang.reflect.Method;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -50,6 +51,6 @@ public class AdapterDocSubmissionProxyJavaImplTest {
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission", annotation.serviceType());
-        assertEquals("", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyJavaImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyJavaImplTest.java
@@ -51,6 +51,6 @@ public class AdapterDocSubmissionProxyJavaImplTest {
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyNoOpImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyNoOpImplTest.java
@@ -51,6 +51,6 @@ public class AdapterDocSubmissionProxyNoOpImplTest {
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyNoOpImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyNoOpImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,13 +26,14 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.adapter.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionBaseEventDescriptionBuilder;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 import java.lang.reflect.Method;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -50,6 +51,6 @@ public class AdapterDocSubmissionProxyNoOpImplTest {
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission", annotation.serviceType());
-        assertEquals("", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyWebServiceSecuredImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyWebServiceSecuredImplTest.java
@@ -52,6 +52,6 @@ public class AdapterDocSubmissionProxyWebServiceSecuredImplTest {
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyWebServiceSecuredImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyWebServiceSecuredImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,13 +26,14 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.adapter.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionBaseEventDescriptionBuilder;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 import java.lang.reflect.Method;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -51,6 +52,6 @@ public class AdapterDocSubmissionProxyWebServiceSecuredImplTest {
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission", annotation.serviceType());
-        assertEquals("", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyWebServiceUnsecuredImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyWebServiceUnsecuredImplTest.java
@@ -52,7 +52,7 @@ public class AdapterDocSubmissionProxyWebServiceUnsecuredImplTest {
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyWebServiceUnsecuredImplTest.java
+++ b/Product/Production/Services/DocumentSubmissionCore/src/test/java/gov/hhs/fha/nhinc/docsubmission/adapter/proxy/AdapterDocSubmissionProxyWebServiceUnsecuredImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,13 +26,14 @@
  */
 package gov.hhs.fha.nhinc.docsubmission.adapter.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.docsubmission.aspect.DocSubmissionBaseEventDescriptionBuilder;
 import ihe.iti.xds_b._2007.ProvideAndRegisterDocumentSetRequestType;
 import java.lang.reflect.Method;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -51,7 +52,7 @@ public class AdapterDocSubmissionProxyWebServiceUnsecuredImplTest {
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(DocSubmissionBaseEventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Document Submission", annotation.serviceType());
-        assertEquals("", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorProxyJavaImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorProxyJavaImpl.java
@@ -48,7 +48,7 @@ public class AdapterPatientDiscoveryDeferredReqErrorProxyJavaImpl implements
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
             serviceType = "Patient Discovery Deferred Request",
-            version = "LEVEL_A0")
+            version = "LEVEL_a0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncReqError(PRPAIN201305UV02 request, PRPAIN201306UV02 response,
             AssertionType assertion, String errMsg) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorProxyJavaImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorProxyJavaImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -48,7 +48,7 @@ public class AdapterPatientDiscoveryDeferredReqErrorProxyJavaImpl implements
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
             serviceType = "Patient Discovery Deferred Request",
-            version = "1.0")
+            version = "LEVEL_A0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncReqError(PRPAIN201305UV02 request, PRPAIN201306UV02 response,
             AssertionType assertion, String errMsg) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorProxyNoOpImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorProxyNoOpImpl.java
@@ -44,7 +44,7 @@ public class AdapterPatientDiscoveryDeferredReqErrorProxyNoOpImpl implements
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
             serviceType = "Patient Discovery Deferred Request",
-            version = "LEVEL_A0")
+            version = "LEVEL_a0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncReqError(PRPAIN201305UV02 request, PRPAIN201306UV02 response,
             AssertionType assertion, String errMsg) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorProxyNoOpImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorProxyNoOpImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -44,7 +44,7 @@ public class AdapterPatientDiscoveryDeferredReqErrorProxyNoOpImpl implements
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
             serviceType = "Patient Discovery Deferred Request",
-            version = "1.0")
+            version = "LEVEL_A0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncReqError(PRPAIN201305UV02 request, PRPAIN201306UV02 response,
             AssertionType assertion, String errMsg) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorProxyWebServiceSecuredImpl.java
@@ -68,7 +68,7 @@ public class AdapterPatientDiscoveryDeferredReqErrorProxyWebServiceSecuredImpl i
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
             serviceType = "Patient Discovery Deferred Request",
-            version = "1.0")
+            version = "LEVEL_A0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncReqError(PRPAIN201305UV02 request, PRPAIN201306UV02 response,
             AssertionType assertion, String errMsg) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorProxyWebServiceSecuredImpl.java
@@ -68,7 +68,7 @@ public class AdapterPatientDiscoveryDeferredReqErrorProxyWebServiceSecuredImpl i
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
             serviceType = "Patient Discovery Deferred Request",
-            version = "LEVEL_A0")
+            version = "LEVEL_a0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncReqError(PRPAIN201305UV02 request, PRPAIN201306UV02 response,
             AssertionType assertion, String errMsg) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorProxyWebServiceUnsecuredImpl.java
@@ -67,7 +67,7 @@ public class AdapterPatientDiscoveryDeferredReqErrorProxyWebServiceUnsecuredImpl
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
             serviceType = "Patient Discovery Deferred Request",
-            version = "1.0")
+            version = "LEVEL_A0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncReqError(PRPAIN201305UV02 request, PRPAIN201306UV02 response,
             AssertionType assertion, String errMsg) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorProxyWebServiceUnsecuredImpl.java
@@ -67,7 +67,7 @@ public class AdapterPatientDiscoveryDeferredReqErrorProxyWebServiceUnsecuredImpl
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
             serviceType = "Patient Discovery Deferred Request",
-            version = "LEVEL_A0")
+            version = "LEVEL_a0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncReqError(PRPAIN201305UV02 request, PRPAIN201306UV02 response,
             AssertionType assertion, String errMsg) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/proxy/AdapterPatientDiscoveryDeferredReqProxyJavaImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/proxy/AdapterPatientDiscoveryDeferredReqProxyJavaImpl.java
@@ -45,7 +45,7 @@ public class AdapterPatientDiscoveryDeferredReqProxyJavaImpl implements AdapterP
 
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
-            serviceType = "Patient Discovery Deferred Request", version = "LEVEL_A0")
+            serviceType = "Patient Discovery Deferred Request", version = "LEVEL_a0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncReq(PRPAIN201305UV02 request, AssertionType assertion) {
         LOG.debug("Using Java Implementation for Adapter Patient Discovery Deferred Request Service");

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/proxy/AdapterPatientDiscoveryDeferredReqProxyJavaImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/proxy/AdapterPatientDiscoveryDeferredReqProxyJavaImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -45,7 +45,7 @@ public class AdapterPatientDiscoveryDeferredReqProxyJavaImpl implements AdapterP
 
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
-            serviceType = "Patient Discovery Deferred Request", version = "1.0")
+            serviceType = "Patient Discovery Deferred Request", version = "LEVEL_A0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncReq(PRPAIN201305UV02 request, AssertionType assertion) {
         LOG.debug("Using Java Implementation for Adapter Patient Discovery Deferred Request Service");

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/proxy/AdapterPatientDiscoveryDeferredReqProxyNoOpImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/proxy/AdapterPatientDiscoveryDeferredReqProxyNoOpImpl.java
@@ -41,7 +41,7 @@ public class AdapterPatientDiscoveryDeferredReqProxyNoOpImpl implements AdapterP
 
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
-            serviceType = "Patient Discovery Deferred Request", version = "LEVEL_A0")
+            serviceType = "Patient Discovery Deferred Request", version = "LEVEL_a0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncReq(PRPAIN201305UV02 request, AssertionType assertion) {
         return new MCCIIN000002UV01();

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/proxy/AdapterPatientDiscoveryDeferredReqProxyNoOpImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/proxy/AdapterPatientDiscoveryDeferredReqProxyNoOpImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -41,7 +41,7 @@ public class AdapterPatientDiscoveryDeferredReqProxyNoOpImpl implements AdapterP
 
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
-            serviceType = "Patient Discovery Deferred Request", version = "1.0")
+            serviceType = "Patient Discovery Deferred Request", version = "LEVEL_A0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncReq(PRPAIN201305UV02 request, AssertionType assertion) {
         return new MCCIIN000002UV01();

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/proxy/AdapterPatientDiscoveryDeferredReqProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/proxy/AdapterPatientDiscoveryDeferredReqProxyWebServiceSecuredImpl.java
@@ -66,7 +66,7 @@ public class AdapterPatientDiscoveryDeferredReqProxyWebServiceSecuredImpl implem
 
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
-            serviceType = "Patient Discovery Deferred Request", version = "LEVEL_A0")
+            serviceType = "Patient Discovery Deferred Request", version = "LEVEL_a0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncReq(PRPAIN201305UV02 request, AssertionType assertion) {
         LOG.debug("Begin processPatientDiscoveryAsyncReqError");

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/proxy/AdapterPatientDiscoveryDeferredReqProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/proxy/AdapterPatientDiscoveryDeferredReqProxyWebServiceSecuredImpl.java
@@ -66,7 +66,7 @@ public class AdapterPatientDiscoveryDeferredReqProxyWebServiceSecuredImpl implem
 
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
-            serviceType = "Patient Discovery Deferred Request", version = "1.0")
+            serviceType = "Patient Discovery Deferred Request", version = "LEVEL_A0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncReq(PRPAIN201305UV02 request, AssertionType assertion) {
         LOG.debug("Begin processPatientDiscoveryAsyncReqError");

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/proxy/AdapterPatientDiscoveryDeferredReqProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/proxy/AdapterPatientDiscoveryDeferredReqProxyWebServiceUnsecuredImpl.java
@@ -67,7 +67,7 @@ public class AdapterPatientDiscoveryDeferredReqProxyWebServiceUnsecuredImpl impl
 
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
-            serviceType = "Patient Discovery Deferred Request", version = "LEVEL_A0")
+            serviceType = "Patient Discovery Deferred Request", version = "LEVEL_a0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncReq(PRPAIN201305UV02 request, AssertionType assertion) {
         LOG.debug("Begin processPatientDiscoveryAsyncReqError");

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/proxy/AdapterPatientDiscoveryDeferredReqProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/proxy/AdapterPatientDiscoveryDeferredReqProxyWebServiceUnsecuredImpl.java
@@ -67,7 +67,7 @@ public class AdapterPatientDiscoveryDeferredReqProxyWebServiceUnsecuredImpl impl
 
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
-            serviceType = "Patient Discovery Deferred Request", version = "1.0")
+            serviceType = "Patient Discovery Deferred Request", version = "LEVEL_A0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncReq(PRPAIN201305UV02 request, AssertionType assertion) {
         LOG.debug("Begin processPatientDiscoveryAsyncReqError");

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyJavaImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyJavaImpl.java
@@ -45,7 +45,7 @@ public class AdapterPatientDiscoveryDeferredRespProxyJavaImpl implements Adapter
 
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201306UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
-            serviceType = "Patient Discovery Deferred Response", version = "LEVEL_A0")
+            serviceType = "Patient Discovery Deferred Response", version = "LEVEL_a0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncResp(PRPAIN201306UV02 request, AssertionType assertion) {
         LOG.debug("Using Java Implementation for Adapter Patient Discovery Deferred Response Service");

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyJavaImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyJavaImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -45,7 +45,7 @@ public class AdapterPatientDiscoveryDeferredRespProxyJavaImpl implements Adapter
 
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201306UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
-            serviceType = "Patient Discovery Deferred Response", version = "1.0")
+            serviceType = "Patient Discovery Deferred Response", version = "LEVEL_A0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncResp(PRPAIN201306UV02 request, AssertionType assertion) {
         LOG.debug("Using Java Implementation for Adapter Patient Discovery Deferred Response Service");

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyNoOpImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyNoOpImpl.java
@@ -45,7 +45,7 @@ public class AdapterPatientDiscoveryDeferredRespProxyNoOpImpl implements Adapter
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201306UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
             serviceType = "Patient Discovery Deferred Response",
-            version = "LEVEL_A0")
+            version = "LEVEL_a0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncResp(PRPAIN201306UV02 request, AssertionType assertion) {
         LOG.debug("Using NoOp Implementation for Adapter Patient Discovery Deferred Response Service");

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyNoOpImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyNoOpImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -45,7 +45,7 @@ public class AdapterPatientDiscoveryDeferredRespProxyNoOpImpl implements Adapter
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201306UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
             serviceType = "Patient Discovery Deferred Response",
-            version = "1.0")
+            version = "LEVEL_A0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncResp(PRPAIN201306UV02 request, AssertionType assertion) {
         LOG.debug("Using NoOp Implementation for Adapter Patient Discovery Deferred Response Service");

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyWebServiceSecuredImpl.java
@@ -66,7 +66,7 @@ public class AdapterPatientDiscoveryDeferredRespProxyWebServiceSecuredImpl imple
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201306UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
             serviceType = "Patient Discovery Deferred Response",
-            version = "1.0")
+            version = "LEVEL_A0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncResp(PRPAIN201306UV02 request, AssertionType assertion) {
         LOG.debug("Begin processPatientDiscoveryAsyncReqError");

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyWebServiceSecuredImpl.java
@@ -66,7 +66,7 @@ public class AdapterPatientDiscoveryDeferredRespProxyWebServiceSecuredImpl imple
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201306UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
             serviceType = "Patient Discovery Deferred Response",
-            version = "LEVEL_A0")
+            version = "LEVEL_a0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncResp(PRPAIN201306UV02 request, AssertionType assertion) {
         LOG.debug("Begin processPatientDiscoveryAsyncReqError");

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyWebServiceUnsecuredImpl.java
@@ -68,7 +68,7 @@ public class AdapterPatientDiscoveryDeferredRespProxyWebServiceUnsecuredImpl imp
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201306UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
             serviceType = "Patient Discovery Deferred Response",
-            version = "1.0")
+            version = "LEVEL_A0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncResp(PRPAIN201306UV02 request, AssertionType assertion) {
         LOG.debug("Begin processPatientDiscoveryAsyncReqError");

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyWebServiceUnsecuredImpl.java
@@ -68,7 +68,7 @@ public class AdapterPatientDiscoveryDeferredRespProxyWebServiceUnsecuredImpl imp
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201306UV02EventDescriptionBuilder.class,
             afterReturningBuilder = MCCIIN000002UV01EventDescriptionBuilder.class,
             serviceType = "Patient Discovery Deferred Response",
-            version = "LEVEL_A0")
+            version = "LEVEL_a0")
     @Override
     public MCCIIN000002UV01 processPatientDiscoveryAsyncResp(PRPAIN201306UV02 request, AssertionType assertion) {
         LOG.debug("Begin processPatientDiscoveryAsyncReqError");

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyJavaImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyJavaImpl.java
@@ -56,7 +56,7 @@ public class AdapterPatientDiscoveryProxyJavaImpl implements AdapterPatientDisco
 
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
             afterReturningBuilder = PRPAIN201306UV02EventDescriptionBuilder.class, serviceType = "Patient Discovery",
-            version = "LEVEL_A0")
+            version = "LEVEL_a0")
     @Override
     public PRPAIN201306UV02 respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 body, AssertionType assertion) {
         LOG.debug("Entering AdapterPatientDiscoveryProxyJavaImpl.respondingGatewayPRPAIN201305UV02");

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyJavaImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyJavaImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -56,7 +56,7 @@ public class AdapterPatientDiscoveryProxyJavaImpl implements AdapterPatientDisco
 
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
             afterReturningBuilder = PRPAIN201306UV02EventDescriptionBuilder.class, serviceType = "Patient Discovery",
-            version = "1.0")
+            version = "LEVEL_A0")
     @Override
     public PRPAIN201306UV02 respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 body, AssertionType assertion) {
         LOG.debug("Entering AdapterPatientDiscoveryProxyJavaImpl.respondingGatewayPRPAIN201305UV02");

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyNoOpImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyNoOpImpl.java
@@ -52,7 +52,7 @@ public class AdapterPatientDiscoveryProxyNoOpImpl implements AdapterPatientDisco
      */
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
             afterReturningBuilder = PRPAIN201306UV02EventDescriptionBuilder.class, serviceType = "Patient Discovery",
-            version = "LEVEL_A0")
+            version = "LEVEL_a0")
     @Override
     public PRPAIN201306UV02 respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 body, AssertionType assertion) {
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyNoOpImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyNoOpImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -52,7 +52,7 @@ public class AdapterPatientDiscoveryProxyNoOpImpl implements AdapterPatientDisco
      */
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
             afterReturningBuilder = PRPAIN201306UV02EventDescriptionBuilder.class, serviceType = "Patient Discovery",
-            version = "1.0")
+            version = "LEVEL_A0")
     @Override
     public PRPAIN201306UV02 respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 body, AssertionType assertion) {
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyWebServiceSecuredImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -54,7 +54,7 @@ public class AdapterPatientDiscoveryProxyWebServiceSecuredImpl implements Adapte
      */
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
         afterReturningBuilder = PRPAIN201306UV02EventDescriptionBuilder.class, serviceType = "Patient Discovery",
-        version = "1.0")
+        version = "LEVEL_A0")
     @Override
     public PRPAIN201306UV02 respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 body, AssertionType assertion)
         throws PatientDiscoveryException {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyWebServiceSecuredImpl.java
@@ -54,7 +54,7 @@ public class AdapterPatientDiscoveryProxyWebServiceSecuredImpl implements Adapte
      */
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
         afterReturningBuilder = PRPAIN201306UV02EventDescriptionBuilder.class, serviceType = "Patient Discovery",
-        version = "LEVEL_A0")
+        version = "LEVEL_a0")
     @Override
     public PRPAIN201306UV02 respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 body, AssertionType assertion)
         throws PatientDiscoveryException {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyWebServiceUnsecuredImpl.java
@@ -54,7 +54,7 @@ public class AdapterPatientDiscoveryProxyWebServiceUnsecuredImpl implements Adap
      */
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
         afterReturningBuilder = PRPAIN201306UV02EventDescriptionBuilder.class, serviceType = "Patient Discovery",
-        version = "LEVEL_A0")
+        version = "LEVEL_a0")
     @Override
     public PRPAIN201306UV02 respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 body, AssertionType assertion)
         throws PatientDiscoveryException {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyWebServiceUnsecuredImpl.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -54,7 +54,7 @@ public class AdapterPatientDiscoveryProxyWebServiceUnsecuredImpl implements Adap
      */
     @AdapterDelegationEvent(beforeBuilder = PRPAIN201305UV02EventDescriptionBuilder.class,
         afterReturningBuilder = PRPAIN201306UV02EventDescriptionBuilder.class, serviceType = "Patient Discovery",
-        version = "1.0")
+        version = "LEVEL_A0")
     @Override
     public PRPAIN201306UV02 respondingGatewayPRPAIN201305UV02(PRPAIN201305UV02 body, AssertionType assertion)
         throws PatientDiscoveryException {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientlocationquery/adapter/proxy/AdapterPatientLocationQueryProxyJavaImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientlocationquery/adapter/proxy/AdapterPatientLocationQueryProxyJavaImpl.java
@@ -43,7 +43,7 @@ public class AdapterPatientLocationQueryProxyJavaImpl implements AdapterPatientL
 
     @AdapterDelegationEvent(beforeBuilder = DefaultTargetedArgTransfomer.class,
         afterReturningBuilder = DefaultDelegatingEventDescriptionBuilder.class,
-        serviceType = "Patient Location Query", version = "1.0")
+        serviceType = "Patient Location Query", version = "LEVEL_A0")
     @Override
     public PatientLocationQueryResponseType adapterPatientLocationQueryResponse(PatientLocationQueryRequestType request,
         AssertionType assertion) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientlocationquery/adapter/proxy/AdapterPatientLocationQueryProxyJavaImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientlocationquery/adapter/proxy/AdapterPatientLocationQueryProxyJavaImpl.java
@@ -43,7 +43,7 @@ public class AdapterPatientLocationQueryProxyJavaImpl implements AdapterPatientL
 
     @AdapterDelegationEvent(beforeBuilder = DefaultTargetedArgTransfomer.class,
         afterReturningBuilder = DefaultDelegatingEventDescriptionBuilder.class,
-        serviceType = "Patient Location Query", version = "LEVEL_A0")
+        serviceType = "Patient Location Query", version = "LEVEL_a0")
     @Override
     public PatientLocationQueryResponseType adapterPatientLocationQueryResponse(PatientLocationQueryRequestType request,
         AssertionType assertion) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientlocationquery/adapter/proxy/AdapterPatientLocationQueryProxyNoOpImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientlocationquery/adapter/proxy/AdapterPatientLocationQueryProxyNoOpImpl.java
@@ -41,7 +41,7 @@ public class AdapterPatientLocationQueryProxyNoOpImpl implements AdapterPatientL
 
     @AdapterDelegationEvent(beforeBuilder = DefaultTargetedArgTransfomer.class,
         afterReturningBuilder = DefaultDelegatingEventDescriptionBuilder.class,
-        serviceType = "Patient Location Query", version = "LEVEL_A0")
+        serviceType = "Patient Location Query", version = "LEVEL_a0")
     @Override
     public PatientLocationQueryResponseType adapterPatientLocationQueryResponse(PatientLocationQueryRequestType request,
         AssertionType assertion) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientlocationquery/adapter/proxy/AdapterPatientLocationQueryProxyNoOpImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientlocationquery/adapter/proxy/AdapterPatientLocationQueryProxyNoOpImpl.java
@@ -41,7 +41,7 @@ public class AdapterPatientLocationQueryProxyNoOpImpl implements AdapterPatientL
 
     @AdapterDelegationEvent(beforeBuilder = DefaultTargetedArgTransfomer.class,
         afterReturningBuilder = DefaultDelegatingEventDescriptionBuilder.class,
-        serviceType = "Patient Location Query", version = "1.0")
+        serviceType = "Patient Location Query", version = "LEVEL_A0")
     @Override
     public PatientLocationQueryResponseType adapterPatientLocationQueryResponse(PatientLocationQueryRequestType request,
         AssertionType assertion) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientlocationquery/adapter/proxy/AdapterPatientLocationQueryProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientlocationquery/adapter/proxy/AdapterPatientLocationQueryProxyWebServiceSecuredImpl.java
@@ -50,7 +50,7 @@ public class AdapterPatientLocationQueryProxyWebServiceSecuredImpl implements Ad
 
     @AdapterDelegationEvent(beforeBuilder = DefaultTargetedArgTransfomer.class,
         afterReturningBuilder = DefaultDelegatingEventDescriptionBuilder.class,
-        serviceType = "Patient Location Query", version = "LEVEL_A0")
+        serviceType = "Patient Location Query", version = "LEVEL_a0")
     @Override
     public PatientLocationQueryResponseType adapterPatientLocationQueryResponse(PatientLocationQueryRequestType request,
         AssertionType assertion) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientlocationquery/adapter/proxy/AdapterPatientLocationQueryProxyWebServiceSecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientlocationquery/adapter/proxy/AdapterPatientLocationQueryProxyWebServiceSecuredImpl.java
@@ -50,7 +50,7 @@ public class AdapterPatientLocationQueryProxyWebServiceSecuredImpl implements Ad
 
     @AdapterDelegationEvent(beforeBuilder = DefaultTargetedArgTransfomer.class,
         afterReturningBuilder = DefaultDelegatingEventDescriptionBuilder.class,
-        serviceType = "Patient Location Query", version = "1.0")
+        serviceType = "Patient Location Query", version = "LEVEL_A0")
     @Override
     public PatientLocationQueryResponseType adapterPatientLocationQueryResponse(PatientLocationQueryRequestType request,
         AssertionType assertion) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientlocationquery/adapter/proxy/AdapterPatientLocationQueryProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientlocationquery/adapter/proxy/AdapterPatientLocationQueryProxyWebServiceUnsecuredImpl.java
@@ -53,7 +53,7 @@ public class AdapterPatientLocationQueryProxyWebServiceUnsecuredImpl implements 
 
     @AdapterDelegationEvent(beforeBuilder = DefaultTargetedArgTransfomer.class,
         afterReturningBuilder = DefaultDelegatingEventDescriptionBuilder.class,
-        serviceType = "Patient Location Query", version = "LEVEL_A0")
+        serviceType = "Patient Location Query", version = "LEVEL_a0")
     @Override
     public PatientLocationQueryResponseType adapterPatientLocationQueryResponse(PatientLocationQueryRequestType request,
         AssertionType assertion) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientlocationquery/adapter/proxy/AdapterPatientLocationQueryProxyWebServiceUnsecuredImpl.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/main/java/gov/hhs/fha/nhinc/patientlocationquery/adapter/proxy/AdapterPatientLocationQueryProxyWebServiceUnsecuredImpl.java
@@ -53,7 +53,7 @@ public class AdapterPatientLocationQueryProxyWebServiceUnsecuredImpl implements 
 
     @AdapterDelegationEvent(beforeBuilder = DefaultTargetedArgTransfomer.class,
         afterReturningBuilder = DefaultDelegatingEventDescriptionBuilder.class,
-        serviceType = "Patient Location Query", version = "1.0")
+        serviceType = "Patient Location Query", version = "LEVEL_A0")
     @Override
     public PatientLocationQueryResponseType adapterPatientLocationQueryResponse(PatientLocationQueryRequestType request,
         AssertionType assertion) {

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/req/proxy/AdapterPatientDiscoveryAsyncReqNoOpImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/req/proxy/AdapterPatientDiscoveryAsyncReqNoOpImplTest.java
@@ -93,7 +93,7 @@ public class AdapterPatientDiscoveryAsyncReqNoOpImplTest {
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Request", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/req/proxy/AdapterPatientDiscoveryAsyncReqNoOpImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/req/proxy/AdapterPatientDiscoveryAsyncReqNoOpImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,6 +26,9 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.req.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.request.proxy.AdapterPatientDiscoveryDeferredReqProxyNoOpImpl;
@@ -36,7 +39,6 @@ import org.hl7.v3.MCCIIN000002UV01;
 import org.hl7.v3.PRPAIN201305UV02;
 import org.junit.After;
 import org.junit.AfterClass;
-import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -91,7 +93,7 @@ public class AdapterPatientDiscoveryAsyncReqNoOpImplTest {
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Request", annotation.serviceType());
-        assertEquals("1.0", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/req/proxy/AdapterPatientDiscoveryDeferredReqProxyJavaImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/req/proxy/AdapterPatientDiscoveryDeferredReqProxyJavaImplTest.java
@@ -53,7 +53,7 @@ public class AdapterPatientDiscoveryDeferredReqProxyJavaImplTest {
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Request", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/req/proxy/AdapterPatientDiscoveryDeferredReqProxyJavaImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/req/proxy/AdapterPatientDiscoveryDeferredReqProxyJavaImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,6 +26,9 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.req.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.request.proxy.AdapterPatientDiscoveryDeferredReqProxyJavaImpl;
@@ -33,8 +36,6 @@ import gov.hhs.fha.nhinc.patientdiscovery.aspect.MCCIIN000002UV01EventDescriptio
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201305UV02EventDescriptionBuilder;
 import java.lang.reflect.Method;
 import org.hl7.v3.PRPAIN201305UV02;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -52,7 +53,7 @@ public class AdapterPatientDiscoveryDeferredReqProxyJavaImplTest {
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Request", annotation.serviceType());
-        assertEquals("1.0", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/req/proxy/AdapterPatientDiscoveryDeferredReqProxyWebServiceSecuredImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/req/proxy/AdapterPatientDiscoveryDeferredReqProxyWebServiceSecuredImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,6 +26,9 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.req.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.request.proxy.AdapterPatientDiscoveryDeferredReqProxyWebServiceSecuredImpl;
@@ -33,8 +36,6 @@ import gov.hhs.fha.nhinc.patientdiscovery.aspect.MCCIIN000002UV01EventDescriptio
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201305UV02EventDescriptionBuilder;
 import java.lang.reflect.Method;
 import org.hl7.v3.PRPAIN201305UV02;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -53,6 +54,6 @@ public class AdapterPatientDiscoveryDeferredReqProxyWebServiceSecuredImplTest {
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Request", annotation.serviceType());
-        assertEquals("1.0", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/req/proxy/AdapterPatientDiscoveryDeferredReqProxyWebServiceSecuredImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/req/proxy/AdapterPatientDiscoveryDeferredReqProxyWebServiceSecuredImplTest.java
@@ -54,6 +54,6 @@ public class AdapterPatientDiscoveryDeferredReqProxyWebServiceSecuredImplTest {
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Request", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/req/proxy/AdapterPatientDiscoveryDeferredReqProxyWebServiceUnsecuredImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/req/proxy/AdapterPatientDiscoveryDeferredReqProxyWebServiceUnsecuredImplTest.java
@@ -53,6 +53,6 @@ public class AdapterPatientDiscoveryDeferredReqProxyWebServiceUnsecuredImplTest 
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Request", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/req/proxy/AdapterPatientDiscoveryDeferredReqProxyWebServiceUnsecuredImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/req/proxy/AdapterPatientDiscoveryDeferredReqProxyWebServiceUnsecuredImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,6 +26,9 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.req.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.request.proxy.AdapterPatientDiscoveryDeferredReqProxyWebServiceUnsecuredImpl;
@@ -33,8 +36,6 @@ import gov.hhs.fha.nhinc.patientdiscovery.aspect.MCCIIN000002UV01EventDescriptio
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201305UV02EventDescriptionBuilder;
 import java.lang.reflect.Method;
 import org.hl7.v3.PRPAIN201305UV02;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -52,6 +53,6 @@ public class AdapterPatientDiscoveryDeferredReqProxyWebServiceUnsecuredImplTest 
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Request", annotation.serviceType());
-        assertEquals("1.0", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryAsyncReqErrorNoOpImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryAsyncReqErrorNoOpImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,6 +26,9 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.request.error.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.MCCIIN000002UV01EventDescriptionBuilder;
@@ -36,7 +39,6 @@ import org.hl7.v3.PRPAIN201305UV02;
 import org.hl7.v3.PRPAIN201306UV02;
 import org.junit.After;
 import org.junit.AfterClass;
-import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -92,7 +94,7 @@ public class AdapterPatientDiscoveryAsyncReqErrorNoOpImplTest {
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Request", annotation.serviceType());
-        assertEquals("1.0", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryAsyncReqErrorNoOpImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryAsyncReqErrorNoOpImplTest.java
@@ -94,7 +94,7 @@ public class AdapterPatientDiscoveryAsyncReqErrorNoOpImplTest {
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Request", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorWebServiceSecuredImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorWebServiceSecuredImplTest.java
@@ -54,6 +54,6 @@ public class AdapterPatientDiscoveryDeferredReqErrorWebServiceSecuredImplTest {
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Request", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorWebServiceSecuredImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorWebServiceSecuredImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,6 +26,9 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.request.error.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.MCCIIN000002UV01EventDescriptionBuilder;
@@ -33,8 +36,6 @@ import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201305UV02EventDescriptio
 import java.lang.reflect.Method;
 import org.hl7.v3.PRPAIN201305UV02;
 import org.hl7.v3.PRPAIN201306UV02;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -53,6 +54,6 @@ public class AdapterPatientDiscoveryDeferredReqErrorWebServiceSecuredImplTest {
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Request", annotation.serviceType());
-        assertEquals("1.0", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorWebServiceUnsecuredImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorWebServiceUnsecuredImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,6 +26,9 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.request.error.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.MCCIIN000002UV01EventDescriptionBuilder;
@@ -33,8 +36,6 @@ import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201305UV02EventDescriptio
 import java.lang.reflect.Method;
 import org.hl7.v3.PRPAIN201305UV02;
 import org.hl7.v3.PRPAIN201306UV02;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -53,6 +54,6 @@ public class AdapterPatientDiscoveryDeferredReqErrorWebServiceUnsecuredImplTest 
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Request", annotation.serviceType());
-        assertEquals("1.0", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorWebServiceUnsecuredImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientDiscoveryDeferredReqErrorWebServiceUnsecuredImplTest.java
@@ -54,6 +54,6 @@ public class AdapterPatientDiscoveryDeferredReqErrorWebServiceUnsecuredImplTest 
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Request", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientdiscoveryDeferredreqErrorJavaImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientdiscoveryDeferredreqErrorJavaImplTest.java
@@ -54,6 +54,6 @@ public class AdapterPatientdiscoveryDeferredreqErrorJavaImplTest {
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Request", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientdiscoveryDeferredreqErrorJavaImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/request/error/proxy/AdapterPatientdiscoveryDeferredreqErrorJavaImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,6 +26,9 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.request.error.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.MCCIIN000002UV01EventDescriptionBuilder;
@@ -33,8 +36,6 @@ import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201305UV02EventDescriptio
 import java.lang.reflect.Method;
 import org.hl7.v3.PRPAIN201305UV02;
 import org.hl7.v3.PRPAIN201306UV02;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -53,6 +54,6 @@ public class AdapterPatientdiscoveryDeferredreqErrorJavaImplTest {
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Request", annotation.serviceType());
-        assertEquals("1.0", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryAsyncRespNoOpImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryAsyncRespNoOpImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,6 +26,9 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.response.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.MCCIIN000002UV01EventDescriptionBuilder;
@@ -35,7 +38,6 @@ import org.hl7.v3.MCCIIN000002UV01;
 import org.hl7.v3.PRPAIN201306UV02;
 import org.junit.After;
 import org.junit.AfterClass;
-import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -91,7 +93,7 @@ public class AdapterPatientDiscoveryAsyncRespNoOpImplTest {
         assertEquals(PRPAIN201306UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Response", annotation.serviceType());
-        assertEquals("1.0", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryAsyncRespNoOpImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryAsyncRespNoOpImplTest.java
@@ -93,7 +93,7 @@ public class AdapterPatientDiscoveryAsyncRespNoOpImplTest {
         assertEquals(PRPAIN201306UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Response", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyJavaImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyJavaImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,15 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.response.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.MCCIIN000002UV01EventDescriptionBuilder;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201306UV02EventDescriptionBuilder;
 import java.lang.reflect.Method;
 import org.hl7.v3.PRPAIN201306UV02;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -52,7 +53,7 @@ public class AdapterPatientDiscoveryDeferredRespProxyJavaImplTest {
         assertEquals(PRPAIN201306UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Response", annotation.serviceType());
-        assertEquals("1.0", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyJavaImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyJavaImplTest.java
@@ -53,7 +53,7 @@ public class AdapterPatientDiscoveryDeferredRespProxyJavaImplTest {
         assertEquals(PRPAIN201306UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Response", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyWebServiceSecuredImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyWebServiceSecuredImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,15 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.response.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.MCCIIN000002UV01EventDescriptionBuilder;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201306UV02EventDescriptionBuilder;
 import java.lang.reflect.Method;
 import org.hl7.v3.PRPAIN201306UV02;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -52,7 +53,7 @@ public class AdapterPatientDiscoveryDeferredRespProxyWebServiceSecuredImplTest {
         assertEquals(PRPAIN201306UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Response", annotation.serviceType());
-        assertEquals("1.0", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyWebServiceSecuredImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespProxyWebServiceSecuredImplTest.java
@@ -53,7 +53,7 @@ public class AdapterPatientDiscoveryDeferredRespProxyWebServiceSecuredImplTest {
         assertEquals(PRPAIN201306UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Response", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespWebServiceUnsecuredImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespWebServiceUnsecuredImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,15 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.response.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.MCCIIN000002UV01EventDescriptionBuilder;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201306UV02EventDescriptionBuilder;
 import java.lang.reflect.Method;
 import org.hl7.v3.PRPAIN201306UV02;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -52,7 +53,7 @@ public class AdapterPatientDiscoveryDeferredRespWebServiceUnsecuredImplTest {
         assertEquals(PRPAIN201306UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Response", annotation.serviceType());
-        assertEquals("1.0", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespWebServiceUnsecuredImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/deferred/response/proxy/AdapterPatientDiscoveryDeferredRespWebServiceUnsecuredImplTest.java
@@ -53,7 +53,7 @@ public class AdapterPatientDiscoveryDeferredRespWebServiceUnsecuredImplTest {
         assertEquals(PRPAIN201306UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(MCCIIN000002UV01EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery Deferred Response", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyJavaImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyJavaImplTest.java
@@ -51,7 +51,7 @@ public class AdapterPatientDiscoveryProxyJavaImplTest {
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(PRPAIN201306UV02EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyJavaImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyJavaImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,15 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.adapter.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201305UV02EventDescriptionBuilder;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201306UV02EventDescriptionBuilder;
 import java.lang.reflect.Method;
 import org.hl7.v3.PRPAIN201305UV02;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -50,7 +51,7 @@ public class AdapterPatientDiscoveryProxyJavaImplTest {
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(PRPAIN201306UV02EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery", annotation.serviceType());
-        assertEquals("1.0", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyNoOpImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyNoOpImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,15 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.adapter.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201305UV02EventDescriptionBuilder;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201306UV02EventDescriptionBuilder;
 import java.lang.reflect.Method;
 import org.hl7.v3.PRPAIN201305UV02;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -51,7 +52,7 @@ public class AdapterPatientDiscoveryProxyNoOpImplTest {
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(PRPAIN201306UV02EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery", annotation.serviceType());
-        assertEquals("1.0", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyNoOpImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyNoOpImplTest.java
@@ -52,7 +52,7 @@ public class AdapterPatientDiscoveryProxyNoOpImplTest {
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(PRPAIN201306UV02EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyWebServiceSecuredImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyWebServiceSecuredImplTest.java
@@ -53,7 +53,7 @@ public class AdapterPatientDiscoveryProxyWebServiceSecuredImplTest {
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(PRPAIN201306UV02EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyWebServiceSecuredImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyWebServiceSecuredImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,15 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.adapter.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201305UV02EventDescriptionBuilder;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201306UV02EventDescriptionBuilder;
 import java.lang.reflect.Method;
 import org.hl7.v3.PRPAIN201305UV02;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -52,7 +53,7 @@ public class AdapterPatientDiscoveryProxyWebServiceSecuredImplTest {
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(PRPAIN201306UV02EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery", annotation.serviceType());
-        assertEquals("1.0", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 
 

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyWebServiceUnsecuredImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyWebServiceUnsecuredImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,14 +26,15 @@
  */
 package gov.hhs.fha.nhinc.patientdiscovery.adapter.proxy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import gov.hhs.fha.nhinc.aspect.AdapterDelegationEvent;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201305UV02EventDescriptionBuilder;
 import gov.hhs.fha.nhinc.patientdiscovery.aspect.PRPAIN201306UV02EventDescriptionBuilder;
 import java.lang.reflect.Method;
 import org.hl7.v3.PRPAIN201305UV02;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 /**
@@ -52,6 +53,6 @@ public class AdapterPatientDiscoveryProxyWebServiceUnsecuredImplTest {
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(PRPAIN201306UV02EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery", annotation.serviceType());
-        assertEquals("1.0", annotation.version());
+        assertEquals("LEVEL_A0", annotation.version());
     }
 }

--- a/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyWebServiceUnsecuredImplTest.java
+++ b/Product/Production/Services/PatientDiscoveryCore/src/test/java/gov/hhs/fha/nhinc/patientdiscovery/adapter/proxy/AdapterPatientDiscoveryProxyWebServiceUnsecuredImplTest.java
@@ -53,6 +53,6 @@ public class AdapterPatientDiscoveryProxyWebServiceUnsecuredImplTest {
         assertEquals(PRPAIN201305UV02EventDescriptionBuilder.class, annotation.beforeBuilder());
         assertEquals(PRPAIN201306UV02EventDescriptionBuilder.class, annotation.afterReturningBuilder());
         assertEquals("Patient Discovery", annotation.serviceType());
-        assertEquals("LEVEL_A0", annotation.version());
+        assertEquals("LEVEL_a0", annotation.version());
     }
 }


### PR DESCRIPTION
Adding workaround for logging the action into the database event. Changed adapter levels to be 'LEVEL_A0'

Changes the following services:
- AdminDistribution
- Document Data Submission
- Document Query
- Document Retrieve
- Document Submission
- Patient Discovery 
- Patient Location Query
