### PR TITLE
Conn 2386 - Configurable SAML Signature

### DIFF
--- a/Product/Production/Adapters/AdminDistribution_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/Product/Production/Adapters/AdminDistribution_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -50,6 +50,7 @@
         </jaxws:properties>
         <jaxws:inInterceptors>
             <ref bean="timestampInInterceptor" />
+            <ref bean="securityConfigInInterceptor" />
         </jaxws:inInterceptors>
         <jaxws:outFaultInterceptors>
             <ref bean="attachmentFaultOutInterceptor" />

--- a/Product/Production/Adapters/CORE_X12DocSubmission_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/Product/Production/Adapters/CORE_X12DocSubmission_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -49,6 +49,9 @@ the License. -->
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
     </jaxws:endpoint>
 
     <jaxws:endpoint xmlns:tns="urn:gov:hhs:fha:nhinc:adaptercore"
@@ -78,6 +81,9 @@ the License. -->
             <entry key="ws-security.enable.timestamp.cache" value="false" />
             <entry key="mtom-enabled" value="true" />
         </jaxws:properties>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
     </jaxws:endpoint>
 
     <jaxws:endpoint xmlns:tns="urn:gov:hhs:fha:nhinc:adaptercore"
@@ -108,6 +114,9 @@ the License. -->
             <entry key="ws-security.enable.timestamp.cache" value="false" />
             <entry key="mtom-enabled" value="true" />
         </jaxws:properties>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
     </jaxws:endpoint>
 
     <jaxws:endpoint xmlns:tns="urn:gov:hhs:fha:nhinc:adaptercore"

--- a/Product/Production/Adapters/DocumentDataSubmission_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/Product/Production/Adapters/DocumentDataSubmission_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -51,6 +51,9 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
     </jaxws:endpoint>
 
     <jaxws:endpoint xmlns:tns="urn:gov:hhs:fha:nhinc:adapterxds"

--- a/Product/Production/Adapters/DocumentQuery_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/Product/Production/Adapters/DocumentQuery_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -48,6 +48,9 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
     </jaxws:endpoint>
 
     <bean id="SOAPHeaderHandler" class="gov.hhs.fha.nhinc.callback.SOAPHeaderHandler" />

--- a/Product/Production/Adapters/DocumentRetrieve_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/Product/Production/Adapters/DocumentRetrieve_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -54,6 +54,9 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
     </jaxws:endpoint>
 
     <bean id="SOAPHeaderHandler" class="gov.hhs.fha.nhinc.callback.SOAPHeaderHandler" />

--- a/Product/Production/Adapters/DocumentSubmission_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/Product/Production/Adapters/DocumentSubmission_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -197,6 +197,9 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
     </jaxws:endpoint>
 
     <jaxws:endpoint xmlns:tns="urn:gov:hhs:fha:nhinc:adapterxdrresponse" id="AdapterXDRResponse"

--- a/Product/Production/Adapters/DocumentSubmission_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/Product/Production/Adapters/DocumentSubmission_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -49,6 +49,7 @@
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
         <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
             <ref bean="timestampInInterceptor" />
         </jaxws:inInterceptors>
         <jaxws:outFaultInterceptors>
@@ -84,6 +85,7 @@
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
         <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
             <ref bean="timestampInInterceptor" />
         </jaxws:inInterceptors>
         <jaxws:outFaultInterceptors>
@@ -117,6 +119,7 @@
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
         <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
             <ref bean="timestampInInterceptor" />
         </jaxws:inInterceptors>
         <jaxws:outFaultInterceptors>
@@ -163,6 +166,7 @@
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
         <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
             <ref bean="timestampInInterceptor" />
         </jaxws:inInterceptors>
         <jaxws:outFaultInterceptors>

--- a/Product/Production/Adapters/General/CONNECTAdapterWeb/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/Product/Production/Adapters/General/CONNECTAdapterWeb/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -34,7 +34,9 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
-
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
     </jaxws:endpoint>
 
     <jaxws:endpoint xmlns:ape="urn:gov:hhs:fha:nhinc:adapterpolicyengine" id="AdapterPolicyEngine"

--- a/Product/Production/Adapters/PatientDiscovery_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/Product/Production/Adapters/PatientDiscovery_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -55,7 +55,7 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
-         <jaxws:inInterceptors>
+        <jaxws:inInterceptors>
             <ref bean="securityConfigInInterceptor" />
         </jaxws:inInterceptors>
         <jaxws:handlers>

--- a/Product/Production/Adapters/PatientDiscovery_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/Product/Production/Adapters/PatientDiscovery_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -48,6 +48,7 @@
         serviceName="tns:AdapterMpiSecuredService" endpointName="tns:AdapterMpiSecuredPortType" implementor="gov.hhs.fha.nhinc.mpi.adapter.AdapterMpiSecured"
         wsdlLocation="classpath:wsdl/AdapterMpiSecured.wsdl">
         <jaxws:properties>
+            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -71,6 +72,7 @@
         address="/AdapterComponentMpiSecuredService" serviceName="tns:AdapterComponentMpiSecuredService" endpointName="tns:AdapterComponentMpiSecuredPort"
         implementor="gov.hhs.fha.nhinc.mpi.adapter.component.AdapterComponentMpiSecured" wsdlLocation="classpath:wsdl/AdapterComponentSecuredMpi.wsdl">
         <jaxws:properties>
+            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -94,6 +96,7 @@
         address="/AdapterPatientDiscoverySecured" serviceName="tns:AdapterPatientDiscoverySecured" endpointName="tns:AdapterPatientDiscoverySecuredPortSoap"
         implementor="gov.hhs.fha.nhinc.patientdiscovery.adapter.AdapterPatientDiscoverySecured" wsdlLocation="classpath:wsdl/AdapterPatientDiscoverySecured.wsdl">
         <jaxws:properties>
+            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -121,6 +124,7 @@
         implementor="gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.request.AdapterPatientDiscoveryDeferredRequestSecured"
         wsdlLocation="classpath:wsdl/AdapterPatientDiscoverySecuredAsyncReq.wsdl">
         <jaxws:properties>
+            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -148,6 +152,7 @@
         implementor="gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.response.AdapterPatientDiscoveryDeferredResponseSecured"
         wsdlLocation="classpath:wsdl/AdapterPatientDiscoverySecuredAsyncResp.wsdl">
         <jaxws:properties>
+            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -184,6 +189,7 @@
         implementor="gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.request.error.AdapterPatientDiscoveryDeferredRequestErrorSecured"
         wsdlLocation="classpath:wsdl/AdapterPatientDiscoverySecuredAsyncReqError.wsdl">
         <jaxws:properties>
+            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -205,6 +211,7 @@
         implementor="gov.hhs.fha.nhinc.patientlocationquery.adapter.AdapterPatientLocationQuerySecured"
         wsdlLocation="classpath:wsdl/AdapterPatientLocationQuerySecured.wsdl">
         <jaxws:properties>
+            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">

--- a/Product/Production/Adapters/PatientDiscovery_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/Product/Production/Adapters/PatientDiscovery_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -48,7 +48,6 @@
         serviceName="tns:AdapterMpiSecuredService" endpointName="tns:AdapterMpiSecuredPortType" implementor="gov.hhs.fha.nhinc.mpi.adapter.AdapterMpiSecured"
         wsdlLocation="classpath:wsdl/AdapterMpiSecured.wsdl">
         <jaxws:properties>
-            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -72,7 +71,6 @@
         address="/AdapterComponentMpiSecuredService" serviceName="tns:AdapterComponentMpiSecuredService" endpointName="tns:AdapterComponentMpiSecuredPort"
         implementor="gov.hhs.fha.nhinc.mpi.adapter.component.AdapterComponentMpiSecured" wsdlLocation="classpath:wsdl/AdapterComponentSecuredMpi.wsdl">
         <jaxws:properties>
-            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -96,7 +94,6 @@
         address="/AdapterPatientDiscoverySecured" serviceName="tns:AdapterPatientDiscoverySecured" endpointName="tns:AdapterPatientDiscoverySecuredPortSoap"
         implementor="gov.hhs.fha.nhinc.patientdiscovery.adapter.AdapterPatientDiscoverySecured" wsdlLocation="classpath:wsdl/AdapterPatientDiscoverySecured.wsdl">
         <jaxws:properties>
-            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -124,7 +121,6 @@
         implementor="gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.request.AdapterPatientDiscoveryDeferredRequestSecured"
         wsdlLocation="classpath:wsdl/AdapterPatientDiscoverySecuredAsyncReq.wsdl">
         <jaxws:properties>
-            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -152,7 +148,6 @@
         implementor="gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.response.AdapterPatientDiscoveryDeferredResponseSecured"
         wsdlLocation="classpath:wsdl/AdapterPatientDiscoverySecuredAsyncResp.wsdl">
         <jaxws:properties>
-            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -189,7 +184,6 @@
         implementor="gov.hhs.fha.nhinc.patientdiscovery.adapter.deferred.request.error.AdapterPatientDiscoveryDeferredRequestErrorSecured"
         wsdlLocation="classpath:wsdl/AdapterPatientDiscoverySecuredAsyncReqError.wsdl">
         <jaxws:properties>
-            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -211,7 +205,6 @@
         implementor="gov.hhs.fha.nhinc.patientlocationquery.adapter.AdapterPatientLocationQuerySecured"
         wsdlLocation="classpath:wsdl/AdapterPatientLocationQuerySecured.wsdl">
         <jaxws:properties>
-            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2000/09/xmldsig#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">

--- a/Product/Production/Adapters/PatientDiscovery_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/Product/Production/Adapters/PatientDiscovery_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -233,6 +233,9 @@
         <jaxws:handlers>
             <ref bean="SOAPHeaderHandler" />
         </jaxws:handlers>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
     </jaxws:endpoint>
 
     <jaxws:endpoint xmlns:tns="urn:gov:hhs:fha:nhinc:adapterpatientlocationquery" id="AdapterPatientLocationQuery"

--- a/Product/Production/Adapters/PatientDiscovery_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/Product/Production/Adapters/PatientDiscovery_a0/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -55,6 +55,9 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
+         <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
         <jaxws:handlers>
             <ref bean="SOAPHeaderHandler" />
         </jaxws:handlers>
@@ -78,6 +81,9 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
         <jaxws:handlers>
             <ref bean="SOAPHeaderHandler" />
         </jaxws:handlers>
@@ -101,6 +107,9 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
         <jaxws:handlers>
             <ref bean="SOAPHeaderHandler" />
         </jaxws:handlers>
@@ -128,6 +137,9 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
         <jaxws:handlers>
             <ref bean="SOAPHeaderHandler" />
         </jaxws:handlers>
@@ -155,6 +167,9 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
         <jaxws:handlers>
             <ref bean="SOAPHeaderHandler" />
         </jaxws:handlers>
