### PR TITLE
CONN-2407: Retrieve system property to set up proxy for fhir client

### DIFF
--- a/Product/Production/Services/ConnectionManagerCore/src/main/java/gov/hhs/fha/nhinc/exchangemgr/fhir/FhirClient.java
+++ b/Product/Production/Services/ConnectionManagerCore/src/main/java/gov/hhs/fha/nhinc/exchangemgr/fhir/FhirClient.java
@@ -66,7 +66,7 @@ public class FhirClient {
     public String sendRequest(HttpUriRequest request) throws FhirClientException {
         LOG.info("sendRequest: {}", request);
         HttpClientBuilder client = HttpClientBuilder.create();
-        try (CloseableHttpClient httpClient = client.setSSLSocketFactory(createSSLConnectionSocketFactory()).build()) {
+        try (CloseableHttpClient httpClient = client.useSystemProperties().setSSLSocketFactory(createSSLConnectionSocketFactory()).build()) {
             try (CloseableHttpResponse response = httpClient.execute(request)) {
                 return unmarshallResponse(response);
             }


### PR DESCRIPTION
Retrieve System Property to build fhir client so that it can use proxy if needed.