### PR TITLE
CONN-2430 update Exchange Manager

### DIFF
--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/application/EndpointManager.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/application/EndpointManager.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2019, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- *  
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -23,7 +23,7 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ */
 package gov.hhs.fha.nhinc.admingui.application;
 
 import java.util.Collection;
@@ -35,11 +35,14 @@ import java.util.Date;
  */
 public interface EndpointManager {
 
-    public void addOrUpdateEndpoint(String url, Date timestamp, boolean pingResult, int httpCode);
+    public void addOrUpdateEndpoint(String exchangeName, int id, String url, Date timestamp, boolean pingResult,
+        int httpCode);
 
-    public EndpointManagerCache.EndpointCacheInfo getEndpointInfo(String url);
+    public EndpointManagerCache.EndpointCacheInfo getEndpointInfo(String exchangeName, int id);
 
-    public void loadCache(Collection<EndpointManagerCache.EndpointCacheInfo> endpoints);
+    public void deleteCache(String exchangeName);
+
+    public void loadCache(String exchangeName, Collection<EndpointManagerCache.EndpointCacheInfo> endpoints);
 
     public Collection getAllCache();
 

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/ConnectionManagerBean.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/managed/ConnectionManagerBean.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2019, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- *  
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -23,7 +23,7 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ */
 package gov.hhs.fha.nhinc.admingui.managed;
 
 import static gov.hhs.fha.nhinc.admingui.services.impl.PingServiceImpl.IGNORE_DEADHOST;
@@ -34,6 +34,7 @@ import gov.hhs.fha.nhinc.admingui.model.ConnectionEndpoint;
 import gov.hhs.fha.nhinc.admingui.services.PingService;
 import gov.hhs.fha.nhinc.admingui.services.impl.PingServiceImpl;
 import gov.hhs.fha.nhinc.admingui.util.ConnectionHelper;
+import gov.hhs.fha.nhinc.admingui.util.HelperUtil;
 import gov.hhs.fha.nhinc.exchange.directory.ContactType;
 import gov.hhs.fha.nhinc.exchange.directory.EndpointConfigurationType;
 import gov.hhs.fha.nhinc.exchange.directory.EndpointType;
@@ -49,6 +50,7 @@ import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+
 
 /**
  *
@@ -130,15 +132,17 @@ public class ConnectionManagerBean {
         return hcid;
     }
 
-    public void ping() {
+    public void ping(String exchangeName, String hcid) {
         if (selectedEndpoint != null) {
             selectedEndpoint.setResponseCode(pingService.ping(selectedEndpoint.getServiceUrl(), IGNORE_DEADHOST));
-            EndpointManagerCache.getInstance().addOrUpdateEndpoint(selectedEndpoint.getServiceUrl(), new Date(),
+            EndpointManagerCache.getInstance().addOrUpdateEndpoint(exchangeName,
+                HelperUtil.getHashCodeBy(hcid, selectedEndpoint.getServiceUrl()),
+                selectedEndpoint.getServiceUrl(), new Date(),
                 selectedEndpoint.isPingSuccessful(), selectedEndpoint.getResponseCode());
         }
     }
 
-    public List<ConnectionEndpoint> getEndpoints() {
+    public List<ConnectionEndpoint> getEndpoints(String exchangeName, String hcid) {
         List<ConnectionEndpoint> endpoints = new ArrayList<>();
         List<EndpointType> orgEndpoints = ExchangeManagerHelper.getEndpointTypeBy(selectedEntity);
         if (selectedEntity != null && CollectionUtils.isNotEmpty(orgEndpoints)) {
@@ -151,7 +155,7 @@ public class ConnectionManagerBean {
                     int code = 0;
                     String url = epConf.getUrl();
                     EndpointManagerCache.EndpointCacheInfo info = EndpointManagerCache.getInstance()
-                        .getEndpointInfo(url);
+                        .getEndpointInfo(exchangeName, HelperUtil.getHashCodeBy(hcid, url));
 
                     if (info != null) {
                         timestamp = formatDate(DATE_FORMAT, info.getTimestamp());
@@ -159,7 +163,8 @@ public class ConnectionManagerBean {
                     }
 
                     endpoints.add(
-                        new ConnectionEndpoint(endpoint.getName().get(0), url, epConf.getVersion(), code, timestamp));
+                        new ConnectionEndpoint(endpoint.getName().get(0), url, epConf.getVersion(), code,
+                            timestamp));
                 }
             }
         }

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/model/ConnectionEndpoint.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/model/ConnectionEndpoint.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2019, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- *  
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -23,10 +23,12 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ */
 package gov.hhs.fha.nhinc.admingui.model;
 
 import static java.net.HttpURLConnection.HTTP_OK;
+
+import gov.hhs.fha.nhinc.admingui.util.HelperUtil;
 
 /**
  *
@@ -39,10 +41,13 @@ public class ConnectionEndpoint {
     private String serviceUrl;
     private String pingTimestamp;
     private int responseCode;
+    private int id;
 
     public ConnectionEndpoint(String name, String serviceUrl, String serviceSpec, int responseCode,
         String pingTimestamp) {
         this.name = name;
+        id = HelperUtil.getHashCodeBy(name, serviceUrl, serviceSpec);
+
         this.serviceSpec = serviceSpec;
         this.serviceUrl = serviceUrl;
         this.responseCode = responseCode;
@@ -100,6 +105,14 @@ public class ConnectionEndpoint {
 
     public void setResponseCode(int responseCode) {
         this.responseCode = responseCode;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
     }
 
 }

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/ExchangeManagerService.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/ExchangeManagerService.java
@@ -23,7 +23,7 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ */
 package gov.hhs.fha.nhinc.admingui.services;
 
 import gov.hhs.fha.nhinc.admingui.model.ConnectionEndpoint;
@@ -55,5 +55,5 @@ public interface ExchangeManagerService {
 
     public List<ExchangeDownloadStatusType> refreshExchangeManager();
 
-    public int pingService(ConnectionEndpoint connEndpoint);
+    public int pingService(ConnectionEndpoint connEndpoint, String exchangeName, String hcid);
 }

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/impl/ExchangeManagerServiceImpl.java
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/java/gov/hhs/fha/nhinc/admingui/services/impl/ExchangeManagerServiceImpl.java
@@ -188,14 +188,18 @@ public class ExchangeManagerServiceImpl implements ExchangeManagerService {
                 String timestamp = null;
                 int httpCode = 0;
                 String url = epConf.getUrl();
-                EndpointManagerCache.EndpointCacheInfo info = EndpointManagerCache.getInstance().getEndpointInfo(url);
+
+                EndpointManagerCache.EndpointCacheInfo info = EndpointManagerCache.getInstance()
+                    .getEndpointInfo(exchangeName, HelperUtil.getHashCodeBy(hcid, url));
 
                 if (info != null) {
                     timestamp = HelperUtil.getDate(DATE_FORMAT, info.getTimestamp());
                     httpCode = info.getHttpCode();
                 }
                 endpoints.add(
-                    new ConnectionEndpoint(endpoint.getName().get(0), url, epConf.getVersion(), httpCode, timestamp));
+                    new ConnectionEndpoint(endpoint.getName().get(0), url, epConf.getVersion(), httpCode,
+                        timestamp));
+
             }
         }
         return endpoints;
