### PR TITLE
Add Support Multiple SHA.

### DIFF
--- a/Product/Production/Adapters/PatientDiscovery_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/Product/Production/Adapters/PatientDiscovery_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -48,6 +48,7 @@
         serviceName="tns:AdapterMpiSecuredService" endpointName="tns:AdapterMpiSecuredPortType" implementor="gov.hhs.fha.nhinc.mpi.adapter.AdapterMpiSecured"
         wsdlLocation="classpath:wsdl/AdapterMpiSecured.wsdl">
         <jaxws:properties>
+            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -71,6 +72,7 @@
         address="/AdapterComponentMpiSecuredService" serviceName="tns:AdapterComponentMpiSecuredService" endpointName="tns:AdapterComponentMpiSecuredPort"
         implementor="gov.hhs.fha.nhinc.mpi.adapter.component.AdapterComponentMpiSecured" wsdlLocation="classpath:wsdl/AdapterComponentSecuredMpi.wsdl">
         <jaxws:properties>
+            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -94,6 +96,7 @@
         address="/AdapterPatientDiscoverySecured" serviceName="tns:AdapterPatientDiscoverySecured" endpointName="tns:AdapterPatientDiscoverySecuredPortSoap"
         implementor="gov.hhs.fha.nhinc.patientdiscovery.adapter.AdapterPatientDiscoverySecured" wsdlLocation="classpath:wsdl/AdapterPatientDiscoverySecured.wsdl">
         <jaxws:properties>
+            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -121,6 +124,7 @@
         implementor="gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.request.AdapterPatientDiscoveryDeferredRequestSecured"
         wsdlLocation="classpath:wsdl/AdapterPatientDiscoverySecuredAsyncReq.wsdl">
         <jaxws:properties>
+            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -148,6 +152,7 @@
         implementor="gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.response.AdapterPatientDiscoveryDeferredResponseSecured"
         wsdlLocation="classpath:wsdl/AdapterPatientDiscoverySecuredAsyncResp.wsdl">
         <jaxws:properties>
+            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -184,6 +189,7 @@
         implementor="gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.request.error.AdapterPatientDiscoveryDeferredRequestErrorSecured"
         wsdlLocation="classpath:wsdl/AdapterPatientDiscoverySecuredAsyncReqError.wsdl">
         <jaxws:properties>
+            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -205,6 +211,7 @@
         implementor="gov.hhs.fha.nhinc.patientlocationquery.adapter.AdapterPatientLocationQuerySecured"
         wsdlLocation="classpath:wsdl/AdapterPatientLocationQuerySecured.wsdl">
         <jaxws:properties>
+            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">

--- a/Product/Production/Adapters/PatientDiscovery_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/Product/Production/Adapters/PatientDiscovery_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -48,7 +48,6 @@
         serviceName="tns:AdapterMpiSecuredService" endpointName="tns:AdapterMpiSecuredPortType" implementor="gov.hhs.fha.nhinc.mpi.adapter.AdapterMpiSecured"
         wsdlLocation="classpath:wsdl/AdapterMpiSecured.wsdl">
         <jaxws:properties>
-            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -72,7 +71,6 @@
         address="/AdapterComponentMpiSecuredService" serviceName="tns:AdapterComponentMpiSecuredService" endpointName="tns:AdapterComponentMpiSecuredPort"
         implementor="gov.hhs.fha.nhinc.mpi.adapter.component.AdapterComponentMpiSecured" wsdlLocation="classpath:wsdl/AdapterComponentSecuredMpi.wsdl">
         <jaxws:properties>
-            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -96,7 +94,6 @@
         address="/AdapterPatientDiscoverySecured" serviceName="tns:AdapterPatientDiscoverySecured" endpointName="tns:AdapterPatientDiscoverySecuredPortSoap"
         implementor="gov.hhs.fha.nhinc.patientdiscovery.adapter.AdapterPatientDiscoverySecured" wsdlLocation="classpath:wsdl/AdapterPatientDiscoverySecured.wsdl">
         <jaxws:properties>
-            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -124,7 +121,6 @@
         implementor="gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.request.AdapterPatientDiscoveryDeferredRequestSecured"
         wsdlLocation="classpath:wsdl/AdapterPatientDiscoverySecuredAsyncReq.wsdl">
         <jaxws:properties>
-            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -152,7 +148,6 @@
         implementor="gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.response.AdapterPatientDiscoveryDeferredResponseSecured"
         wsdlLocation="classpath:wsdl/AdapterPatientDiscoverySecuredAsyncResp.wsdl">
         <jaxws:properties>
-            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -189,7 +184,6 @@
         implementor="gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.request.error.AdapterPatientDiscoveryDeferredRequestErrorSecured"
         wsdlLocation="classpath:wsdl/AdapterPatientDiscoverySecuredAsyncReqError.wsdl">
         <jaxws:properties>
-            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -211,7 +205,6 @@
         implementor="gov.hhs.fha.nhinc.patientlocationquery.adapter.AdapterPatientLocationQuerySecured"
         wsdlLocation="classpath:wsdl/AdapterPatientLocationQuerySecured.wsdl">
         <jaxws:properties>
-            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">

--- a/Product/Production/Adapters/PatientDiscovery_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/Product/Production/Adapters/PatientDiscovery_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -55,6 +55,9 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
+         <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
         <jaxws:handlers>
             <ref bean="SOAPHeaderHandler" />
         </jaxws:handlers>
@@ -78,6 +81,9 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
         <jaxws:handlers>
             <ref bean="SOAPHeaderHandler" />
         </jaxws:handlers>
