### PR TITLE
CONN_2143: Removing old JIRA ticket references

### DIFF
--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/CONNECTSamlAssertionValidator.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/cxf/CONNECTSamlAssertionValidator.java
@@ -348,7 +348,7 @@ public class CONNECTSamlAssertionValidator extends SamlAssertionValidator {
         } catch (final WSSecurityException e) {
             if (certs == null && publicKey != null) {
                 LOG.warn("Could not establish trust of the signature's public key because no matching public key "
-                    + "exists in the truststore. Please see GATEWAY-3146 for more details.");
+                    + "exists in the truststore.");
             } else {
                 throw e;
             }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/callback/opensaml/HOKSAMLAssertionBuilder.java
@@ -115,11 +115,6 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
             final PrivateKey privateKey = certificateManager.getPrivateKeyBy(certificateAlias);
             Assertion assertion = componentBuilder.createAssertion();
 
-            // create the assertion id
-            // Per GATEWAY-847 the id attribute should not be allowed to start
-            // with a number (UUIDs can). Direction
-            // given from 2011 specification set was to prepend with and
-            // underscore.
             final String aID = createAssertionId();
             LOG.debug("Assertion ID: {}", aID);
 
@@ -697,6 +692,13 @@ public class HOKSAMLAssertionBuilder extends SAMLAssertionBuilder {
         return statements;
     }
 
+    /**
+     * Summer 2011 Authorization Framework specification has provided a clarification regarding the SAML assertion ID
+     * attribute, in that this value should be a properly formatted W3C ID Type object. Currently this Id is
+     * represented by a UUID, however this can be incorrect because a UUID can start with a number, where as the W3C
+     * ID Type cannot. The specification provides guidance that an underscore can be prepended to a UUID to conform
+     * to the spec
+     */
     private static String createAssertionId() {
         return ID_PREFIX.concat(String.valueOf(UUID.randomUUID())).replaceAll("-", "");
     }

--- a/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/opensaml/extraction/AttributeHelper.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/main/java/gov/hhs/fha/nhinc/opensaml/extraction/AttributeHelper.java
@@ -165,7 +165,7 @@ public class AttributeHelper {
      * @return The string value (or if there are multiple values, the concatenated string value.)
      */
     public String extractAttributeValueString(Attribute attrib) {
-        // this method was rewritten for GATEWAY-426
+
         StringBuilder strBuilder = new StringBuilder();
 
         if (attrib != null) {

--- a/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/opensaml/extraction/OpenSAMLAssertionExtractorImplTest.java
+++ b/Product/Production/Common/CONNECTCoreLib/src/test/java/gov/hhs/fha/nhinc/opensaml/extraction/OpenSAMLAssertionExtractorImplTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2019, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- *  
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -184,9 +184,8 @@ public class OpenSAMLAssertionExtractorImplTest {
      * @return
      */
     private String getTestFilePath(String filename) {
-        // the first "/" is intentionally not using File.separator due to differences in how windows and unix based
-        // operating systems handle the class.getResource method. Please see GATEWAY-2873 for more details.
-        return "/" + "testing_saml" + File.separator + filename;
+        // the first "/" is intentionally not using File.separator in order to get the absolute path to the file.
+        return "/testing_saml" + File.separator + filename;
     }
 
     private void verifyIssuer(SamlIssuerType issuer) {

--- a/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditDBStoreImplTest.java
+++ b/Product/Production/Services/AuditRepositoryCore/src/test/java/gov/hhs/fha/nhinc/auditrepository/nhinc/AuditDBStoreImplTest.java
@@ -66,10 +66,6 @@ public class AuditDBStoreImplTest {
     @Test
     public void testCreateDBAuditObj() {
 
-        /*
-         * FHAC-977: Override getBlobFromAuditMessage() in AuditDBStoreImpl so HibernateUtil will not be used during
-         * testing.
-         */
         AuditDBStoreImpl dbStore = new AuditDBStoreImpl() {
             @Override
             protected Blob getBlobFromAuditMessage(AuditMessageType mess) {

--- a/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectAdapter.java
+++ b/Product/Production/Services/DirectCore/src/main/java/gov/hhs/fha/nhinc/direct/DirectAdapter.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2019, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- *  
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -133,11 +133,7 @@ public abstract class DirectAdapter {
     }
 
     /**
-     * The SmtpAgentConfig.xml is removed as part of CONN-1213. The direct.appcontext.xml invokes smtpAgent and looks
-     * for ConfigurationService endpoints to be published before the deployment of Direct and this fails in case of
-     * Appservers JBoss,WebLogic and WebSphere whereas GlassFish works.
-     *
-     * CONN-1213: The SmtpAgent is created after the deployment of Direct. Whenever the DirectSender/DirectReceiver is
+     * The SmtpAgent is created after the deployment of Direct. Whenever the DirectSender/DirectReceiver is
      * initiated the SmtpAgent is created and the aAgent is used for further processing of Direct Messages. The
      * SmtpAgent injection is removed from direct.beans.xml whereas ConfigurationService url can be configured in
      * internalConnectionInfo.xml like any other CONNECT service.


### PR DESCRIPTION
Removes confusing / unnecessary references to JIRA tickets when the comments and java docs should just provide an appropriate entry for each.