@@ -191,6 +206,9 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
         <jaxws:handlers>
             <ref bean="SOAPHeaderHandler" />
         </jaxws:handlers>

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/SamlConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/SamlConstants.java
@@ -135,4 +135,8 @@ public class SamlConstants {
     public static final String ATTRIBUTE_FRIENDLY_NAME_XUA_IACP = "Patient Privacy Policy Acknowledgement Document";
     public static final String URI_NAME_FORMAT = "urn:oasis:names:tc:SAML:2.0:attrname-format:uri";
     public static final String ADMIN_AUTH_METHOD = "urn:oasis:names:tc:SAML:2.0:ac:classes:Password";
+    public static final String SIGNATURE_KEY = "Signatures";
+    public static final String DIGEST_KEY = "Digests";
+    public static final String SIG_ALGO_PROPERTY = "saml.SignatureAlgorithm";
+    public static final String DIG_ALGO_PROPERTY = "saml.DigestAlgorithm";
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/SamlConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/SamlConstants.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -137,6 +137,8 @@ public class SamlConstants {
     public static final String ADMIN_AUTH_METHOD = "urn:oasis:names:tc:SAML:2.0:ac:classes:Password";
     public static final String SIGNATURE_KEY = "Signatures";
     public static final String DIGEST_KEY = "Digests";
-    public static final String SIG_ALGO_PROPERTY = "saml.SignatureAlgorithm";
-    public static final String DIG_ALGO_PROPERTY = "saml.DigestAlgorithm";
+    public static final String SIG_ALGO_PROPERTY = "saml.signatureAlgorithms";
+    public static final String DIG_ALGO_PROPERTY = "saml.digestAlgorithms";
+    public static final String DEFAULT_DIG_ALGO_PROPERTY = "saml.defaultDigestAlgorithm";
+    public static final String DEFAULT_SIG_ALGO_PROPERTY = "saml.defaultSignatureAlgorithm";
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandler.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandler.java
@@ -50,6 +50,7 @@ import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.common.saml.SAMLCallback;
 import org.apache.wss4j.common.saml.bean.Version;
 import org.apache.wss4j.policy.SPConstants;
+import org.opensaml.xmlsec.signature.support.SignatureConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,6 +63,9 @@ public class CXFSAMLCallbackHandler implements CallbackHandler {
     private static final Logger LOG = LoggerFactory.getLogger(CXFSAMLCallbackHandler.class);
     private PropertyAccessor accessor;
     public static final String HOK_CONFIRM = "urn:oasis:names:tc:SAML:2.0:cm:holder-of-key";
+    private static final String PROPERTY_FILE_NAME = "assertioninfo";
+    private static final String SIG_ALGO = "saml.SignatureAlgorithm";
+    private static final String DIG_ALGO = "saml.DigestAlgorithm";
     private HOKSAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder();
     private Crypto issuerCrypto = null;
 
@@ -105,8 +109,14 @@ public class CXFSAMLCallbackHandler implements CallbackHandler {
                         NhincConstants.SIGNATURE_PROPERTIES_STRING));
                     oSAMLCallback.setIssuerCrypto(issuerCrypto);
                     oSAMLCallback.setSamlVersion(Version.SAML_20);
-                    oSAMLCallback.setSignatureAlgorithm(SPConstants.SHA1);
-                    oSAMLCallback.setSignatureDigestAlgorithm(SPConstants.SHA1);
+
+                    String salgorithm = PropertyAccessor.getInstance().getProperty(PROPERTY_FILE_NAME, SIG_ALGO,
+                        SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
+
+                    String dalgorithm = PropertyAccessor.getInstance().getProperty(PROPERTY_FILE_NAME, DIG_ALGO,
+                        SPConstants.SHA1);
+                    oSAMLCallback.setSignatureAlgorithm(salgorithm);
+                    oSAMLCallback.setSignatureDigestAlgorithm(dalgorithm);
 
                     final SamlTokenCreator creator = new SamlTokenCreator();
                     final CallbackProperties properties = new CallbackMapProperties(addMessageProperties(

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandler.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandler.java
@@ -106,8 +106,8 @@ public class CXFSAMLCallbackHandler implements CallbackHandler {
                     oSAMLCallback.setIssuerCrypto(issuerCrypto);
                     oSAMLCallback.setSamlVersion(Version.SAML_20);
 
-                    oSAMLCallback.setSignatureAlgorithm(SAMLUtils.getSignatureAlgorithm());
-                    oSAMLCallback.setSignatureDigestAlgorithm(SAMLUtils.getDigestAlgorithm());
+                    oSAMLCallback.setSignatureAlgorithm(SAMLUtils.extractSignatureFromAssertion(custAssertion));
+                    oSAMLCallback.setSignatureDigestAlgorithm(SAMLUtils.extractDigestFromAssertion(custAssertion));
 
                     final SamlTokenCreator creator = new SamlTokenCreator();
                     final CallbackProperties properties = new CallbackMapProperties(addMessageProperties(

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandler.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandler.java
@@ -31,6 +31,7 @@ import gov.hhs.fha.nhinc.callback.opensaml.CallbackMapProperties;
 import gov.hhs.fha.nhinc.callback.opensaml.CallbackProperties;
 import gov.hhs.fha.nhinc.callback.opensaml.HOKSAMLAssertionBuilder;
 import gov.hhs.fha.nhinc.callback.opensaml.SAMLAssertionBuilderException;
+import gov.hhs.fha.nhinc.callback.opensaml.SAMLUtils;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.cryptostore.StoreUtil;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
@@ -49,8 +50,6 @@ import org.apache.wss4j.common.crypto.CryptoFactory;
 import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.common.saml.SAMLCallback;
 import org.apache.wss4j.common.saml.bean.Version;
-import org.apache.wss4j.policy.SPConstants;
-import org.opensaml.xmlsec.signature.support.SignatureConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,9 +62,6 @@ public class CXFSAMLCallbackHandler implements CallbackHandler {
     private static final Logger LOG = LoggerFactory.getLogger(CXFSAMLCallbackHandler.class);
     private PropertyAccessor accessor;
     public static final String HOK_CONFIRM = "urn:oasis:names:tc:SAML:2.0:cm:holder-of-key";
-    private static final String PROPERTY_FILE_NAME = "assertioninfo";
-    private static final String SIG_ALGO = "saml.SignatureAlgorithm";
-    private static final String DIG_ALGO = "saml.DigestAlgorithm";
     private HOKSAMLAssertionBuilder builder = new HOKSAMLAssertionBuilder();
     private Crypto issuerCrypto = null;
 
@@ -110,13 +106,8 @@ public class CXFSAMLCallbackHandler implements CallbackHandler {
                     oSAMLCallback.setIssuerCrypto(issuerCrypto);
                     oSAMLCallback.setSamlVersion(Version.SAML_20);
 
-                    String salgorithm = PropertyAccessor.getInstance().getProperty(PROPERTY_FILE_NAME, SIG_ALGO,
-                        SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
-
-                    String dalgorithm = PropertyAccessor.getInstance().getProperty(PROPERTY_FILE_NAME, DIG_ALGO,
-                        SPConstants.SHA1);
-                    oSAMLCallback.setSignatureAlgorithm(salgorithm);
-                    oSAMLCallback.setSignatureDigestAlgorithm(dalgorithm);
+                    oSAMLCallback.setSignatureAlgorithm(SAMLUtils.getSignatureAlgorithm());
+                    oSAMLCallback.setSignatureDigestAlgorithm(SAMLUtils.getDigestAlgorithm());
 
                     final SamlTokenCreator creator = new SamlTokenCreator();
                     final CallbackProperties properties = new CallbackMapProperties(addMessageProperties(

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/wss/CONNECTSignatureProcessor.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/wss/CONNECTSignatureProcessor.java
@@ -36,7 +36,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import javax.activation.DataHandler;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.cxf.binding.soap.SoapMessage;
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.message.Attachment;
@@ -88,12 +87,14 @@ public class CONNECTSignatureProcessor extends SignatureProcessor {
     }
 
     private static boolean isCustomAlgorithmSet(List<String> signatureAlgorithms, List<String> digestAlgorithms) {
-        boolean isPopulated =  CollectionUtils.isNotEmpty(signatureAlgorithms) && CollectionUtils.isNotEmpty(digestAlgorithms);
+
+        if (signatureAlgorithms == null || digestAlgorithms == null) {
+            return false;
+        }
 
         boolean isSHA1 = signatureAlgorithms.size() == 1 && SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1.equals(signatureAlgorithms.get(0))
             && digestAlgorithms.size() == 1 && SignatureConstants.ALGO_ID_DIGEST_SHA1.equals(digestAlgorithms.get(0));
-
-        return isPopulated && !isSHA1;
+        return !isSHA1;
     }
 
     private List<WSSecurityEngineResult> handleCustomAlgorithm(Element signatureElem, RequestData data,

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackMapProperties.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackMapProperties.java
@@ -37,6 +37,7 @@ import org.apache.cxf.helpers.CastUtils;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
+import org.opensaml.xmlsec.signature.support.SignatureConstants;
 
 /**
  * @author bhumphrey
@@ -555,6 +556,22 @@ public class CallbackMapProperties implements CallbackProperties {
         } else {
             return new ArrayList<SAMLSubjectConfirmation>();
         }
+    }
+
+    /* (non-Javadoc)
+     * @see gov.hhs.fha.nhinc.callback.opensaml.CallbackProperties#getSignatureAlgorithm()
+     */
+    @Override
+    public String getSignatureAlgorithm() {
+        return getNullSafeString(SamlConstants.SIGNATURE_KEY, SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
+    }
+
+    /* (non-Javadoc)
+     * @see gov.hhs.fha.nhinc.callback.opensaml.CallbackProperties#getDigestAlgorithm()
+     */
+    @Override
+    public String getDigestAlgorithm() {
+        return getNullSafeString(SamlConstants.DIGEST_KEY, SignatureConstants.ALGO_ID_DIGEST_SHA1);
     }
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackMapProperties.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackMapProperties.java
@@ -57,361 +57,181 @@ public class CallbackMapProperties implements CallbackProperties {
         map.putAll(properties);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getAssertionIssuerFormat()
-     */
     @Override
     public String getAssertionIssuerFormat() {
         return getNullSafeString(SamlConstants.ASSERTION_ISSUER_FORMAT_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getIssuer()
-     */
     @Override
     public String getIssuer() {
         return getNullSafeString(SamlConstants.ASSERTION_ISSUER_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getUsername()
-     */
     @Override
     public String getUsername() {
         return getNullSafeString(SamlConstants.USER_NAME_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getAuthenticationStatementExists()
-     */
     @Override
     public Boolean getAuthenticationStatementExists() {
         return getNullSafeBoolean(SamlConstants.AUTHN_STATEMENT_EXISTS_PROP, Boolean.FALSE);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getAuthenicationContextClass()
-     */
     @Override
     public String getAuthenticationContextClass() {
         return getNullSafeString(SamlConstants.AUTHN_CONTEXT_CLASS_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getAuthenicationSessionIndex()
-     */
     @Override
     public String getAuthenticationSessionIndex() {
         return getNullSafeString(SamlConstants.AUTHN_SESSION_INDEX_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getAuthenicationInstant()
-     */
     @Override
     public DateTime getAuthenticationInstant() {
         return getNullSafeDateTime(SamlConstants.AUTHN_INSTANT_PROP, null);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getSamlConditionsNotBefore()
-     */
     @Override
     public DateTime getSamlConditionsNotBefore() {
         return getNullSafeDateTime(SamlConstants.SAMLCONDITIONS_NOT_BEFORE_PROP, null);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getEvidenceConditionNotAfter()
-     */
     @Override
     public DateTime getSamlConditionsNotAfter() {
         return getNullSafeDateTime(SamlConstants.SAMLCONDITIONS_NOT_AFTER_PROP, null);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getSubjectLocality()
-     */
     @Override
     public String getSubjectLocality() {
         return getNullSafeString(SamlConstants.SUBJECT_LOCALITY_ADDR_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getSubjectDNS()
-     */
     @Override
     public String getSubjectDNS() {
         return getNullSafeString(SamlConstants.SUBJECT_LOCALITY_DNS_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getAuthenicationStatementExists()
-     */
     @Override
     public Boolean getAuthorizationStatementExists() {
         return getNullSafeBoolean(SamlConstants.AUTHZ_STATEMENT_EXISTS_PROP, Boolean.FALSE);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getAuthnicationResource()
-     */
     @Override
     public String getAuthorizationResource() {
         return getNullSafeString(SamlConstants.RESOURCE_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getAuthenicationDecision()
-     */
     @Override
     public String getAuthorizationDecision() {
         return getNullSafeString(SamlConstants.AUTHZ_DECISION_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getEvidenceID()
-     */
     @Override
     public String getEvidenceID() {
         return getNullSafeString(SamlConstants.EVIDENCE_ID_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getEvidenceInstant()
-     */
     @Override
     public DateTime getEvidenceInstant() {
         return getNullSafeDateTime(SamlConstants.EVIDENCE_INSTANT_PROP, null);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getEvidenceIssuerFormat()
-     */
     @Override
     public String getEvidenceIssuerFormat() {
         return getNullSafeString(SamlConstants.EVIDENCE_ISSUER_FORMAT_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getEvidenceIssuer()
-     */
     @Override
     public String getEvidenceIssuer() {
         return getNullSafeString(SamlConstants.EVIDENCE_ISSUER_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getEvidenceConditionNotBefore()
-     */
     @Override
     public DateTime getEvidenceConditionNotBefore() {
         return getNullSafeDateTime(SamlConstants.EVIDENCE_CONDITION_NOT_BEFORE_PROP, null);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getEvidenceConditionNotAfter()
-     */
     @Override
     public DateTime getEvidenceConditionNotAfter() {
         return getNullSafeDateTime(SamlConstants.EVIDENCE_CONDITION_NOT_AFTER_PROP, null);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getEvidenceAccessConstent()
-     */
     @Override
     public List<Object> getEvidenceAccessConstent() {
         return getNullSafeList(SamlConstants.EVIDENCE_ACCESS_CONSENT_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getEvidenceInstanctAccessConsent()
-     */
     @Override
     public List<Object> getEvidenceInstantAccessConsent() {
         return getNullSafeList(SamlConstants.EVIDENCE_INST_ACCESS_CONSENT_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getEvidenceSubject()
-     */
     @Override
     public String getEvidenceSubject() {
         return getNullSafeString(SamlConstants.EVIDENCE_SUBJECT_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getUserCode()
-     */
     @Override
     public String getUserCode() {
         return getNullSafeString(SamlConstants.USER_CODE_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getUserSystem()
-     */
     @Override
     public String getUserSystem() {
         return getNullSafeString(SamlConstants.USER_SYST_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getUserSystemName()
-     */
     @Override
     public String getUserSystemName() {
         return getNullSafeString(SamlConstants.USER_SYST_NAME_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getUserDisplay()
-     */
     @Override
     public String getUserDisplay() {
         return getNullSafeString(SamlConstants.USER_DISPLAY_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getPurposeCode()
-     */
     @Override
     public String getPurposeCode() {
         return getNullSafeString(SamlConstants.PURPOSE_CODE_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getPurposeSystem()
-     */
     @Override
     public String getPurposeSystem() {
         return getNullSafeString(SamlConstants.PURPOSE_SYST_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getPurposeSystemName()
-     */
     @Override
     public String getPurposeSystemName() {
         return getNullSafeString(SamlConstants.PURPOSE_SYST_NAME_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getPurposeDisplay()
-     */
     @Override
     public String getPurposeDisplay() {
         return getNullSafeString(SamlConstants.PURPOSE_DISPLAY_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getUserOrganization()
-     */
     @Override
     public String getUserOrganization() {
         return getNullSafeString(SamlConstants.USER_ORG_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getUserOrganization()
-     */
     @Override
     public String getUserOrganizationId() {
         return getNullSafeString(SamlConstants.USER_ORG_ID_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getHomeCommunity()
-     */
     @Override
     public String getHomeCommunity() {
         return getNullSafeString(SamlConstants.HOME_COM_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getPatientID()
-     */
     @Override
     public String getPatientID() {
         return getNullSafeString(SamlConstants.PATIENT_ID_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getUserFullName()
-     */
     @Override
     public String getUserFullName() {
         StringBuilder nameConstruct = new StringBuilder();
@@ -439,21 +259,11 @@ public class CallbackMapProperties implements CallbackProperties {
         return nameConstruct.toString();
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getTargetHomeCommunityId()
-     */
     @Override
     public String getTargetHomeCommunityId() {
         return getNullSafeString(NhincConstants.WS_SOAP_TARGET_HOME_COMMUNITY_ID);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getAction()
-     */
     @Override
     public String getAction() {
         return getNullSafeString(SamlConstants.ACTION_PROP);
@@ -464,11 +274,6 @@ public class CallbackMapProperties implements CallbackProperties {
         return getNullSafeString(NhincConstants.SERVICE_NAME);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.openSAML.CallbackProperties#getTargetApiLevel()
-     */
     @Override
     public GATEWAY_API_LEVEL getTargetApiLevel() {
         return (GATEWAY_API_LEVEL) getNullSafeObject(NhincConstants.TARGET_API_LEVEL, null);
@@ -543,11 +348,6 @@ public class CallbackMapProperties implements CallbackProperties {
         return getNullSafeString(SamlConstants.IACP_ATTRIBUTE_PROP);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see gov.hhs.fha.nhinc.callback.opensaml.CallbackProperties#getSubjectConfirmations()
-     */
     @Override
     public List<SAMLSubjectConfirmation> getSubjectConfirmations() {
         List<Object> senderObj = getNullSafeList(SamlConstants.SUBJECT_CONFIRMATION);
@@ -558,17 +358,11 @@ public class CallbackMapProperties implements CallbackProperties {
         }
     }
 
-    /* (non-Javadoc)
-     * @see gov.hhs.fha.nhinc.callback.opensaml.CallbackProperties#getSignatureAlgorithm()
-     */
     @Override
     public String getSignatureAlgorithm() {
         return getNullSafeString(SamlConstants.SIGNATURE_KEY, SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
     }
 
-    /* (non-Javadoc)
-     * @see gov.hhs.fha.nhinc.callback.opensaml.CallbackProperties#getDigestAlgorithm()
-     */
     @Override
     public String getDigestAlgorithm() {
         return getNullSafeString(SamlConstants.DIGEST_KEY, SignatureConstants.ALGO_ID_DIGEST_SHA1);

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackProperties.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackProperties.java
@@ -260,12 +260,12 @@ public interface CallbackProperties {
     List<SAMLSubjectConfirmation> getSubjectConfirmations();
 
     /**
-     * @return
+     * @return the requested Signature Algorithm
      */
     public String getSignatureAlgorithm();
 
     /**
-     * @return
+     * @return The requested Digest Algorithm
      */
     public String getDigestAlgorithm();
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackProperties.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/CallbackProperties.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -235,16 +235,16 @@ public interface CallbackProperties {
      * @return
      */
     public String getNPI();
-    
+
     /**
-     * 
-     * @return 
+     *
+     * @return
      */
     public String getAcpAttribute();
-    
+
     /**
-     * 
-     * @return 
+     *
+     * @return
      */
     public String getIacpAttribute();
 
@@ -258,5 +258,15 @@ public interface CallbackProperties {
      * @return List of subject confirmation
      */
     List<SAMLSubjectConfirmation> getSubjectConfirmations();
+
+    /**
+     * @return
+     */
+    public String getSignatureAlgorithm();
+
+    /**
+     * @return
+     */
+    public String getDigestAlgorithm();
 
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
@@ -89,7 +89,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
     private final OpenSAML2ComponentBuilder componentBuilder;
     private static final String PROPERTY_FILE_NAME = "assertioninfo";
     private static final String PROPERTY_SAML_ISSUER_NAME = "SamlIssuerName";
-
+    private static final String DIG_ALGO = "saml.DigestAlgorithm";
     public HOKSAMLAssertionBuilder() {
         certificateManager = CertificateManagerImpl.getInstance();
         componentBuilder = OpenSAML2ComponentBuilder.getInstance();
@@ -159,7 +159,10 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
                 publicKey);
             final SamlAssertionWrapper wrapper = new SamlAssertionWrapper(assertion);
 
-            wrapper.setSignature(signature, SignatureConstants.ALGO_ID_DIGEST_SHA1);
+            String algorithm = PropertyAccessor.getInstance().getProperty(PROPERTY_FILE_NAME, DIG_ALGO,
+                SignatureConstants.ALGO_ID_DIGEST_SHA1);
+
+            wrapper.setSignature(signature, algorithm);
             final MarshallerFactory marshallerFactory = XMLObjectProviderRegistrySupport.getMarshallerFactory();
             final Marshaller marshaller = marshallerFactory.getMarshaller(wrapper.getSamlObject());
             assertionElement = marshaller.marshall(wrapper.getSamlObject());

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
@@ -133,7 +133,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
             assertion.getStatements().addAll(
                 createAttributeStatements(properties, createEvidenceSubject(properties, certificate, publicKey)));
 
-            signedAssertion = sign(assertion, certificate, privateKey, publicKey);
+            signedAssertion = sign(properties, assertion, certificate, privateKey, publicKey);
         } catch (final SAMLComponentBuilderException | CertificateManagerException ex) {
             LOG.error("Unable to create HOK Assertion: {}", ex.getLocalizedMessage());
             throw new SAMLAssertionBuilderException(ex.getLocalizedMessage(), ex);
@@ -143,21 +143,22 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
     }
 
     /**
+     * @param properties
      * @param assertion
      * @param privateKey
      * @param certificate
      * @param publicKey
      * @return
      */
-    protected Element sign(final Assertion assertion, final X509Certificate certificate, final PrivateKey privateKey,
+    protected Element sign(CallbackProperties properties, final Assertion assertion, final X509Certificate certificate, final PrivateKey privateKey,
         final PublicKey publicKey) {
         Element assertionElement = null;
         try {
-            final Signature signature = OpenSAML2ComponentBuilder.getInstance().createSignature(certificate, privateKey,
+            final Signature signature = OpenSAML2ComponentBuilder.getInstance().createSignature(properties, certificate, privateKey,
                 publicKey);
             final SamlAssertionWrapper wrapper = new SamlAssertionWrapper(assertion);
 
-            wrapper.setSignature(signature, SAMLUtils.getDigestAlgorithm());
+            wrapper.setSignature(signature, properties.getDigestAlgorithm());
             final MarshallerFactory marshallerFactory = XMLObjectProviderRegistrySupport.getMarshallerFactory();
             final Marshaller marshaller = marshallerFactory.getMarshaller(wrapper.getSamlObject());
             assertionElement = marshaller.marshall(wrapper.getSamlObject());

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
@@ -64,7 +64,6 @@ import org.opensaml.saml.saml2.core.Statement;
 import org.opensaml.saml.saml2.core.Subject;
 import org.opensaml.saml.saml2.core.SubjectConfirmation;
 import org.opensaml.xmlsec.signature.Signature;
-import org.opensaml.xmlsec.signature.support.SignatureConstants;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.opensaml.xmlsec.signature.support.Signer;
 import org.slf4j.Logger;
@@ -89,7 +88,6 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
     private final OpenSAML2ComponentBuilder componentBuilder;
     private static final String PROPERTY_FILE_NAME = "assertioninfo";
     private static final String PROPERTY_SAML_ISSUER_NAME = "SamlIssuerName";
-    private static final String DIG_ALGO = "saml.DigestAlgorithm";
     public HOKSAMLAssertionBuilder() {
         certificateManager = CertificateManagerImpl.getInstance();
         componentBuilder = OpenSAML2ComponentBuilder.getInstance();
@@ -159,10 +157,7 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
                 publicKey);
             final SamlAssertionWrapper wrapper = new SamlAssertionWrapper(assertion);
 
-            String algorithm = PropertyAccessor.getInstance().getProperty(PROPERTY_FILE_NAME, DIG_ALGO,
-                SignatureConstants.ALGO_ID_DIGEST_SHA1);
-
-            wrapper.setSignature(signature, algorithm);
+            wrapper.setSignature(signature, SAMLUtils.getDigestAlgorithm());
             final MarshallerFactory marshallerFactory = XMLObjectProviderRegistrySupport.getMarshallerFactory();
             final Marshaller marshaller = marshallerFactory.getMarshaller(wrapper.getSamlObject());
             assertionElement = marshaller.marshall(wrapper.getSamlObject());

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
@@ -637,6 +637,7 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
 
     /**
      * Creates the signature.
+     * @param properties
      *
      * @param certificate the certificate
      * @param privateKey the private key
@@ -644,7 +645,7 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
      * @return the signature
      * @throws SAMLComponentBuilderException the exception
      */
-    public Signature createSignature(final X509Certificate certificate, final PrivateKey privateKey,
+    public Signature createSignature(CallbackProperties properties, final X509Certificate certificate, final PrivateKey privateKey,
         final PublicKey publicKey) {
         final BasicX509Credential credential = new BasicX509Credential(certificate, privateKey);
         credential.setEntityCertificate(certificate);
@@ -653,7 +654,7 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
         final Signature signature = OpenSAMLUtil.buildSignature();
         signature.setSigningCredential(credential);
 
-        signature.setSignatureAlgorithm(SAMLUtils.getSignatureAlgorithm());
+        signature.setSignatureAlgorithm(properties.getSignatureAlgorithm());
 
         signature.setCanonicalizationAlgorithm(SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS);
         try {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
@@ -96,7 +96,7 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
     private static final String X509_NAME_ID = "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName";
     private static final String NAME_FORMAT_STRING = "urn:oasis:names:tc:SAML:2.0:attrname-format:uri";
     private static final String PROPERTY_FILE_NAME = "assertioninfo";
-    private static final String SIG_ALGO = "saml.DigestAlgorithm";
+    private static final String SIG_ALGO = "saml.SignatureAlgorithm";
     private final SAMLObjectBuilder<Evidence> evidenceBuilder;
     private final XSAnyBuilder xsAnyBuilder;
     private static OpenSAML2ComponentBuilder openSamlInstance;

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
@@ -95,8 +95,6 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
     private final SAMLObjectBuilder<AttributeStatement> attributeStatementBuilder;
     private static final String X509_NAME_ID = "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName";
     private static final String NAME_FORMAT_STRING = "urn:oasis:names:tc:SAML:2.0:attrname-format:uri";
-    private static final String PROPERTY_FILE_NAME = "assertioninfo";
-    private static final String SIG_ALGO = "saml.SignatureAlgorithm";
     private final SAMLObjectBuilder<Evidence> evidenceBuilder;
     private final XSAnyBuilder xsAnyBuilder;
     private static OpenSAML2ComponentBuilder openSamlInstance;
@@ -655,10 +653,7 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
         final Signature signature = OpenSAMLUtil.buildSignature();
         signature.setSigningCredential(credential);
 
-        String algorithm = PropertyAccessor.getInstance().getProperty(PROPERTY_FILE_NAME, SIG_ALGO,
-            SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
-
-        signature.setSignatureAlgorithm(algorithm);
+        signature.setSignatureAlgorithm(SAMLUtils.getSignatureAlgorithm());
 
         signature.setCanonicalizationAlgorithm(SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS);
         try {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/OpenSAML2ComponentBuilder.java
@@ -92,19 +92,14 @@ import org.slf4j.LoggerFactory;
  */
 public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
 
-
     private final SAMLObjectBuilder<AttributeStatement> attributeStatementBuilder;
-
     private static final String X509_NAME_ID = "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName";
-
     private static final String NAME_FORMAT_STRING = "urn:oasis:names:tc:SAML:2.0:attrname-format:uri";
-
+    private static final String PROPERTY_FILE_NAME = "assertioninfo";
+    private static final String SIG_ALGO = "saml.DigestAlgorithm";
     private final SAMLObjectBuilder<Evidence> evidenceBuilder;
-
     private final XSAnyBuilder xsAnyBuilder;
-
     private static OpenSAML2ComponentBuilder openSamlInstance;
-
     private static final Logger LOG = LoggerFactory.getLogger(OpenSAML2ComponentBuilder.class);
 
     /**
@@ -660,7 +655,10 @@ public class OpenSAML2ComponentBuilder implements SAMLCompontentBuilder {
         final Signature signature = OpenSAMLUtil.buildSignature();
         signature.setSigningCredential(credential);
 
-        signature.setSignatureAlgorithm(SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
+        String algorithm = PropertyAccessor.getInstance().getProperty(PROPERTY_FILE_NAME, SIG_ALGO,
+            SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
+
+        signature.setSignatureAlgorithm(algorithm);
 
         signature.setCanonicalizationAlgorithm(SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS);
         try {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/SAMLUtils.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/SAMLUtils.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above
+ *       copyright notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of the United States Government nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE UNITED STATES GOVERNMENT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package gov.hhs.fha.nhinc.callback.opensaml;
+
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
+import gov.hhs.fha.nhinc.nhinclib.NhincConstants.SHA_TYPE;
+import gov.hhs.fha.nhinc.properties.PropertyAccessor;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.opensaml.xmlsec.signature.support.SignatureConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SAMLUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(SAMLUtils.class);
+    private static final String DIG_ALGO = "saml.DigestAlgorithm";
+    private static final String SIG_ALGO = "saml.SignatureAlgorithm";
+    /**
+     * @return
+     */
+    public static String getDigestAlgorithm() {
+        return PropertyAccessor.getInstance().getProperty(NhincConstants.ASSERTION_INFO_PROPERTY_FILE, DIG_ALGO,
+            SignatureConstants.ALGO_ID_DIGEST_SHA1);
+    }
+    /**
+     * @return
+     */
+    public static String getSignatureAlgorithm() {
+        return PropertyAccessor.getInstance().getProperty(NhincConstants.ASSERTION_INFO_PROPERTY_FILE, SIG_ALGO,
+            SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
+    }
+
+    public String getResolvedNamespace(String uri) {
+        String resolved = null;
+        try {
+            SignatureConstants.class.getDeclaredField(uri);
+        } catch (NoSuchFieldException e) {
+            // Not a constant value, is it a manual namespace?
+            if (uri.indexOf("http://") == 0) {
+                resolved = uri;
+            } else {
+                LOG.error("Could not resove SAML algorithm: {}. Not a URL or constant field found in org.opensaml.xmlsec.signature.support.SignatureConstants.class",uri, e);
+                throw new SAMLAssertionBuilderException(e.getMessage());
+            }
+        } catch (SecurityException e) {
+            LOG.error("Could not resolve SAML algorithm: {}",uri, e);
+            throw new SAMLAssertionBuilderException(e.getMessage());
+        }
+
+        return resolved;
+    }
+
+    public List<SHA_TYPE> getConfigurableSHA() {
+        String configurableProperty = PropertyAccessor.getInstance().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE,
+            NhincConstants.CONFIG_SHA, SHA_TYPE.SHA1.name());
+        List<String> configurablePropertyList = Arrays.asList(StringUtils.split(configurableProperty, ","));
+        List<SHA_TYPE> SHATypeList = new ArrayList<>();
+        for (String sha : configurablePropertyList) {
+            SHA_TYPE shaType = SHA_TYPE.getSHAType(sha);
+            if (shaType != null) {
+                SHATypeList.add(shaType);
+            }
+        }
+        return SHATypeList;
+
+    }
+}

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/SAMLUtils.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/SAMLUtils.java
@@ -48,20 +48,14 @@ public class SAMLUtils {
 
     }
 
-    /**
-     * @param string
-     * @return
-     */
+
     public static String getDigestAlgorithm() {
         String algo = PropertyAccessor.getInstance().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE, SamlConstants.DEFAULT_DIG_ALGO_PROPERTY,
             SignatureConstants.ALGO_ID_DIGEST_SHA1);
 
         return constructNamespace(algo);
     }
-    /**
-     * @param string
-     * @return
-     */
+
     public static String getSignatureAlgorithm() {
         String algo = PropertyAccessor.getInstance().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE, SamlConstants.DEFAULT_SIG_ALGO_PROPERTY,
             SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
@@ -97,6 +91,12 @@ public class SAMLUtils {
         return list;
     }
 
+    /**
+     * Gets the configuration for SAML Signature and Digest algorithms.
+     *
+     * The configuration takes in a comma separated list of either the constant string from SignatureConstants
+     * or the full URI of the requested algorithm.
+     */
     public static Map<String, List<String>> getConfigurableSHA() {
         String digestAlgorithms = PropertyAccessor.getInstance().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE,
             SamlConstants.DIG_ALGO_PROPERTY, SignatureConstants.ALGO_ID_DIGEST_SHA1);

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/SAMLUtils.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/SAMLUtils.java
@@ -50,14 +50,14 @@ public class SAMLUtils {
 
 
     public static String getDigestAlgorithm() {
-        String algo = PropertyAccessor.getInstance().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE, SamlConstants.DEFAULT_DIG_ALGO_PROPERTY,
+        String algo = PropertyAccessor.getInstance().getProperty(NhincConstants.SAML_PROPERTY_FILE, SamlConstants.DEFAULT_DIG_ALGO_PROPERTY,
             SignatureConstants.ALGO_ID_DIGEST_SHA1);
 
         return constructNamespace(algo);
     }
 
     public static String getSignatureAlgorithm() {
-        String algo = PropertyAccessor.getInstance().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE, SamlConstants.DEFAULT_SIG_ALGO_PROPERTY,
+        String algo = PropertyAccessor.getInstance().getProperty(NhincConstants.SAML_PROPERTY_FILE, SamlConstants.DEFAULT_SIG_ALGO_PROPERTY,
             SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
 
         return constructNamespace(algo);
@@ -98,10 +98,10 @@ public class SAMLUtils {
      * or the full URI of the requested algorithm.
      */
     public static Map<String, List<String>> getConfigurableSHA() {
-        String digestAlgorithms = PropertyAccessor.getInstance().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE,
+        String digestAlgorithms = PropertyAccessor.getInstance().getProperty(NhincConstants.SAML_PROPERTY_FILE,
             SamlConstants.DIG_ALGO_PROPERTY, SignatureConstants.ALGO_ID_DIGEST_SHA1);
 
-        String signatureAlgorithms = PropertyAccessor.getInstance().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE,
+        String signatureAlgorithms = PropertyAccessor.getInstance().getProperty(NhincConstants.SAML_PROPERTY_FILE,
             SamlConstants.SIG_ALGO_PROPERTY, SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
 
         HashMap<String, List<String>> configSHA = new HashMap<>();
@@ -113,10 +113,10 @@ public class SAMLUtils {
     }
 
     public static String extractSignatureFromAssertion(AssertionType assertion) {
-        return assertion != null && !StringUtils.isBlank(assertion.getSignatureAlgorithm()) ?  assertion.getSignatureAlgorithm() : getSignatureAlgorithm();
+        return assertion != null && StringUtils.isNotBlank(assertion.getSignatureAlgorithm()) ?  assertion.getSignatureAlgorithm() : getSignatureAlgorithm();
     }
 
     public static String extractDigestFromAssertion(AssertionType assertion) {
-        return assertion != null && !StringUtils.isBlank(assertion.getDigestAlgorithm()) ?  assertion.getDigestAlgorithm() : getDigestAlgorithm();
+        return assertion != null && StringUtils.isNotBlank(assertion.getDigestAlgorithm()) ?  assertion.getDigestAlgorithm() : getDigestAlgorithm();
     }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/SAMLUtils.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/SAMLUtils.java
@@ -53,16 +53,20 @@ public class SAMLUtils {
      * @return
      */
     public static String getDigestAlgorithm() {
-        return PropertyAccessor.getInstance().getProperty(NhincConstants.ASSERTION_INFO_PROPERTY_FILE, SamlConstants.DIG_ALGO_PROPERTY,
+        String algo = PropertyAccessor.getInstance().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE, SamlConstants.DEFAULT_DIG_ALGO_PROPERTY,
             SignatureConstants.ALGO_ID_DIGEST_SHA1);
+
+        return constructNamespace(algo);
     }
     /**
      * @param string
      * @return
      */
     public static String getSignatureAlgorithm() {
-        return PropertyAccessor.getInstance().getProperty(NhincConstants.ASSERTION_INFO_PROPERTY_FILE, SamlConstants.SIG_ALGO_PROPERTY,
+        String algo = PropertyAccessor.getInstance().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE, SamlConstants.DEFAULT_SIG_ALGO_PROPERTY,
             SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
+
+        return constructNamespace(algo);
     }
 
 
@@ -76,7 +80,7 @@ public class SAMLUtils {
                 return uri;
             } else {
                 LOG.error("Could not resove SAML algorithm: {}. Not a URL or constant field found in org.opensaml.xmlsec.signature.support.SignatureConstants",uri, e);
-                throw new SAMLAssertionBuilderException(e.getMessage());
+                throw new SAMLAssertionBuilderException(uri + " is not a valid algorithm");
             }
         } catch (SecurityException | IllegalArgumentException | IllegalAccessException e) {
             LOG.error("Could not resolve SAML algorithm: {}",uri, e);
@@ -99,8 +103,8 @@ public class SAMLUtils {
 
         String signatureAlgorithms = PropertyAccessor.getInstance().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE,
             SamlConstants.SIG_ALGO_PROPERTY, SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
-        HashMap<String, List<String>> configSHA = new HashMap<>();
 
+        HashMap<String, List<String>> configSHA = new HashMap<>();
         configSHA.put(SamlConstants.DIGEST_KEY, constructNamespaceList(StringUtils.split(digestAlgorithms, ",")));
         configSHA.put(SamlConstants.SIGNATURE_KEY, constructNamespaceList(StringUtils.split(signatureAlgorithms, ",")));
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/SAMLUtils.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/SAMLUtils.java
@@ -26,68 +26,93 @@
  */
 package gov.hhs.fha.nhinc.callback.opensaml;
 
+import gov.hhs.fha.nhinc.callback.SamlConstants;
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
-import gov.hhs.fha.nhinc.nhinclib.NhincConstants.SHA_TYPE;
 import gov.hhs.fha.nhinc.properties.PropertyAccessor;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.opensaml.xmlsec.signature.support.SignatureConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SAMLUtils {
+
     private static final Logger LOG = LoggerFactory.getLogger(SAMLUtils.class);
-    private static final String DIG_ALGO = "saml.DigestAlgorithm";
-    private static final String SIG_ALGO = "saml.SignatureAlgorithm";
+
+    private SAMLUtils() {
+
+    }
+
     /**
+     * @param string
      * @return
      */
     public static String getDigestAlgorithm() {
-        return PropertyAccessor.getInstance().getProperty(NhincConstants.ASSERTION_INFO_PROPERTY_FILE, DIG_ALGO,
+        return PropertyAccessor.getInstance().getProperty(NhincConstants.ASSERTION_INFO_PROPERTY_FILE, SamlConstants.DIG_ALGO_PROPERTY,
             SignatureConstants.ALGO_ID_DIGEST_SHA1);
     }
     /**
+     * @param string
      * @return
      */
     public static String getSignatureAlgorithm() {
-        return PropertyAccessor.getInstance().getProperty(NhincConstants.ASSERTION_INFO_PROPERTY_FILE, SIG_ALGO,
+        return PropertyAccessor.getInstance().getProperty(NhincConstants.ASSERTION_INFO_PROPERTY_FILE, SamlConstants.SIG_ALGO_PROPERTY,
             SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
     }
 
-    public String getResolvedNamespace(String uri) {
-        String resolved = null;
+
+    private static String constructNamespace(String uri) {
         try {
-            SignatureConstants.class.getDeclaredField(uri);
+            Field field = SignatureConstants.class.getDeclaredField(uri);
+            return (String) field.get(null);
         } catch (NoSuchFieldException e) {
             // Not a constant value, is it a manual namespace?
             if (uri.indexOf("http://") == 0) {
-                resolved = uri;
+                return uri;
             } else {
-                LOG.error("Could not resove SAML algorithm: {}. Not a URL or constant field found in org.opensaml.xmlsec.signature.support.SignatureConstants.class",uri, e);
+                LOG.error("Could not resove SAML algorithm: {}. Not a URL or constant field found in org.opensaml.xmlsec.signature.support.SignatureConstants",uri, e);
                 throw new SAMLAssertionBuilderException(e.getMessage());
             }
-        } catch (SecurityException e) {
+        } catch (SecurityException | IllegalArgumentException | IllegalAccessException e) {
             LOG.error("Could not resolve SAML algorithm: {}",uri, e);
             throw new SAMLAssertionBuilderException(e.getMessage());
         }
-
-        return resolved;
     }
 
-    public List<SHA_TYPE> getConfigurableSHA() {
-        String configurableProperty = PropertyAccessor.getInstance().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE,
-            NhincConstants.CONFIG_SHA, SHA_TYPE.SHA1.name());
-        List<String> configurablePropertyList = Arrays.asList(StringUtils.split(configurableProperty, ","));
-        List<SHA_TYPE> SHATypeList = new ArrayList<>();
-        for (String sha : configurablePropertyList) {
-            SHA_TYPE shaType = SHA_TYPE.getSHAType(sha);
-            if (shaType != null) {
-                SHATypeList.add(shaType);
-            }
-        }
-        return SHATypeList;
+    private static List<String> constructNamespaceList(String[] uriArray) {
+        LinkedList<String> list = new LinkedList<>();
 
+        for (String uri : uriArray) {
+            list.add(constructNamespace(uri));
+        }
+        return list;
+    }
+
+    public static Map<String, List<String>> getConfigurableSHA() {
+        String digestAlgorithms = PropertyAccessor.getInstance().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE,
+            SamlConstants.DIG_ALGO_PROPERTY, SignatureConstants.ALGO_ID_DIGEST_SHA1);
+
+        String signatureAlgorithms = PropertyAccessor.getInstance().getProperty(NhincConstants.GATEWAY_PROPERTY_FILE,
+            SamlConstants.SIG_ALGO_PROPERTY, SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
+        HashMap<String, List<String>> configSHA = new HashMap<>();
+
+        configSHA.put(SamlConstants.DIGEST_KEY, constructNamespaceList(StringUtils.split(digestAlgorithms, ",")));
+        configSHA.put(SamlConstants.SIGNATURE_KEY, constructNamespaceList(StringUtils.split(signatureAlgorithms, ",")));
+
+        return configSHA;
+
+    }
+
+    public static String extractSignatureFromAssertion(AssertionType assertion) {
+        return assertion != null && !StringUtils.isBlank(assertion.getSignatureAlgorithm()) ?  assertion.getSignatureAlgorithm() : getSignatureAlgorithm();
+    }
+
+    public static String extractDigestFromAssertion(AssertionType assertion) {
+        return assertion != null && !StringUtils.isBlank(assertion.getDigestAlgorithm()) ?  assertion.getDigestAlgorithm() : getDigestAlgorithm();
     }
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/CONNECTCXFClient.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/CONNECTCXFClient.java
@@ -49,13 +49,13 @@ public abstract class CONNECTCXFClient<T> extends CONNECTBaseClient<T> {
 
     protected CONNECTCXFClient(ServicePortDescriptor<T> portDescriptor, String url, AssertionType assertion,
         ServicePortBuilder<T> portBuilder) {
-        serviceEndpoint = super.configureBasePort(portBuilder.createPort(StoreUtil.getGatewayAlias(url)), url,
+        serviceEndpoint = super.configureBasePort(portBuilder.createPort(StoreUtil.getGatewayAlias(url), assertion), url,
             assertion != null ? assertion.getTransactionTimeout() : null);
     }
 
     protected CONNECTCXFClient(ServicePortDescriptor<T> portDescriptor, String url, AssertionType assertion,
         ServicePortBuilder<T> portBuilder, String subscriptionId) {
-        serviceEndpoint = super.configureBasePort(portBuilder.createPort(StoreUtil.getGatewayAlias(url)),
+        serviceEndpoint = super.configureBasePort(portBuilder.createPort(StoreUtil.getGatewayAlias(url), assertion),
             subscriptionId, assertion != null ? assertion.getTransactionTimeout() : null);
     }
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/CONNECTCXFClientSecured.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/CONNECTCXFClientSecured.java
@@ -31,6 +31,7 @@ import gov.hhs.fha.nhinc.cryptostore.StoreUtil;
 import gov.hhs.fha.nhinc.messaging.service.decorator.HttpHeaderServiceEndpointDecorator;
 import gov.hhs.fha.nhinc.messaging.service.decorator.SAMLServiceEndpointDecorator;
 import gov.hhs.fha.nhinc.messaging.service.decorator.cxf.WsAddressingServiceEndpointDecorator;
+import gov.hhs.fha.nhinc.messaging.service.decorator.cxf.WsSecurityServiceEndpointDecorator;
 import gov.hhs.fha.nhinc.messaging.service.port.CachingCXFSecuredServicePortBuilder;
 import gov.hhs.fha.nhinc.messaging.service.port.ServicePortDescriptor;
 import org.slf4j.Logger;
@@ -38,7 +39,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * @author akong
- *
  */
 public class CONNECTCXFClientSecured<T> extends CONNECTCXFClient<T> {
 
@@ -54,11 +54,11 @@ public class CONNECTCXFClientSecured<T> extends CONNECTCXFClient<T> {
 
     CONNECTCXFClientSecured(ServicePortDescriptor<T> portDescriptor, AssertionType assertion, String url,
         String targetHomeCommunityId, String serviceName) {
+
         super(portDescriptor, url, assertion,
             new CachingCXFSecuredServicePortBuilder<>(portDescriptor, StoreUtil.getGatewayAlias(url)));
         decorateEndpoint(assertion, url, portDescriptor.getWSAddressingAction(), targetHomeCommunityId,
             serviceName);
-
         serviceEndpoint.configure();
     }
 
@@ -74,6 +74,7 @@ public class CONNECTCXFClientSecured<T> extends CONNECTCXFClient<T> {
         serviceEndpoint = new WsAddressingServiceEndpointDecorator<>(serviceEndpoint, wsAddressingTo,
             wsAddressingActionId, assertion);
         serviceEndpoint = new HttpHeaderServiceEndpointDecorator<>(serviceEndpoint, assertion);
+        serviceEndpoint = new WsSecurityServiceEndpointDecorator<>(serviceEndpoint, StoreUtil.getGatewayAlias(wsAddressingTo));
     }
 
     /*

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/CONNECTCXFClientSecured.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/CONNECTCXFClientSecured.java
@@ -74,7 +74,7 @@ public class CONNECTCXFClientSecured<T> extends CONNECTCXFClient<T> {
         serviceEndpoint = new WsAddressingServiceEndpointDecorator<>(serviceEndpoint, wsAddressingTo,
             wsAddressingActionId, assertion);
         serviceEndpoint = new HttpHeaderServiceEndpointDecorator<>(serviceEndpoint, assertion);
-        serviceEndpoint = new WsSecurityServiceEndpointDecorator<>(serviceEndpoint, StoreUtil.getGatewayAlias(wsAddressingTo));
+        serviceEndpoint = new WsSecurityServiceEndpointDecorator<>(serviceEndpoint, StoreUtil.getGatewayAlias(wsAddressingTo), assertion);
     }
 
     /*

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/UDDIBaseClient.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/client/UDDIBaseClient.java
@@ -53,7 +53,7 @@ public class UDDIBaseClient<T> implements CONNECTClient<T> {
 
         CXFServicePortBuilder<T> portBuilder = new CXFServicePortBuilder<>(portDescriptor);
 
-        serviceEndpoint = new BaseServiceEndpoint<>(portBuilder.createPort(StoreUtil.getGatewayAlias(url)));
+        serviceEndpoint = new BaseServiceEndpoint<>(portBuilder.createPort(StoreUtil.getGatewayAlias(url), null));
         serviceEndpoint = new URLServiceEndpointDecorator<>(serviceEndpoint, url);
         serviceEndpoint = new TimeoutServiceEndpointDecorator<>(serviceEndpoint, -1);
         serviceEndpoint = new TLSUDDIClientEndpointDecorator<>(serviceEndpoint, StoreUtil.getGatewayAlias(url));

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsSecurityConfigFactory.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsSecurityConfigFactory.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.Properties;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.wss4j.dom.handler.WSHandlerConstants;
-import org.apache.wss4j.policy.SPConstants;
 
 /**
  * @author akong
@@ -93,9 +92,6 @@ public class WsSecurityConfigFactory {
         outProps.put(WSHandlerConstants.SAML_CALLBACK_CLASS, "gov.hhs.fha.nhinc.callback.cxf.CXFSAMLCallbackHandler");
         outProps.put(CRYPTO_PROPERTIES, getSignatureProperties());
         outProps.put(WSHandlerConstants.SIG_PROP_REF_ID, CRYPTO_PROPERTIES);
-        outProps.put(WSHandlerConstants.SIG_ALGO, SPConstants.RSA_SHA1);
-        outProps.put(WSHandlerConstants.SIG_DIGEST_ALGO, SPConstants.SHA1);
-
         outProps.put(WSHandlerConstants.SIGNATURE_PARTS,
             "{Element}{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd}Timestamp;");
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsSecurityServiceEndpointDecorator.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsSecurityServiceEndpointDecorator.java
@@ -29,12 +29,16 @@ package gov.hhs.fha.nhinc.messaging.service.decorator.cxf;
 import gov.hhs.fha.nhinc.messaging.client.interceptor.HttpHeaderRequestOutInterceptor;
 import gov.hhs.fha.nhinc.messaging.service.ServiceEndpoint;
 import gov.hhs.fha.nhinc.messaging.service.decorator.ServiceEndpointDecorator;
+import gov.hhs.fha.nhinc.properties.PropertyAccessor;
 import java.util.Map;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.frontend.ClientProxy;
 import org.apache.cxf.interceptor.Interceptor;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.ws.security.wss4j.WSS4JOutInterceptor;
+import org.apache.wss4j.dom.handler.WSHandlerConstants;
+import org.apache.wss4j.policy.SPConstants;
+import org.opensaml.xmlsec.signature.support.SignatureConstants;
 
 /**
  * @author akong
@@ -44,6 +48,9 @@ public class WsSecurityServiceEndpointDecorator<T> extends ServiceEndpointDecora
 
     private WsSecurityConfigFactory configFactory = null;
     private String gatewayAlias = null;
+    private static final String ASSERTION_PROPERTY_FILE_NAME = "assertioninfo";
+    private static final String SIG_ALGO = "saml.SignatureAlgorithm";
+    private static final String DIG_ALGO = "saml.DigestAlgorithm";
 
     /**
      * Constructor.
@@ -77,7 +84,12 @@ public class WsSecurityServiceEndpointDecorator<T> extends ServiceEndpointDecora
 
         Client client = ClientProxy.getClient(getPort());
         Map<String, Object> outProps = configFactory.getConfiguration(gatewayAlias);
-
+        String salgorithm = PropertyAccessor.getInstance().getProperty(ASSERTION_PROPERTY_FILE_NAME, SIG_ALGO,
+            SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
+        String dalgorithm = PropertyAccessor.getInstance().getProperty(ASSERTION_PROPERTY_FILE_NAME, DIG_ALGO,
+            SPConstants.SHA1);
+        outProps.put(WSHandlerConstants.SIG_ALGO, salgorithm);
+        outProps.put(WSHandlerConstants.SIG_DIGEST_ALGO, dalgorithm);
         configureWSSecurityOnClient(client, outProps);
     }
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsSecurityServiceEndpointDecorator.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsSecurityServiceEndpointDecorator.java
@@ -76,12 +76,6 @@ public class WsSecurityServiceEndpointDecorator<T> extends ServiceEndpointDecora
     }
 
     /**
-     * @param assertion
-     * @return
-     */
-
-
-    /**
      * Configures the endpoint for WS-Security. This call is not thread safe if the port is a shared instance as it adds
      * interceptors to the CXF client.
      */

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsSecurityServiceEndpointDecorator.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsSecurityServiceEndpointDecorator.java
@@ -26,10 +26,11 @@
  */
 package gov.hhs.fha.nhinc.messaging.service.decorator.cxf;
 
+import gov.hhs.fha.nhinc.callback.opensaml.SAMLUtils;
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.messaging.client.interceptor.HttpHeaderRequestOutInterceptor;
 import gov.hhs.fha.nhinc.messaging.service.ServiceEndpoint;
 import gov.hhs.fha.nhinc.messaging.service.decorator.ServiceEndpointDecorator;
-import gov.hhs.fha.nhinc.properties.PropertyAccessor;
 import java.util.Map;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.frontend.ClientProxy;
@@ -37,8 +38,6 @@ import org.apache.cxf.interceptor.Interceptor;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.ws.security.wss4j.WSS4JOutInterceptor;
 import org.apache.wss4j.dom.handler.WSHandlerConstants;
-import org.apache.wss4j.policy.SPConstants;
-import org.opensaml.xmlsec.signature.support.SignatureConstants;
 
 /**
  * @author akong
@@ -48,17 +47,16 @@ public class WsSecurityServiceEndpointDecorator<T> extends ServiceEndpointDecora
 
     private WsSecurityConfigFactory configFactory = null;
     private String gatewayAlias = null;
-    private static final String ASSERTION_PROPERTY_FILE_NAME = "assertioninfo";
-    private static final String SIG_ALGO = "saml.SignatureAlgorithm";
-    private static final String DIG_ALGO = "saml.DigestAlgorithm";
+    private String sigAlgorithm;
+    private String digAlgorithm;
 
     /**
      * Constructor.
      *
      * @param decoratoredEndpoint - endpoint instance where this decorator will be applied
      */
-    public WsSecurityServiceEndpointDecorator(ServiceEndpoint<T> decoratoredEndpoint, String gatewayAlias) {
-        this(decoratoredEndpoint, WsSecurityConfigFactory.getInstance());
+    public WsSecurityServiceEndpointDecorator(ServiceEndpoint<T> decoratoredEndpoint, String gatewayAlias, AssertionType assertion) {
+        this(decoratoredEndpoint, WsSecurityConfigFactory.getInstance(), assertion);
         this.gatewayAlias = gatewayAlias;
     }
 
@@ -68,11 +66,20 @@ public class WsSecurityServiceEndpointDecorator<T> extends ServiceEndpointDecora
      * @param decoratoredEndpoint - endpoint instance where this decorator will be applied
      * @param configFactory - factory that produce a config map
      */
-    public WsSecurityServiceEndpointDecorator(ServiceEndpoint<T> decoratoredEndpoint,
-        WsSecurityConfigFactory configFactory) {
+    public WsSecurityServiceEndpointDecorator(ServiceEndpoint<T> decoratoredEndpoint, WsSecurityConfigFactory configFactory, AssertionType assertion) {
         super(decoratoredEndpoint);
+
+        sigAlgorithm = SAMLUtils.extractSignatureFromAssertion(assertion);
+        digAlgorithm = SAMLUtils.extractDigestFromAssertion(assertion);
+
         this.configFactory = configFactory;
     }
+
+    /**
+     * @param assertion
+     * @return
+     */
+
 
     /**
      * Configures the endpoint for WS-Security. This call is not thread safe if the port is a shared instance as it adds
@@ -84,12 +91,9 @@ public class WsSecurityServiceEndpointDecorator<T> extends ServiceEndpointDecora
 
         Client client = ClientProxy.getClient(getPort());
         Map<String, Object> outProps = configFactory.getConfiguration(gatewayAlias);
-        String salgorithm = PropertyAccessor.getInstance().getProperty(ASSERTION_PROPERTY_FILE_NAME, SIG_ALGO,
-            SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
-        String dalgorithm = PropertyAccessor.getInstance().getProperty(ASSERTION_PROPERTY_FILE_NAME, DIG_ALGO,
-            SPConstants.SHA1);
-        outProps.put(WSHandlerConstants.SIG_ALGO, salgorithm);
-        outProps.put(WSHandlerConstants.SIG_DIGEST_ALGO, dalgorithm);
+
+        outProps.put(WSHandlerConstants.SIG_ALGO, sigAlgorithm);
+        outProps.put(WSHandlerConstants.SIG_DIGEST_ALGO, digAlgorithm);
         configureWSSecurityOnClient(client, outProps);
     }
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/port/CXFServicePortBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/port/CXFServicePortBuilder.java
@@ -26,6 +26,7 @@
  */
 package gov.hhs.fha.nhinc.messaging.service.port;
 
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import org.apache.cxf.jaxws.JaxWsProxyFactoryBean;
 
 /**
@@ -57,7 +58,7 @@ public class CXFServicePortBuilder<T> implements ServicePortBuilder<T> {
 
     @SuppressWarnings("unchecked")
     @Override
-    public T createPort(String gatewayAlias) {
+    public T createPort(String gatewayAlias, AssertionType assertion) {
         JaxWsProxyFactoryBean clientFactory = new JaxWsProxyFactoryBean();
         configureJaxWsProxyFactory(clientFactory);
         return (T) clientFactory.create();

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/port/CachingCXFSecuredServicePortBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/port/CachingCXFSecuredServicePortBuilder.java
@@ -26,6 +26,7 @@
  */
 package gov.hhs.fha.nhinc.messaging.service.port;
 
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.cryptostore.StoreUtil;
 import gov.hhs.fha.nhinc.messaging.service.BaseServiceEndpoint;
 import gov.hhs.fha.nhinc.messaging.service.ServiceEndpoint;
@@ -40,7 +41,7 @@ import java.util.Map;
  */
 public class CachingCXFSecuredServicePortBuilder<T> extends CachingCXFWSAServicePortBuilder<T> {
 
-    private static Map<String, Map<Class<?>, Object>> CACHED_PORTS = new HashMap<>();
+    private static final Map<String, Map<Class<?>, Object>> CACHED_PORTS = new HashMap<>();
     private String gatewayAlias;
 
     /**
@@ -59,8 +60,8 @@ public class CachingCXFSecuredServicePortBuilder<T> extends CachingCXFWSAService
      * @see gov.hhs.fha.nhinc.messaging.service.port.CachingCXFServicePortBuilder#getCache()
      */
     @Override
-    protected Map<Class<?>, Object> getCache(String gatewayAlias) {
-        String defaultAlias = StoreUtil.getGatewayAliasDefaultTo(gatewayAlias);
+    protected Map<Class<?>, Object> getCache(String alias) {
+        String defaultAlias = StoreUtil.getGatewayAliasDefaultTo(alias);
         if (CACHED_PORTS.get(defaultAlias) == null) {
             CACHED_PORTS.put(defaultAlias, new HashMap<Class<?>, Object>());
         }
@@ -74,12 +75,12 @@ public class CachingCXFSecuredServicePortBuilder<T> extends CachingCXFWSAService
      * @see gov.hhs.fha.nhinc.messaging.service.port.CachingCXFServicePortBuilder#configurePort(java.lang.Object)
      */
     @Override
-    protected void configurePort(T port) {
-        super.configurePort(port);
+    protected void configurePort(T port, AssertionType assertion) {
+        super.configurePort(port, assertion);
 
         ServiceEndpoint<T> serviceEndpoint = new BaseServiceEndpoint<>(port);
         serviceEndpoint = new TLSClientServiceEndpointDecorator<>(serviceEndpoint, gatewayAlias);
-        serviceEndpoint = new WsSecurityServiceEndpointDecorator<>(serviceEndpoint, gatewayAlias);
+        serviceEndpoint = new WsSecurityServiceEndpointDecorator<>(serviceEndpoint, gatewayAlias, assertion);
         serviceEndpoint.configure();
     }
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/port/CachingCXFServicePortBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/port/CachingCXFServicePortBuilder.java
@@ -26,6 +26,7 @@
  */
 package gov.hhs.fha.nhinc.messaging.service.port;
 
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.messaging.service.BaseServiceEndpoint;
 import gov.hhs.fha.nhinc.messaging.service.ServiceEndpoint;
 import gov.hhs.fha.nhinc.messaging.service.decorator.cxf.SoapResponseServiceEndpointDecorator;
@@ -78,8 +79,9 @@ public abstract class CachingCXFServicePortBuilder<T> extends CXFServicePortBuil
      * request context if configured for thread local 2. HTTPClientPolicy BUT only through the request context
      *
      * @param port The port to be configured
+     * @param assertion
      */
-    protected void configurePort(T port) {
+    protected void configurePort(T port, AssertionType assertion) {
         ServiceEndpoint<T> serviceEndpoint = new BaseServiceEndpoint<>(port);
         serviceEndpoint = new SoapResponseServiceEndpointDecorator<>(serviceEndpoint);
         serviceEndpoint.configure();
@@ -90,14 +92,14 @@ public abstract class CachingCXFServicePortBuilder<T> extends CXFServicePortBuil
      */
     @SuppressWarnings("unchecked")
     @Override
-    public synchronized T createPort(String gatewayAlias) {
+    public synchronized T createPort(String gatewayAlias, AssertionType assertion) {
         LOG.debug("createPort-gatewayAlias: {}", gatewayAlias);
         T port = (T) getCache(gatewayAlias).get(serviceEndpointClass);
         if (port == null) {
-            port = super.createPort(gatewayAlias);
+            port = super.createPort(gatewayAlias, assertion);
             ((BindingProvider) port).getRequestContext().put(THREAD_LOCAL_REQUEST_CONTEXT, Boolean.TRUE);
 
-            configurePort(port);
+            configurePort(port, assertion);
 
             getCache(gatewayAlias).put(serviceEndpointClass, port);
         }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/port/CachingCXFWSAServicePortBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/port/CachingCXFWSAServicePortBuilder.java
@@ -26,6 +26,7 @@
  */
 package gov.hhs.fha.nhinc.messaging.service.port;
 
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.cryptostore.StoreUtil;
 import gov.hhs.fha.nhinc.messaging.service.BaseServiceEndpoint;
 import gov.hhs.fha.nhinc.messaging.service.ServiceEndpoint;
@@ -72,8 +73,8 @@ public class CachingCXFWSAServicePortBuilder<T> extends CachingCXFServicePortBui
      * @see gov.hhs.fha.nhinc.messaging.service.port.CachingCXFServicePortBuilder#configurePort(java.lang.Object)
      */
     @Override
-    protected void configurePort(T port) {
-        super.configurePort(port);
+    protected void configurePort(T port, AssertionType assertion) {
+        super.configurePort(port, assertion);
 
         ServiceEndpoint<T> serviceEndpoint = new BaseServiceEndpoint<>(port);
         serviceEndpoint.configure();

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/port/ServicePortBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/messaging/service/port/ServicePortBuilder.java
@@ -26,11 +26,13 @@
  */
 package gov.hhs.fha.nhinc.messaging.service.port;
 
+import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
+
 /**
  * @author akong
  *
  */
 public interface ServicePortBuilder<T> {
 
-    public T createPort(String gatewayAlias);
+    public T createPort(String gatewayAlias, AssertionType assertion);
 }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
@@ -31,7 +31,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.wss4j.policy.SPConstants;
 
 /**
  *
@@ -40,36 +39,7 @@ import org.apache.wss4j.policy.SPConstants;
  * @author Jon Hoppesch
  */
 public class NhincConstants {
-    public static final String CONFIG_SHA = "configurableSHA";
 
-    public static enum SHA_TYPE {
-        SHA1(SPConstants.RSA_SHA1, SPConstants.SHA1), SHA256(SPConstants.RSA_SHA256, SPConstants.SHA256), SHA512(
-            SPConstants.RSA_SHA512, SPConstants.SHA512);
-        private String signatureAlgorithm = null;
-        private String digestAlgorithm = null;
-
-        SHA_TYPE(String signatureAlgorithm, String digestAlgorithm) {
-            this.signatureAlgorithm = signatureAlgorithm;
-            this.digestAlgorithm = digestAlgorithm;
-        }
-
-        public static SHA_TYPE getSHAType(String type) {
-            for (SHA_TYPE SHAType : SHA_TYPE.values()) {
-                if (SHAType.name().equalsIgnoreCase(type)) {
-                    return SHAType;
-                }
-            }
-            return null;// match nothing
-        }
-
-        public String getSignatureAlgorithm() {
-            return signatureAlgorithm;
-        }
-
-        public String getDigestAlgorithm() {
-            return digestAlgorithm;
-        }
-    }
     public static enum GATEWAY_API_LEVEL {
 
         LEVEL_g0, LEVEL_g1

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
@@ -247,7 +247,6 @@ public class NhincConstants {
     public static final String FHIR_DIRECTORY_FILE = "FHIRDirectoryMapping";
     public static final String MESSAGES_PROPERTY_FILE = "messages";
     public static final String ASSIGNING_AUTH_PROPERTY = "assigningAuthorityId";
-    public static final String ASSERTION_INFO_PROPERTY_FILE = "assertioninfo";
     // Concurrent Executor Service Constants (used to retrieve values from
     // gateway.properties)
     public static final String CONCURRENT_POOL_SIZE = "ConcurrentPoolSize";

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.wss4j.policy.SPConstants;
 
 /**
  *
@@ -39,7 +40,36 @@ import java.util.Map;
  * @author Jon Hoppesch
  */
 public class NhincConstants {
+    public static final String CONFIG_SHA = "configurableSHA";
 
+    public static enum SHA_TYPE {
+        SHA1(SPConstants.RSA_SHA1, SPConstants.SHA1), SHA256(SPConstants.RSA_SHA256, SPConstants.SHA256), SHA512(
+            SPConstants.RSA_SHA512, SPConstants.SHA512);
+        private String signatureAlgorithm = null;
+        private String digestAlgorithm = null;
+
+        SHA_TYPE(String signatureAlgorithm, String digestAlgorithm) {
+            this.signatureAlgorithm = signatureAlgorithm;
+            this.digestAlgorithm = digestAlgorithm;
+        }
+
+        public static SHA_TYPE getSHAType(String type) {
+            for (SHA_TYPE SHAType : SHA_TYPE.values()) {
+                if (SHAType.name().equalsIgnoreCase(type)) {
+                    return SHAType;
+                }
+            }
+            return null;// match nothing
+        }
+
+        public String getSignatureAlgorithm() {
+            return signatureAlgorithm;
+        }
+
+        public String getDigestAlgorithm() {
+            return digestAlgorithm;
+        }
+    }
     public static enum GATEWAY_API_LEVEL {
 
         LEVEL_g0, LEVEL_g1
@@ -193,7 +223,7 @@ public class NhincConstants {
                 if (!m.equals(EVENT_LOGGING_SERVICE_NAME.DOCUMENT_SUBMISSION_DEFERRED_REQUEST) && !m.equals(
                     EVENT_LOGGING_SERVICE_NAME.DOCUMENT_SUBMISSION_DEFERRED_RESPONSE) && !m.equals(
                         EVENT_LOGGING_SERVICE_NAME.PATIENT_DISCOVERY_DEFERRED_REQUEST)
-                    && !m.equals(EVENT_LOGGING_SERVICE_NAME.PATIENT_DISCOVERY_DEFERRED_RESPONSE)) {
+                        && !m.equals(EVENT_LOGGING_SERVICE_NAME.PATIENT_DISCOVERY_DEFERRED_RESPONSE)) {
                     enumServiceNames.add(m.getAbbServiceName());
                 }
             }
@@ -211,11 +241,11 @@ public class NhincConstants {
 
     // Authorization Framework
     public static final String AUTH_FRWK_NAME_ID_FORMAT_EMAIL_ADDRESS
-        = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
+    = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
     public static final String AUTH_FRWK_NAME_ID_FORMAT_X509
-        = "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName";
+    = "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName";
     public static final String AUTH_FRWK_NAME_ID_FORMAT_WINDOWS_NAME
-        = "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName";
+    = "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName";
     // SAML constants
     public static final String SAML_DEFAULT_ISSUER_NAME = "CN=SAML User,OU=SU,O=SAML User,L=Los Angeles,ST=CA,C=US";
     public static final String ACTION_NAMESPACE_STRING = "urn:oasis:names:tc:SAML:1.0:action:rwedc";
@@ -382,7 +412,7 @@ public class NhincConstants {
     public static final String WS_SOAP_HEADER_ACTION = "Action";
     public static final String WS_RETRIEVE_DOCUMENT_ACTION = "urn:ihe:iti:2007:RetrieveDocumentSet";
     public static final String WS_PROVIDE_AND_REGISTER_DOCUMENT_ACTION
-        = "urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b";
+    = "urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b";
     public static final String WS_SOAP_ATTR_MUSTUNDERSTAND = "mustUnderstand";
     public static final String WS_SOAP_HEADER_TO = "To";
     public static final String WS_SOAP_HEADER_REPLYTO = "ReplyTo";
@@ -399,7 +429,7 @@ public class NhincConstants {
     public static final String ENTITY_DOC_QUERY_PROXY_SERVICE_NAME = "entitydocqueryproxy";
     public static final String ENTITY_DOC_QUERY_SECURED_SERVICE_NAME = "entitydocquerysecured";
     public static final String NHINC_ADHOC_QUERY_SUCCESS_RESPONSE
-        = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success";
+    = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success";
     public static final BigInteger NHINC_ADHOC_QUERY_NO_RESULT_COUNT = BigInteger.valueOf(0L);
     // Document Retrieve Constants
     public static final String ADAPTER_DOC_RETRIEVE_SERVICE_NAME = "adapterdocretrieve";
@@ -423,28 +453,28 @@ public class NhincConstants {
     public static final String ADAPTER_PATIENT_DISCOVERY_SECURED_SERVICE_NAME = "adapterpatientdiscoverysecured";
     public static final String PATIENT_DISCOVERY_ADAPTER_ASYNC_REQ_SERVICE_NAME = "adapterpatientdiscoveryasyncreq";
     public static final String PATIENT_DISCOVERY_ADAPTER_SECURED_ASYNC_REQ_SERVICE_NAME
-        = "adapterpatientdiscoverysecuredasyncreq";
+    = "adapterpatientdiscoverysecuredasyncreq";
     public static final String PATIENT_DISCOVERY_ADAPTER_ASYNC_REQ_ERROR_SERVICE_NAME
-        = "adapterpatientdiscoveryasyncreqerror";
+    = "adapterpatientdiscoveryasyncreqerror";
     public static final String PATIENT_DISCOVERY_ADAPTER_SECURED_ASYNC_REQ_ERROR_SERVICE_NAME
-        = "adapterpatientdiscoverysecuredasyncreqerror";
+    = "adapterpatientdiscoverysecuredasyncreqerror";
     public static final String PATIENT_DISCOVERY_ADAPTER_ASYNC_RESP_SERVICE_NAME = "adapterpatientdiscoveryasyncresp";
     public static final String PATIENT_DISCOVERY_ADAPTER_SECURED_ASYNC_RESP_SERVICE_NAME
-        = "adapterpatientdiscoverysecuredasyncresp";
+    = "adapterpatientdiscoverysecuredasyncresp";
     public static final String ENTITY_PATIENT_DISCOVERY_SECURED_SERVICE_NAME = "entitypatientdiscoverysecured";
     public static final String ENTITY_PATIENT_DISCOVERY_SERVICE_NAME = "entitypatientdiscovery";
     public static final String PATIENT_DISCOVERY_ENTITY_ASYNC_REQ_SERVICE_NAME = "entitypatientdiscoveryasyncreq";
     public static final String PATIENT_DISCOVERY_ENTITY_SECURED_ASYNC_REQ_SERVICE_NAME
-        = "entitypatientdiscoverysecuredasyncreq";
+    = "entitypatientdiscoverysecuredasyncreq";
     public static final String PATIENT_DISCOVERY_ENTITY_ASYNC_RESP_SERVICE_NAME = "entitypatientdiscoveryasyncresp";
     public static final String PATIENT_DISCOVERY_ENTITY_SECURED_ASYNC_RESP_SERVICE_NAME
-        = "entitypatientdiscoverysecuredasyncresp";
+    = "entitypatientdiscoverysecuredasyncresp";
     public static final String PATIENT_DISCOVERY_ADAPTER_ASYNC_REQ_QUEUE_SERVICE_NAME
-        = "adapterpatientdiscoveryasyncreqqueue";
+    = "adapterpatientdiscoveryasyncreqqueue";
     public static final String PATIENT_DISCOVERY_ADAPTER_SECURED_ASYNC_REQ_QUEUE_SERVICE_NAME
-        = "adapterpatientdiscoverysecuredasyncreqqueue";
+    = "adapterpatientdiscoverysecuredasyncreqqueue";
     public static final String PATIENT_DISCOVERY_ADAPTER_ASYNC_REQ_QUEUE_PROCESS_SERVICE_NAME
-        = "adapterpatientdiscoverydeferredreqqueueprocess";
+    = "adapterpatientdiscoverydeferredreqqueueprocess";
 
     // Patient Discovery Error Constants
     public static final String PATIENT_DISCOVERY_ANSWER_NOT_AVAIL_ERR_CODE = "AnswerNotAvailable";
@@ -454,7 +484,7 @@ public class NhincConstants {
     public static final String PATIENT_DISCOVERY_TELCOM_MORE_CODE = "PatientTelecomRequested";
     public static final String PATIENT_DISCOVERY_BIRTH_PLACE_NAME_MORE_CODE = "LivingSubjectBirthPlaceNameRequested";
     public static final String PATIENT_DISCOVERY_BIRTH_PLACE_ADDRESS_MORE_CODE
-        = "LivingSubjectBirthPlaceAddressRequested";
+    = "LivingSubjectBirthPlaceAddressRequested";
     public static final String PATIENT_DISCOVERY_MOTHERS_MAIDEN_NAME_MORE_CODE = "MothersMaidenNameRequested";
     public static final String PATIENT_DISCOVERY_SSN_MORE_CODE = "SSNRequested";
     // XDR Constants
@@ -485,7 +515,7 @@ public class NhincConstants {
     public static final String ADAPTER_COMPONENT_XDR_RESPONSE_SERVICE_NAME = "adaptercomponentxdrresponse";
     public static final String XDR_ACK_STATUS_MSG = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:RequestAccepted";
     public static final String XDR_RESP_ACK_STATUS_MSG
-        = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:ResponseAccepted";
+    = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:ResponseAccepted";
     public static final String XDR_ACK_FAILURE_STATUS_MSG = "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Failure";
 
     // Administrative Distribution Constants
@@ -515,39 +545,39 @@ public class NhincConstants {
 
     public static final String NHIN_CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME = "nhincore_x12dsgenericbatchrequest";
     public static final String NHIN_CORE_X12DS_GENERICBATCH_REQUEST_SECURED_SERVICE_NAME
-        = "nhincore_x12dsgenericbatchrequestwssecured";
+    = "nhincore_x12dsgenericbatchrequestwssecured";
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME
-        = "entitycore_x12dsgenericbatchrequest";
+    = "entitycore_x12dsgenericbatchrequest";
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_REQUEST_SECURED_SERVICE_NAME
-        = "entitycore_x12dsgenericbatchrequestsecured";
+    = "entitycore_x12dsgenericbatchrequestsecured";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_SERVICE_NAME
-        = "adaptercore_x12dsgenericbatchrequest";
+    = "adaptercore_x12dsgenericbatchrequest";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_SECURED_SERVICE_NAME
-        = "adaptercore_x12dsgenericbatchrequestsecured";
+    = "adaptercore_x12dsgenericbatchrequestsecured";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_NOOP_SERVICE_NAME
-        = "adaptercore_x12dsgenericbatchrequestnoop";
+    = "adaptercore_x12dsgenericbatchrequestnoop";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_JAVA_SERVICE_NAME
-        = "adaptercore_x12dsgenericbatchrequestjava";
+    = "adaptercore_x12dsgenericbatchrequestjava";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_REQUEST_PROXY_SERVICE_NAME
-        = "adaptercore_x12dsgenericbatchrequestproxybean";
+    = "adaptercore_x12dsgenericbatchrequestproxybean";
 
     public static final String NHIN_CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME = "nhincore_x12dsgenericbatchresponse";
     public static final String NHIN_CORE_X12DS_GENERICBATCH_RESPONSE_SECURED_SERVICE_NAME
-        = "nhincore_x12dsgenericbatchresponsewssecured";
+    = "nhincore_x12dsgenericbatchresponsewssecured";
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME
-        = "entitycore_x12dsgenericbatchresponse";
+    = "entitycore_x12dsgenericbatchresponse";
     public static final String ENTITY_CORE_X12DS_GENERICBATCH_RESPONSE_SECURED_SERVICE_NAME
-        = "entitycore_x12dsgenericbatchresponsesecured";
+    = "entitycore_x12dsgenericbatchresponsesecured";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_SERVICE_NAME
-        = "adaptercore_x12dsgenericbatchresponse";
+    = "adaptercore_x12dsgenericbatchresponse";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_SECURED_SERVICE_NAME
-        = "adaptercore_x12dsgenericbatchresponsesecured";
+    = "adaptercore_x12dsgenericbatchresponsesecured";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_NOOP_SERVICE_NAME
-        = "adaptercore_x12dsgenericbatchresponsenoop";
+    = "adaptercore_x12dsgenericbatchresponsenoop";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_JAVA_SERVICE_NAME
-        = "adaptercore_x12dsgenericbatchresponsejava";
+    = "adaptercore_x12dsgenericbatchresponsejava";
     public static final String ADAPTER_CORE_X12DS_GENERICBATCH_RESPONSE_PROXY_SERVICE_NAME
-        = "adaptercore_x12dsgenericbatchresponseproxybean";
+    = "adaptercore_x12dsgenericbatchresponseproxybean";
     public static final String CORE_X12DS_GENERICBATCH_PROXY_CONFIG_FILE_NAME = "CORE_X12DSGenericBatchProxyConfig.xml";
     public static final String CORE_X12DS_ACK_ERROR_MSG = null;
     public static final String CORE_X12DS_ACK_ERROR_CODE = null;
@@ -574,20 +604,20 @@ public class NhincConstants {
     public static final String HIBERNATE_ADMINGUI_REPOSITORY = "admingui.hibernate.cfg.xml";
 
     public static final String XDS_REGISTRY_ERROR_SEVERITY_WARNING
-        = "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Warning";
+    = "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Warning";
     public static final String XDS_REGISTRY_ERROR_SEVERITY_ERROR
-        = "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error";
+    = "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error";
     public static final String DIRECT_SOAP_EDGE_SERVICE_NAME = "directsoapedge";
     // JMX configurations
     public static final String JMX_ENABLED_SYSTEM_PROPERTY = "org.connectopensource.enablejmx";
     public static final String JMX_CONFIGURATION_BEAN_NAME = "org.connectopensource.mbeans:type=Configuration";
 
     public static final String JMX_DOCUMENT_QUERY_30_BEAN_NAME
-        = "org.connectopensource.mbeans:type=DocumentQuery30WebServices";
+    = "org.connectopensource.mbeans:type=DocumentQuery30WebServices";
     public static final String JMX_DOCUMENT_QUERY_20_BEAN_NAME
-        = "org.connectopensource.mbeans:type=DocumentQuery20WebServices";
+    = "org.connectopensource.mbeans:type=DocumentQuery20WebServices";
     public static final String JMX_PATIENT_DISCOVERY_10_BEAN_NAME
-        = "org.connectopensource.mbeans:type=PatientDiscovery10WebServices";
+    = "org.connectopensource.mbeans:type=PatientDiscovery10WebServices";
     // Standard Format for parsing String into Date
     public static final String DATE_PARSE_FORMAT = "yyyyMMddHHmmss";
     // Document Type property for UClient

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/nhinclib/NhincConstants.java
@@ -277,6 +277,7 @@ public class NhincConstants {
     public static final String FHIR_DIRECTORY_FILE = "FHIRDirectoryMapping";
     public static final String MESSAGES_PROPERTY_FILE = "messages";
     public static final String ASSIGNING_AUTH_PROPERTY = "assigningAuthorityId";
+    public static final String ASSERTION_INFO_PROPERTY_FILE = "assertioninfo";
     // Concurrent Executor Service Constants (used to retrieve values from
     // gateway.properties)
     public static final String CONCURRENT_POOL_SIZE = "ConcurrentPoolSize";

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/saml/extraction/SamlTokenCreator.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/saml/extraction/SamlTokenCreator.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -28,6 +28,7 @@ package gov.hhs.fha.nhinc.saml.extraction;
 
 import gov.hhs.fha.nhinc.callback.SamlConstants;
 import gov.hhs.fha.nhinc.callback.opensaml.SAMLSubjectConfirmation;
+import gov.hhs.fha.nhinc.callback.opensaml.SAMLUtils;
 import gov.hhs.fha.nhinc.common.nhinccommon.AssertionType;
 import gov.hhs.fha.nhinc.common.nhinccommon.HomeCommunityType;
 import gov.hhs.fha.nhinc.common.nhinccommon.SamlConditionsType;
@@ -42,6 +43,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 import org.slf4j.Logger;
@@ -74,7 +76,7 @@ public class SamlTokenCreator {
             if (NullChecker.isNotNullish(NPI)) {
                 requestContext.put(NhincConstants.ATTRIBUTE_NAME_NPI, NPI);
             }
-            
+
             extractAccessConsentAttributes(requestContext, assertion);
             extractSubjectConfirmation(requestContext, assertion);
             extractUserInfo(requestContext, assertion);
@@ -97,6 +99,7 @@ public class SamlTokenCreator {
             extractSamlAuthnStatement(assertion, requestContext);
             extractSamlAuthzDecisionStatement(assertion, requestContext);
             extractSamlIssuerAttributes(assertion, requestContext);
+            extractSamlAlgorithmTypes(assertion, requestContext);
 
         } else {
             LOG.error("Error: samlSendOperation input assertion is null");
@@ -125,6 +128,24 @@ public class SamlTokenCreator {
         LOG.trace("Exiting SamlTokenCreator.CreateRequestContext...");
         return requestContext;
 
+    }
+
+    /**
+     * @param assertion
+     * @param requestContext
+     */
+    private static void extractSamlAlgorithmTypes(AssertionType assertion, Map<String, Object> requestContext) {
+        String signature = assertion.getSignatureAlgorithm();
+        if (StringUtils.isBlank(signature)) {
+            signature = SAMLUtils.getSignatureAlgorithm();
+        }
+
+        String digest = assertion.getDigestAlgorithm();
+        if (StringUtils.isBlank(digest)) {
+            digest = SAMLUtils.getDigestAlgorithm();
+        }
+        requestContext.put(SamlConstants.SIGNATURE_KEY, signature);
+        requestContext.put(SamlConstants.DIGEST_KEY, digest);
     }
 
     /**

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/saml/extraction/SamlTokenCreator.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/saml/extraction/SamlTokenCreator.java
@@ -130,10 +130,6 @@ public class SamlTokenCreator {
 
     }
 
-    /**
-     * @param assertion
-     * @param requestContext
-     */
     private static void extractSamlAlgorithmTypes(AssertionType assertion, Map<String, Object> requestContext) {
         String signature = assertion.getSignatureAlgorithm();
         if (StringUtils.isBlank(signature)) {

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/NhinUtils.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/NhinUtils.java
@@ -115,7 +115,8 @@ public class NhinUtils {
         try {
             name = new LdapName(userName);
         } catch (InvalidNameException ex) {
-            LOG.error("Invalid distinguished name {}", userName, ex);
+            LOG.error("Invalid distinguished name {}", userName);
+            LOG.debug("Invalid distinguished name {}", userName, ex);
         }
         return name != null;
     }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/NhinUtils.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/NhinUtils.java
@@ -115,8 +115,7 @@ public class NhinUtils {
         try {
             name = new LdapName(userName);
         } catch (InvalidNameException ex) {
-            LOG.error("Invalid distinguished name {}", userName);
-            LOG.debug("Invalid distinguished name {}", userName, ex);
+            LOG.error("Invalid distinguished name {}", userName, ex);
         }
         return name != null;
     }

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandlerTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandlerTest.java
@@ -27,7 +27,6 @@
 package gov.hhs.fha.nhinc.callback.cxf;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -44,7 +43,6 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.apache.cxf.message.Message;
 import org.apache.wss4j.common.saml.SAMLCallback;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -69,7 +67,6 @@ public class CXFSAMLCallbackHandlerTest {
     }
 
     @Test
-    @Ignore
     public void testHandle() throws Exception {
         Callback[] callbackList = new Callback[1];
         SAMLCallback samlCallback = new SAMLCallback();
@@ -96,7 +93,6 @@ public class CXFSAMLCallbackHandlerTest {
 
         assertEquals(samlCallback.getSamlVersion(), org.opensaml.saml.common.SAMLVersion.VERSION_20);
         assertEquals(samlCallback.getAssertionElement().getTextContent(), ASSERTION);
-        assertNotNull(null);
     }
 
     @Test

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandlerTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/callback/cxf/CXFSAMLCallbackHandlerTest.java
@@ -27,6 +27,7 @@
 package gov.hhs.fha.nhinc.callback.cxf;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -43,6 +44,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.apache.cxf.message.Message;
 import org.apache.wss4j.common.saml.SAMLCallback;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -67,6 +69,7 @@ public class CXFSAMLCallbackHandlerTest {
     }
 
     @Test
+    @Ignore
     public void testHandle() throws Exception {
         Callback[] callbackList = new Callback[1];
         SAMLCallback samlCallback = new SAMLCallback();
@@ -93,6 +96,7 @@ public class CXFSAMLCallbackHandlerTest {
 
         assertEquals(samlCallback.getSamlVersion(), org.opensaml.saml.common.SAMLVersion.VERSION_20);
         assertEquals(samlCallback.getAssertionElement().getTextContent(), ASSERTION);
+        assertNotNull(null);
     }
 
     @Test

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/messaging/client/CONNECTTestClient.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/messaging/client/CONNECTTestClient.java
@@ -51,7 +51,7 @@ public class CONNECTTestClient<T> implements CONNECTClient<T> {
      */
     public CONNECTTestClient(ServicePortDescriptor<T> portDescriptor) {
         serviceEndpoint = new BaseServiceEndpoint<>(
-            new CachingCXFSecuredServicePortBuilder<>(portDescriptor, null).createPort(null));
+            new CachingCXFSecuredServicePortBuilder<>(portDescriptor, null).createPort(null, null));
     }
 
     public ServiceEndpoint<T> getServiceEndpoint() {

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsSecurityConfigFactoryTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsSecurityConfigFactoryTest.java
@@ -59,6 +59,7 @@ public class WsSecurityConfigFactoryTest {
 
         when(propFileUtil.loadPropertyFile("signature")).thenReturn(sigProperties);
         when(cryptoStoreUtil.getPrivateKeyAlias()).thenReturn("gateway");
+
     }
 
     @Test
@@ -91,8 +92,6 @@ public class WsSecurityConfigFactoryTest {
         assertEquals("PasswordDigest", properties.get(WSHandlerConstants.PASSWORD_TYPE));
         assertNotNull("cryptoProperties", properties.get("cryptoProperties"));
         assertEquals("cryptoProperties", properties.get(WSHandlerConstants.SIG_PROP_REF_ID));
-        assertEquals(SPConstants.RSA_SHA1, properties.get(WSHandlerConstants.SIG_ALGO));
-        assertEquals(SPConstants.SHA1, properties.get(WSHandlerConstants.SIG_DIGEST_ALGO));
         assertEquals(
             "{Element}{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd}Timestamp;",
             properties.get(WSHandlerConstants.SIGNATURE_PARTS));

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsSecurityServiceEndpointDecoratorTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/messaging/service/decorator/cxf/WsSecurityServiceEndpointDecoratorTest.java
@@ -107,7 +107,7 @@ public class WsSecurityServiceEndpointDecoratorTest {
 
         ServiceEndpoint<TestServicePortType> serviceEndpoint = testClient.getServiceEndpoint();
 
-        serviceEndpoint = new WsSecurityServiceEndpointDecorator<>(serviceEndpoint, (String) null);
+        serviceEndpoint = new WsSecurityServiceEndpointDecorator<>(serviceEndpoint, (String) null, null);
         serviceEndpoint.configure();
 
         return testClient;

--- a/Product/Production/Common/Properties/src/main/resources/assertioninfo.properties
+++ b/Product/Production/Common/Properties/src/main/resources/assertioninfo.properties
@@ -20,5 +20,3 @@ InstanceAccessPolicyConsent=urn:oid:1.2.3.4.123456789
 SamlAuthInstant=2009-04-16T13:15:39Z
 AuthContextClassRef=urn:oasis:names:tc:SAML:2.0:ac:classes:X509
 SamlIssuerName=SamlIssuerName=CN=SAML User\,OU=SU\,O=SAML User\,L=Los Angeles\,ST=CA\,C=US
-saml.DigestAlgorithm=http://www.w3.org/2001/04/xmlenc#sha512
-saml.SignatureAlgorithm=http://www.w3.org/2001/04/xmldsig-more#rsa-sha512

--- a/Product/Production/Common/Properties/src/main/resources/assertioninfo.properties
+++ b/Product/Production/Common/Properties/src/main/resources/assertioninfo.properties
@@ -20,3 +20,5 @@ InstanceAccessPolicyConsent=urn:oid:1.2.3.4.123456789
 SamlAuthInstant=2009-04-16T13:15:39Z
 AuthContextClassRef=urn:oasis:names:tc:SAML:2.0:ac:classes:X509
 SamlIssuerName=SamlIssuerName=CN=SAML User\,OU=SU\,O=SAML User\,L=Los Angeles\,ST=CA\,C=US
+saml.SignatureAlgorithm=http://www.w3.org/2001/04/xmldsig-more#rsa-sha512
+saml.DigestAlgorithm=http://www.w3.org/2000/09/xmldsig#rsa-sha512

--- a/Product/Production/Common/Properties/src/main/resources/assertioninfo.properties
+++ b/Product/Production/Common/Properties/src/main/resources/assertioninfo.properties
@@ -20,3 +20,5 @@ InstanceAccessPolicyConsent=urn:oid:1.2.3.4.123456789
 SamlAuthInstant=2009-04-16T13:15:39Z
 AuthContextClassRef=urn:oasis:names:tc:SAML:2.0:ac:classes:X509
 SamlIssuerName=SamlIssuerName=CN=SAML User\,OU=SU\,O=SAML User\,L=Los Angeles\,ST=CA\,C=US
+saml.DigestAlgorithm=http://www.w3.org/2001/04/xmlenc#sha512
+saml.SignatureAlgorithm=http://www.w3.org/2001/04/xmldsig-more#rsa-sha512

--- a/Product/Production/Common/Properties/src/main/resources/assertioninfo.properties
+++ b/Product/Production/Common/Properties/src/main/resources/assertioninfo.properties
@@ -20,5 +20,3 @@ InstanceAccessPolicyConsent=urn:oid:1.2.3.4.123456789
 SamlAuthInstant=2009-04-16T13:15:39Z
 AuthContextClassRef=urn:oasis:names:tc:SAML:2.0:ac:classes:X509
 SamlIssuerName=SamlIssuerName=CN=SAML User\,OU=SU\,O=SAML User\,L=Los Angeles\,ST=CA\,C=US
-saml.SignatureAlgorithm=http://www.w3.org/2001/04/xmldsig-more#rsa-sha512
-saml.DigestAlgorithm=http://www.w3.org/2000/09/xmldsig#rsa-sha512

--- a/Product/Production/Common/Properties/src/main/resources/saml.properties
+++ b/Product/Production/Common/Properties/src/main/resources/saml.properties
@@ -18,3 +18,13 @@ org.apache.ws.security.saml.callback=gov.hhs.fha.nhinc.callback.cxf.CXFSAMLCallb
 #The following are the new keystore alias and password
 org.apache.ws.security.saml.issuer.key.name=gateway
 org.apache.ws.security.saml.issuer.key.password=changeit
+
+# SAML Configuration for supported Signature and Digest methods for incoming and outgoing messages. Accepts a comma separated list of a constant found 
+# in org.opensaml.xmlsec.signature.support.SignatureConstants, or a full URI for the algorithm
+# saml.signatureAlgorithms=ALGO_ID_SIGNATURE_RSA_SHA512,http://www.w3.org/2000/09/xmldsig#rsa-sha1
+# saml.digestAlgorithms=ALGO_ID_DIGEST_SHA512,http://www.w3.org/2000/09/xmldsig#sha1
+
+# SAML Configuration for default Signature and Digest methods to be used for outoing requests. This configuration must be supported in the respective saml.signatureAlgorithms
+# and saml.digestAlgorithms properties.
+# saml.defaultSignatureAlgorithm=ALGO_ID_SIGNATURE_RSA_SHA512
+# saml.defaultDigestAlgorithm=ALGO_ID_DIGEST_SHA512

--- a/Product/Production/Gateway/CONNECTGatewayWeb/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/Product/Production/Gateway/CONNECTGatewayWeb/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -47,7 +47,9 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
-
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
     </jaxws:endpoint>
 
     <!-- AuditQueryLog services -->

--- a/Product/Production/Gateway/CONNECTGatewayWeb/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/Product/Production/Gateway/CONNECTGatewayWeb/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -76,7 +76,9 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
-
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
     </jaxws:endpoint>
 
     <bean id="SOAPHeaderHandler" class="gov.hhs.fha.nhinc.callback.SOAPHeaderHandler" />

--- a/Product/Production/Gateway/CORE_X12DocumentSubmission_10/src/main/resources/x12docsubmission/_10/webservices.xml
+++ b/Product/Production/Gateway/CORE_X12DocumentSubmission_10/src/main/resources/x12docsubmission/_10/webservices.xml
@@ -51,6 +51,9 @@
             <ref bean="SOAPHeaderHandler" />
             <ref bean="TransactionHandler" />
         </jaxws:handlers>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
     </jaxws:endpoint>
 
     <jaxws:endpoint
@@ -77,6 +80,9 @@
             <ref bean="SOAPHeaderHandler" />
             <ref bean="TransactionHandler" />
         </jaxws:handlers>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
     </jaxws:endpoint>
 
     <jaxws:endpoint
@@ -103,6 +109,9 @@
             <ref bean="SOAPHeaderHandler" />
             <ref bean="TransactionHandler" />
         </jaxws:handlers>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
     </jaxws:endpoint>
 
     <!-- Entity Unsecured services -->

--- a/Product/Production/Gateway/DocumentDataSubmission_10/src/main/resources/docdatasubmission/_10/webservices.xml
+++ b/Product/Production/Gateway/DocumentDataSubmission_10/src/main/resources/docdatasubmission/_10/webservices.xml
@@ -43,6 +43,9 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
     </jaxws:endpoint>
 
     <!-- Entity services -->
@@ -67,5 +70,8 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
+        <jaxws:inInterceptors>
+            <ref bean="securityConfigInInterceptor" />
+        </jaxws:inInterceptors>
     </jaxws:endpoint>
 </beans>

--- a/Product/Production/Gateway/PatientDiscovery_10/src/main/resources/patientdiscovery/_10/webservices.xml
+++ b/Product/Production/Gateway/PatientDiscovery_10/src/main/resources/patientdiscovery/_10/webservices.xml
@@ -6,9 +6,6 @@
     in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
     ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under
     the License. -->
-    
-
-    
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:jaxws="http://cxf.apache.org/jaxws"
@@ -24,9 +21,8 @@
         http://cxf.apache.org/policy                http://cxf.apache.org/schemas/policy.xsd
         http://cxf.apache.org/core                  http://cxf.apache.org/schemas/core.xsd
         http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
-        
-        
-    <context:property-placeholder location="file:///${nhinc.properties.dir}/assertioninfo.properties"/>
+
+    
     <!-- Patient Discovery -->
 
     <cxf:bus>
@@ -34,7 +30,8 @@
             <p:policies />
         </cxf:features>
     </cxf:bus>
-
+    <context:property-placeholder location="file:///${nhinc.properties.dir}/assertioninfo.properties"/>
+    
     <!-- Nhin services -->
 
     <jaxws:endpoint xmlns:tns="urn:ihe:iti:xcpd:2009" id="RespondingGateway_Service" address="/NhinService/NhinPatientDiscovery"
@@ -238,6 +235,7 @@
         endpointName="tns:EntityPatientLocationQuerySecuredPortSoap" implementor="#entitySecuredPLQ"
         wsdlLocation="classpath:wsdl/EntityPatientLocationQuerySecured.wsdl">
         <jaxws:properties>
+            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">

--- a/Product/Production/Gateway/PatientDiscovery_10/src/main/resources/patientdiscovery/_10/webservices.xml
+++ b/Product/Production/Gateway/PatientDiscovery_10/src/main/resources/patientdiscovery/_10/webservices.xml
@@ -30,7 +30,8 @@
             <p:policies />
         </cxf:features>
     </cxf:bus>
-    <context:property-placeholder location="file:///${nhinc.properties.dir}/assertioninfo.properties"/>
+    <context:property-placeholder />
+
     
     <!-- Nhin services -->
 
@@ -38,7 +39,7 @@
         serviceName="tns:RespondingGateway_Service" endpointName="tns:RespondingGateway_Port_Soap" implementor="#nhinPD"
         wsdlLocation="classpath:wsdl/NhinPatientDiscovery.wsdl">
         <jaxws:properties>
-            <entry key="ws-security.asymmetric.signature.algorithm" value="${saml.SignatureAlgorithm : http://www.w3.org/2000/09/xmldsig#rsa-sha1}"/>
+            
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">
@@ -235,7 +236,6 @@
         endpointName="tns:EntityPatientLocationQuerySecuredPortSoap" implementor="#entitySecuredPLQ"
         wsdlLocation="classpath:wsdl/EntityPatientLocationQuerySecured.wsdl">
         <jaxws:properties>
-            <entry key="ws-security.asymmetric.signature.algorithm" value="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">

--- a/Product/Production/Gateway/PatientDiscovery_10/src/main/resources/patientdiscovery/_10/webservices.xml
+++ b/Product/Production/Gateway/PatientDiscovery_10/src/main/resources/patientdiscovery/_10/webservices.xml
@@ -13,14 +13,12 @@
        xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:cxf="http://cxf.apache.org/core"
        xmlns:p="http://cxf.apache.org/policy"
-       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
         http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
         http://cxf.apache.org/bindings/soap         http://cxf.apache.org/schemas/configuration/soap.xsd
         http://cxf.apache.org/jaxws                 http://cxf.apache.org/schemas/jaxws.xsd
         http://cxf.apache.org/policy                http://cxf.apache.org/schemas/policy.xsd
-        http://cxf.apache.org/core                  http://cxf.apache.org/schemas/core.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+        http://cxf.apache.org/core                  http://cxf.apache.org/schemas/core.xsd">
 
     
     <!-- Patient Discovery -->
@@ -30,7 +28,6 @@
             <p:policies />
         </cxf:features>
     </cxf:bus>
-    <context:property-placeholder />
 
     
     <!-- Nhin services -->

--- a/Product/Production/Gateway/PatientDiscovery_10/src/main/resources/patientdiscovery/_10/webservices.xml
+++ b/Product/Production/Gateway/PatientDiscovery_10/src/main/resources/patientdiscovery/_10/webservices.xml
@@ -44,7 +44,6 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
-
         <jaxws:inInterceptors>
             <ref bean="securityConfigInInterceptor" />
         </jaxws:inInterceptors>
@@ -68,7 +67,6 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
-
         <jaxws:inInterceptors>
             <ref bean="securityConfigInInterceptor" />
         </jaxws:inInterceptors>
@@ -103,7 +101,6 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
-
         <jaxws:inInterceptors>
             <ref bean="securityConfigInInterceptor" />
         </jaxws:inInterceptors>
@@ -127,7 +124,6 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
-
         <jaxws:inInterceptors>
             <ref bean="securityConfigInInterceptor" />
         </jaxws:inInterceptors>
@@ -162,7 +158,6 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
-
         <jaxws:inInterceptors>
             <ref bean="securityConfigInInterceptor" />
         </jaxws:inInterceptors>
@@ -186,7 +181,6 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
-
         <jaxws:inInterceptors>
             <ref bean="securityConfigInInterceptor" />
         </jaxws:inInterceptors>
@@ -217,7 +211,6 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
-
         <jaxws:inInterceptors>
             <ref bean="securityConfigInInterceptor" />
         </jaxws:inInterceptors>
@@ -240,7 +233,6 @@
             </entry>
             <entry key="ws-security.enable.timestamp.cache" value="false" />
         </jaxws:properties>
-
         <jaxws:inInterceptors>
             <ref bean="securityConfigInInterceptor" />
         </jaxws:inInterceptors>

--- a/Product/Production/Gateway/PatientDiscovery_10/src/main/resources/patientdiscovery/_10/webservices.xml
+++ b/Product/Production/Gateway/PatientDiscovery_10/src/main/resources/patientdiscovery/_10/webservices.xml
@@ -6,6 +6,9 @@
     in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
     ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under
     the License. -->
+    
+
+    
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:jaxws="http://cxf.apache.org/jaxws"
@@ -13,13 +16,17 @@
        xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:cxf="http://cxf.apache.org/core"
        xmlns:p="http://cxf.apache.org/policy"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
         http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
         http://cxf.apache.org/bindings/soap         http://cxf.apache.org/schemas/configuration/soap.xsd
         http://cxf.apache.org/jaxws                 http://cxf.apache.org/schemas/jaxws.xsd
         http://cxf.apache.org/policy                http://cxf.apache.org/schemas/policy.xsd
-        http://cxf.apache.org/core                  http://cxf.apache.org/schemas/core.xsd">
-
+        http://cxf.apache.org/core                  http://cxf.apache.org/schemas/core.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+        
+        
+    <context:property-placeholder location="file:///${nhinc.properties.dir}/assertioninfo.properties"/>
     <!-- Patient Discovery -->
 
     <cxf:bus>
@@ -34,6 +41,7 @@
         serviceName="tns:RespondingGateway_Service" endpointName="tns:RespondingGateway_Port_Soap" implementor="#nhinPD"
         wsdlLocation="classpath:wsdl/NhinPatientDiscovery.wsdl">
         <jaxws:properties>
+            <entry key="ws-security.asymmetric.signature.algorithm" value="${saml.SignatureAlgorithm : http://www.w3.org/2000/09/xmldsig#rsa-sha1}"/>
             <entry key="ws-security.signature.properties" value="file:///${nhinc.properties.dir}/signature.properties" />
             <entry key="ws-security.encryption.properties" value="file:///${nhinc.properties.dir}/truststore.properties" />
             <entry key="ws-security.saml2.validator">


### PR DESCRIPTION
Adds 4 new properties to gateway.properties:

- saml.signatureAlgorithms = list of supported algorithms for signing the signature
- saml.digestAlgorithms = list of supported algorithms for the digest method
- saml.defaultSignatureAlgorithm = default algorithm to be used to sign the signature
- saml.defaultDigestAlgorithm = default algorithm for the digest method.

Also allows the Entity message to specify a requested algorithm in the assertion block. 

Relies on https://github.com/CONNECT-Solution/Common-Types/pull/89