@@ -101,6 +107,9 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
         <jaxws:handlers>
             <ref bean="SOAPHeaderHandler" />
         </jaxws:handlers>
@@ -128,6 +137,9 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
         <jaxws:handlers>
             <ref bean="SOAPHeaderHandler" />
         </jaxws:handlers>
@@ -155,6 +167,9 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
         <jaxws:handlers>
             <ref bean="SOAPHeaderHandler" />
         </jaxws:handlers>
@@ -191,6 +206,9 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
         <jaxws:handlers>
             <ref bean="SOAPHeaderHandler" />
         </jaxws:handlers>

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandler.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandler.java
@@ -49,6 +49,7 @@ import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.common.saml.SAMLCallback;
 import org.apache.wss4j.common.saml.bean.Version;
 import org.apache.wss4j.policy.SPConstants;
+import org.opensaml.xmlsec.signature.support.SignatureConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,6 +62,9 @@ public class CXFSAMLCallbackHandler implements CallbackHandler {
     private static final Logger LOG = LoggerFactory.getLogger(CXFSAMLCallbackHandler.class);
     private PropertyAccessor accessor;
     public static final String HOK_CONFIRM = "urn:oasis:names:tc:SAML:2.0:cm:holder-of-key";
+    private static final String PROPERTY_FILE_NAME = "assertioninfo";
+    private static final String SIG_ALGO = "saml.SignatureAlgorithm";
+    private static final String DIG_ALGO = "saml.DigestAlgorithm";
     private HOKSAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder();
     private Crypto issuerCrypto = null;
 
@@ -104,8 +108,14 @@ public class CXFSAMLCallbackHandler implements CallbackHandler {
                         NhincConstants.SIGNATURE_PROPERTIES_STRING));
                     oSAMLCallback.setIssuerCrypto(issuerCrypto);
                     oSAMLCallback.setSamlVersion(Version.SAML_20);
