### PR TITLE
CONN-2017b/2375 fix default-exchange logic

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/exchangemgr/ExchangeManager.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/exchangemgr/ExchangeManager.java
@@ -544,8 +544,13 @@ public class ExchangeManager extends AbstractExchangeManager<UDDI_SPEC_VERSION> 
 
     @Override
     protected String getGatewayAlias(String exchangeName) {
+        String defaultExchange = StringUtils.isNotBlank(exchangeName) ? exchangeName : getDefaultExchange();
+        if (StringUtils.isBlank(defaultExchange)) {
+            return null;
+        }
+
         ExchangeType exchange = ExchangeManagerHelper
-            .findExchangeTypeBy(ExchangeManagerHelper.getExchangeTypeBy(exInfo), exchangeName);
+            .findExchangeTypeBy(ExchangeManagerHelper.getExchangeTypeBy(exInfo), defaultExchange);
         return null != exchange ? exchange.getCertificateAlias() : null;
     }
 }


### PR DESCRIPTION
null--exchangeName did not get mapped back to the default-exchange alias.