### PR TITLE
CONN_2395: Handling login more elegantly

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/LoginBean.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/LoginBean.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2019, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- *  
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -30,7 +30,6 @@ import gov.hhs.fha.nhinc.admingui.constant.NavigationConstant;
 import gov.hhs.fha.nhinc.admingui.jee.jsf.UserAuthorizationListener;
 import gov.hhs.fha.nhinc.admingui.model.Login;
 import gov.hhs.fha.nhinc.admingui.services.LoginService;
-import gov.hhs.fha.nhinc.admingui.services.exception.UserLoginException;
 import gov.hhs.fha.nhinc.admingui.services.persistence.jpa.entity.UserLogin;
 import javax.faces.application.FacesMessage;
 import javax.faces.bean.ManagedBean;
@@ -160,19 +159,15 @@ public class LoginBean {
     private boolean login() {
         boolean loggedIn = false;
         Login login = new Login(userName, password);
-        try {
-            UserLogin user = loginService.login(login);
+        UserLogin user = loginService.login(login);
 
-            if (user != null) {
-                loggedIn = true;
-                FacesContext facesContext = FacesContext.getCurrentInstance();
-                ExternalContext externalContext = facesContext.getExternalContext();
-                externalContext.invalidateSession();
-                HttpSession session = (HttpSession) externalContext.getSession(true);
-                session.setAttribute(UserAuthorizationListener.USER_INFO_SESSION_ATTRIBUTE, user);
-            }
-        } catch (UserLoginException e) {
-            LOG.error("Exception during login: " + e.getLocalizedMessage(), e);
+        if (user != null) {
+            loggedIn = true;
+            FacesContext facesContext = FacesContext.getCurrentInstance();
+            ExternalContext externalContext = facesContext.getExternalContext();
+            externalContext.invalidateSession();
+            HttpSession session = (HttpSession) externalContext.getSession(true);
+            session.setAttribute(UserAuthorizationListener.USER_INFO_SESSION_ATTRIBUTE, user);
         }
 
         userName = null;

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/LoginService.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/LoginService.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2019, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- *  
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -47,7 +47,7 @@ public interface LoginService {
      * @return true, if successful
      * @throws UserLoginException
      */
-    public UserLogin login(Login login) throws UserLoginException;
+    public UserLogin login(Login login);
 
     /**
      * Adds the user.

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/SHA2PasswordService.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/SHA2PasswordService.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2019, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- *  
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -28,12 +28,14 @@ package gov.hhs.fha.nhinc.admingui.services;
 
 import java.security.SecureRandom;
 import org.apache.commons.codec.binary.Base64;
+import org.springframework.stereotype.Service;
 
 /**
  * The Class SHA2PasswordService.
  *
  * @author msw
  */
+@Service
 public class SHA2PasswordService implements PasswordService {
 
     private static final SecureRandom RANDOM = new SecureRandom();

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/test/java/gov/hhs/fha/nhinc/admingui/hibernate/LoginServiceImplTest.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/test/java/gov/hhs/fha/nhinc/admingui/hibernate/LoginServiceImplTest.java
@@ -153,12 +153,4 @@ public class LoginServiceImplTest {
         UserLogin loggedInUser = loginService.login(login);
         assertEquals(null, loggedInUser);
     }
-
-    public void doTests() {
-        //loginService.addUser(user, role, firstName, middleName, lastName, transRoleDesc);
-        //loginService.deleteUser(user);
-        //loginService.getAllUsers();
-        //loginService.getUserRoleList();
-        //loginService.login(login);
-    }
 }

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/test/java/gov/hhs/fha/nhinc/admingui/hibernate/LoginServiceImplTest.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/test/java/gov/hhs/fha/nhinc/admingui/hibernate/LoginServiceImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2019, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- *  
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,25 +26,29 @@
 */
 package gov.hhs.fha.nhinc.admingui.hibernate;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import gov.hhs.fha.nhinc.admingui.hibernate.dao.UserLoginDAO;
 import gov.hhs.fha.nhinc.admingui.model.Login;
+import gov.hhs.fha.nhinc.admingui.services.PasswordService;
 import gov.hhs.fha.nhinc.admingui.services.exception.UserLoginException;
 import gov.hhs.fha.nhinc.admingui.services.persistence.jpa.entity.UserLogin;
-import gov.hhs.fha.nhinc.admingui.services.exception.PasswordServiceException;
-import java.io.IOException;
+import gov.hhs.fha.nhinc.util.SHA2PasswordUtil;
+import gov.hhs.fha.nhinc.util.UtilException;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
 
 /**
  *
  * @author sadusumilli, msw
  */
+@RunWith(MockitoJUnitRunner.class)
 public class LoginServiceImplTest {
 
     /**
@@ -53,33 +57,108 @@ public class LoginServiceImplTest {
     @InjectMocks
     private LoginServiceImpl loginService;
 
-    /**
-     * The mock dao.
-     */
-    @Mock
-    private UserLoginDAO mockDao;
 
-    /**
-     * Sets the up.
-     */
+    @Mock
+    private UserLoginDAO userDAO;
+
+    @Mock
+    private PasswordService passwordService;
+
+    private String salt = "SALT";
+
     @Before
-    public void setUp() {
-        MockitoAnnotations.initMocks(this);
+    public void setup() {
+
+        Mockito.when(passwordService.generateRandomSalt()).thenReturn("SALT".getBytes());
     }
 
-    /**
-     * Test adduser_ pass.
-     *
-     * @throws IOException Signals that an I/O exception has occurred.
-     * @throws PasswordServiceException the password service exception
-     * @throws UserLoginException the user login exception
-     */
     @Test
-    public void testAdduser_Pass() throws IOException, PasswordServiceException, UserLoginException {
+    public void testAdduser_Pass() throws UserLoginException, UtilException {
         Login login = new Login();
         login.setUserName("ABCD");
         login.setPassword("ABCDEFGH");
-        Mockito.when(mockDao.createUser(Mockito.any(UserLogin.class))).thenReturn(true);
-        assertNotNull(loginService.addUser(login, 1, "firstName", "middleName", "lastName", "role description"));
+        Mockito.when(userDAO.createUser(Mockito.any(UserLogin.class))).thenReturn(true);
+        UserLogin addedUser = loginService.addUser(login, 1, "firstName", "middleName", "lastName", "role description");
+        assertNotNull(addedUser);
+
+        Mockito.verify(passwordService).generateRandomSalt();
+
+        String expectedHash = new String(SHA2PasswordUtil.calculateHash(salt.getBytes(), login.getPassword().getBytes()));
+        assertEquals(expectedHash, addedUser.getSha2());
+
+        assertEquals("firstName", addedUser.getFirstName());
+        assertEquals("middleName", addedUser.getMiddleName());
+        assertEquals("lastName", addedUser.getLastName());
+        assertEquals(salt, addedUser.getSalt());
+
+    }
+
+
+    @Test
+    public void testLogin(){
+        Login login = new Login();
+        login.setUserName("ABCD");
+        login.setPassword("ABCDEFGH");
+
+        UserLogin returnedUser = new UserLogin();
+        returnedUser.setSalt(salt);
+        returnedUser.setSha2("osoSSNvkHcYvZs0+Y54qW9oGVOVz6WB9UVn15NRAq0x4doJ3pjvlT9hlu9bFFxy71YELxql5O+w6+0UctMRP6Q==");
+
+        Mockito.when(userDAO.login(Mockito.isA(Login.class))).thenReturn(returnedUser);
+        UserLogin loggedInUser = loginService.login(login);
+        assertEquals(returnedUser, loggedInUser);
+    }
+
+    @Test
+    public void testLogin_badPassword(){
+        Login login = new Login();
+        login.setUserName("ABCD");
+        login.setPassword("ABCDEFGH");
+
+        UserLogin returnedUser = new UserLogin();
+        returnedUser.setSalt(salt);
+        returnedUser.setSha2("ThIsIsThEwRoNgHaSh");
+
+        Mockito.when(userDAO.login(Mockito.isA(Login.class))).thenReturn(returnedUser);
+        UserLogin loggedInUser = loginService.login(login);
+        assertEquals(null, loggedInUser);
+    }
+
+    @Test
+    public void testLogin_noPassword(){
+        Login login = new Login();
+        login.setUserName("ABCD");
+        login.setPassword("");
+
+        UserLogin returnedUser = new UserLogin();
+        returnedUser.setSalt(salt);
+        returnedUser.setSha2("");
+
+        Mockito.when(userDAO.login(Mockito.isA(Login.class))).thenReturn(returnedUser);
+        UserLogin loggedInUser = loginService.login(login);
+        assertEquals(null, loggedInUser);
+    }
+
+    @Test
+    public void testLogin_noDBPassword(){
+        Login login = new Login();
+        login.setUserName("ABCD");
+        login.setPassword("1234");
+
+        UserLogin returnedUser = new UserLogin();
+        returnedUser.setSalt(salt);
+        returnedUser.setSha2("");
+
+        Mockito.when(userDAO.login(Mockito.isA(Login.class))).thenReturn(returnedUser);
+        UserLogin loggedInUser = loginService.login(login);
+        assertEquals(null, loggedInUser);
+    }
+
+    public void doTests() {
+        //loginService.addUser(user, role, firstName, middleName, lastName, transRoleDesc);
+        //loginService.deleteUser(user);
+        //loginService.getAllUsers();
+        //loginService.getUserRoleList();
+        //loginService.login(login);
     }
 }

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/test/java/gov/hhs/fha/nhinc/admingui/managed/CreateuserBeanTest.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/test/java/gov/hhs/fha/nhinc/admingui/managed/CreateuserBeanTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2019, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- *  
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -38,10 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import javax.servlet.http.HttpSession;
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -55,24 +52,13 @@ public class CreateuserBeanTest {
 
     private final HttpSession session = mock(HttpSession.class);
 
-    public CreateuserBeanTest() {
-    }
-
-    @BeforeClass
-    public static void setUpClass() {
-    }
-
-    @AfterClass
-    public static void tearDownClass() {
-    }
-
     @Before
-    public void setUp() throws UserLoginException {
+    public void setUp() {
 
         LoginService loginservice = new LoginService() {
 
             @Override
-            public UserLogin login(Login login) throws UserLoginException {
+            public UserLogin login(Login login) {
                 return new UserLogin();
             }
 
@@ -111,13 +97,8 @@ public class CreateuserBeanTest {
 
     }
 
-    @After
-    public void tearDown() {
-    }
-
     @Test
-    @SuppressWarnings("empty-statement")
-    public void testCreateUser_Pass1() throws UserLoginException {
+    public void testCreateUser_Pass1() {
         assertTrue(createuserBean.createUser());
     }
 

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/SHA2PasswordUtil.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/SHA2PasswordUtil.java
@@ -55,7 +55,7 @@ public class SHA2PasswordUtil {
             outputStream.write(candidatePassword);
             candidateHash = calculateHash(outputStream.toByteArray());
         } catch (NoSuchAlgorithmException | IOException e) {
-            LOG.error("Failed to check password hash token: {}", e.getLocalizedMessage());
+            LOG.error("Failed to check password hash token: {}", e.getLocalizedMessage(), e);
             return false;
         }
         return Arrays.equals(passwordHash, candidateHash);
@@ -70,7 +70,6 @@ public class SHA2PasswordUtil {
             outputStream.write(password);
             hash = calculateHash(outputStream.toByteArray());
         } catch (NoSuchAlgorithmException | IOException e) {
-            LOG.error("Failed to calculate hash token: {}", e.getLocalizedMessage());
             throw new UtilException("Failed to calculate hash token", e);
         }
         return hash;

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/SHA2PasswordUtil.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/util/SHA2PasswordUtil.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2019, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- *  
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -46,8 +46,7 @@ public class SHA2PasswordUtil {
     private SHA2PasswordUtil() {
     }
 
-    public static boolean checkPassword(byte[] passwordHash, byte[] candidatePassword, byte[] salt)
-        throws UtilException {
+    public static boolean checkPassword(byte[] passwordHash, byte[] candidatePassword, byte[] salt) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         byte[] candidateHash;
 
@@ -57,7 +56,7 @@ public class SHA2PasswordUtil {
             candidateHash = calculateHash(outputStream.toByteArray());
         } catch (NoSuchAlgorithmException | IOException e) {
             LOG.error("Failed to check password hash token: {}", e.getLocalizedMessage());
-            throw new UtilException("Failed to check password hash token", e);
+            return false;
         }
         return Arrays.equals(passwordHash, candidateHash);
     }
@@ -77,7 +76,7 @@ public class SHA2PasswordUtil {
         return hash;
     }
 
-    private static byte[] calculateHash(byte[] input) throws IOException, NoSuchAlgorithmException {
+    private static byte[] calculateHash(byte[] input) throws NoSuchAlgorithmException {
         byte[] digest;
 
         MessageDigest md = MessageDigest.getInstance(HASH_ALGORITHM);

--- a/Product/Production/Gateway/AdminGUIWebservices/src/main/java/gov/hhs/fha/nhinc/configadmin/ConfigAdmin.java
+++ b/Product/Production/Gateway/AdminGUIWebservices/src/main/java/gov/hhs/fha/nhinc/configadmin/ConfigAdmin.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2019, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- *  
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -47,7 +47,6 @@ import gov.hhs.fha.nhinc.common.configadmin.ListTrustStoresRequestMessageType;
 import gov.hhs.fha.nhinc.common.configadmin.ListTrustStoresResponseMessageType;
 import gov.hhs.fha.nhinc.common.configadmin.SimpleCertificateResponseMessageType;
 import gov.hhs.fha.nhinc.util.SHA2PasswordUtil;
-import gov.hhs.fha.nhinc.util.UtilException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.cert.Certificate;
@@ -126,16 +125,7 @@ public class ConfigAdmin implements EntityConfigAdminPortType {
     }
 
     private static boolean validateHash(String userName, String hashToken, String passKey) {
-        boolean hashCheck = false;
-        try {
-            hashCheck = SHA2PasswordUtil.checkPassword(hashToken.getBytes(),
-                passKey.getBytes(),
-                userName.getBytes());
-        } catch (UtilException e) {
-            LOG.error("Error while getting the hash token: ", e.getLocalizedMessage(), e);
-        }
-
-        return hashCheck;
+        return SHA2PasswordUtil.checkPassword(hashToken.getBytes(),passKey.getBytes(),userName.getBytes());
     }
 
     /*


### PR DESCRIPTION
Even though Primefaces seems to be preventing this from happening, we should not return a user if we couldn't validate the password, or if they are blank.