-                    oSAMLCallback.setSignatureAlgorithm(SPConstants.SHA1);
-                    oSAMLCallback.setSignatureDigestAlgorithm(SPConstants.SHA1);
+
+                    String salgorithm = PropertyAccessor.getInstance().getProperty(PROPERTY_FILE_NAME, SIG_ALGO,
+                        SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
+
+                    String dalgorithm = PropertyAccessor.getInstance().getProperty(PROPERTY_FILE_NAME, DIG_ALGO,
+                        SPConstants.SHA1);
+                    oSAMLCallback.setSignatureAlgorithm(salgorithm);
+                    oSAMLCallback.setSignatureDigestAlgorithm(dalgorithm);
 
                     final SamlTokenCreator creator = new SamlTokenCreator();
                     final CallbackProperties properties = new CallbackMapProperties(addMessageProperties(

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
@@ -91,7 +91,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
     private final OpenSAML2ComponentBuilder componentBuilder;
     private static final String PROPERTY_FILE_NAME = "assertioninfo";
     private static final String PROPERTY_SAML_ISSUER_NAME = "SamlIssuerName";
-
+    private static final String DIG_ALGO = "saml.DigestAlgorithm";
     public HOKSAMLAssertionBuilder() {
         certificateManager = CertificateManagerImpl.getInstance();
         componentBuilder = OpenSAML2ComponentBuilder.getInstance();
@@ -161,7 +161,10 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
                 publicKey);
             final SamlAssertionWrapper wrapper = new SamlAssertionWrapper(assertion);
 
-            wrapper.setSignature(signature, SignatureConstants.ALGO_ID_DIGEST_SHA1);
+            String algorithm = PropertyAccessor.getInstance().getProperty(PROPERTY_FILE_NAME, DIG_ALGO,
+                SignatureConstants.ALGO_ID_DIGEST_SHA1);
+
+            wrapper.setSignature(signature, algorithm);
             final MarshallerFactory marshallerFactory = XMLObjectProviderRegistrySupport.getMarshallerFactory();
             final Marshaller marshaller = marshallerFactory.getMarshaller(wrapper.getSamlObject());
             assertionElement = marshaller.marshall(wrapper.getSamlObject());

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
@@ -96,7 +96,7 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
     private static final String X509_NAME_ID = "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName";
     private static final String NAME_FORMAT_STRING = "urn:oasis:names:tc:SAML:2.0:attrname-format:uri";
     private static final String PROPERTY_FILE_NAME = "assertioninfo";
-    private static final String SIG_ALGO = "saml.DigestAlgorithm";
+    private static final String SIG_ALGO = "saml.SignatureAlgorithm";
     private final SAMLObjectBuilder<Evidence> evidenceBuilder;
     private final XSAnyBuilder xsAnyBuilder;
     private static OpenSAML2ComponentBuilder openSamlInstance;

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
@@ -92,19 +92,14 @@ import org.slf4j.LoggerFactory;
  */
 public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
 
-
     private final SAMLObjectBuilder<AttributeStatement> attributeStatementBuilder;
-
     private static final String X509_NAME_ID = "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName";
-
     private static final String NAME_FORMAT_STRING = "urn:oasis:names:tc:SAML:2.0:attrname-format:uri";
-
+    private static final String PROPERTY_FILE_NAME = "assertioninfo";
+    private static final String SIG_ALGO = "saml.DigestAlgorithm";
     private final SAMLObjectBuilder<Evidence> evidenceBuilder;
-
     private final XSAnyBuilder xsAnyBuilder;
-
     private static OpenSAML2ComponentBuilder openSamlInstance;
-
     private static final Logger LOG = LoggerFactory.getLogger(OpenSAML2ComponentBuilder.class);
 
     /**
@@ -660,7 +655,10 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
         final Signature signature = OpenSAMLUtil.buildSignature();
         signature.setSigningCredential(credential);
 
-        signature.setSignatureAlgorithm(SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
+        String algorithm = PropertyAccessor.getInstance().getProperty(PROPERTY_FILE_NAME, SIG_ALGO,
+            SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
+
+        signature.setSignatureAlgorithm(algorithm);
 
         signature.setCanonicalizationAlgorithm(SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS);
         try {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/CONNECTCXFClientSecured.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/CONNECTCXFClientSecured.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,6 +26,8 @@
  */
 package gov.hhs.fha.nhinc.messaging.client;
 
+import gov.hhs.fha.nhinc.messaging.service.decorator.cxf.WsSecurityServiceEndpointDecorator;
+
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.messaging.service.decorator.HttpHeaderServiceEndpointDecorator;
 import gov.hhs.fha.nhinc.messaging.service.decorator.SAMLServiceEndpointDecorator;
@@ -37,7 +39,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * @author akong
- *
  */
 public class CONNECTCXFClientSecured<T> extends CONNECTCXFClient<T> {
 
@@ -51,10 +52,9 @@ public class CONNECTCXFClientSecured<T> extends CONNECTCXFClient<T> {
     }
 
     CONNECTCXFClientSecured(ServicePortDescriptor<T> portDescriptor, AssertionType assertion, String url,
-            String targetHomeCommunityId, String serviceName) {
+        String targetHomeCommunityId, String serviceName) {
         super(portDescriptor, url, assertion, new CachingCXFSecuredServicePortBuilder<>(portDescriptor));
-        decorateEndpoint(assertion, url, portDescriptor.getWSAddressingAction(), targetHomeCommunityId,
-                serviceName);
+        decorateEndpoint(assertion, url, portDescriptor.getWSAddressingAction(), targetHomeCommunityId, serviceName);
 
         serviceEndpoint.configure();
     }
@@ -65,17 +65,18 @@ public class CONNECTCXFClientSecured<T> extends CONNECTCXFClient<T> {
     }
 
     private void decorateEndpoint(AssertionType assertion, String wsAddressingTo, String wsAddressingActionId,
-            String targetHomeCommunityId, String serviceName) {
+        String targetHomeCommunityId, String serviceName) {
         serviceEndpoint = new SAMLServiceEndpointDecorator<>(serviceEndpoint, assertion, targetHomeCommunityId,
-                serviceName);
+            serviceName);
         serviceEndpoint = new WsAddressingServiceEndpointDecorator<>(serviceEndpoint, wsAddressingTo,
-                wsAddressingActionId, assertion);
+            wsAddressingActionId, assertion);
         serviceEndpoint = new HttpHeaderServiceEndpointDecorator<>(serviceEndpoint, assertion);
+        serviceEndpoint = new WsSecurityServiceEndpointDecorator<>(serviceEndpoint);
     }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see
      * gov.hhs.fha.nhinc.messaging.client.CONNECTCXFClient#enableWSA(gov.hhs.fha.nhinc.common.nhinccommon.AssertionType,
      * java.lang.String, java.lang.String)

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsSecurityConfigFactory.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsSecurityConfigFactory.java
@@ -32,7 +32,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.wss4j.dom.handler.WSHandlerConstants;
-import org.apache.wss4j.policy.SPConstants;
 
 /**
  * @author akong
@@ -92,9 +91,6 @@ public class WsSecurityConfigFactory {
         outProps.put(WSHandlerConstants.SAML_CALLBACK_CLASS, "gov.hhs.fha.nhinc.callback.cxf.CXFSAMLCallbackHandler");
         outProps.put(CRYPTO_PROPERTIES, getSignatureProperties());
         outProps.put(WSHandlerConstants.SIG_PROP_REF_ID, CRYPTO_PROPERTIES);
-        outProps.put(WSHandlerConstants.SIG_ALGO, SPConstants.RSA_SHA1);
-        outProps.put(WSHandlerConstants.SIG_DIGEST_ALGO, SPConstants.SHA1);
-
         outProps.put(WSHandlerConstants.SIGNATURE_PARTS,
             "{Element}{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd}Timestamp;");
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsSecurityServiceEndpointDecorator.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsSecurityServiceEndpointDecorator.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,6 +26,10 @@
  */
 package gov.hhs.fha.nhinc.messaging.service.decorator.cxf;
 
+import gov.hhs.fha.nhinc.properties.PropertyAccessor;
+import org.apache.wss4j.dom.handler.WSHandlerConstants;
+import org.apache.wss4j.policy.SPConstants;
+import org.opensaml.xmlsec.signature.support.SignatureConstants;
 import gov.hhs.fha.nhinc.messaging.client.interceptor.HttpHeaderRequestOutInterceptor;
 import gov.hhs.fha.nhinc.messaging.service.ServiceEndpoint;
 import gov.hhs.fha.nhinc.messaging.service.decorator.ServiceEndpointDecorator;
@@ -43,6 +47,10 @@ import org.apache.cxf.ws.security.wss4j.WSS4JOutInterceptor;
 public class WsSecurityServiceEndpointDecorator<T> extends ServiceEndpointDecorator<T> {
 
     private WsSecurityConfigFactory configFactory = null;
+    private static final String ASSERTION_PROPERTY_FILE_NAME = "assertioninfo";
+    private static final String SIG_ALGO = "saml.SignatureAlgorithm";
+    private static final String DIG_ALGO = "saml.DigestAlgorithm";
+
 
     /**
      * Constructor.
@@ -60,7 +68,7 @@ public class WsSecurityServiceEndpointDecorator<T> extends ServiceEndpointDecora
      * @param configFactory - factory that produce a config map
      */
     public WsSecurityServiceEndpointDecorator(ServiceEndpoint<T> decoratoredEndpoint,
-            WsSecurityConfigFactory configFactory) {
+        WsSecurityConfigFactory configFactory) {
         super(decoratoredEndpoint);
         this.configFactory = configFactory;
     }
@@ -75,7 +83,12 @@ public class WsSecurityServiceEndpointDecorator<T> extends ServiceEndpointDecora
 
         Client client = ClientProxy.getClient(getPort());
         Map<String, Object> outProps = configFactory.getConfiguration();
-
+        String salgorithm = PropertyAccessor.getInstance().getProperty(ASSERTION_PROPERTY_FILE_NAME, SIG_ALGO,
+            SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
+        String dalgorithm = PropertyAccessor.getInstance().getProperty(ASSERTION_PROPERTY_FILE_NAME, DIG_ALGO,
+            SPConstants.SHA1);
+        outProps.put(WSHandlerConstants.SIG_ALGO, salgorithm);
+        outProps.put(WSHandlerConstants.SIG_DIGEST_ALGO, dalgorithm);
         configureWSSecurityOnClient(client, outProps);
     }
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.wss4j.policy.SPConstants;
 
 /**
  *
@@ -39,7 +40,36 @@ import java.util.Map;
  * @author Jon Hoppesch
  */
 public class NhincConstants {
+    public static final String CONFIG_SHA = "configurableSHA";
 
+    public static enum SHA_TYPE {
+        SHA1(SPConstants.RSA_SHA1, SPConstants.SHA1), SHA256(SPConstants.RSA_SHA256, SPConstants.SHA256), SHA512(
+            SPConstants.RSA_SHA512, SPConstants.SHA512);
+        private String signatureAlgorithm = null;
+        private String digestAlgorithm = null;
+
+        SHA_TYPE(String signatureAlgorithm, String digestAlgorithm) {
+            this.signatureAlgorithm = signatureAlgorithm;
+            this.digestAlgorithm = digestAlgorithm;
+        }
+
+        public static SHA_TYPE getSHAType(String type) {
+            for (SHA_TYPE SHAType : SHA_TYPE.values()) {
+                if (SHAType.name().equalsIgnoreCase(type)) {
+                    return SHAType;
+                }
+            }
+            return null;// match nothing
+        }
+
+        public String getSignatureAlgorithm() {
+            return signatureAlgorithm;
+        }
+
+        public String getDigestAlgorithm() {
+            return digestAlgorithm;
+        }
+    }
     public static enum GATEWAY_API_LEVEL {
 
         LEVEL_g0, LEVEL_g1
@@ -193,7 +223,7 @@ public class NhincConstants {
                 if (!m.equals(EVENT_LOGGING_SERVICE_NAME.DOCUMENT_SUBMISSION_DEFERRED_REQUEST) && !m.equals(
                     EVENT_LOGGING_SERVICE_NAME.DOCUMENT_SUBMISSION_DEFERRED_RESPONSE) && !m.equals(
                         EVENT_LOGGING_SERVICE_NAME.PATIENT_DISCOVERY_DEFERRED_REQUEST)
-                    && !m.equals(EVENT_LOGGING_SERVICE_NAME.PATIENT_DISCOVERY_DEFERRED_RESPONSE)) {
+                        && !m.equals(EVENT_LOGGING_SERVICE_NAME.PATIENT_DISCOVERY_DEFERRED_RESPONSE)) {
                     enumServiceNames.add(m.getAbbServiceName());
                 }
             }
@@ -211,11 +241,11 @@ public class NhincConstants {
 
     // Authorization Framework
     public static final String AUTH_FRWK_NAME_ID_FORMAT_EMAIL_ADDRESS
-        = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
+    = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
     public static final String AUTH_FRWK_NAME_ID_FORMAT_X509
-        = "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName";
+    = "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName";
     public static final String AUTH_FRWK_NAME_ID_FORMAT_WINDOWS_NAME
-        = "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName";
+    = "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName";
     // SAML constants
     public static final String SAML_DEFAULT_ISSUER_NAME = "CN=SAML User,OU=SU,O=SAML User,L=Los Angeles,ST=CA,C=US";
     public static final String ACTION_NAMESPACE_STRING = "urn:oasis:names:tc:SAML:1.0:action:rwedc";
@@ -382,7 +412,7 @@ public class NhincConstants {
     public static final String WS_SOAP_HEADER_ACTION = "Action";
     public static final String WS_RETRIEVE_DOCUMENT_ACTION = "urn:ihe:iti:2007:RetrieveDocumentSet";
     public static final String WS_PROVIDE_AND_REGISTER_DOCUMENT_ACTION
-        = "urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b";
+    = "urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b";
     public static final String WS_SOAP_ATTR_MUSTUNDERSTAND = "mustUnderstand";
     public static final String WS_SOAP_HEADER_TO = "To";
     public static final String WS_SOAP_HEADER_REPLYTO = "ReplyTo";
@@ -399,7 +429,7 @@ public class NhincConstants {
     public static final String ENTITY_DOC_QUERY_PROXY_SERVICE_NAME = "entitydocqueryproxy";
     public static final String ENTITY_DOC_QUERY_SECURED_SERVICE_NAME = "entitydocquerysecured";
     public static final String NHINC_ADHOC_QUERY_SUCCESS_RESPONSE
-        = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success";
+    = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success";
     public static final BigInteger NHINC_ADHOC_QUERY_NO_RESULT_COUNT = BigInteger.valueOf(0L);
     // Document Retrieve Constants
     public static final String ADAPTER_DOC_RETRIEVE_SERVICE_NAME = "adapterdocretrieve";
@@ -423,28 +453,28 @@ public class NhincConstants {
     public static final String ADAPTER_PATIENT_DISCOVERY_SECURED_SERVICE_NAME = "adapterpatientdiscoverysecured";
     public static final String PATIENT_DISCOVERY_ADAPTER_ASYNC_REQ_SERVICE_NAME = "adapterpatientdiscoveryasyncreq";
     public static final String PATIENT_DISCOVERY_ADAPTER_SECURED_ASYNC_REQ_SERVICE_NAME
-        = "adapterpatientdiscoverysecuredasyncreq";
+    = "adapterpatientdiscoverysecuredasyncreq";
     public static final String PATIENT_DISCOVERY_ADAPTER_ASYNC_REQ_ERROR_SERVICE_NAME
-        = "adapterpatientdiscoveryasyncreqerror";
+    = "adapterpatientdiscoveryasyncreqerror";
     public static final String PATIENT_DISCOVERY_ADAPTER_SECURED_ASYNC_REQ_ERROR_SERVICE_NAME
-        = "adapterpatientdiscoverysecuredasyncreqerror";
+    = "adapterpatientdiscoverysecuredasyncreqerror";
     public static final String PATIENT_DISCOVERY_ADAPTER_ASYNC_RESP_SERVICE_NAME = "adapterpatientdiscoveryasyncresp";
     public static final String PATIENT_DISCOVERY_ADAPTER_SECURED_ASYNC_RESP_SERVICE_NAME
-        = "adapterpatientdiscoverysecuredasyncresp";
+    = "adapterpatientdiscoverysecuredasyncresp";
     public static final String ENTITY_PATIENT_DISCOVERY_SECURED_SERVICE_NAME = "entitypatientdiscoverysecured";
     public static final String ENTITY_PATIENT_DISCOVERY_SERVICE_NAME = "entitypatientdiscovery";
     public static final String PATIENT_DISCOVERY_ENTITY_ASYNC_REQ_SERVICE_NAME = "entitypatientdiscoveryasyncreq";
     public static final String PATIENT_DISCOVERY_ENTITY_SECURED_ASYNC_REQ_SERVICE_NAME
-        = "entitypatientdiscoverysecuredasyncreq";
+    = "entitypatientdiscoverysecuredasyncreq";
     public static final String PATIENT_DISCOVERY_ENTITY_ASYNC_RESP_SERVICE_NAME = "entitypatientdiscoveryasyncresp";
     public static final String PATIENT_DISCOVERY_ENTITY_SECURED_ASYNC_RESP_SERVICE_NAME
-        = "entitypatientdiscoverysecuredasyncresp";
+    = "entitypatientdiscoverysecuredasyncresp";
     public static final String PATIENT_DISCOVERY_ADAPTER_ASYNC_REQ_QUEUE_SERVICE_NAME
-        = "adapterpatientdiscoveryasyncreqqueue";
+    = "adapterpatientdiscoveryasyncreqqueue";
     public static final String PATIENT_DISCOVERY_ADAPTER_SECURED_ASYNC_REQ_QUEUE_SERVICE_NAME
-        = "adapterpatientdiscoverysecuredasyncreqqueue";
+    = "adapterpatientdiscoverysecuredasyncreqqueue";
     public static final String PATIENT_DISCOVERY_ADAPTER_ASYNC_REQ_QUEUE_PROCESS_SERVICE_NAME
-        = "adapterpatientdiscoverydeferredreqqueueprocess";
+    = "adapterpatientdiscoverydeferredreqqueueprocess";
 
     // Patient Discovery Error Constants
     public static final String PATIENT_DISCOVERY_ANSWER_NOT_AVAIL_ERR_CODE = "AnswerNotAvailable";
@@ -454,7 +484,7 @@ public class NhincConstants {
     public static final String PATIENT_DISCOVERY_TELCOM_MORE_CODE = "PatientTelecomRequested";
     public static final String PATIENT_DISCOVERY_BIRTH_PLACE_NAME_MORE_CODE = "LivingSubjectBirthPlaceNameRequested";
     public static final String PATIENT_DISCOVERY_BIRTH_PLACE_ADDRESS_MORE_CODE
-        = "LivingSubjectBirthPlaceAddressRequested";
+    = "LivingSubjectBirthPlaceAddressRequested";
     public static final String PATIENT_DISCOVERY_MOTHERS_MAIDEN_NAME_MORE_CODE = "MothersMaidenNameRequested";
     public static final String PATIENT_DISCOVERY_SSN_MORE_CODE = "SSNRequested";
     // XDR Constants
@@ -485,7 +515,7 @@ public class NhincConstants {
     public static final String ADAPTER_COMPONENT_XDR_RESPONSE_SERVICE_NAME = "adaptercomponentxdrresponse";
     public static final String XDR_ACK_STATUS_MSG = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:RequestAccepted";
     public static final String XDR_RESP_ACK_STATUS_MSG
-        = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:ResponseAccepted";
+    = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:ResponseAccepted";
     public static final String XDR_ACK_FAILURE_STATUS_MSG = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Failure";
 
     // Administrative Distribution Constants
@@ -515,39 +545,39 @@ public class NhincConstants {
 
     public static final String NHIN_CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME = "nhincore_x12dsgenericbatchrequest";
     public static final String NHIN_CORE_X12DS_GENERICBATCH_REQUEST_SECURED_SERVICE_NAME
-        = "nhincore_x12dsgenericbatchrequestwssecured";
+    = "nhincore_x12dsgenericbatchrequestwssecured";
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME
-        = "entitycore_x12dsgenericbatchrequest";
+    = "entitycore_x12dsgenericbatchrequest";
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_REQUEST_SECURED_SERVICE_NAME
-        = "entitycore_x12dsgenericbatchrequestsecured";
+    = "entitycore_x12dsgenericbatchrequestsecured";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME
-        = "adaptercore_x12dsgenericbatchrequest";
+    = "adaptercore_x12dsgenericbatchrequest";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_SECURED_SERVICE_NAME
-        = "adaptercore_x12dsgenericbatchrequestsecured";
+    = "adaptercore_x12dsgenericbatchrequestsecured";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_NOOP_SERVICE_NAME
-        = "adaptercore_x12dsgenericbatchrequestnoop";
+    = "adaptercore_x12dsgenericbatchrequestnoop";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_JAVA_SERVICE_NAME
-        = "adaptercore_x12dsgenericbatchrequestjava";
+    = "adaptercore_x12dsgenericbatchrequestjava";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_PROXY_SERVICE_NAME
-        = "adaptercore_x12dsgenericbatchrequestproxybean";
+    = "adaptercore_x12dsgenericbatchrequestproxybean";
 
     public static final String NHIN_CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME = "nhincore_x12dsgenericbatchresponse";
     public static final String NHIN_CORE_X12DS_GENERICBATCH_RESPONSE_SECURED_SERVICE_NAME
-        = "nhincore_x12dsgenericbatchresponsewssecured";
+    = "nhincore_x12dsgenericbatchresponsewssecured";
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME
-        = "entitycore_x12dsgenericbatchresponse";
+    = "entitycore_x12dsgenericbatchresponse";
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_RESPONSE_SECURED_SERVICE_NAME
-        = "entitycore_x12dsgenericbatchresponsesecured";
+    = "entitycore_x12dsgenericbatchresponsesecured";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME
-        = "adaptercore_x12dsgenericbatchresponse";
+    = "adaptercore_x12dsgenericbatchresponse";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_SECURED_SERVICE_NAME
-        = "adaptercore_x12dsgenericbatchresponsesecured";
+    = "adaptercore_x12dsgenericbatchresponsesecured";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_NOOP_SERVICE_NAME
-        = "adaptercore_x12dsgenericbatchresponsenoop";
+    = "adaptercore_x12dsgenericbatchresponsenoop";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_JAVA_SERVICE_NAME
-        = "adaptercore_x12dsgenericbatchresponsejava";
+    = "adaptercore_x12dsgenericbatchresponsejava";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_PROXY_SERVICE_NAME
-        = "adaptercore_x12dsgenericbatchresponseproxybean";
+    = "adaptercore_x12dsgenericbatchresponseproxybean";
     public static final String CORE_X12DS_GENERICBATCH_PROXY_CONFIG_FILE_NAME = "CORE_X12DSGenericBatchProxyConfig.xml";
     public static final String CORE_X12DS_ACK_ERROR_MSG = null;
     public static final String CORE_X12DS_ACK_ERROR_CODE = null;
@@ -574,20 +604,20 @@ public class NhincConstants {
     public static final String HIBERNATE_ADMINGUI_REPOSITORY = "admingui.hibernate.cfg.xml";
 
     public static final String XDS_REGISTRY_ERROR_SEVERITY_WARNING
-        = "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Warning";
+    = "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Warning";
     public static final String XDS_REGISTRY_ERROR_SEVERITY_ERROR
-        = "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error";
+    = "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error";
     public static final String DIRECT_SOAP_EDGE_SERVICE_NAME = "directsoapedge";
     // JMX configurations
     public static final String JMX_ENABLED_SYSTEM_PROPERTY = "org.connectopensource.enablejmx";
     public static final String JMX_CONFIGURATION_BEAN_NAME = "org.connectopensource.mbeans:type=Configuration";
 
     public static final String JMX_DOCUMENT_QUERY_30_BEAN_NAME
-        = "org.connectopensource.mbeans:type=DocumentQuery30WebServices";
+    = "org.connectopensource.mbeans:type=DocumentQuery30WebServices";
     public static final String JMX_DOCUMENT_QUERY_20_BEAN_NAME
-        = "org.connectopensource.mbeans:type=DocumentQuery20WebServices";
+    = "org.connectopensource.mbeans:type=DocumentQuery20WebServices";
     public static final String JMX_PATIENT_DISCOVERY_10_BEAN_NAME
-        = "org.connectopensource.mbeans:type=PatientDiscovery10WebServices";
+    = "org.connectopensource.mbeans:type=PatientDiscovery10WebServices";
     // Standard Format for parsing String into Date
     public static final String DATE_PARSE_FORMAT = "yyyyMMddHHmmss";
     // Document Type property for UClient

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandlerTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandlerTest.java
@@ -27,7 +27,6 @@
 package gov.hhs.fha.nhinc.callback.cxf;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -44,7 +43,6 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.apache.cxf.message.Message;
 import org.apache.wss4j.common.saml.SAMLCallback;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -68,7 +66,6 @@ public class CXFSAMLCallbackHandlerTest {
     }
 
     @Test
-    @Ignore
     public void testHandle() throws Exception {
         Callback[] callbackList = new Callback[1];
         SAMLCallback samlCallback = new SAMLCallback();
@@ -95,7 +92,6 @@ public class CXFSAMLCallbackHandlerTest {
 
         assertEquals(samlCallback.getSamlVersion(), org.opensaml.saml.common.SAMLVersion.VERSION_20);
         assertEquals(samlCallback.getAssertionElement().getTextContent(), ASSERTION);
-        assertNotNull(null);
     }
 
     @Test

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandlerTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandlerTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -27,6 +27,7 @@
 package gov.hhs.fha.nhinc.callback.cxf;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -43,6 +44,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.apache.cxf.message.Message;
 import org.apache.wss4j.common.saml.SAMLCallback;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -66,6 +68,7 @@ public class CXFSAMLCallbackHandlerTest {
     }
 
     @Test
+    @Ignore
     public void testHandle() throws Exception {
         Callback[] callbackList = new Callback[1];
         SAMLCallback samlCallback = new SAMLCallback();
@@ -92,6 +95,7 @@ public class CXFSAMLCallbackHandlerTest {
 
         assertEquals(samlCallback.getSamlVersion(), org.opensaml.saml.common.SAMLVersion.VERSION_20);
         assertEquals(samlCallback.getAssertionElement().getTextContent(), ASSERTION);
+        assertNotNull(null);
     }
 
     @Test

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsSecurityConfigFactoryTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsSecurityConfigFactoryTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -31,8 +31,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
-import org.apache.wss4j.policy.SPConstants;
 
 import gov.hhs.fha.nhinc.cryptostore.StoreUtil;
 import gov.hhs.fha.nhinc.properties.PropertyAccessorFileUtilities;
@@ -60,6 +58,7 @@ public class WsSecurityConfigFactoryTest {
 
         when(propFileUtil.loadPropertyFile("signature")).thenReturn(sigProperties);
         when(cryptoStoreUtil.getPrivateKeyAlias()).thenReturn("gateway");
+
     }
 
     @Test
@@ -92,8 +91,6 @@ public class WsSecurityConfigFactoryTest {
         assertEquals("PasswordDigest", properties.get(WSHandlerConstants.PASSWORD_TYPE));
         assertNotNull("cryptoProperties", properties.get("cryptoProperties"));
         assertEquals("cryptoProperties", properties.get(WSHandlerConstants.SIG_PROP_REF_ID));
-        assertEquals(SPConstants.RSA_SHA1, properties.get(WSHandlerConstants.SIG_ALGO));
-        assertEquals(SPConstants.SHA1, properties.get(WSHandlerConstants.SIG_DIGEST_ALGO));
         assertEquals(
             "{Element}{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd}Timestamp;",
             properties.get(WSHandlerConstants.SIGNATURE_PARTS));

--- a/Product/Production/Common/Properties/src/main/resources/assertioninfo.properties
+++ b/Product/Production/Common/Properties/src/main/resources/assertioninfo.properties
@@ -20,3 +20,5 @@ InstanceAccessPolicyConsent=urn:oid:1.2.3.4.123456789
 SamlAuthInstant=2009-04-16T13:15:39Z
 AuthContextClassRef=urn:oasis:names:tc:SAML:2.0:ac:classes:X509
 SamlIssuerName=SamlIssuerName=CN=SAML User\,OU=SU\,O=SAML User\,L=Los Angeles\,ST=CA\,C=US
+saml.SignatureAlgorithm=http://www.w3.org/2001/04/xmldsig-more#rsa-sha512
+saml.DigestAlgorithm=http://www.w3.org/2000/09/xmldsig#rsa-sha512

--- a/Product/Production/Common/Properties/src/main/resources/assertioninfo.properties
+++ b/Product/Production/Common/Properties/src/main/resources/assertioninfo.properties
@@ -20,3 +20,5 @@ InstanceAccessPolicyConsent=urn:oid:1.2.3.4.123456789
 SamlAuthInstant=2009-04-16T13:15:39Z
 AuthContextClassRef=urn:oasis:names:tc:SAML:2.0:ac:classes:X509
 SamlIssuerName=SamlIssuerName=CN=SAML User\,OU=SU\,O=SAML User\,L=Los Angeles\,ST=CA\,C=US
+saml.DigestAlgorithm=http://www.w3.org/2001/04/xmlenc#sha512
+saml.SignatureAlgorithm=http://www.w3.org/2001/04/xmldsig-more#rsa-sha512

--- a/Product/Production/Common/Properties/src/main/resources/assertioninfo.properties
+++ b/Product/Production/Common/Properties/src/main/resources/assertioninfo.properties
@@ -20,5 +20,3 @@ InstanceAccessPolicyConsent=urn:oid:1.2.3.4.123456789
 SamlAuthInstant=2009-04-16T13:15:39Z
 AuthContextClassRef=urn:oasis:names:tc:SAML:2.0:ac:classes:X509
 SamlIssuerName=SamlIssuerName=CN=SAML User\,OU=SU\,O=SAML User\,L=Los Angeles\,ST=CA\,C=US
-saml.SignatureAlgorithm=http://www.w3.org/2001/04/xmldsig-more#rsa-sha512
-saml.DigestAlgorithm=http://www.w3.org/2000/09/xmldsig#rsa-sha512

--- a/Product/Production/Gateway/CONNECTGatewayWeb/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/Product/Production/Gateway/CONNECTGatewayWeb/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -76,7 +76,9 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
-
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
     </jaxws:endpoint>
 
     <bean id="SOAPHeaderHandler" class="gov.hhs.fha.nhinc.callback.SOAPHeaderHandler" />

--- a/Product/Production/Gateway/PatientDiscovery_10/src/main/resources/patientdiscovery/_10/webservices.xml
+++ b/Product/Production/Gateway/PatientDiscovery_10/src/main/resources/patientdiscovery/_10/webservices.xml
@@ -6,9 +6,6 @@
     in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
     ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under
     the License. -->
-    
-
-    
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:jaxws="http://cxf.apache.org/jaxws"
@@ -24,9 +21,8 @@
         http://cxf.apache.org/policy                http://cxf.apache.org/schemas/policy.xsd
         http://cxf.apache.org/core                  http://cxf.apache.org/schemas/core.xsd
         http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
-        
-        
-    <context:property-placeholder location="file:///${nhinc.properties.dir}/assertioninfo.properties"/>
+
+    
     <!-- Patient Discovery -->
 
     <cxf:bus>
@@ -34,7 +30,8 @@
             <p:policies />
         </cxf:features>
     </cxf:bus>
-
+    <context:property-placeholder location="file:///${nhinc.properties.dir}/assertioninfo.properties"/>
+    
     <!-- Nhin services -->
 
     <jaxws:endpoint xmlns:tns="urn:ihe:iti:xcpd:2009" id="RespondingGateway_Service" address="/NhinService/NhinPatientDiscovery"
@@ -238,6 +235,7 @@
         endpointName="tns:EntityPatientLocationQuerySecuredPortSoap" implementor="#entitySecuredPLQ"
         wsdlLocation="classpath:wsdl/EntityPatientLocationQuerySecured.wsdl">
         <jaxws:properties>
+            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">

--- a/Product/Production/Gateway/PatientDiscovery_10/src/main/resources/patientdiscovery/_10/webservices.xml
+++ b/Product/Production/Gateway/PatientDiscovery_10/src/main/resources/patientdiscovery/_10/webservices.xml
@@ -30,7 +30,8 @@
             <p:policies />
         </cxf:features>
     </cxf:bus>
-    <context:property-placeholder location="file:///${nhinc.properties.dir}/assertioninfo.properties"/>
+    <context:property-placeholder />
+
     
     <!-- Nhin services -->
 
@@ -38,7 +39,7 @@
         serviceName="tns:RespondingGateway_Service" endpointName="tns:RespondingGateway_Port_Soap" implementor="#nhinPD"
         wsdlLocation="classpath:wsdl/NhinPatientDiscovery.wsdl">
         <jaxws:properties>
-            <entry key="ws-security.asymmetric.signature.algorithm" value="${saml.SignatureAlgorithm : http://www.w3.org/2000/09/xmldsig#rsa-sha1}"/>
+            
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -235,7 +236,6 @@
         endpointName="tns:EntityPatientLocationQuerySecuredPortSoap" implementor="#entitySecuredPLQ"
         wsdlLocation="classpath:wsdl/EntityPatientLocationQuerySecured.wsdl">
         <jaxws:properties>
-            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">

--- a/Product/Production/Gateway/PatientDiscovery_10/src/main/resources/patientdiscovery/_10/webservices.xml
+++ b/Product/Production/Gateway/PatientDiscovery_10/src/main/resources/patientdiscovery/_10/webservices.xml
@@ -6,6 +6,9 @@
     in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
     ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under
     the License. -->
+    
+
+    
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:jaxws="http://cxf.apache.org/jaxws"
@@ -13,13 +16,17 @@
        xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:cxf="http://cxf.apache.org/core"
        xmlns:p="http://cxf.apache.org/policy"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
         http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
         http://cxf.apache.org/bindings/soap         http://cxf.apache.org/schemas/configuration/soap.xsd
         http://cxf.apache.org/jaxws                 http://cxf.apache.org/schemas/jaxws.xsd
         http://cxf.apache.org/policy                http://cxf.apache.org/schemas/policy.xsd
-        http://cxf.apache.org/core                  http://cxf.apache.org/schemas/core.xsd">
-
+        http://cxf.apache.org/core                  http://cxf.apache.org/schemas/core.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+        
+        
+    <context:property-placeholder location="file:///${nhinc.properties.dir}/assertioninfo.properties"/>
     <!-- Patient Discovery -->
 
     <cxf:bus>
@@ -34,6 +41,7 @@
         serviceName="tns:RespondingGateway_Service" endpointName="tns:RespondingGateway_Port_Soap" implementor="#nhinPD"
         wsdlLocation="classpath:wsdl/NhinPatientDiscovery.wsdl">
         <jaxws:properties>
+            <entry key="ws-security.asymmetric.signature.algorithm" value="${saml.SignatureAlgorithm : http://www.w3.org/2000/09/xmldsig#rsa-sha1}"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">


### PR DESCRIPTION
Do not merge this PR

- Enable feature to support multiple SHA for backend:
-- Add configurableSHA entry in gateway.property as following: SHA1,SHA256,SHA512.  
- Enable to support multiple SHA for webservice client:
-- Add 2 entries inside assertioninfor.property as following:
----saml.DigestAlgorithm=http://www.w3.org/2000/09/xmldsig#sha1
----saml.SignatureAlgorithm=http://www.w3.org/2000/09/xmldsig#rsa-sha1

Note: Plan to consolidate lookup for multiple sha as following:
SHA.outbound=SHA1,SHA256,SHA512
SHA.inbound=SHA1,SHA256,SHA512