@@ -257,11 +261,14 @@ public class ExchangeManagerServiceImpl implements ExchangeManagerService {
     }
 
     @Override
-    public int pingService(ConnectionEndpoint connEndpoint) {
+    public int pingService(ConnectionEndpoint connEndpoint, String exchangeName, String hcid) {
         if (null != connEndpoint) {
             connEndpoint.setResponseCode(pingService.ping(connEndpoint.getServiceUrl(), IGNORE_DEADHOST));
             connEndpoint.setPingTimestamp(HelperUtil.getDateNow(DATE_FORMAT));
-            EndpointManagerCache.getInstance().addOrUpdateEndpoint(connEndpoint.getServiceUrl(), new Date(),
+            EndpointManagerCache.getInstance().addOrUpdateEndpoint(
+                exchangeName, HelperUtil.getHashCodeBy(hcid, connEndpoint.getServiceUrl()),
+                connEndpoint.getServiceUrl(),
+                new Date(),
                 connEndpoint.isPingSuccessful(), connEndpoint.getResponseCode());
             return connEndpoint.getResponseCode();
         }

--- a/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/exchangeManager.xhtml
+++ b/Product/Production/Adapters/General/CONNECTAdminGUI/src/main/webapp/exchangeManager.xhtml
@@ -231,7 +231,7 @@
                                                                 value="#{exchangeManagerBean.filterExchange}"
                                                                 filter="true" filterMatchMode="startsWith">
                                                                 <p:ajax event="change" update="inputFilterOrganization, displayName, displayHcid, displayDescription, displayContact, dataTableConnectionEndpoint" />
-                                                                <f:selectItem itemLabel="---" itemValue=""
+                                                                <f:selectItem itemLabel="---" itemValue="#{exchangeManagerBean.listFilterExchanges}"
                                                                     noSelectionOption="false" />
                                                                 <f:selectItems
                                                                     value="#{exchangeManagerBean.listFilterExchanges}"
@@ -249,7 +249,7 @@
                                                                 filter="true" filterMatchMode="startsWith">
                                                                 <p:ajax event="change"
                                                                     update="displayName, displayHcid, displayDescription, displayContact, dataTableConnectionEndpoint" />
-                                                                <f:selectItem itemLabel="---" itemValue=""
+                                                                <f:selectItem itemLabel="---" itemValue="#{exchangeManagerBean.listFilterExchanges}"
                                                                     noSelectionOption="false" />
                                                                 <f:selectItems
                                                                     value="#{exchangeManagerBean.listFilterOrganizations}"
@@ -289,7 +289,7 @@
                                                     styleClass="table table-striped table-domains" var="rec"
                                                     value="#{exchangeManagerBean.connectionEndpoints}"
                                                     selection="#{exchangeManagerBean.selectedEndpoint}"
-                                                    rowKey="#{rec.serviceUrl}^^^#{rec.serviceSpec}" scrollable="true"
+                                                    rowKey="#{rec.id}" scrollable="true"
                                                     scrollHeight="400">
 
                                                     <p:ajax event="rowSelectRadio" process="@this"


### PR DESCRIPTION
Updated Exchange Manager to clear endpoints for each organization and keep track of each organizations of ping success.  Also to delete exchange cache info when exchange is deleted. 