### PR TITLE
Update for SAML Attribute processing without explicit value types

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/opensaml/extraction/AttributeHelper.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/opensaml/extraction/AttributeHelper.java
@@ -186,6 +186,8 @@ public class AttributeHelper {
                     // why the string values are treated differently I am not going to change this logic.
                 } else if (o instanceof XSStringImpl) {
                     strBuilder.append(((XSStringImpl) o).getValue());
+                } else if (o instanceof XSAnyImpl) {
+                    strBuilder.append(((XSAnyImpl) o).getTextContent());
                 }
             }
         }

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/cxf/CONNECTSamlAssertionValidatorTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/cxf/CONNECTSamlAssertionValidatorTest.java
@@ -67,6 +67,7 @@ import org.junit.Test;
 import org.opensaml.core.xml.XMLObjectBuilderFactory;
 import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
 import org.opensaml.core.xml.io.UnmarshallingException;
+import org.opensaml.core.xml.schema.impl.XSAnyImpl;
 import org.opensaml.saml.common.SAMLObjectBuilder;
 import org.opensaml.saml.common.SAMLObjectContentReference;
 import org.opensaml.saml.common.SAMLVersion;
@@ -550,6 +551,39 @@ public class CONNECTSamlAssertionValidatorTest {
         statements.add(attributeStatement);
 
         when(saml2Assertion.getAttributeStatements()).thenReturn(statements);
+
+        CONNECTSamlAssertionValidator validator = new CONNECTSamlAssertionValidator();
+        validator.checkAttributes(assertionWrapper);
+    }
+    
+    @Test
+    public void testValidateAttributesAnyType() throws WSSecurityException {
+        final org.opensaml.saml.saml2.core.Assertion saml2Assertion = mock(org.opensaml.saml.saml2.core.Assertion.class);
+        final SamlAssertionWrapper assertionWrapper = new SamlAssertionWrapper(saml2Assertion);
+        final XMLObjectBuilderFactory builderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
+        final SAMLObjectBuilder<AttributeStatement> attributeStatementBuilder = (SAMLObjectBuilder<AttributeStatement>) builderFactory
+                .getBuilder(AttributeStatement.DEFAULT_ELEMENT_NAME);
+        final XSAnyImpl anyType = mock(XSAnyImpl.class);
+
+        List<Object> values = new ArrayList<>();
+            values.add("value");
+        List<Attribute> attributes = new ArrayList<>();
+        for (String name : VALIDATED_ATTRIBUTES) {
+            Attribute attr = SAML2ComponentBuilder.createAttribute("", name, "nameFormat", values);
+            if(name.equals(NhincConstants.ATTRIBUTE_NAME_ORG)) {
+                attr.getAttributeValues().clear();
+                attr.getAttributeValues().add(anyType);
+            }
+            attributes.add(attr);
+        }
+
+        final AttributeStatement attributeStatement = attributeStatementBuilder.buildObject();
+        attributeStatement.getAttributes().addAll(attributes);
+        List<AttributeStatement> statements = new ArrayList<>();
+        statements.add(attributeStatement);
+
+        when(saml2Assertion.getAttributeStatements()).thenReturn(statements);
+        when(anyType.getTextContent()).thenReturn("value");
 
         CONNECTSamlAssertionValidator validator = new CONNECTSamlAssertionValidator();
         validator.checkAttributes(assertionWrapper);

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/opensaml/extraction/AttributeHelperTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/opensaml/extraction/AttributeHelperTest.java
@@ -33,7 +33,6 @@ import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.CeType;
 import gov.hhs.fha.nhinc.common.nhinccommon.PersonNameType;
 import gov.hhs.fha.nhinc.common.nhinccommon.UserType;
-import gov.hhs.fha.nhinc.opensaml.extraction.AttributeHelper;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Assert;
@@ -41,6 +40,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.schema.impl.XSStringImpl;
+import org.opensaml.core.xml.schema.impl.XSAnyImpl;
 import org.opensaml.saml.saml2.core.Attribute;
 
 /**
@@ -96,6 +96,20 @@ public class AttributeHelperTest {
         String result = helper.extractAttributeValueString(attrib);
         Assert.assertEquals("ONC Team", result);
 
+    }
+    
+    @Test
+    public final void testExtractAttributeValueAnyString() {
+        // Test for exceptions if attribute is Null
+        final String testValue = "ONC Team";
+        Attribute attrib = mock(Attribute.class);
+        List<XMLObject> attrVals = new ArrayList<>();
+        XSAnyImpl mockAnyValue = mock(XSAnyImpl.class);
+        when(mockAnyValue.getTextContent()).thenReturn(testValue);
+        attrVals.add(mockAnyValue);
+        when(attrib.getAttributeValues()).thenReturn(attrVals);
+        String result = helper.extractAttributeValueString(attrib);
+        Assert.assertEquals(testValue, result);
     }
 
     @Test


### PR DESCRIPTION
Does 2 things:

- Focuses type validation for XSAny values to only examine specific named attributes (Role and PurposeOfUse).
- Builds UserInfo assertion type info from XSAny objects.